### PR TITLE
Implement Supabase Auth (Apple + Email/Password)

### DIFF
--- a/SUPABASE_SETUP.md
+++ b/SUPABASE_SETUP.md
@@ -1,0 +1,136 @@
+# Supabase Setup Guide for XomFit iOS
+
+This guide walks through the steps needed to configure Supabase authentication for the XomFit iOS app.
+
+## Prerequisites
+
+- Xcode 15.0 or later
+- An Apple Developer account (for signing the app)
+- A Supabase account (free tier works fine)
+
+---
+
+## Step 1: Set Up Supabase Project
+
+1. Go to [supabase.com](https://supabase.com) and sign in or create an account
+2. Create a new project:
+   - Choose any region (e.g., us-east-1)
+   - Set a strong database password
+3. Once the project is created, go to **Settings > API** and note:
+   - **Project URL** (e.g., `https://your-project.supabase.co`)
+   - **Anon Key** (public key)
+
+## Step 2: Enable Authentication Providers
+
+In your Supabase dashboard:
+
+1. Go to **Authentication > Providers**
+2. Enable **Email Provider**:
+   - Click "Email" and toggle it on
+   - Keep default settings
+3. Enable **Apple Provider**:
+   - Click "Apple"
+   - You'll need:
+     - **Services ID** (from Apple Developer)
+     - **Team ID** (from Apple Developer)
+     - **Key ID** (from Apple Developer)
+   - See [Supabase Apple Provider Docs](https://supabase.com/docs/guides/auth/social-login/auth-apple) for details
+
+> **Optional**: Google provider is stubbed out in `LoginView.swift`. To enable it, follow the [Supabase Google OAuth Guide](https://supabase.com/docs/guides/auth/social-login/auth-google).
+
+## Step 3: Configure Redirect URLs
+
+1. In your Supabase dashboard, go to **Authentication > URL Configuration**
+2. Add this redirect URL:
+   ```
+   xomfit://
+   ```
+   - This tells Supabase to redirect back to the iOS app after OAuth
+
+## Step 4: Set Up URL Scheme in Xcode
+
+1. Open `XomFit.xcodeproj` in Xcode
+2. Select the **XomFit** target
+3. Go to **Info** tab
+4. Under **URL Types**, click **+** to add a new URL scheme:
+   - **Identifier**: `com.xomware.xomfit` (or similar)
+   - **URL Schemes**: `xomfit`
+5. Save and close
+
+---
+
+## Step 5: Add supabase-swift Package
+
+1. In Xcode, select **File > Add Packages...**
+2. Enter the repository URL:
+   ```
+   https://github.com/supabase/supabase-swift
+   ```
+3. Select version: **2.x**
+4. Choose the **XomFit** target to add the package to
+5. Click **Add Package**
+
+---
+
+## Step 6: Fill in Config.swift
+
+1. Open `XomFit/Config.swift`
+2. Replace the placeholder values:
+   ```swift
+   enum Config {
+       static let supabaseURL = "https://your-project.supabase.co"
+       static let supabaseAnonKey = "your-anon-key-here"
+   }
+   ```
+   - Use the **Project URL** and **Anon Key** from Step 1
+
+---
+
+## Step 7: Test the App
+
+1. Build and run the app on a simulator or device
+2. Try these flows:
+   - **Email/Password Sign Up**: Create a new account with email and password
+   - **Email/Password Sign In**: Log in with the account you just created
+   - **Sign In with Apple**: Use your Apple ID to sign in (requires a real device or simulator with Face ID/Touch ID)
+3. Check the Supabase dashboard:
+   - Go to **Authentication > Users** to see created users
+
+---
+
+## Troubleshooting
+
+### "Invalid Supabase URL or Key"
+- Make sure you've filled in `Config.swift` with real values
+- Double-check there are no trailing spaces
+
+### "Redirect URL mismatch" during OAuth
+- Verify the `xomfit://` URL scheme is registered in Xcode
+- Verify `xomfit://` is in Supabase **URL Configuration**
+
+### Apple Sign In not working on simulator
+- Apple Sign In requires a real device or simulator with proper sign-in credentials configured
+- Test with email/password sign in first
+
+### Session not persisting after app close
+- Supabase-swift automatically stores sessions in Keychain
+- If sessions don't persist, check that Keychain sharing is enabled in your app's capabilities
+
+---
+
+## Next Steps
+
+Once authentication is working:
+
+1. **User Profiles**: Create a `users` table in Supabase to store profile data (username, bio, stats, etc.)
+2. **Profile View**: Update the app to fetch and display user profiles from Supabase
+3. **Google Sign In**: Implement Google OAuth if needed
+4. **Email Verification**: Optionally require email verification before sign-in
+
+---
+
+## References
+
+- [Supabase Swift Docs](https://supabase.com/docs/reference/swift/introduction)
+- [Supabase Auth Docs](https://supabase.com/docs/guides/auth)
+- [ASAuthorizationController Apple Docs](https://developer.apple.com/documentation/authenticationservices/asauthorizationcontroller)

--- a/XomFit/Config.swift
+++ b/XomFit/Config.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+enum Config {
+    static let supabaseURL = "YOUR_SUPABASE_URL"
+    static let supabaseAnonKey = "YOUR_SUPABASE_ANON_KEY"
+}

--- a/XomFit/Services/AuthService.swift
+++ b/XomFit/Services/AuthService.swift
@@ -1,42 +1,189 @@
 import Foundation
+import AuthenticationServices
 
 @MainActor
-class AuthService: ObservableObject {
+class AuthService: NSObject, ObservableObject {
     @Published var isAuthenticated = false
     @Published var currentUser: User?
     @Published var isLoading = false
     @Published var errorMessage: String?
     
-    func signIn(email: String, password: String) {
-        isLoading = true
-        errorMessage = nil
-        
-        // Mock auth — replace with real API
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1) { [weak self] in
-            self?.currentUser = .mock
-            self?.isAuthenticated = true
-            self?.isLoading = false
+    private var authStateTask: Task<Void, Never>?
+    
+    override init() {
+        super.init()
+        setupAuthStateListener()
+    }
+    
+    /// Set up listener for auth state changes
+    private func setupAuthStateListener() {
+        authStateTask = Task {
+            for await state in supabase.auth.authStateChanges {
+                await MainActor.run {
+                    switch state {
+                    case .signedIn(let session):
+                        self.isAuthenticated = true
+                        // Create User from session metadata
+                        self.currentUser = User(
+                            id: session.user.id.uuidString,
+                            username: session.user.userMetadata?["username"] as? String ?? "",
+                            displayName: session.user.userMetadata?["display_name"] as? String ?? session.user.email ?? "",
+                            avatarURL: session.user.userMetadata?["avatar_url"] as? String,
+                            bio: session.user.userMetadata?["bio"] as? String ?? "",
+                            stats: User.UserStats(
+                                totalWorkouts: 0,
+                                totalVolume: 0,
+                                totalPRs: 0,
+                                currentStreak: 0,
+                                longestStreak: 0,
+                                favoriteExercise: nil
+                            ),
+                            isPrivate: false,
+                            createdAt: session.user.createdAt ?? Date()
+                        )
+                    case .signedOut:
+                        self.isAuthenticated = false
+                        self.currentUser = nil
+                    @unknown default:
+                        break
+                    }
+                }
+            }
         }
     }
     
-    func signUp(username: String, email: String, password: String) {
+    /// Sign in with email and password
+    func signIn(email: String, password: String) async throws {
         isLoading = true
         errorMessage = nil
         
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1) { [weak self] in
-            self?.currentUser = .mock
-            self?.isAuthenticated = true
-            self?.isLoading = false
+        do {
+            let session = try await supabase.auth.signIn(email: email, password: password)
+            // Auth state listener will handle updating the UI
+        } catch {
+            errorMessage = error.localizedDescription
+            isLoading = false
+            throw error
         }
     }
     
+    /// Sign up with username, email, and password
+    func signUp(username: String, email: String, password: String) async throws {
+        isLoading = true
+        errorMessage = nil
+        
+        do {
+            let session = try await supabase.auth.signUp(email: email, password: password)
+            
+            // Update user metadata with username
+            try await supabase.auth.update(
+                user: UserAttributes(data: [
+                    "username": username,
+                    "display_name": username
+                ])
+            )
+            
+            // Auth state listener will handle updating the UI
+        } catch {
+            errorMessage = error.localizedDescription
+            isLoading = false
+            throw error
+        }
+    }
+    
+    /// Sign in with Apple using ASAuthorizationController
     func signInWithApple() {
-        // TODO: Implement Apple Sign In
-        signIn(email: "demo@xomfit.com", password: "demo")
+        let request = ASAuthorizationAppleIDProvider().createRequest()
+        request.requestedScopes = [.fullName, .email]
+        
+        let controller = ASAuthorizationController(authorizationRequests: [request])
+        controller.delegate = self
+        controller.presentationContextProvider = self
+        controller.performRequests()
     }
     
-    func signOut() {
-        currentUser = nil
-        isAuthenticated = false
+    /// Sign out
+    func signOut() async throws {
+        isLoading = true
+        errorMessage = nil
+        
+        do {
+            try await supabase.auth.signOut()
+            // Auth state listener will handle updating the UI
+        } catch {
+            errorMessage = error.localizedDescription
+            isLoading = false
+            throw error
+        }
+    }
+    
+    deinit {
+        authStateTask?.cancel()
+    }
+}
+
+// MARK: - ASAuthorizationControllerDelegate
+extension AuthService: ASAuthorizationControllerDelegate {
+    func authorizationController(
+        controller: ASAuthorizationController,
+        didCompleteWithAuthorization authorization: ASAuthorization
+    ) {
+        guard let appleIDCredential = authorization.credential as? ASAuthorizationAppleIDCredential else {
+            errorMessage = "Failed to retrieve Apple ID credential"
+            isLoading = false
+            return
+        }
+        
+        guard let identityToken = appleIDCredential.identityToken,
+              let tokenString = String(data: identityToken, encoding: .utf8) else {
+            errorMessage = "Failed to retrieve identity token"
+            isLoading = false
+            return
+        }
+        
+        Task {
+            do {
+                isLoading = true
+                errorMessage = nil
+                
+                let session = try await supabase.auth.signInWithIdToken(
+                    credentials: .init(provider: .apple, idToken: tokenString)
+                )
+                
+                // Update user metadata if we have a name
+                if let fullName = appleIDCredential.fullName {
+                    let displayName = [fullName.givenName, fullName.familyName]
+                        .compactMap { $0 }
+                        .joined(separator: " ")
+                    
+                    try? await supabase.auth.update(
+                        user: UserAttributes(data: [
+                            "display_name": displayName
+                        ])
+                    )
+                }
+                
+                // Auth state listener will handle updating the UI
+            } catch {
+                errorMessage = error.localizedDescription
+                isLoading = false
+            }
+        }
+    }
+    
+    func authorizationController(
+        controller: ASAuthorizationController,
+        didCompleteWithError error: Error
+    ) {
+        errorMessage = error.localizedDescription
+        isLoading = false
+    }
+}
+
+// MARK: - ASAuthorizationControllerPresentationContextProviding
+extension AuthService: ASAuthorizationControllerPresentationContextProviding {
+    func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
+        let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene
+        return windowScene?.windows.first ?? ASPresentationAnchor()
     }
 }

--- a/XomFit/Services/SupabaseClient.swift
+++ b/XomFit/Services/SupabaseClient.swift
@@ -1,0 +1,7 @@
+import Foundation
+import Supabase
+
+let supabase = SupabaseClient(
+    supabaseURL: URL(string: Config.supabaseURL)!,
+    supabaseKey: Config.supabaseAnonKey
+)

--- a/XomFit/Views/Auth/LoginView.swift
+++ b/XomFit/Views/Auth/LoginView.swift
@@ -1,10 +1,15 @@
 import SwiftUI
+import AuthenticationServices
 
 struct LoginView: View {
     @EnvironmentObject var authService: AuthService
     @State private var email = ""
     @State private var password = ""
     @State private var showingSignUp = false
+    
+    var isEmailPasswordValid: Bool {
+        !email.isEmpty && !password.isEmpty
+    }
     
     var body: some View {
         ZStack {
@@ -30,6 +35,17 @@ struct LoginView: View {
                 
                 Spacer()
                 
+                // Error Message
+                if let errorMessage = authService.errorMessage {
+                    Text(errorMessage)
+                        .font(Theme.fontCaption)
+                        .foregroundColor(Theme.destructive)
+                        .padding()
+                        .background(Theme.destructive.opacity(0.1))
+                        .cornerRadius(Theme.cornerRadius)
+                        .padding(.horizontal, Theme.paddingLarge)
+                }
+                
                 // Input Fields
                 VStack(spacing: 16) {
                     TextField("Email", text: $email)
@@ -49,7 +65,11 @@ struct LoginView: View {
                 .padding(.horizontal, Theme.paddingLarge)
                 
                 // Sign In Button
-                Button(action: { authService.signIn(email: email, password: password) }) {
+                Button(action: {
+                    Task {
+                        try? await authService.signIn(email: email, password: password)
+                    }
+                }) {
                     if authService.isLoading {
                         ProgressView()
                             .tint(.black)
@@ -61,15 +81,33 @@ struct LoginView: View {
                 .foregroundColor(.black)
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, 16)
-                .background(Theme.accent)
+                .background(isEmailPasswordValid && !authService.isLoading ? Theme.accent : Theme.accent.opacity(0.3))
+                .cornerRadius(Theme.cornerRadius)
+                .padding(.horizontal, Theme.paddingLarge)
+                .disabled(!isEmailPasswordValid || authService.isLoading)
+                
+                // Apple Sign In Button
+                SignInWithAppleButton(
+                    onRequest: { request in
+                        request.requestedScopes = [.fullName, .email]
+                    },
+                    onCompletion: { result in
+                        Task {
+                            authService.signInWithApple()
+                        }
+                    }
+                )
+                .frame(height: 50)
                 .cornerRadius(Theme.cornerRadius)
                 .padding(.horizontal, Theme.paddingLarge)
                 
-                // Apple Sign In
-                Button(action: { authService.signInWithApple() }) {
+                // Google Sign In Button (Stub)
+                Button(action: {
+                    authService.errorMessage = "Google Sign In coming soon"
+                }) {
                     HStack {
-                        Image(systemName: "apple.logo")
-                        Text("Sign in with Apple")
+                        Image(systemName: "globe")
+                        Text("Sign in with Google")
                             .font(.system(size: 16, weight: .semibold))
                     }
                     .foregroundColor(Theme.textPrimary)

--- a/XomFit/Views/Auth/SignUpView.swift
+++ b/XomFit/Views/Auth/SignUpView.swift
@@ -64,20 +64,42 @@ struct SignUpView: View {
                         }
                         .padding(.horizontal, Theme.paddingLarge)
                         
+                        // Error Message
+                        if let errorMessage = authService.errorMessage {
+                            Text(errorMessage)
+                                .font(Theme.fontCaption)
+                                .foregroundColor(Theme.destructive)
+                                .padding()
+                                .background(Theme.destructive.opacity(0.1))
+                                .cornerRadius(Theme.cornerRadius)
+                                .padding(.horizontal, Theme.paddingLarge)
+                        }
+                        
                         // Sign Up Button
                         Button(action: {
-                            authService.signUp(username: username, email: email, password: password)
-                            dismiss()
+                            Task {
+                                do {
+                                    try await authService.signUp(username: username, email: email, password: password)
+                                    dismiss()
+                                } catch {
+                                    // Error is already displayed in authService.errorMessage
+                                }
+                            }
                         }) {
-                            Text("Create Account")
-                                .font(.system(size: 18, weight: .bold))
-                                .foregroundColor(.black)
-                                .frame(maxWidth: .infinity)
-                                .padding(.vertical, 16)
-                                .background(isValid ? Theme.accent : Theme.accent.opacity(0.3))
-                                .cornerRadius(Theme.cornerRadius)
+                            if authService.isLoading {
+                                ProgressView()
+                                    .tint(.black)
+                            } else {
+                                Text("Create Account")
+                                    .font(.system(size: 18, weight: .bold))
+                                    .foregroundColor(.black)
+                            }
                         }
-                        .disabled(!isValid)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 16)
+                        .background(isValid && !authService.isLoading ? Theme.accent : Theme.accent.opacity(0.3))
+                        .cornerRadius(Theme.cornerRadius)
+                        .disabled(!isValid || authService.isLoading)
                         .padding(.horizontal, Theme.paddingLarge)
                     }
                 }

--- a/XomFit/XomFitApp.swift
+++ b/XomFit/XomFitApp.swift
@@ -16,6 +16,11 @@ struct XomFitApp: App {
                     .preferredColorScheme(.dark)
             }
         }
+        .onOpenURL { url in
+            Task {
+                try? await supabase.auth.session(from: url)
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
Closes #2: Replace mock auth with real Supabase Auth integration.

## Changes
- **Config.swift** — Supabase URL + anon key placeholders
- **SupabaseClient.swift** — Singleton Supabase client initialization
- **AuthService.swift** — Full rewrite: real sign in/up/out via Supabase, Apple Sign In with ASAuthorizationController, auth state listener, keychain session persistence
- **LoginView.swift** — Added Sign in with Apple button, improved error handling
- **SignUpView.swift** — Wired up to real Supabase signUp
- **XomFitApp.swift** — Added deep link handling for OAuth callbacks
- **SUPABASE_SETUP.md** — Setup instructions for Supabase project, Apple Developer config, URL scheme, and SPM package addition

## Setup Required (Dom)
1. Add `supabase-swift` SPM package in Xcode (v2.x)
2. Create Supabase project and enable Apple + Email providers
3. Fill in `Config.swift` with real credentials
4. Add `xomfit://` URL scheme in Xcode
See `SUPABASE_SETUP.md` for full instructions.