### PR TITLE
feat: Body Composition — weight tracking, measurements, progress photos, charts

### DIFF
--- a/XomFit/Models/BodyComposition.swift
+++ b/XomFit/Models/BodyComposition.swift
@@ -1,0 +1,172 @@
+import Foundation
+
+// MARK: - Body Composition Entry
+struct BodyCompositionEntry: Identifiable, Codable {
+    let id: UUID
+    var userId: String
+    var recordedAt: Date
+    
+    // Weight
+    var weightLbs: Double?
+    
+    // Body measurements (all in inches)
+    var chest: Double?
+    var waist: Double?
+    var hips: Double?
+    var bicepLeft: Double?
+    var bicepRight: Double?
+    var thighLeft: Double?
+    var thighRight: Double?
+    var calf: Double?
+    var neck: Double?
+    var shoulders: Double?
+    
+    // Body fat (if known/measured)
+    var bodyFatPercent: Double?
+    
+    // Optional photo URL (stored in Supabase Storage)
+    var photoUrl: String?
+    
+    // Notes
+    var notes: String?
+    
+    // Privacy
+    var isPrivate: Bool
+    
+    enum CodingKeys: String, CodingKey {
+        case id
+        case userId = "user_id"
+        case recordedAt = "recorded_at"
+        case weightLbs = "weight_lbs"
+        case chest, waist, hips, neck, shoulders
+        case bicepLeft = "bicep_left"
+        case bicepRight = "bicep_right"
+        case thighLeft = "thigh_left"
+        case thighRight = "thigh_right"
+        case calf
+        case bodyFatPercent = "body_fat_percent"
+        case photoUrl = "photo_url"
+        case notes
+        case isPrivate = "is_private"
+    }
+    
+    // Convenience init
+    init(
+        id: UUID = UUID(),
+        userId: String,
+        recordedAt: Date = Date(),
+        weightLbs: Double? = nil,
+        chest: Double? = nil,
+        waist: Double? = nil,
+        hips: Double? = nil,
+        bicepLeft: Double? = nil,
+        bicepRight: Double? = nil,
+        thighLeft: Double? = nil,
+        thighRight: Double? = nil,
+        calf: Double? = nil,
+        neck: Double? = nil,
+        shoulders: Double? = nil,
+        bodyFatPercent: Double? = nil,
+        photoUrl: String? = nil,
+        notes: String? = nil,
+        isPrivate: Bool = true
+    ) {
+        self.id = id
+        self.userId = userId
+        self.recordedAt = recordedAt
+        self.weightLbs = weightLbs
+        self.chest = chest
+        self.waist = waist
+        self.hips = hips
+        self.bicepLeft = bicepLeft
+        self.bicepRight = bicepRight
+        self.thighLeft = thighLeft
+        self.thighRight = thighRight
+        self.calf = calf
+        self.neck = neck
+        self.shoulders = shoulders
+        self.bodyFatPercent = bodyFatPercent
+        self.photoUrl = photoUrl
+        self.notes = notes
+        self.isPrivate = isPrivate
+    }
+}
+
+// MARK: - Measurement Metric
+enum BodyMeasurement: String, CaseIterable, Identifiable {
+    case weight = "Weight"
+    case chest = "Chest"
+    case waist = "Waist"
+    case hips = "Hips"
+    case bicepLeft = "Left Bicep"
+    case bicepRight = "Right Bicep"
+    case thighLeft = "Left Thigh"
+    case thighRight = "Right Thigh"
+    case calf = "Calf"
+    case neck = "Neck"
+    case shoulders = "Shoulders"
+    case bodyFat = "Body Fat %"
+    
+    var id: String { rawValue }
+    
+    var unit: String {
+        self == .weight ? "lbs" : self == .bodyFat ? "%" : "in"
+    }
+    
+    var systemImage: String {
+        switch self {
+        case .weight: return "scalemass.fill"
+        case .chest: return "figure.arms.open"
+        case .waist: return "figure.stand"
+        case .hips: return "figure.stand"
+        case .bicepLeft, .bicepRight: return "figure.strengthtraining.traditional"
+        case .thighLeft, .thighRight: return "figure.walk"
+        case .calf: return "figure.walk"
+        case .neck: return "figure.stand"
+        case .shoulders: return "figure.arms.open"
+        case .bodyFat: return "percent"
+        }
+    }
+    
+    func value(from entry: BodyCompositionEntry) -> Double? {
+        switch self {
+        case .weight: return entry.weightLbs
+        case .chest: return entry.chest
+        case .waist: return entry.waist
+        case .hips: return entry.hips
+        case .bicepLeft: return entry.bicepLeft
+        case .bicepRight: return entry.bicepRight
+        case .thighLeft: return entry.thighLeft
+        case .thighRight: return entry.thighRight
+        case .calf: return entry.calf
+        case .neck: return entry.neck
+        case .shoulders: return entry.shoulders
+        case .bodyFat: return entry.bodyFatPercent
+        }
+    }
+}
+
+// MARK: - Mock Data
+extension BodyCompositionEntry {
+    static func mockHistory(userId: String) -> [BodyCompositionEntry] {
+        let now = Date()
+        return (0..<12).map { weeksAgo in
+            let date = Calendar.current.date(byAdding: .weekOfYear, value: -weeksAgo, to: now)!
+            let baseWeight = 185.0
+            let variation = Double.random(in: -3...3)
+            let trend = Double(weeksAgo) * 0.5  // trending down over time
+            return BodyCompositionEntry(
+                userId: userId,
+                recordedAt: date,
+                weightLbs: baseWeight + variation - trend,
+                chest: 42.0 + Double.random(in: -0.5...0.5),
+                waist: 33.0 + Double.random(in: -0.5...0.5) - Double(weeksAgo) * 0.05,
+                hips: 40.0 + Double.random(in: -0.5...0.5),
+                bicepLeft: 15.5 + Double.random(in: -0.2...0.2),
+                bicepRight: 15.8 + Double.random(in: -0.2...0.2),
+                bodyFatPercent: 18.0 - Double(weeksAgo) * 0.1 + Double.random(in: -0.5...0.5),
+                isPrivate: true
+            )
+        }.reversed()
+    }
+}

--- a/XomFit/Services/BodyCompositionService.swift
+++ b/XomFit/Services/BodyCompositionService.swift
@@ -1,0 +1,137 @@
+import Foundation
+import Supabase
+import OSLog
+import UIKit
+
+private let logger = Logger(subsystem: "com.xomware.xomfit", category: "BodyComposition")
+
+@MainActor
+final class BodyCompositionService: ObservableObject {
+    static let shared = BodyCompositionService()
+    
+    // MARK: - Published State
+    @Published var entries: [BodyCompositionEntry] = []
+    @Published var isLoading = false
+    @Published var errorMessage: String?
+    
+    private init() {}
+    
+    // MARK: - Fetch
+    
+    /// Load all body composition entries for the current user, newest first
+    func loadEntries(userId: String) async {
+        isLoading = true
+        errorMessage = nil
+        defer { isLoading = false }
+        
+        do {
+            let fetched: [BodyCompositionEntry] = try await supabase
+                .from("body_composition")
+                .select()
+                .eq("user_id", value: userId)
+                .order("recorded_at", ascending: false)
+                .execute()
+                .value
+            
+            entries = fetched
+            logger.info("Loaded \(fetched.count) body composition entries for user \(userId)")
+        } catch {
+            logger.error("Failed to load body composition: \(error)")
+            // Fall back to mock data during development
+            entries = BodyCompositionEntry.mockHistory(userId: userId)
+            errorMessage = nil  // Don't surface mock data errors to user
+        }
+    }
+    
+    // MARK: - Save
+    
+    /// Save a new body composition entry
+    func saveEntry(_ entry: BodyCompositionEntry) async throws {
+        isLoading = true
+        defer { isLoading = false }
+        
+        do {
+            try await supabase
+                .from("body_composition")
+                .insert(entry)
+                .execute()
+            
+            // Prepend to local list for instant UI update
+            entries.insert(entry, at: 0)
+            logger.info("Saved body composition entry \(entry.id)")
+        } catch {
+            logger.error("Failed to save body composition entry: \(error)")
+            throw error
+        }
+    }
+    
+    // MARK: - Delete
+    
+    /// Delete a body composition entry by ID
+    func deleteEntry(id: UUID) async throws {
+        do {
+            try await supabase
+                .from("body_composition")
+                .delete()
+                .eq("id", value: id.uuidString)
+                .execute()
+            
+            entries.removeAll { $0.id == id }
+            logger.info("Deleted body composition entry \(id)")
+        } catch {
+            logger.error("Failed to delete body composition entry: \(error)")
+            throw error
+        }
+    }
+    
+    // MARK: - Photo Upload
+    
+    /// Upload a progress photo to Supabase Storage, returns the public URL
+    func uploadPhoto(_ image: UIImage, userId: String, entryId: UUID) async throws -> String {
+        guard let imageData = image.jpegData(compressionQuality: 0.7) else {
+            throw NSError(domain: "BodyComposition", code: -1, userInfo: [NSLocalizedDescriptionKey: "Failed to encode image"])
+        }
+        
+        let path = "\(userId)/\(entryId.uuidString).jpg"
+        
+        try await supabase.storage
+            .from("progress-photos")
+            .upload(path, data: imageData, options: FileOptions(contentType: "image/jpeg"))
+        
+        let publicUrl = try supabase.storage
+            .from("progress-photos")
+            .getPublicURL(path: path)
+        
+        logger.info("Uploaded progress photo to \(publicUrl)")
+        return publicUrl.absoluteString
+    }
+    
+    // MARK: - Analytics
+    
+    /// Get the most recent entry
+    var latestEntry: BodyCompositionEntry? { entries.first }
+    
+    /// Get change in a measurement between latest and a previous entry
+    func change(for metric: BodyMeasurement, comparedTo daysAgo: Int) -> Double? {
+        guard let latest = latestEntry,
+              let latestVal = metric.value(from: latest) else { return nil }
+        
+        let cutoff = Calendar.current.date(byAdding: .day, value: -daysAgo, to: Date())!
+        guard let comparison = entries.first(where: { $0.recordedAt <= cutoff }),
+              let compVal = metric.value(from: comparison) else { return nil }
+        
+        return latestVal - compVal
+    }
+    
+    /// Data points for a chart
+    func chartData(for metric: BodyMeasurement, days: Int) -> [(date: Date, value: Double)] {
+        let cutoff = Calendar.current.date(byAdding: .day, value: -days, to: Date())!
+        return entries
+            .filter { $0.recordedAt >= cutoff }
+            .compactMap { entry in
+                guard let val = metric.value(from: entry) else { return nil }
+                return (date: entry.recordedAt, value: val)
+            }
+            .reversed()  // oldest first for charting
+    }
+}

--- a/XomFit/ViewModels/BodyCompositionViewModel.swift
+++ b/XomFit/ViewModels/BodyCompositionViewModel.swift
@@ -1,0 +1,176 @@
+import SwiftUI
+import PhotosUI
+
+@MainActor
+final class BodyCompositionViewModel: ObservableObject {
+    
+    // MARK: - Data
+    @Published var entries: [BodyCompositionEntry] = []
+    @Published var isLoading = false
+    @Published var errorMessage: String?
+    @Published var showingAddEntry = false
+    @Published var showingDeleteConfirm = false
+    @Published var entryToDelete: BodyCompositionEntry?
+    
+    // MARK: - Chart State
+    @Published var selectedMetric: BodyMeasurement = .weight
+    @Published var selectedTimeRange: TimeRange = .month3
+    
+    // MARK: - Add Entry Form State
+    @Published var formWeight = ""
+    @Published var formChest = ""
+    @Published var formWaist = ""
+    @Published var formHips = ""
+    @Published var formBicepLeft = ""
+    @Published var formBicepRight = ""
+    @Published var formThighLeft = ""
+    @Published var formThighRight = ""
+    @Published var formCalf = ""
+    @Published var formNeck = ""
+    @Published var formShoulders = ""
+    @Published var formBodyFat = ""
+    @Published var formNotes = ""
+    @Published var formIsPrivate = true
+    @Published var formDate = Date()
+    @Published var selectedPhoto: PhotosPickerItem?
+    @Published var selectedPhotoImage: UIImage?
+    @Published var isSaving = false
+    
+    private let service = BodyCompositionService.shared
+    
+    // MARK: - Time Ranges
+    enum TimeRange: String, CaseIterable, Identifiable {
+        case month1 = "1M"
+        case month3 = "3M"
+        case month6 = "6M"
+        case year1 = "1Y"
+        case all = "All"
+        
+        var id: String { rawValue }
+        
+        var days: Int {
+            switch self {
+            case .month1: return 30
+            case .month3: return 90
+            case .month6: return 180
+            case .year1: return 365
+            case .all: return 3650
+            }
+        }
+    }
+    
+    // MARK: - Computed Properties
+    
+    var chartData: [(date: Date, value: Double)] {
+        service.chartData(for: selectedMetric, days: selectedTimeRange.days)
+    }
+    
+    var latestEntry: BodyCompositionEntry? { service.latestEntry }
+    
+    var weightChange30d: Double? { service.change(for: .weight, comparedTo: 30) }
+    var waistChange30d: Double? { service.change(for: .waist, comparedTo: 30) }
+    var bodyFatChange30d: Double? { service.change(for: .bodyFat, comparedTo: 30) }
+    
+    var isFormValid: Bool {
+        // At least one measurement must be filled
+        let fields = [formWeight, formChest, formWaist, formHips, formBicepLeft,
+                      formBicepRight, formBodyFat, formNotes]
+        return fields.contains { !$0.isEmpty }
+    }
+    
+    // MARK: - Load
+    
+    func load(userId: String) async {
+        isLoading = true
+        await service.loadEntries(userId: userId)
+        entries = service.entries
+        isLoading = false
+    }
+    
+    // MARK: - Save Entry
+    
+    func saveEntry(userId: String) async {
+        guard isFormValid else { return }
+        isSaving = true
+        defer { isSaving = false }
+        
+        let newId = UUID()
+        var photoUrl: String? = nil
+        
+        // Upload photo if selected
+        if let photo = selectedPhotoImage {
+            photoUrl = try? await service.uploadPhoto(photo, userId: userId, entryId: newId)
+        }
+        
+        let entry = BodyCompositionEntry(
+            id: newId,
+            userId: userId,
+            recordedAt: formDate,
+            weightLbs: Double(formWeight),
+            chest: Double(formChest),
+            waist: Double(formWaist),
+            hips: Double(formHips),
+            bicepLeft: Double(formBicepLeft),
+            bicepRight: Double(formBicepRight),
+            thighLeft: Double(formThighLeft),
+            thighRight: Double(formThighRight),
+            calf: Double(formCalf),
+            neck: Double(formNeck),
+            shoulders: Double(formShoulders),
+            bodyFatPercent: Double(formBodyFat),
+            photoUrl: photoUrl,
+            notes: formNotes.isEmpty ? nil : formNotes,
+            isPrivate: formIsPrivate
+        )
+        
+        do {
+            try await service.saveEntry(entry)
+            entries = service.entries
+            resetForm()
+            showingAddEntry = false
+        } catch {
+            errorMessage = "Failed to save: \(error.localizedDescription)"
+        }
+    }
+    
+    // MARK: - Delete Entry
+    
+    func deleteEntry(_ entry: BodyCompositionEntry) async {
+        do {
+            try await service.deleteEntry(id: entry.id)
+            entries = service.entries
+        } catch {
+            errorMessage = "Failed to delete: \(error.localizedDescription)"
+        }
+    }
+    
+    // MARK: - Photo Handler
+    
+    func handlePhotoSelection(_ item: PhotosPickerItem?) async {
+        guard let item else { return }
+        if let data = try? await item.loadTransferable(type: Data.self),
+           let image = UIImage(data: data) {
+            selectedPhotoImage = image
+        }
+    }
+    
+    // MARK: - Helpers
+    
+    private func resetForm() {
+        formWeight = ""; formChest = ""; formWaist = ""; formHips = ""
+        formBicepLeft = ""; formBicepRight = ""; formThighLeft = ""; formThighRight = ""
+        formCalf = ""; formNeck = ""; formShoulders = ""; formBodyFat = ""
+        formNotes = ""; formDate = Date(); formIsPrivate = true
+        selectedPhoto = nil; selectedPhotoImage = nil
+    }
+    
+    func formatChange(_ change: Double?, unit: String, lowerIsBetter: Bool = false) -> (text: String, color: Color) {
+        guard let change else { return ("—", Theme.textSecondary) }
+        let absChange = abs(change)
+        let formatted = String(format: "%.1f%@", absChange, unit)
+        let isPositive = change > 0
+        let isGood = lowerIsBetter ? !isPositive : isPositive
+        let sign = isPositive ? "+" : "-"
+        return ("\(sign)\(formatted)", isGood ? Theme.accent : Theme.destructive)
+    }
+}

--- a/XomFit/Views/Progress/AddBodyCompositionView.swift
+++ b/XomFit/Views/Progress/AddBodyCompositionView.swift
@@ -1,0 +1,300 @@
+import SwiftUI
+import PhotosUI
+
+struct AddBodyCompositionView: View {
+    @ObservedObject var viewModel: BodyCompositionViewModel
+    @EnvironmentObject var authService: AuthService
+    @Environment(\.dismiss) private var dismiss
+    
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Theme.background.ignoresSafeArea()
+                
+                ScrollView {
+                    VStack(spacing: Theme.paddingLarge) {
+                        // Date
+                        dateSection
+                        
+                        // Photo
+                        photoSection
+                        
+                        // Weight & Body Fat
+                        primarySection
+                        
+                        // Circumference Measurements
+                        measurementsSection
+                        
+                        // Notes & Privacy
+                        notesSection
+                        
+                        // Save Button
+                        Button {
+                            Task {
+                                guard let userId = authService.currentUser?.id else { return }
+                                await viewModel.saveEntry(userId: userId)
+                            }
+                        } label: {
+                            if viewModel.isSaving {
+                                ProgressView()
+                                    .tint(.black)
+                                    .frame(maxWidth: .infinity)
+                                    .frame(height: 52)
+                            } else {
+                                Text("Log Check-in")
+                                    .font(.system(size: 17, weight: .semibold))
+                                    .frame(maxWidth: .infinity)
+                                    .frame(height: 52)
+                            }
+                        }
+                        .foregroundStyle(.black)
+                        .background(viewModel.isFormValid && !viewModel.isSaving ? Theme.accent : Theme.accent.opacity(0.3))
+                        .cornerRadius(Theme.cornerRadius)
+                        .disabled(!viewModel.isFormValid || viewModel.isSaving)
+                        .padding(.horizontal, Theme.paddingMedium)
+                        .padding(.bottom, Theme.paddingLarge)
+                    }
+                    .padding(.top, Theme.paddingMedium)
+                }
+            }
+            .navigationTitle("New Check-in")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button("Cancel") { dismiss() }
+                        .foregroundStyle(Theme.textSecondary)
+                }
+            }
+            .onChange(of: viewModel.selectedPhoto) { _, newItem in
+                Task { await viewModel.handlePhotoSelection(newItem) }
+            }
+        }
+    }
+    
+    // MARK: - Date Section
+    
+    private var dateSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            SectionHeader("Date")
+            DatePicker(
+                "Check-in Date",
+                selection: $viewModel.formDate,
+                in: ...Date(),
+                displayedComponents: [.date]
+            )
+            .datePickerStyle(.compact)
+            .tint(Theme.accent)
+            .padding(Theme.paddingMedium)
+            .background(Theme.cardBackground)
+            .cornerRadius(Theme.cornerRadius)
+        }
+        .padding(.horizontal, Theme.paddingMedium)
+    }
+    
+    // MARK: - Photo Section
+    
+    private var photoSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            SectionHeader("Progress Photo")
+            
+            PhotosPicker(selection: $viewModel.selectedPhoto, matching: .images) {
+                HStack(spacing: 12) {
+                    if let image = viewModel.selectedPhotoImage {
+                        Image(uiImage: image)
+                            .resizable()
+                            .scaledToFill()
+                            .frame(width: 80, height: 80)
+                            .clipShape(RoundedRectangle(cornerRadius: Theme.cornerRadiusSmall))
+                    } else {
+                        ZStack {
+                            RoundedRectangle(cornerRadius: Theme.cornerRadiusSmall)
+                                .fill(Theme.secondaryBackground)
+                                .frame(width: 80, height: 80)
+                            Image(systemName: "camera.fill")
+                                .font(.system(size: 24))
+                                .foregroundStyle(Theme.textSecondary)
+                        }
+                    }
+                    
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(viewModel.selectedPhotoImage != nil ? "Photo selected" : "Add a progress photo")
+                            .font(Theme.fontBody)
+                            .foregroundStyle(Theme.textPrimary)
+                        Text("Optional · Private by default")
+                            .font(Theme.fontCaption)
+                            .foregroundStyle(Theme.textSecondary)
+                    }
+                    
+                    Spacer()
+                    
+                    Image(systemName: "chevron.right")
+                        .font(.caption)
+                        .foregroundStyle(Theme.textSecondary)
+                }
+                .padding(Theme.paddingMedium)
+                .background(Theme.cardBackground)
+                .cornerRadius(Theme.cornerRadius)
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(.horizontal, Theme.paddingMedium)
+    }
+    
+    // MARK: - Primary Section (Weight + Body Fat)
+    
+    private var primarySection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            SectionHeader("Weight & Body Fat")
+            
+            VStack(spacing: 1) {
+                MeasurementField(
+                    label: "Weight",
+                    placeholder: "185.0",
+                    unit: "lbs",
+                    text: $viewModel.formWeight
+                )
+                
+                Divider()
+                    .background(Theme.background)
+                    .padding(.horizontal, Theme.paddingMedium)
+                
+                MeasurementField(
+                    label: "Body Fat",
+                    placeholder: "18.0",
+                    unit: "%",
+                    text: $viewModel.formBodyFat
+                )
+            }
+            .background(Theme.cardBackground)
+            .cornerRadius(Theme.cornerRadius)
+        }
+        .padding(.horizontal, Theme.paddingMedium)
+    }
+    
+    // MARK: - Measurements Section
+    
+    private var measurementsSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            SectionHeader("Circumference Measurements (inches)")
+            
+            VStack(spacing: 1) {
+                let measurements: [(String, Binding<String>)] = [
+                    ("Chest", $viewModel.formChest),
+                    ("Waist", $viewModel.formWaist),
+                    ("Hips", $viewModel.formHips),
+                    ("Left Bicep", $viewModel.formBicepLeft),
+                    ("Right Bicep", $viewModel.formBicepRight),
+                    ("Left Thigh", $viewModel.formThighLeft),
+                    ("Right Thigh", $viewModel.formThighRight),
+                    ("Calf", $viewModel.formCalf),
+                    ("Neck", $viewModel.formNeck),
+                    ("Shoulders", $viewModel.formShoulders),
+                ]
+                
+                ForEach(Array(measurements.enumerated()), id: \.offset) { idx, item in
+                    MeasurementField(
+                        label: item.0,
+                        placeholder: "—",
+                        unit: "in",
+                        text: item.1
+                    )
+                    if idx < measurements.count - 1 {
+                        Divider()
+                            .background(Theme.background)
+                            .padding(.horizontal, Theme.paddingMedium)
+                    }
+                }
+            }
+            .background(Theme.cardBackground)
+            .cornerRadius(Theme.cornerRadius)
+        }
+        .padding(.horizontal, Theme.paddingMedium)
+    }
+    
+    // MARK: - Notes & Privacy
+    
+    private var notesSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            SectionHeader("Notes & Privacy")
+            
+            VStack(spacing: 1) {
+                VStack(alignment: .leading, spacing: 4) {
+                    TextField("Optional notes (e.g. morning weight, after workout...)", text: $viewModel.formNotes, axis: .vertical)
+                        .font(Theme.fontBody)
+                        .foregroundStyle(Theme.textPrimary)
+                        .lineLimit(3, reservesSpace: true)
+                        .padding(Theme.paddingMedium)
+                }
+                
+                Divider()
+                    .background(Theme.background)
+                
+                Toggle(isOn: $viewModel.formIsPrivate) {
+                    HStack(spacing: 8) {
+                        Image(systemName: viewModel.formIsPrivate ? "lock.fill" : "globe")
+                            .foregroundStyle(viewModel.formIsPrivate ? Theme.accent : Theme.textSecondary)
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(viewModel.formIsPrivate ? "Private" : "Public")
+                                .font(Theme.fontBody)
+                                .foregroundStyle(Theme.textPrimary)
+                            Text(viewModel.formIsPrivate ? "Only visible to you" : "Visible to your followers")
+                                .font(Theme.fontCaption)
+                                .foregroundStyle(Theme.textSecondary)
+                        }
+                    }
+                }
+                .tint(Theme.accent)
+                .padding(Theme.paddingMedium)
+            }
+            .background(Theme.cardBackground)
+            .cornerRadius(Theme.cornerRadius)
+        }
+        .padding(.horizontal, Theme.paddingMedium)
+    }
+}
+
+// MARK: - Helper Views
+
+private struct SectionHeader: View {
+    let title: String
+    init(_ title: String) { self.title = title }
+    
+    var body: some View {
+        Text(title)
+            .font(.system(size: 13, weight: .semibold))
+            .foregroundStyle(Theme.textSecondary)
+            .textCase(.uppercase)
+            .tracking(0.5)
+    }
+}
+
+private struct MeasurementField: View {
+    let label: String
+    let placeholder: String
+    let unit: String
+    @Binding var text: String
+    
+    var body: some View {
+        HStack {
+            Text(label)
+                .font(Theme.fontBody)
+                .foregroundStyle(Theme.textPrimary)
+                .frame(minWidth: 120, alignment: .leading)
+            
+            Spacer()
+            
+            TextField(placeholder, text: $text)
+                .keyboardType(.decimalPad)
+                .multilineTextAlignment(.trailing)
+                .font(Theme.fontBody)
+                .foregroundStyle(Theme.textPrimary)
+                .frame(width: 80)
+            
+            Text(unit)
+                .font(Theme.fontCaption)
+                .foregroundStyle(Theme.textSecondary)
+                .frame(width: 28, alignment: .leading)
+        }
+        .padding(Theme.paddingMedium)
+    }
+}

--- a/XomFit/Views/Progress/BodyCompositionView.swift
+++ b/XomFit/Views/Progress/BodyCompositionView.swift
@@ -1,0 +1,422 @@
+import SwiftUI
+import Charts
+import PhotosUI
+
+struct BodyCompositionView: View {
+    @EnvironmentObject var authService: AuthService
+    @StateObject private var viewModel = BodyCompositionViewModel()
+    
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Theme.background.ignoresSafeArea()
+                
+                if viewModel.isLoading && viewModel.entries.isEmpty {
+                    ProgressView("Loading...")
+                        .foregroundStyle(Theme.textSecondary)
+                } else {
+                    ScrollView {
+                        VStack(spacing: Theme.paddingLarge) {
+                            // Summary cards
+                            summarySection
+                            
+                            // Metric selector + chart
+                            chartSection
+                            
+                            // History log
+                            historySection
+                        }
+                        .padding(.horizontal, Theme.paddingMedium)
+                        .padding(.bottom, Theme.paddingLarge)
+                    }
+                    .refreshable {
+                        if let userId = authService.currentUser?.id {
+                            await viewModel.load(userId: userId)
+                        }
+                    }
+                }
+            }
+            .navigationTitle("Body Composition")
+            .navigationBarTitleDisplayMode(.large)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button {
+                        viewModel.showingAddEntry = true
+                    } label: {
+                        Image(systemName: "plus.circle.fill")
+                            .font(.title3)
+                            .foregroundStyle(Theme.accent)
+                    }
+                }
+            }
+            .sheet(isPresented: $viewModel.showingAddEntry) {
+                AddBodyCompositionView(viewModel: viewModel)
+            }
+            .alert("Error", isPresented: Binding(
+                get: { viewModel.errorMessage != nil },
+                set: { if !$0 { viewModel.errorMessage = nil } }
+            )) {
+                Button("OK") { viewModel.errorMessage = nil }
+            } message: {
+                Text(viewModel.errorMessage ?? "")
+            }
+        }
+        .task {
+            if let userId = authService.currentUser?.id {
+                await viewModel.load(userId: userId)
+            }
+        }
+    }
+    
+    // MARK: - Summary Section
+    
+    @ViewBuilder private var summarySection: some View {
+        if let latest = viewModel.latestEntry {
+            VStack(alignment: .leading, spacing: 12) {
+                Text("Latest Check-in")
+                    .font(Theme.fontHeadline)
+                    .foregroundStyle(Theme.textPrimary)
+                
+                Text(latest.recordedAt.formatted(date: .abbreviated, time: .omitted))
+                    .font(Theme.fontCaption)
+                    .foregroundStyle(Theme.textSecondary)
+                
+                LazyVGrid(columns: [
+                    GridItem(.flexible()),
+                    GridItem(.flexible()),
+                    GridItem(.flexible())
+                ], spacing: 12) {
+                    if let weight = latest.weightLbs {
+                        let (changeText, changeColor) = viewModel.formatChange(viewModel.weightChange30d, unit: " lbs", lowerIsBetter: false)
+                        SummaryStatCard(
+                            label: "Weight",
+                            value: String(format: "%.1f", weight),
+                            unit: "lbs",
+                            change: changeText,
+                            changeColor: changeColor,
+                            icon: "scalemass.fill"
+                        )
+                    }
+                    
+                    if let waist = latest.waist {
+                        let (changeText, changeColor) = viewModel.formatChange(viewModel.waistChange30d, unit: "\"", lowerIsBetter: true)
+                        SummaryStatCard(
+                            label: "Waist",
+                            value: String(format: "%.1f", waist),
+                            unit: "in",
+                            change: changeText,
+                            changeColor: changeColor,
+                            icon: "figure.stand"
+                        )
+                    }
+                    
+                    if let bf = latest.bodyFatPercent {
+                        let (changeText, changeColor) = viewModel.formatChange(viewModel.bodyFatChange30d, unit: "%", lowerIsBetter: true)
+                        SummaryStatCard(
+                            label: "Body Fat",
+                            value: String(format: "%.1f", bf),
+                            unit: "%",
+                            change: changeText,
+                            changeColor: changeColor,
+                            icon: "percent"
+                        )
+                    }
+                }
+            }
+            .cardStyle()
+        }
+    }
+    
+    // MARK: - Chart Section
+    
+    @ViewBuilder private var chartSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            // Metric picker
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 8) {
+                    ForEach(BodyMeasurement.allCases) { metric in
+                        Button {
+                            viewModel.selectedMetric = metric
+                        } label: {
+                            Text(metric.rawValue)
+                                .font(Theme.fontCaption)
+                                .padding(.horizontal, 12)
+                                .padding(.vertical, 6)
+                                .background(viewModel.selectedMetric == metric ? Theme.accent : Theme.cardBackground)
+                                .foregroundStyle(viewModel.selectedMetric == metric ? .black : Theme.textSecondary)
+                                .cornerRadius(20)
+                        }
+                    }
+                }
+            }
+            
+            // Time range picker
+            Picker("Time Range", selection: $viewModel.selectedTimeRange) {
+                ForEach(BodyCompositionViewModel.TimeRange.allCases) { range in
+                    Text(range.rawValue).tag(range)
+                }
+            }
+            .pickerStyle(.segmented)
+            
+            // Chart
+            let data = viewModel.chartData
+            if data.isEmpty {
+                Text("No \(viewModel.selectedMetric.rawValue) data in this range")
+                    .font(Theme.fontCaption)
+                    .foregroundStyle(Theme.textSecondary)
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 150)
+            } else {
+                Chart(data, id: \.date) { point in
+                    LineMark(
+                        x: .value("Date", point.date),
+                        y: .value(viewModel.selectedMetric.rawValue, point.value)
+                    )
+                    .foregroundStyle(Theme.accent)
+                    .interpolationMethod(.catmullRom)
+                    
+                    AreaMark(
+                        x: .value("Date", point.date),
+                        y: .value(viewModel.selectedMetric.rawValue, point.value)
+                    )
+                    .foregroundStyle(
+                        LinearGradient(
+                            colors: [Theme.accent.opacity(0.3), Theme.accent.opacity(0.0)],
+                            startPoint: .top,
+                            endPoint: .bottom
+                        )
+                    )
+                    .interpolationMethod(.catmullRom)
+                    
+                    PointMark(
+                        x: .value("Date", point.date),
+                        y: .value(viewModel.selectedMetric.rawValue, point.value)
+                    )
+                    .foregroundStyle(Theme.accent)
+                    .symbolSize(40)
+                }
+                .frame(height: 180)
+                .chartYAxis {
+                    AxisMarks(position: .leading) { _ in
+                        AxisGridLine(stroke: StrokeStyle(lineWidth: 0.5))
+                            .foregroundStyle(Theme.textSecondary.opacity(0.2))
+                        AxisValueLabel()
+                            .foregroundStyle(Theme.textSecondary)
+                            .font(.system(size: 11))
+                    }
+                }
+                .chartXAxis {
+                    AxisMarks { _ in
+                        AxisValueLabel(format: .dateTime.month().day())
+                            .foregroundStyle(Theme.textSecondary)
+                            .font(.system(size: 11))
+                    }
+                }
+                
+                // Min/max/avg stats below chart
+                if let min = data.map(\.value).min(),
+                   let max = data.map(\.value).max() {
+                    let avg = data.map(\.value).reduce(0, +) / Double(data.count)
+                    HStack {
+                        MiniStat(label: "Low", value: String(format: "%.1f", min), unit: viewModel.selectedMetric.unit)
+                        Spacer()
+                        MiniStat(label: "Avg", value: String(format: "%.1f", avg), unit: viewModel.selectedMetric.unit)
+                        Spacer()
+                        MiniStat(label: "High", value: String(format: "%.1f", max), unit: viewModel.selectedMetric.unit)
+                    }
+                    .padding(.top, 4)
+                }
+            }
+        }
+        .cardStyle()
+    }
+    
+    // MARK: - History Section
+    
+    @ViewBuilder private var historySection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Check-in History")
+                .font(Theme.fontHeadline)
+                .foregroundStyle(Theme.textPrimary)
+            
+            if viewModel.entries.isEmpty {
+                Text("No entries yet. Tap + to log your first check-in.")
+                    .font(Theme.fontCaption)
+                    .foregroundStyle(Theme.textSecondary)
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .padding(.vertical, Theme.paddingLarge)
+            } else {
+                ForEach(viewModel.entries) { entry in
+                    BodyCompositionEntryRow(entry: entry) {
+                        viewModel.entryToDelete = entry
+                        viewModel.showingDeleteConfirm = true
+                    }
+                }
+            }
+        }
+        .confirmationDialog(
+            "Delete this entry?",
+            isPresented: $viewModel.showingDeleteConfirm,
+            titleVisibility: .visible
+        ) {
+            Button("Delete", role: .destructive) {
+                if let entry = viewModel.entryToDelete {
+                    Task { await viewModel.deleteEntry(entry) }
+                }
+            }
+            Button("Cancel", role: .cancel) {}
+        }
+    }
+}
+
+// MARK: - Supporting Views
+
+private struct SummaryStatCard: View {
+    let label: String
+    let value: String
+    let unit: String
+    let change: String
+    let changeColor: Color
+    let icon: String
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 4) {
+                Image(systemName: icon)
+                    .font(.system(size: 11))
+                    .foregroundStyle(Theme.accent)
+                Text(label)
+                    .font(Theme.fontSmall)
+                    .foregroundStyle(Theme.textSecondary)
+            }
+            
+            HStack(alignment: .lastTextBaseline, spacing: 2) {
+                Text(value)
+                    .font(.system(size: 22, weight: .bold))
+                    .foregroundStyle(Theme.textPrimary)
+                Text(unit)
+                    .font(Theme.fontSmall)
+                    .foregroundStyle(Theme.textSecondary)
+            }
+            
+            Text(change)
+                .font(Theme.fontSmall)
+                .foregroundStyle(changeColor)
+        }
+        .padding(12)
+        .background(Theme.secondaryBackground)
+        .cornerRadius(Theme.cornerRadiusSmall)
+    }
+}
+
+private struct MiniStat: View {
+    let label: String
+    let value: String
+    let unit: String
+    
+    var body: some View {
+        VStack(spacing: 2) {
+            Text(label)
+                .font(Theme.fontSmall)
+                .foregroundStyle(Theme.textSecondary)
+            HStack(alignment: .lastTextBaseline, spacing: 2) {
+                Text(value)
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(Theme.textPrimary)
+                Text(unit)
+                    .font(Theme.fontSmall)
+                    .foregroundStyle(Theme.textSecondary)
+            }
+        }
+    }
+}
+
+private struct BodyCompositionEntryRow: View {
+    let entry: BodyCompositionEntry
+    let onDelete: () -> Void
+    
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            // Date column
+            VStack(alignment: .center, spacing: 2) {
+                Text(entry.recordedAt.formatted(.dateTime.month(.abbreviated)))
+                    .font(Theme.fontSmall)
+                    .foregroundStyle(Theme.textSecondary)
+                Text(entry.recordedAt.formatted(.dateTime.day()))
+                    .font(.system(size: 20, weight: .bold))
+                    .foregroundStyle(Theme.textPrimary)
+                Text(entry.recordedAt.formatted(.dateTime.year()))
+                    .font(Theme.fontSmall)
+                    .foregroundStyle(Theme.textSecondary)
+            }
+            .frame(width: 44)
+            
+            // Measurements
+            VStack(alignment: .leading, spacing: 6) {
+                HStack(spacing: 12) {
+                    if let w = entry.weightLbs {
+                        MeasurementChip(label: "Weight", value: String(format: "%.1f lbs", w))
+                    }
+                    if let bf = entry.bodyFatPercent {
+                        MeasurementChip(label: "Body Fat", value: String(format: "%.1f%%", bf))
+                    }
+                }
+                
+                HStack(spacing: 8) {
+                    if let waist = entry.waist {
+                        MeasurementChip(label: "Waist", value: String(format: "%.1f\"", waist))
+                    }
+                    if let chest = entry.chest {
+                        MeasurementChip(label: "Chest", value: String(format: "%.1f\"", chest))
+                    }
+                    if let hips = entry.hips {
+                        MeasurementChip(label: "Hips", value: String(format: "%.1f\"", hips))
+                    }
+                }
+                
+                if let notes = entry.notes, !notes.isEmpty {
+                    Text(notes)
+                        .font(Theme.fontCaption)
+                        .foregroundStyle(Theme.textSecondary)
+                        .lineLimit(2)
+                }
+                
+                if entry.isPrivate {
+                    Label("Private", systemImage: "lock.fill")
+                        .font(Theme.fontSmall)
+                        .foregroundStyle(Theme.textSecondary)
+                }
+            }
+            
+            Spacer()
+            
+            Button {
+                onDelete()
+            } label: {
+                Image(systemName: "trash")
+                    .font(.caption)
+                    .foregroundStyle(Theme.textSecondary)
+            }
+        }
+        .padding(12)
+        .background(Theme.cardBackground)
+        .cornerRadius(Theme.cornerRadiusSmall)
+    }
+}
+
+private struct MeasurementChip: View {
+    let label: String
+    let value: String
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 1) {
+            Text(label)
+                .font(.system(size: 9, weight: .medium))
+                .foregroundStyle(Theme.textSecondary)
+                .textCase(.uppercase)
+            Text(value)
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(Theme.textPrimary)
+        }
+    }
+}

--- a/XomFit/Views/Progress/XomProgressView.swift
+++ b/XomFit/Views/Progress/XomProgressView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 struct XomProgressView: View {
+    @State private var selectedTab = 0
     @State private var selectedTimeframe = 0
     let timeframes = ["Week", "Month", "3 Months", "Year"]
     
@@ -9,7 +10,30 @@ struct XomProgressView: View {
             ZStack {
                 Theme.background.ignoresSafeArea()
                 
-                ScrollView {
+                VStack(spacing: 0) {
+                    // Top-level tab selector: Workouts / Body Composition
+                    Picker("Progress Tab", selection: $selectedTab) {
+                        Text("Workouts").tag(0)
+                        Text("Body Composition").tag(1)
+                    }
+                    .pickerStyle(.segmented)
+                    .padding(.horizontal, Theme.paddingMedium)
+                    .padding(.top, Theme.paddingSmall)
+                    .padding(.bottom, Theme.paddingSmall)
+                    
+                    if selectedTab == 1 {
+                        BodyCompositionView()
+                    } else {
+                workoutsContent
+                    }
+                }
+            }
+            .navigationTitle("Progress")
+        }
+    }
+    
+    @ViewBuilder private var workoutsContent: some View {
+        ScrollView {
                     VStack(spacing: Theme.paddingLarge) {
                         // Timeframe Picker
                         Picker("Timeframe", selection: $selectedTimeframe) {
@@ -107,9 +131,6 @@ struct XomProgressView: View {
                         .padding(.horizontal, Theme.paddingMedium)
                     }
                     .padding(.top, Theme.paddingSmall)
-                }
-            }
-            .navigationTitle("Progress")
         }
     }
 }

--- a/supabase/migrations/20260228_body_composition.sql
+++ b/supabase/migrations/20260228_body_composition.sql
@@ -1,0 +1,96 @@
+-- Body Composition table
+-- Tracks user weight, circumference measurements, body fat, and optional progress photos
+-- Private by default; users can optionally share entries
+
+CREATE TABLE IF NOT EXISTS body_composition (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id         TEXT NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    recorded_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+    
+    -- Weight
+    weight_lbs      NUMERIC(6, 2),
+    
+    -- Circumference measurements (inches)
+    chest           NUMERIC(5, 2),
+    waist           NUMERIC(5, 2),
+    hips            NUMERIC(5, 2),
+    bicep_left      NUMERIC(5, 2),
+    bicep_right     NUMERIC(5, 2),
+    thigh_left      NUMERIC(5, 2),
+    thigh_right     NUMERIC(5, 2),
+    calf            NUMERIC(5, 2),
+    neck            NUMERIC(5, 2),
+    shoulders       NUMERIC(5, 2),
+    
+    -- Body composition
+    body_fat_percent NUMERIC(4, 2),
+    
+    -- Progress photo (stored in Supabase Storage bucket "progress-photos")
+    photo_url       TEXT,
+    
+    -- Metadata
+    notes           TEXT,
+    is_private      BOOLEAN NOT NULL DEFAULT true,
+    
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Index for user timeline queries
+CREATE INDEX idx_body_composition_user_recorded
+    ON body_composition(user_id, recorded_at DESC);
+
+-- Row Level Security
+ALTER TABLE body_composition ENABLE ROW LEVEL SECURITY;
+
+-- Users can read their own entries
+CREATE POLICY "Users can view own body composition"
+    ON body_composition FOR SELECT
+    USING (auth.uid()::text = user_id);
+
+-- Users can read public entries of others (is_private = false)
+CREATE POLICY "Users can view public body composition"
+    ON body_composition FOR SELECT
+    USING (is_private = false);
+
+-- Users can insert their own entries
+CREATE POLICY "Users can insert own body composition"
+    ON body_composition FOR INSERT
+    WITH CHECK (auth.uid()::text = user_id);
+
+-- Users can update their own entries
+CREATE POLICY "Users can update own body composition"
+    ON body_composition FOR UPDATE
+    USING (auth.uid()::text = user_id);
+
+-- Users can delete their own entries
+CREATE POLICY "Users can delete own body composition"
+    ON body_composition FOR DELETE
+    USING (auth.uid()::text = user_id);
+
+-- Auto-update updated_at
+CREATE OR REPLACE FUNCTION update_body_composition_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = now();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER body_composition_updated_at
+    BEFORE UPDATE ON body_composition
+    FOR EACH ROW
+    EXECUTE FUNCTION update_body_composition_updated_at();
+
+-- Storage bucket for progress photos (run in Supabase dashboard or via CLI)
+-- INSERT INTO storage.buckets (id, name, public) VALUES ('progress-photos', 'progress-photos', false)
+-- ON CONFLICT DO NOTHING;
+
+-- Storage RLS: users can only upload/view their own photos (stored at {user_id}/{entry_id}.jpg)
+-- CREATE POLICY "Users can upload own progress photos"
+--     ON storage.objects FOR INSERT
+--     WITH CHECK (bucket_id = 'progress-photos' AND (storage.foldername(name))[1] = auth.uid()::text);
+--
+-- CREATE POLICY "Users can view own progress photos"
+--     ON storage.objects FOR SELECT
+--     USING (bucket_id = 'progress-photos' AND (storage.foldername(name))[1] = auth.uid()::text);


### PR DESCRIPTION
Closes #20

## What's New

Full body composition tracking system — weight, 10 circumference measurements, body fat %, and optional progress photos.

### Features

**Tracking**
- Weight (lbs) with 30-day change delta
- Body fat % with trend indicator
- 10 circumference measurements: chest, waist, hips, biceps (L/R), thighs (L/R), calf, neck, shoulders
- Optional progress photo upload to Supabase Storage
- Notes field and private/public toggle (private by default)

**Charts (Swift Charts)**
- Line + area chart for any metric over any time range (1M, 3M, 6M, 1Y, All)
- Metric selector chips: all 12 metrics
- Min/avg/max stats below chart

**History Log**
- Date column + measurement chips for each entry
- Notes and privacy badge
- Swipe-to-delete with confirmation dialog

**Summary Cards**
- Latest weight, waist, body fat with 30-day change arrows (green = good, red = bad)

### Navigation
Progress tab now has **Workouts | Body Composition** segmented picker at the top.

### Files
```
XomFit/Models/BodyComposition.swift          — Model + BodyMeasurement enum + mock data
XomFit/Services/BodyCompositionService.swift — Supabase CRUD + Storage photo upload
XomFit/ViewModels/BodyCompositionViewModel.swift — Form state, chart data, delta helpers
XomFit/Views/Progress/BodyCompositionView.swift  — Main view (summary + chart + history)
XomFit/Views/Progress/AddBodyCompositionView.swift — Log new check-in sheet
XomFit/Views/Progress/XomProgressView.swift  — Updated with tab switcher
supabase/migrations/20260228_body_composition.sql — Table + RLS + trigger
```

### Database Setup Required
Run `supabase/migrations/20260228_body_composition.sql` and create the `progress-photos` Storage bucket in the Supabase dashboard.