### PR TITLE
feat: User Profile — setup, avatar, bio, stats

### DIFF
--- a/SUPABASE_SETUP.md
+++ b/SUPABASE_SETUP.md
@@ -118,14 +118,37 @@ In your Supabase dashboard:
 
 ---
 
+## User Profiles Setup (Issue #3)
+
+### Database Migration
+
+Run `supabase/migrations/20240001_profiles.sql` in the Supabase SQL Editor.
+It creates:
+- **`public.profiles`** table with username, display_name, bio, avatar_url, is_private, and lifetime stats columns
+- RLS policies (users read/write their own profile; public profiles readable by all)
+- **`avatars`** Storage bucket (public) with per-user folder upload policies
+
+### Storage Bucket
+
+The migration creates the `avatars` bucket automatically. Verify in:
+**Supabase Dashboard → Storage → Buckets** that `avatars` exists and is set to **Public**.
+
+### How the Profile Flow Works
+
+1. After sign-in, `ProfileView` calls `loadProfile(userId:)`.
+2. If no row exists in `profiles`, the **ProfileSetupView** wizard appears (4 steps: welcome → name → avatar → bio).
+3. On completion, a row is inserted and the avatar (if chosen) is uploaded to `storage/avatars/<userId>/avatar.jpg`.
+4. The **Edit Profile** sheet (pencil icon, top-right) lets users change any field at any time.
+
+---
+
 ## Next Steps
 
 Once authentication is working:
 
-1. **User Profiles**: Create a `users` table in Supabase to store profile data (username, bio, stats, etc.)
-2. **Profile View**: Update the app to fetch and display user profiles from Supabase
-3. **Google Sign In**: Implement Google OAuth if needed
-4. **Email Verification**: Optionally require email verification before sign-in
+1. ✅ **User Profiles**: Implemented in `feature/user-profile` branch
+2. **Google Sign In**: Implement Google OAuth if needed
+3. **Email Verification**: Optionally require email verification before sign-in
 
 ---
 

--- a/XomFit/Services/ProfileService.swift
+++ b/XomFit/Services/ProfileService.swift
@@ -1,0 +1,128 @@
+import Foundation
+import Supabase
+
+// MARK: - UserProfile (Supabase DB model)
+struct UserProfile: Codable {
+    var id: String
+    var username: String
+    var displayName: String
+    var bio: String
+    var avatarURL: String?
+    var isPrivate: Bool
+    var totalWorkouts: Int
+    var totalVolume: Double
+    var totalPRs: Int
+    var currentStreak: Int
+    var longestStreak: Int
+    var favoriteExercise: String?
+    var createdAt: Date
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case username
+        case displayName = "display_name"
+        case bio
+        case avatarURL = "avatar_url"
+        case isPrivate = "is_private"
+        case totalWorkouts = "total_workouts"
+        case totalVolume = "total_volume"
+        case totalPRs = "total_prs"
+        case currentStreak = "current_streak"
+        case longestStreak = "longest_streak"
+        case favoriteExercise = "favorite_exercise"
+        case createdAt = "created_at"
+    }
+}
+
+// MARK: - Partial update payload (nil fields are omitted — no accidental overwrites)
+struct ProfileUpdatePayload: Encodable {
+    var displayName: String?
+    var username: String?
+    var bio: String?
+    var avatarURL: String?
+    var isPrivate: Bool?
+
+    enum CodingKeys: String, CodingKey {
+        case displayName = "display_name"
+        case username
+        case bio
+        case avatarURL = "avatar_url"
+        case isPrivate = "is_private"
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        if let v = displayName  { try container.encode(v, forKey: .displayName) }
+        if let v = username     { try container.encode(v, forKey: .username) }
+        if let v = bio          { try container.encode(v, forKey: .bio) }
+        if let v = avatarURL    { try container.encode(v, forKey: .avatarURL) }
+        if let v = isPrivate    { try container.encode(v, forKey: .isPrivate) }
+    }
+}
+
+// MARK: - ProfileService
+class ProfileService {
+    static let shared = ProfileService()
+    private let avatarsBucket = "avatars"
+
+    // MARK: Fetch
+
+    func fetchProfile(userId: String) async throws -> UserProfile? {
+        let profiles: [UserProfile] = try await supabase
+            .from("profiles")
+            .select()
+            .eq("id", value: userId)
+            .execute()
+            .value
+        return profiles.first
+    }
+
+    // MARK: Create
+
+    func createProfile(_ profile: UserProfile) async throws -> UserProfile {
+        let created: UserProfile = try await supabase
+            .from("profiles")
+            .insert(profile)
+            .select()
+            .single()
+            .execute()
+            .value
+        return created
+    }
+
+    // MARK: Update
+
+    func updateProfile(userId: String, payload: ProfileUpdatePayload) async throws -> UserProfile {
+        let updated: UserProfile = try await supabase
+            .from("profiles")
+            .update(payload)
+            .eq("id", value: userId)
+            .select()
+            .single()
+            .execute()
+            .value
+        return updated
+    }
+
+    // MARK: Avatar Upload
+
+    /// Uploads JPEG image data to Supabase Storage and returns the public URL.
+    func uploadAvatar(userId: String, imageData: Data) async throws -> String {
+        let path = "\(userId)/avatar.jpg"
+
+        try await supabase.storage
+            .from(avatarsBucket)
+            .upload(
+                path,
+                data: imageData,
+                options: FileOptions(contentType: "image/jpeg", upsert: true)
+            )
+
+        let publicURL = supabase.storage
+            .from(avatarsBucket)
+            .getPublicURL(path: path)
+
+        // Append cache-busting timestamp so the app reloads the new image
+        return "\(publicURL.absoluteString)?t=\(Int(Date().timeIntervalSince1970))"
+    }
+}

--- a/XomFit/Utils/Extensions.swift
+++ b/XomFit/Utils/Extensions.swift
@@ -51,6 +51,13 @@ extension Date {
         formatter.dateFormat = "h:mm a"
         return formatter.string(from: self)
     }
+
+    /// "Jan 2025" — used on the profile header
+    var memberSince: String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMM yyyy"
+        return formatter.string(from: self)
+    }
 }
 
 // MARK: - Double Extensions

--- a/XomFit/ViewModels/ProfileViewModel.swift
+++ b/XomFit/ViewModels/ProfileViewModel.swift
@@ -1,15 +1,151 @@
 import Foundation
+import SwiftUI
 
 @MainActor
 class ProfileViewModel: ObservableObject {
+
+    // MARK: - Published State
     @Published var user: User = .mock
     @Published var recentPRs: [PersonalRecord] = PersonalRecord.mockPRs
-    @Published var workoutCount: Int = 247
     @Published var isLoading = false
-    
-    func refresh() {
+    @Published var isSaving = false
+    @Published var errorMessage: String?
+    /// True when the current user has no Supabase profile yet → show setup flow
+    @Published var showSetupFlow = false
+
+    private let profileService = ProfileService.shared
+
+    // Convenience pass-through
+    var workoutCount: Int { user.stats.totalWorkouts }
+
+    // MARK: - Load Profile
+
+    /// Fetch profile from Supabase. Shows setup flow if none exists.
+    func loadProfile(userId: String) async {
         isLoading = true
-        // Mock refresh
-        isLoading = false
+        errorMessage = nil
+        defer { isLoading = false }
+
+        do {
+            if let profile = try await profileService.fetchProfile(userId: userId) {
+                applyProfile(profile)
+                showSetupFlow = false
+            } else {
+                // No row in `profiles` yet — ask user to set up their profile
+                showSetupFlow = true
+            }
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    // MARK: - Create Profile (Setup Flow)
+
+    func createProfile(userId: String, displayName: String, username: String, bio: String) async {
+        isSaving = true
+        errorMessage = nil
+        defer { isSaving = false }
+
+        let newProfile = UserProfile(
+            id: userId,
+            username: username.trimmingCharacters(in: .whitespaces),
+            displayName: displayName.trimmingCharacters(in: .whitespaces),
+            bio: bio,
+            avatarURL: nil,
+            isPrivate: false,
+            totalWorkouts: 0,
+            totalVolume: 0,
+            totalPRs: 0,
+            currentStreak: 0,
+            longestStreak: 0,
+            favoriteExercise: nil,
+            createdAt: Date()
+        )
+
+        do {
+            let created = try await profileService.createProfile(newProfile)
+            applyProfile(created)
+            showSetupFlow = false
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    // MARK: - Update Profile
+
+    func updateProfile(displayName: String, username: String, bio: String, isPrivate: Bool) async {
+        isSaving = true
+        errorMessage = nil
+        defer { isSaving = false }
+
+        let payload = ProfileUpdatePayload(
+            displayName: displayName.isEmpty ? nil : displayName,
+            username: username.isEmpty ? nil : username,
+            bio: bio,
+            avatarURL: nil,
+            isPrivate: isPrivate
+        )
+
+        do {
+            let updated = try await profileService.updateProfile(userId: user.id, payload: payload)
+            applyProfile(updated)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    // MARK: - Upload Avatar
+
+    /// Compresses the image and uploads it to Supabase Storage, then persists the URL.
+    func uploadAvatar(imageData: Data) async {
+        isSaving = true
+        errorMessage = nil
+        defer { isSaving = false }
+
+        // Compress to JPEG at 80% quality to keep uploads lean
+        let finalData: Data
+        if let img = UIImage(data: imageData),
+           let jpeg = img.jpegData(compressionQuality: 0.8) {
+            finalData = jpeg
+        } else {
+            finalData = imageData
+        }
+
+        do {
+            let avatarURL = try await profileService.uploadAvatar(userId: user.id, imageData: finalData)
+            let payload = ProfileUpdatePayload(avatarURL: avatarURL)
+            let updated = try await profileService.updateProfile(userId: user.id, payload: payload)
+            applyProfile(updated)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    // MARK: - Refresh (legacy / pull-to-refresh)
+
+    func refresh(userId: String) async {
+        await loadProfile(userId: userId)
+    }
+
+    // MARK: - Private Helpers
+
+    private func applyProfile(_ profile: UserProfile) {
+        user = User(
+            id: profile.id,
+            username: profile.username,
+            displayName: profile.displayName,
+            avatarURL: profile.avatarURL,
+            bio: profile.bio,
+            stats: User.UserStats(
+                totalWorkouts: profile.totalWorkouts,
+                totalVolume: profile.totalVolume,
+                totalPRs: profile.totalPRs,
+                currentStreak: profile.currentStreak,
+                longestStreak: profile.longestStreak,
+                favoriteExercise: profile.favoriteExercise
+            ),
+            isPrivate: profile.isPrivate,
+            createdAt: profile.createdAt
+        )
     }
 }

--- a/XomFit/Views/Common/AvatarView.swift
+++ b/XomFit/Views/Common/AvatarView.swift
@@ -1,0 +1,56 @@
+import SwiftUI
+
+/// Reusable circular avatar.
+/// Shows a remote image via AsyncImage when `avatarURL` is set,
+/// otherwise falls back to an initial letter badge.
+struct AvatarView: View {
+    let avatarURL: String?
+    let displayName: String
+    var size: CGFloat = 80
+
+    var body: some View {
+        if let urlString = avatarURL, let url = URL(string: urlString) {
+            AsyncImage(url: url) { phase in
+                switch phase {
+                case .success(let image):
+                    image
+                        .resizable()
+                        .scaledToFill()
+                        .frame(width: size, height: size)
+                        .clipShape(Circle())
+                case .failure, .empty:
+                    initialsBadge
+                @unknown default:
+                    initialsBadge
+                }
+            }
+        } else {
+            initialsBadge
+        }
+    }
+
+    private var initialsBadge: some View {
+        Circle()
+            .fill(Theme.accent.opacity(0.18))
+            .frame(width: size, height: size)
+            .overlay(
+                Text(initial)
+                    .font(.system(size: size * 0.42, weight: .bold))
+                    .foregroundColor(Theme.accent)
+            )
+    }
+
+    private var initial: String {
+        String((displayName.first ?? "?").uppercased())
+    }
+}
+
+#Preview {
+    HStack(spacing: 16) {
+        AvatarView(avatarURL: nil, displayName: "Dom G", size: 96)
+        AvatarView(avatarURL: nil, displayName: "Mike J", size: 60)
+        AvatarView(avatarURL: nil, displayName: "", size: 40)
+    }
+    .padding()
+    .background(Theme.background)
+}

--- a/XomFit/Views/Profile/EditProfileView.swift
+++ b/XomFit/Views/Profile/EditProfileView.swift
@@ -1,0 +1,303 @@
+import SwiftUI
+import PhotosUI
+
+struct EditProfileView: View {
+    @ObservedObject var viewModel: ProfileViewModel
+    @EnvironmentObject var authService: AuthService
+    @Environment(\.dismiss) private var dismiss
+
+    // Form state
+    @State private var displayName: String = ""
+    @State private var username: String = ""
+    @State private var bio: String = ""
+    @State private var isPrivate: Bool = false
+
+    // Avatar picker state
+    @State private var selectedPhoto: PhotosPickerItem?
+    @State private var pendingImageData: Data?
+    @State private var previewImage: UIImage?
+
+    // Toast
+    @State private var showSuccessToast = false
+
+    private let bioLimit = 150
+
+    var body: some View {
+        NavigationStack {
+            ZStack(alignment: .bottom) {
+                Theme.background.ignoresSafeArea()
+
+                ScrollView {
+                    VStack(spacing: Theme.paddingLarge) {
+                        avatarSection
+                        formSection
+                        privacySection
+
+                        // Save Button
+                        saveButton
+                            .padding(.horizontal, Theme.paddingMedium)
+                            .padding(.bottom, Theme.paddingLarge)
+                    }
+                    .padding(.top, Theme.paddingMedium)
+                }
+
+                // Success toast overlay
+                if showSuccessToast {
+                    toastView
+                        .transition(.move(edge: .bottom).combined(with: .opacity))
+                        .zIndex(1)
+                }
+            }
+            .navigationTitle("Edit Profile")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button("Cancel") { dismiss() }
+                        .foregroundColor(Theme.textSecondary)
+                }
+            }
+            .onAppear(perform: populateFields)
+            .errorAlert(message: viewModel.errorMessage) {
+                viewModel.errorMessage = nil
+            }
+        }
+    }
+
+    // MARK: - Avatar
+
+    private var avatarSection: some View {
+        VStack(spacing: 10) {
+            PhotosPicker(selection: $selectedPhoto, matching: .images) {
+                ZStack(alignment: .bottomTrailing) {
+                    Group {
+                        if let img = previewImage {
+                            Image(uiImage: img)
+                                .resizable()
+                                .scaledToFill()
+                                .frame(width: 96, height: 96)
+                                .clipShape(Circle())
+                        } else {
+                            AvatarView(
+                                avatarURL: viewModel.user.avatarURL,
+                                displayName: viewModel.user.displayName,
+                                size: 96
+                            )
+                        }
+                    }
+
+                    Circle()
+                        .fill(Theme.accent)
+                        .frame(width: 30, height: 30)
+                        .overlay(
+                            Image(systemName: "camera.fill")
+                                .font(.system(size: 13))
+                                .foregroundColor(Theme.background)
+                        )
+                        .offset(x: 3, y: 3)
+                }
+            }
+            .onChange(of: selectedPhoto) { _, item in
+                Task {
+                    if let data = try? await item?.loadTransferable(type: Data.self) {
+                        pendingImageData = data
+                        previewImage = UIImage(data: data)
+                    }
+                }
+            }
+
+            Text("Tap to change photo")
+                .font(Theme.fontCaption)
+                .foregroundColor(Theme.textSecondary)
+        }
+    }
+
+    // MARK: - Form Fields
+
+    private var formSection: some View {
+        VStack(spacing: 14) {
+            ProfileFormField(label: "Display Name", placeholder: "Your name", text: $displayName)
+            ProfileFormField(label: "Username", placeholder: "username", text: $username)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+
+            // Bio — multiline
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Bio")
+                    .font(Theme.fontCaption)
+                    .foregroundColor(Theme.textSecondary)
+
+                TextEditor(text: $bio)
+                    .scrollContentBackground(.hidden)
+                    .foregroundColor(Theme.textPrimary)
+                    .font(Theme.fontBody)
+                    .frame(height: 88)
+                    .padding(12)
+                    .background(Theme.cardBackground)
+                    .cornerRadius(Theme.cornerRadius)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: Theme.cornerRadius)
+                            .stroke(Color.white.opacity(0.08), lineWidth: 1)
+                    )
+                    .onChange(of: bio) { _, newValue in
+                        if newValue.count > bioLimit {
+                            bio = String(newValue.prefix(bioLimit))
+                        }
+                    }
+
+                HStack {
+                    Spacer()
+                    Text("\(bio.count)/\(bioLimit)")
+                        .font(Theme.fontCaption)
+                        .foregroundColor(bio.count >= bioLimit ? Theme.destructive : Theme.textSecondary)
+                }
+            }
+            .padding(.horizontal, Theme.paddingMedium)
+        }
+    }
+
+    // MARK: - Privacy Toggle
+
+    private var privacySection: some View {
+        HStack(spacing: 14) {
+            Image(systemName: isPrivate ? "lock.fill" : "globe")
+                .foregroundColor(isPrivate ? Theme.warning : Theme.accent)
+                .frame(width: 24)
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text(isPrivate ? "Private Profile" : "Public Profile")
+                    .font(.system(size: 16, weight: .medium))
+                    .foregroundColor(Theme.textPrimary)
+                Text(isPrivate
+                     ? "Only approved followers see your workouts"
+                     : "Anyone can view your profile and workouts")
+                    .font(Theme.fontCaption)
+                    .foregroundColor(Theme.textSecondary)
+            }
+
+            Spacer()
+
+            Toggle("", isOn: $isPrivate)
+                .tint(Theme.accent)
+                .labelsHidden()
+        }
+        .cardStyle()
+        .padding(.horizontal, Theme.paddingMedium)
+    }
+
+    // MARK: - Save Button
+
+    private var saveButton: some View {
+        Button {
+            Task { await save() }
+        } label: {
+            Group {
+                if viewModel.isSaving {
+                    ProgressView()
+                        .tint(Theme.background)
+                } else {
+                    Text("Save Changes")
+                        .font(.system(size: 16, weight: .semibold))
+                        .foregroundColor(Theme.background)
+                }
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 14)
+            .background(Theme.accent)
+            .cornerRadius(Theme.cornerRadius)
+        }
+        .disabled(viewModel.isSaving || displayName.trimmingCharacters(in: .whitespaces).isEmpty)
+    }
+
+    // MARK: - Toast
+
+    private var toastView: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "checkmark.circle.fill")
+                .foregroundColor(Theme.accent)
+            Text("Profile updated!")
+                .font(.system(size: 15, weight: .medium))
+                .foregroundColor(Theme.textPrimary)
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 12)
+        .background(Theme.cardBackground)
+        .cornerRadius(Theme.cornerRadius)
+        .shadow(color: .black.opacity(0.3), radius: 8, y: 4)
+        .padding(.bottom, 40)
+    }
+
+    // MARK: - Actions
+
+    private func populateFields() {
+        displayName = viewModel.user.displayName
+        username    = viewModel.user.username
+        bio         = viewModel.user.bio
+        isPrivate   = viewModel.user.isPrivate
+    }
+
+    private func save() async {
+        // Upload avatar first if the user selected a new one
+        if let data = pendingImageData {
+            await viewModel.uploadAvatar(imageData: data)
+            guard viewModel.errorMessage == nil else { return }
+            pendingImageData = nil
+            previewImage = nil
+        }
+
+        await viewModel.updateProfile(
+            displayName: displayName,
+            username: username,
+            bio: bio,
+            isPrivate: isPrivate
+        )
+
+        if viewModel.errorMessage == nil {
+            withAnimation(.spring()) { showSuccessToast = true }
+            try? await Task.sleep(for: .seconds(2))
+            withAnimation { showSuccessToast = false }
+            dismiss()
+        }
+    }
+}
+
+// MARK: - Shared Form Field
+
+struct ProfileFormField: View {
+    let label: String
+    let placeholder: String
+    @Binding var text: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(label)
+                .font(Theme.fontCaption)
+                .foregroundColor(Theme.textSecondary)
+
+            TextField(placeholder, text: $text)
+                .foregroundColor(Theme.textPrimary)
+                .padding(12)
+                .background(Theme.cardBackground)
+                .cornerRadius(Theme.cornerRadius)
+                .overlay(
+                    RoundedRectangle(cornerRadius: Theme.cornerRadius)
+                        .stroke(Color.white.opacity(0.08), lineWidth: 1)
+                )
+        }
+        .padding(.horizontal, Theme.paddingMedium)
+    }
+}
+
+// MARK: - Error Alert Helper
+
+extension View {
+    func errorAlert(message: String?, onDismiss: @escaping () -> Void) -> some View {
+        alert("Something went wrong", isPresented: .init(
+            get: { message != nil },
+            set: { if !$0 { onDismiss() } }
+        )) {
+            Button("OK") { onDismiss() }
+        } message: {
+            Text(message ?? "")
+        }
+    }
+}

--- a/XomFit/Views/Profile/ProfileSetupView.swift
+++ b/XomFit/Views/Profile/ProfileSetupView.swift
@@ -1,0 +1,338 @@
+import SwiftUI
+import PhotosUI
+
+/// Onboarding flow shown the first time a new user lands on the Profile tab.
+/// Guides them through: welcome → name/username → avatar → bio.
+struct ProfileSetupView: View {
+    @ObservedObject var viewModel: ProfileViewModel
+    @EnvironmentObject var authService: AuthService
+
+    @State private var step: Int = 0
+    @State private var displayName: String = ""
+    @State private var username: String = ""
+    @State private var bio: String = ""
+    @State private var selectedPhoto: PhotosPickerItem?
+    @State private var previewImage: UIImage?
+    @State private var pendingImageData: Data?
+
+    private let totalSteps = 4
+
+    var body: some View {
+        ZStack {
+            Theme.background.ignoresSafeArea()
+
+            VStack(spacing: 0) {
+                progressBar
+                    .padding(.horizontal, Theme.paddingMedium)
+                    .padding(.top, Theme.paddingLarge)
+
+                Spacer(minLength: 40)
+
+                stepContent
+                    .padding(.horizontal, Theme.paddingMedium)
+                    .animation(.easeInOut(duration: 0.3), value: step)
+
+                Spacer(minLength: 40)
+
+                navigationButtons
+                    .padding(.horizontal, Theme.paddingMedium)
+                    .padding(.bottom, Theme.paddingLarge)
+            }
+        }
+        .onAppear {
+            // Pre-fill name from auth metadata if available
+            if let authUser = authService.currentUser {
+                displayName = authUser.displayName
+                username = authUser.username
+            }
+        }
+    }
+
+    // MARK: - Progress Bar
+
+    private var progressBar: some View {
+        HStack(spacing: 6) {
+            ForEach(0 ..< totalSteps, id: \.self) { index in
+                Capsule()
+                    .fill(index <= step ? Theme.accent : Theme.cardBackground)
+                    .frame(height: 4)
+                    .animation(.easeInOut(duration: 0.3), value: step)
+            }
+        }
+    }
+
+    // MARK: - Step Content
+
+    @ViewBuilder
+    private var stepContent: some View {
+        switch step {
+        case 0: welcomeStep
+        case 1: nameStep
+        case 2: avatarStep
+        case 3: bioStep
+        default: EmptyView()
+        }
+    }
+
+    // Step 0 – Welcome
+    private var welcomeStep: some View {
+        VStack(spacing: 24) {
+            Image(systemName: "figure.strengthtraining.traditional")
+                .font(.system(size: 72))
+                .foregroundColor(Theme.accent)
+
+            VStack(spacing: 12) {
+                Text("Welcome to XomFit!")
+                    .font(Theme.fontTitle)
+                    .foregroundColor(Theme.textPrimary)
+                    .multilineTextAlignment(.center)
+
+                Text("Let's set up your profile so the community can follow your fitness journey.")
+                    .font(Theme.fontBody)
+                    .foregroundColor(Theme.textSecondary)
+                    .multilineTextAlignment(.center)
+            }
+        }
+    }
+
+    // Step 1 – Name & Username
+    private var nameStep: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text("What should we call you?")
+                    .font(Theme.fontTitle)
+                    .foregroundColor(Theme.textPrimary)
+                Text("You can always change this later.")
+                    .font(Theme.fontBody)
+                    .foregroundColor(Theme.textSecondary)
+            }
+
+            SetupFormField(label: "Display Name", placeholder: "John Doe", text: $displayName)
+
+            // Username with @ prefix
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Username")
+                    .font(Theme.fontCaption)
+                    .foregroundColor(Theme.textSecondary)
+                HStack(spacing: 6) {
+                    Text("@")
+                        .foregroundColor(Theme.textSecondary)
+                        .padding(.leading, 12)
+                    TextField("username", text: $username)
+                        .foregroundColor(Theme.textPrimary)
+                        .textInputAutocapitalization(.never)
+                        .autocorrectionDisabled()
+                }
+                .frame(height: 46)
+                .background(Theme.cardBackground)
+                .cornerRadius(Theme.cornerRadius)
+                .overlay(
+                    RoundedRectangle(cornerRadius: Theme.cornerRadius)
+                        .stroke(Color.white.opacity(0.08), lineWidth: 1)
+                )
+            }
+        }
+    }
+
+    // Step 2 – Avatar
+    private var avatarStep: some View {
+        VStack(spacing: 24) {
+            VStack(spacing: 8) {
+                Text("Add a profile photo")
+                    .font(Theme.fontTitle)
+                    .foregroundColor(Theme.textPrimary)
+                Text("Help others recognise you on the leaderboard.")
+                    .font(Theme.fontBody)
+                    .foregroundColor(Theme.textSecondary)
+                    .multilineTextAlignment(.center)
+            }
+
+            PhotosPicker(selection: $selectedPhoto, matching: .images) {
+                ZStack(alignment: .bottomTrailing) {
+                    Group {
+                        if let img = previewImage {
+                            Image(uiImage: img)
+                                .resizable()
+                                .scaledToFill()
+                                .frame(width: 120, height: 120)
+                                .clipShape(Circle())
+                        } else {
+                            Circle()
+                                .fill(Theme.cardBackground)
+                                .frame(width: 120, height: 120)
+                                .overlay(
+                                    Image(systemName: "camera.fill")
+                                        .font(.system(size: 40))
+                                        .foregroundColor(Theme.textSecondary)
+                                )
+                        }
+                    }
+
+                    Circle()
+                        .fill(Theme.accent)
+                        .frame(width: 36, height: 36)
+                        .overlay(
+                            Image(systemName: "plus")
+                                .font(.system(size: 18, weight: .bold))
+                                .foregroundColor(Theme.background)
+                        )
+                        .offset(x: 4, y: 4)
+                }
+            }
+            .onChange(of: selectedPhoto) { _, item in
+                Task {
+                    if let data = try? await item?.loadTransferable(type: Data.self) {
+                        pendingImageData = data
+                        previewImage = UIImage(data: data)
+                    }
+                }
+            }
+
+            Button("Skip for now") { nextStep() }
+                .font(Theme.fontCaption)
+                .foregroundColor(Theme.textSecondary)
+        }
+    }
+
+    // Step 3 – Bio
+    private var bioStep: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Tell us about yourself")
+                    .font(Theme.fontTitle)
+                    .foregroundColor(Theme.textPrimary)
+                Text("What motivates you? What are your goals?")
+                    .font(Theme.fontBody)
+                    .foregroundColor(Theme.textSecondary)
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+                ZStack(alignment: .topLeading) {
+                    TextEditor(text: $bio)
+                        .scrollContentBackground(.hidden)
+                        .foregroundColor(Theme.textPrimary)
+                        .frame(height: 120)
+                        .padding(12)
+                        .background(Theme.cardBackground)
+                        .cornerRadius(Theme.cornerRadius)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: Theme.cornerRadius)
+                                .stroke(Color.white.opacity(0.08), lineWidth: 1)
+                        )
+                        .onChange(of: bio) { _, newVal in
+                            if newVal.count > 150 { bio = String(newVal.prefix(150)) }
+                        }
+
+                    if bio.isEmpty {
+                        Text("e.g. Chasing that 405 deadlift 💪")
+                            .foregroundColor(Theme.textSecondary.opacity(0.45))
+                            .font(Theme.fontBody)
+                            .padding(16)
+                            .allowsHitTesting(false)
+                    }
+                }
+
+                HStack {
+                    Spacer()
+                    Text("\(bio.count)/150")
+                        .font(Theme.fontCaption)
+                        .foregroundColor(Theme.textSecondary)
+                }
+            }
+        }
+    }
+
+    // MARK: - Navigation Buttons
+
+    private var navigationButtons: some View {
+        VStack(spacing: 12) {
+            if viewModel.isSaving {
+                ProgressView()
+                    .tint(Theme.accent)
+            } else {
+                Button {
+                    if step == totalSteps - 1 {
+                        Task { await finish() }
+                    } else {
+                        nextStep()
+                    }
+                } label: {
+                    Text(step == totalSteps - 1 ? "Let's Go! 💪" : "Continue")
+                        .font(.system(size: 16, weight: .semibold))
+                        .foregroundColor(Theme.background)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 14)
+                        .background(Theme.accent)
+                        .cornerRadius(Theme.cornerRadius)
+                }
+                .disabled(step == 1 && !nameStepValid)
+
+                if step > 0 {
+                    Button("Back") { withAnimation { step -= 1 } }
+                        .font(Theme.fontBody)
+                        .foregroundColor(Theme.textSecondary)
+                }
+            }
+
+            if let err = viewModel.errorMessage {
+                Text(err)
+                    .font(Theme.fontCaption)
+                    .foregroundColor(Theme.destructive)
+                    .multilineTextAlignment(.center)
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    private var nameStepValid: Bool {
+        !displayName.trimmingCharacters(in: .whitespaces).isEmpty &&
+        !username.trimmingCharacters(in: .whitespaces).isEmpty
+    }
+
+    private func nextStep() {
+        withAnimation { step = min(step + 1, totalSteps - 1) }
+    }
+
+    private func finish() async {
+        guard let userId = authService.currentUser?.id else { return }
+
+        await viewModel.createProfile(
+            userId: userId,
+            displayName: displayName,
+            username: username,
+            bio: bio
+        )
+
+        // Upload avatar after profile row exists
+        if let data = pendingImageData, viewModel.errorMessage == nil {
+            await viewModel.uploadAvatar(imageData: data)
+        }
+    }
+}
+
+// MARK: - Setup Form Field (standalone; no horizontal padding applied inside)
+
+struct SetupFormField: View {
+    let label: String
+    let placeholder: String
+    @Binding var text: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(label)
+                .font(Theme.fontCaption)
+                .foregroundColor(Theme.textSecondary)
+
+            TextField(placeholder, text: $text)
+                .foregroundColor(Theme.textPrimary)
+                .padding(12)
+                .background(Theme.cardBackground)
+                .cornerRadius(Theme.cornerRadius)
+                .overlay(
+                    RoundedRectangle(cornerRadius: Theme.cornerRadius)
+                        .stroke(Color.white.opacity(0.08), lineWidth: 1)
+                )
+        }
+    }
+}

--- a/XomFit/Views/Profile/ProfileView.swift
+++ b/XomFit/Views/Profile/ProfileView.swift
@@ -3,134 +3,292 @@ import SwiftUI
 struct ProfileView: View {
     @StateObject private var viewModel = ProfileViewModel()
     @EnvironmentObject var authService: AuthService
-    
+    @State private var showEditProfile = false
+
     var body: some View {
         NavigationStack {
             ZStack {
                 Theme.background.ignoresSafeArea()
-                
-                ScrollView {
-                    VStack(spacing: Theme.paddingLarge) {
-                        // Profile Header
-                        VStack(spacing: 12) {
-                            Circle()
-                                .fill(Theme.accent.opacity(0.2))
-                                .frame(width: 80, height: 80)
-                                .overlay(
-                                    Text(String(viewModel.user.displayName.prefix(1)))
-                                        .font(.system(size: 36, weight: .bold))
-                                        .foregroundColor(Theme.accent)
-                                )
-                            
-                            Text(viewModel.user.displayName)
-                                .font(Theme.fontTitle)
-                                .foregroundColor(Theme.textPrimary)
-                            
-                            Text("@\(viewModel.user.username)")
-                                .font(Theme.fontBody)
-                                .foregroundColor(Theme.textSecondary)
-                            
-                            if !viewModel.user.bio.isEmpty {
-                                Text(viewModel.user.bio)
-                                    .font(Theme.fontBody)
-                                    .foregroundColor(Theme.textPrimary)
-                                    .multilineTextAlignment(.center)
-                            }
+
+                if viewModel.showSetupFlow {
+                    // First-time setup
+                    ProfileSetupView(viewModel: viewModel)
+                        .environmentObject(authService)
+                } else {
+                    mainProfileContent
+                }
+            }
+            .navigationTitle(viewModel.showSetupFlow ? "" : "Profile")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                if !viewModel.showSetupFlow {
+                    ToolbarItem(placement: .navigationBarTrailing) {
+                        Button {
+                            showEditProfile = true
+                        } label: {
+                            Image(systemName: "pencil")
+                                .foregroundColor(Theme.accent)
                         }
-                        .padding(.top, Theme.paddingMedium)
-                        
-                        // Stats Grid
-                        LazyVGrid(columns: [
-                            GridItem(.flexible()),
-                            GridItem(.flexible()),
-                            GridItem(.flexible()),
-                        ], spacing: 12) {
-                            ProfileStatCard(value: "\(viewModel.user.stats.totalWorkouts)", label: "Workouts")
-                            ProfileStatCard(value: "\(viewModel.user.stats.totalPRs)", label: "PRs")
-                            ProfileStatCard(value: "\(viewModel.user.stats.currentStreak)🔥", label: "Streak")
-                        }
-                        .padding(.horizontal, Theme.paddingMedium)
-                        
-                        // Total Volume
-                        HStack {
-                            VStack(alignment: .leading, spacing: 4) {
-                                Text("Total Volume")
-                                    .font(Theme.fontCaption)
-                                    .foregroundColor(Theme.textSecondary)
-                                Text("\(Int(viewModel.user.stats.totalVolume / 1000))k lbs")
-                                    .font(.system(size: 28, weight: .bold))
-                                    .foregroundColor(Theme.accent)
-                            }
-                            Spacer()
-                            if let fav = viewModel.user.stats.favoriteExercise {
-                                VStack(alignment: .trailing, spacing: 4) {
-                                    Text("Favorite Lift")
-                                        .font(Theme.fontCaption)
-                                        .foregroundColor(Theme.textSecondary)
-                                    Text(fav)
-                                        .font(.system(size: 16, weight: .semibold))
-                                        .foregroundColor(Theme.textPrimary)
-                                }
-                            }
-                        }
-                        .cardStyle()
-                        .padding(.horizontal, Theme.paddingMedium)
-                        
-                        // Recent PRs
-                        VStack(alignment: .leading, spacing: 12) {
-                            Text("Personal Records")
-                                .font(Theme.fontHeadline)
-                                .foregroundColor(Theme.textPrimary)
-                                .padding(.horizontal, Theme.paddingMedium)
-                            
-                            ForEach(viewModel.recentPRs) { pr in
-                                HStack {
-                                    Image(systemName: "trophy.fill")
-                                        .foregroundColor(Theme.prGold)
-                                    Text(pr.exerciseName)
-                                        .font(.system(size: 15, weight: .medium))
-                                        .foregroundColor(Theme.textPrimary)
-                                    Spacer()
-                                    Text("\(pr.weight.formattedWeight) × \(pr.reps)")
-                                        .font(.system(size: 15, weight: .bold))
-                                        .foregroundColor(Theme.accent)
-                                }
-                                .cardStyle()
-                                .padding(.horizontal, Theme.paddingMedium)
-                            }
-                        }
-                        
-                        // Settings / Sign Out
-                        Button(action: { authService.signOut() }) {
-                            Text("Sign Out")
-                                .font(.system(size: 16, weight: .medium))
-                                .foregroundColor(Theme.destructive)
-                                .frame(maxWidth: .infinity)
-                                .padding(.vertical, 14)
-                                .background(Theme.destructive.opacity(0.1))
-                                .cornerRadius(Theme.cornerRadius)
-                        }
-                        .padding(.horizontal, Theme.paddingMedium)
-                        .padding(.bottom, Theme.paddingLarge)
+                        .accessibilityLabel("Edit Profile")
                     }
                 }
             }
-            .navigationTitle("Profile")
+            .sheet(isPresented: $showEditProfile) {
+                EditProfileView(viewModel: viewModel)
+                    .environmentObject(authService)
+            }
+        }
+        .task {
+            if let userId = authService.currentUser?.id {
+                await viewModel.loadProfile(userId: userId)
+            }
         }
     }
+
+    // MARK: - Main Content
+
+    private var mainProfileContent: some View {
+        ScrollView {
+            VStack(spacing: Theme.paddingLarge) {
+                profileHeader
+                privacyBadge
+                statsGrid
+                volumeCard
+                recentPRsSection
+                signOutButton
+            }
+        }
+        .refreshable {
+            if let userId = authService.currentUser?.id {
+                await viewModel.refresh(userId: userId)
+            }
+        }
+        .overlay {
+            if viewModel.isLoading {
+                ProgressView()
+                    .tint(Theme.accent)
+                    .scaleEffect(1.4)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .background(Theme.background.opacity(0.6))
+            }
+        }
+    }
+
+    // MARK: - Profile Header
+
+    private var profileHeader: some View {
+        VStack(spacing: 12) {
+            AvatarView(
+                avatarURL: viewModel.user.avatarURL,
+                displayName: viewModel.user.displayName,
+                size: 96
+            )
+
+            VStack(spacing: 4) {
+                Text(viewModel.user.displayName)
+                    .font(Theme.fontTitle)
+                    .foregroundColor(Theme.textPrimary)
+
+                Text("@\(viewModel.user.username)")
+                    .font(Theme.fontBody)
+                    .foregroundColor(Theme.textSecondary)
+            }
+
+            if !viewModel.user.bio.isEmpty {
+                Text(viewModel.user.bio)
+                    .font(Theme.fontBody)
+                    .foregroundColor(Theme.textPrimary)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, Theme.paddingLarge)
+            }
+
+            // Member since
+            Text("Member since \(viewModel.user.createdAt.memberSince)")
+                .font(Theme.fontCaption)
+                .foregroundColor(Theme.textSecondary.opacity(0.7))
+        }
+        .padding(.top, Theme.paddingMedium)
+    }
+
+    // MARK: - Privacy Badge
+
+    @ViewBuilder
+    private var privacyBadge: some View {
+        if viewModel.user.isPrivate {
+            HStack(spacing: 6) {
+                Image(systemName: "lock.fill")
+                    .font(.system(size: 11))
+                Text("Private Profile")
+                    .font(Theme.fontCaption)
+            }
+            .foregroundColor(Theme.warning)
+            .padding(.horizontal, 14)
+            .padding(.vertical, 6)
+            .background(Theme.warning.opacity(0.12))
+            .cornerRadius(20)
+        }
+    }
+
+    // MARK: - Stats Grid
+
+    private var statsGrid: some View {
+        LazyVGrid(
+            columns: [GridItem(.flexible()), GridItem(.flexible()), GridItem(.flexible())],
+            spacing: 12
+        ) {
+            ProfileStatCard(
+                value: "\(viewModel.user.stats.totalWorkouts)",
+                label: "Workouts",
+                icon: "dumbbell.fill"
+            )
+            ProfileStatCard(
+                value: "\(viewModel.user.stats.totalPRs)",
+                label: "PRs",
+                icon: "trophy.fill"
+            )
+            ProfileStatCard(
+                value: streakText,
+                label: "Day Streak",
+                icon: nil
+            )
+        }
+        .padding(.horizontal, Theme.paddingMedium)
+    }
+
+    private var streakText: String {
+        let n = viewModel.user.stats.currentStreak
+        return n > 0 ? "\(n) 🔥" : "\(n)"
+    }
+
+    // MARK: - Volume Card
+
+    private var volumeCard: some View {
+        HStack(alignment: .top) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Total Volume Lifted")
+                    .font(Theme.fontCaption)
+                    .foregroundColor(Theme.textSecondary)
+                Text(formattedVolume(viewModel.user.stats.totalVolume))
+                    .font(.system(size: 28, weight: .bold))
+                    .foregroundColor(Theme.accent)
+                Text("Longest streak: \(viewModel.user.stats.longestStreak) days")
+                    .font(Theme.fontCaption)
+                    .foregroundColor(Theme.textSecondary)
+            }
+
+            Spacer()
+
+            if let fav = viewModel.user.stats.favoriteExercise {
+                VStack(alignment: .trailing, spacing: 4) {
+                    Text("Favourite Lift")
+                        .font(Theme.fontCaption)
+                        .foregroundColor(Theme.textSecondary)
+                    Text(fav)
+                        .font(.system(size: 15, weight: .semibold))
+                        .foregroundColor(Theme.textPrimary)
+                }
+            }
+        }
+        .cardStyle()
+        .padding(.horizontal, Theme.paddingMedium)
+    }
+
+    // MARK: - Recent PRs
+
+    @ViewBuilder
+    private var recentPRsSection: some View {
+        if !viewModel.recentPRs.isEmpty {
+            VStack(alignment: .leading, spacing: 12) {
+                Text("Personal Records")
+                    .font(Theme.fontHeadline)
+                    .foregroundColor(Theme.textPrimary)
+                    .padding(.horizontal, Theme.paddingMedium)
+
+                ForEach(viewModel.recentPRs) { pr in
+                    HStack {
+                        Image(systemName: "trophy.fill")
+                            .foregroundColor(Theme.prGold)
+                            .frame(width: 20)
+
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(pr.exerciseName)
+                                .font(.system(size: 15, weight: .medium))
+                                .foregroundColor(Theme.textPrimary)
+                            Text(pr.date.timeAgo)
+                                .font(Theme.fontCaption)
+                                .foregroundColor(Theme.textSecondary)
+                        }
+
+                        Spacer()
+
+                        VStack(alignment: .trailing, spacing: 2) {
+                            Text("\(pr.weight.formattedWeight) lbs × \(pr.reps)")
+                                .font(.system(size: 15, weight: .bold))
+                                .foregroundColor(Theme.accent)
+                            if let imp = pr.improvementString {
+                                Text(imp)
+                                    .font(Theme.fontCaption)
+                                    .foregroundColor(Theme.accent.opacity(0.7))
+                            }
+                        }
+                    }
+                    .cardStyle()
+                    .padding(.horizontal, Theme.paddingMedium)
+                }
+            }
+        }
+    }
+
+    // MARK: - Sign Out
+
+    private var signOutButton: some View {
+        Button {
+            Task { try? await authService.signOut() }
+        } label: {
+            Text("Sign Out")
+                .font(.system(size: 16, weight: .medium))
+                .foregroundColor(Theme.destructive)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 14)
+                .background(Theme.destructive.opacity(0.1))
+                .cornerRadius(Theme.cornerRadius)
+        }
+        .padding(.horizontal, Theme.paddingMedium)
+        .padding(.bottom, Theme.paddingLarge)
+    }
+
+    // MARK: - Helpers
+
+    private func formattedVolume(_ volume: Double) -> String {
+        if volume >= 1_000_000 {
+            return String(format: "%.1fM lbs", volume / 1_000_000)
+        } else if volume >= 1_000 {
+            return String(format: "%.0fk lbs", volume / 1_000)
+        }
+        return "\(Int(volume)) lbs"
+    }
 }
+
+// MARK: - Stat Card
 
 struct ProfileStatCard: View {
     let value: String
     let label: String
-    
+    var icon: String?
+
     var body: some View {
         VStack(spacing: 6) {
+            if let icon {
+                Image(systemName: icon)
+                    .font(.system(size: 14))
+                    .foregroundColor(Theme.accent.opacity(0.75))
+            }
             Text(value)
-                .font(.system(size: 24, weight: .bold))
+                .font(.system(size: 22, weight: .bold))
                 .foregroundColor(Theme.textPrimary)
+                .minimumScaleFactor(0.7)
             Text(label)
-                .font(.system(size: 12))
+                .font(.system(size: 11))
                 .foregroundColor(Theme.textSecondary)
         }
         .frame(maxWidth: .infinity)

--- a/supabase/migrations/20240001_profiles.sql
+++ b/supabase/migrations/20240001_profiles.sql
@@ -1,0 +1,81 @@
+-- ============================================================
+-- XomFit: User Profiles table + Storage bucket
+-- ============================================================
+
+-- 1. Profiles table
+create table if not exists public.profiles (
+    id              uuid references auth.users on delete cascade primary key,
+    username        text unique not null,
+    display_name    text not null default '',
+    bio             text not null default '',
+    avatar_url      text,
+    is_private      boolean not null default false,
+
+    -- Lifetime stats (updated by triggers / Edge Functions when workouts save)
+    total_workouts  integer not null default 0,
+    total_volume    float8  not null default 0,
+    total_prs       integer not null default 0,
+    current_streak  integer not null default 0,
+    longest_streak  integer not null default 0,
+    favorite_exercise text,
+
+    created_at      timestamptz not null default now(),
+    updated_at      timestamptz not null default now()
+);
+
+-- 2. Auto-update updated_at
+create or replace function public.handle_updated_at()
+returns trigger language plpgsql as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists profiles_updated_at on public.profiles;
+create trigger profiles_updated_at
+  before update on public.profiles
+  for each row execute procedure public.handle_updated_at();
+
+-- 3. Row Level Security
+alter table public.profiles enable row level security;
+
+-- Anyone can read public profiles; private profiles visible only to owner
+create policy "Public profiles are readable by all"
+  on public.profiles for select
+  using (is_private = false or auth.uid() = id);
+
+-- Users can only insert/update their own profile
+create policy "Users can insert own profile"
+  on public.profiles for insert
+  with check (auth.uid() = id);
+
+create policy "Users can update own profile"
+  on public.profiles for update
+  using (auth.uid() = id);
+
+-- 4. Storage bucket for avatars
+insert into storage.buckets (id, name, public)
+values ('avatars', 'avatars', true)
+on conflict (id) do nothing;
+
+-- Allow any authenticated user to upload to their own folder
+create policy "Users can upload own avatar"
+  on storage.objects for insert
+  with check (
+    bucket_id = 'avatars'
+    and auth.uid()::text = (storage.foldername(name))[1]
+  );
+
+-- Allow any authenticated user to update their own avatar
+create policy "Users can update own avatar"
+  on storage.objects for update
+  using (
+    bucket_id = 'avatars'
+    and auth.uid()::text = (storage.foldername(name))[1]
+  );
+
+-- Public read for avatars (bucket is already public; belt-and-suspenders)
+create policy "Avatar images are publicly readable"
+  on storage.objects for select
+  using (bucket_id = 'avatars');


### PR DESCRIPTION
## Summary

Closes #3 — Adds a complete user profile system on top of Supabase.

## What's New

### 🧙 ProfileSetupView — First-time onboarding wizard
4-step flow shown when the user has no profile row yet:
1. **Welcome** screen
2. **Name & Username** (pre-filled from auth metadata)
3. **Avatar** — PhotosPicker upload to Supabase Storage (`avatars/<userId>/avatar.jpg`)
4. **Bio** — with character counter (150 char limit)

### ✏️ EditProfileView — Edit sheet (pencil button, top-right)
- **Avatar** swap with PhotosPicker + camera badge overlay
- **Display name & username** text fields
- **Bio** TextEditor with live character count
- **Public/Private toggle** with descriptive copy
- Success toast on save; uploads avatar first if changed

### 👤 ProfileView — Redesigned
- **AvatarView** (AsyncImage + initials fallback) replaces hard-coded Circle
- **Privacy badge** shown when profile is private
- **Stats grid**: Workouts · PRs · Day Streak (with 🔥)
- **Volume card**: Total volume lifted (M/k lbs) + Longest streak + Favourite lift
- **PR list**: exercise name, date, weight × reps, improvement delta
- Pull-to-refresh, loading overlay
- Fixed `signOut()` — now correctly called as `try? await authService.signOut()`

### 🗄️ ProfileService
- `fetchProfile(userId:)` — returns `UserProfile?` (nil → show setup)
- `createProfile(_:)` — inserts new row
- `updateProfile(userId:payload:)` — partial update (nil fields omitted, no accidental overwrites)
- `uploadAvatar(userId:imageData:)` — JPEG upload to Supabase Storage + cache-busting URL

### 📐 ProfileViewModel
- Full Supabase integration replacing all mock data
- `loadProfile` / `createProfile` / `updateProfile` / `uploadAvatar` / `refresh`
- `showSetupFlow` flag wires the setup wizard into the main profile view

### 🗃️ Database Migration
`supabase/migrations/20240001_profiles.sql`
- `public.profiles` table (id → auth.users FK, username unique, bio, avatar_url, is_private, lifetime stats)
- RLS: users read/write their own row; public profiles readable by all
- `avatars` Storage bucket (public) with per-user folder upload policies

## Testing Checklist
- [ ] New user → sees setup wizard → completes all 4 steps → profile created
- [ ] Setup: skip avatar → profile still created, initials shown
- [ ] Profile tab shows real data after setup
- [ ] Edit profile → change display name/bio/privacy → saved to Supabase
- [ ] Edit profile → pick avatar → uploads to Storage, new URL reflected
- [ ] Private profile → lock badge shown on profile tab
- [ ] Pull-to-refresh fetches latest data
- [ ] Sign Out button works (no crash)