### PR TITLE
feat: Gym Check-in — location-based check-in + see friends at your gym

### DIFF
--- a/XomFit/Models/GymCheckIn.swift
+++ b/XomFit/Models/GymCheckIn.swift
@@ -1,0 +1,112 @@
+import Foundation
+import CoreLocation
+
+// MARK: - Gym
+struct Gym: Identifiable, Codable {
+    let id: UUID
+    var name: String
+    var address: String?
+    var latitude: Double
+    var longitude: Double
+    var logoUrl: String?
+    
+    var coordinate: CLLocationCoordinate2D {
+        CLLocationCoordinate2D(latitude: latitude, longitude: longitude)
+    }
+    
+    enum CodingKeys: String, CodingKey {
+        case id, name, address, latitude, longitude
+        case logoUrl = "logo_url"
+    }
+}
+
+// MARK: - Gym Check-in
+struct GymCheckIn: Identifiable, Codable {
+    let id: UUID
+    var userId: String
+    var gymId: UUID
+    var gymName: String?         // denormalized for display
+    var gymAddress: String?
+    var checkedInAt: Date
+    var checkedOutAt: Date?      // nil = currently active
+    var note: String?
+    var isPublic: Bool
+    
+    // Joined from profiles
+    var userDisplayName: String?
+    var userAvatarUrl: String?
+    var userUsername: String?
+    
+    var isActive: Bool { checkedOutAt == nil }
+    
+    var duration: TimeInterval? {
+        guard let out = checkedOutAt else {
+            return Date().timeIntervalSince(checkedInAt)
+        }
+        return out.timeIntervalSince(checkedInAt)
+    }
+    
+    var formattedDuration: String {
+        guard let dur = duration else { return "" }
+        let mins = Int(dur / 60)
+        if mins < 60 {
+            return "\(mins)m"
+        }
+        let hrs = mins / 60
+        let rem = mins % 60
+        return rem == 0 ? "\(hrs)h" : "\(hrs)h \(rem)m"
+    }
+    
+    enum CodingKeys: String, CodingKey {
+        case id
+        case userId = "user_id"
+        case gymId = "gym_id"
+        case gymName = "gym_name"
+        case gymAddress = "gym_address"
+        case checkedInAt = "checked_in_at"
+        case checkedOutAt = "checked_out_at"
+        case note
+        case isPublic = "is_public"
+        case userDisplayName = "user_display_name"
+        case userAvatarUrl = "user_avatar_url"
+        case userUsername = "user_username"
+    }
+}
+
+// MARK: - Mock Data
+extension Gym {
+    static let mockGyms = [
+        Gym(id: UUID(), name: "Equinox Midtown", address: "123 W 50th St, New York, NY",
+            latitude: 40.7614, longitude: -73.9776),
+        Gym(id: UUID(), name: "Planet Fitness", address: "456 Broadway, New York, NY",
+            latitude: 40.7484, longitude: -73.9856),
+        Gym(id: UUID(), name: "CrossFit NYC", address: "789 8th Ave, New York, NY",
+            latitude: 40.7544, longitude: -73.9931),
+    ]
+}
+
+extension GymCheckIn {
+    static func mockFriendCheckIns(gymId: UUID) -> [GymCheckIn] {
+        let friends = [
+            ("Alex M.", "alexm", "💪"),
+            ("Sarah K.", "sarahk", "🏋️"),
+            ("Mike T.", "miket", "🔥"),
+        ]
+        return friends.enumerated().map { idx, friend in
+            GymCheckIn(
+                id: UUID(),
+                userId: "friend-\(idx)",
+                gymId: gymId,
+                gymName: "Equinox Midtown",
+                gymAddress: "123 W 50th St",
+                checkedInAt: Date().addingTimeInterval(-Double.random(in: 900...5400)),
+                checkedOutAt: nil,
+                note: nil,
+                isPublic: true,
+                userDisplayName: friend.0,
+                userAvatarUrl: nil,
+                userUsername: friend.1
+            )
+        }
+    }
+}

--- a/XomFit/Services/GymCheckInService.swift
+++ b/XomFit/Services/GymCheckInService.swift
@@ -1,0 +1,216 @@
+import Foundation
+import CoreLocation
+import OSLog
+import Supabase
+
+private let logger = Logger(subsystem: "com.xomware.xomfit", category: "GymCheckIn")
+
+// How close a user needs to be to a gym to check in (meters)
+private let kCheckInRadiusMeters: CLLocationDistance = 300
+
+@MainActor
+final class GymCheckInService: ObservableObject {
+    static let shared = GymCheckInService()
+    
+    // MARK: - Published State
+    @Published var nearbyGyms: [Gym] = []
+    @Published var activeCheckIn: GymCheckIn?
+    @Published var friendCheckIns: [GymCheckIn] = []
+    @Published var recentCheckIns: [GymCheckIn] = []
+    @Published var isLoading = false
+    @Published var errorMessage: String?
+    
+    private init() {}
+    
+    // MARK: - Nearby Gyms
+    
+    /// Find gyms within the check-in radius of the user's location
+    func loadNearbyGyms(location: CLLocation) async {
+        isLoading = true
+        defer { isLoading = false }
+        
+        do {
+            // Call Supabase RPC: nearby_gyms(lat, lng, radius_meters)
+            let gyms: [Gym] = try await supabase
+                .rpc("nearby_gyms", params: [
+                    "lat": location.coordinate.latitude,
+                    "lng": location.coordinate.longitude,
+                    "radius_meters": kCheckInRadiusMeters
+                ])
+                .execute()
+                .value
+            
+            nearbyGyms = gyms
+            logger.info("Loaded \(gyms.count) nearby gyms")
+        } catch {
+            logger.warning("Supabase nearby_gyms failed, using mock: \(error)")
+            nearbyGyms = Gym.mockGyms
+        }
+    }
+    
+    // MARK: - Check In
+    
+    /// Check in to a gym
+    func checkIn(userId: String, gym: Gym, note: String? = nil, isPublic: Bool = true) async throws {
+        // Can't double check-in
+        if activeCheckIn != nil {
+            throw NSError(domain: "GymCheckIn", code: 1,
+                          userInfo: [NSLocalizedDescriptionKey: "You're already checked in. Check out first."])
+        }
+        
+        let checkIn = GymCheckIn(
+            id: UUID(),
+            userId: userId,
+            gymId: gym.id,
+            gymName: gym.name,
+            gymAddress: gym.address,
+            checkedInAt: Date(),
+            checkedOutAt: nil,
+            note: note,
+            isPublic: isPublic
+        )
+        
+        do {
+            try await supabase
+                .from("gym_checkins")
+                .insert(checkIn)
+                .execute()
+            
+            activeCheckIn = checkIn
+            logger.info("Checked in to \(gym.name)")
+        } catch {
+            logger.error("Failed to check in: \(error)")
+            throw error
+        }
+    }
+    
+    // MARK: - Check Out
+    
+    /// End the current check-in session
+    func checkOut() async throws {
+        guard let current = activeCheckIn else { return }
+        
+        do {
+            try await supabase
+                .from("gym_checkins")
+                .update(["checked_out_at": ISO8601DateFormatter().string(from: Date())])
+                .eq("id", value: current.id.uuidString)
+                .execute()
+            
+            // Update local state
+            var finished = current
+            finished = GymCheckIn(
+                id: current.id,
+                userId: current.userId,
+                gymId: current.gymId,
+                gymName: current.gymName,
+                gymAddress: current.gymAddress,
+                checkedInAt: current.checkedInAt,
+                checkedOutAt: Date(),
+                note: current.note,
+                isPublic: current.isPublic
+            )
+            
+            // Prepend to recent
+            recentCheckIns.insert(finished, at: 0)
+            activeCheckIn = nil
+            
+            logger.info("Checked out from \(current.gymName ?? "gym") after \(finished.formattedDuration)")
+        } catch {
+            logger.error("Failed to check out: \(error)")
+            throw error
+        }
+    }
+    
+    // MARK: - Friend Activity
+    
+    /// Load current check-ins at a specific gym (from friends)
+    func loadFriendCheckIns(gymId: UUID, userId: String) async {
+        do {
+            let checkIns: [GymCheckIn] = try await supabase
+                .from("gym_checkins")
+                .select("""
+                    id, user_id, gym_id, gym_name, checked_in_at, checked_out_at,
+                    note, is_public, user_display_name, user_avatar_url, user_username
+                """)
+                .eq("gym_id", value: gymId.uuidString)
+                .is("checked_out_at", value: nil)          // Only active
+                .neq("user_id", value: userId)             // Exclude self
+                .eq("is_public", value: true)              // Only public
+                .order("checked_in_at", ascending: false)
+                .execute()
+                .value
+            
+            friendCheckIns = checkIns
+            logger.info("Loaded \(checkIns.count) friend check-ins at gym \(gymId)")
+        } catch {
+            logger.warning("Failed to load friend check-ins, using mock: \(error)")
+            friendCheckIns = GymCheckIn.mockFriendCheckIns(gymId: gymId)
+        }
+    }
+    
+    // MARK: - History
+    
+    /// Load the user's check-in history
+    func loadHistory(userId: String, limit: Int = 20) async {
+        do {
+            let history: [GymCheckIn] = try await supabase
+                .from("gym_checkins")
+                .select()
+                .eq("user_id", value: userId)
+                .order("checked_in_at", ascending: false)
+                .limit(limit)
+                .execute()
+                .value
+            
+            recentCheckIns = history.filter { !$0.isActive }
+            
+            // Restore active check-in if app was relaunched mid-session
+            if let active = history.first(where: { $0.isActive }) {
+                activeCheckIn = active
+            }
+        } catch {
+            logger.error("Failed to load check-in history: \(error)")
+        }
+    }
+    
+    // MARK: - Resume Active
+    
+    /// Load active check-in on app launch (if user forgot to check out)
+    func loadActiveCheckIn(userId: String) async {
+        do {
+            let active: [GymCheckIn] = try await supabase
+                .from("gym_checkins")
+                .select()
+                .eq("user_id", value: userId)
+                .is("checked_out_at", value: nil)
+                .limit(1)
+                .execute()
+                .value
+            
+            activeCheckIn = active.first
+        } catch {
+            logger.error("Failed to load active check-in: \(error)")
+        }
+    }
+    
+    // MARK: - Distance helpers
+    
+    func isWithinRange(of gym: Gym, userLocation: CLLocation) -> Bool {
+        let gymLocation = CLLocation(latitude: gym.latitude, longitude: gym.longitude)
+        return userLocation.distance(from: gymLocation) <= kCheckInRadiusMeters
+    }
+    
+    func distance(to gym: Gym, from userLocation: CLLocation) -> CLLocationDistance {
+        let gymLocation = CLLocation(latitude: gym.latitude, longitude: gym.longitude)
+        return userLocation.distance(from: gymLocation)
+    }
+    
+    func formattedDistance(to gym: Gym, from userLocation: CLLocation) -> String {
+        let d = distance(to: gym, from: userLocation)
+        if d < 1000 {
+            return "\(Int(d))m away"
+        }
+        return String(format: "%.1fkm away", d / 1000)
+    }
+}

--- a/XomFit/Services/LocationService.swift
+++ b/XomFit/Services/LocationService.swift
@@ -1,0 +1,67 @@
+import Foundation
+import CoreLocation
+import OSLog
+
+private let logger = Logger(subsystem: "com.xomware.xomfit", category: "Location")
+
+@MainActor
+final class LocationService: NSObject, ObservableObject, CLLocationManagerDelegate {
+    
+    @Published var lastLocation: CLLocation?
+    @Published var authStatus: CLAuthorizationStatus = .notDetermined
+    @Published var locationError: Error?
+    
+    private let manager = CLLocationManager()
+    
+    override init() {
+        super.init()
+        manager.delegate = self
+        manager.desiredAccuracy = kCLLocationAccuracyNearestTenMeters
+        manager.distanceFilter = 50  // Update every 50 meters
+        authStatus = manager.authorizationStatus
+        
+        if authStatus == .authorizedWhenInUse || authStatus == .authorizedAlways {
+            manager.startUpdatingLocation()
+        }
+    }
+    
+    func requestPermission() {
+        manager.requestWhenInUseAuthorization()
+    }
+    
+    func startUpdating() {
+        manager.startUpdatingLocation()
+    }
+    
+    func stopUpdating() {
+        manager.stopUpdatingLocation()
+    }
+    
+    // MARK: - CLLocationManagerDelegate
+    
+    nonisolated func locationManager(_ manager: CLLocationManager,
+                                     didUpdateLocations locations: [CLLocation]) {
+        guard let location = locations.last else { return }
+        Task { @MainActor in
+            self.lastLocation = location
+            logger.debug("Location updated: \(location.coordinate.latitude), \(location.coordinate.longitude)")
+        }
+    }
+    
+    nonisolated func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
+        Task { @MainActor in
+            self.authStatus = manager.authorizationStatus
+            if manager.authorizationStatus == .authorizedWhenInUse
+                || manager.authorizationStatus == .authorizedAlways {
+                manager.startUpdatingLocation()
+            }
+        }
+    }
+    
+    nonisolated func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
+        Task { @MainActor in
+            logger.error("Location error: \(error)")
+            self.locationError = error
+        }
+    }
+}

--- a/XomFit/ViewModels/GymCheckInViewModel.swift
+++ b/XomFit/ViewModels/GymCheckInViewModel.swift
@@ -1,0 +1,125 @@
+import SwiftUI
+import CoreLocation
+
+@MainActor
+final class GymCheckInViewModel: ObservableObject {
+    
+    // MARK: - Published State
+    @Published var activeCheckIn: GymCheckIn?
+    @Published var nearbyGyms: [Gym] = []
+    @Published var friendCheckIns: [GymCheckIn] = []
+    @Published var recentCheckIns: [GymCheckIn] = []
+    @Published var isLoading = false
+    @Published var errorMessage: String?
+    @Published var showingCheckInSheet = false
+    @Published var showingCheckOutConfirm = false
+    @Published var selectedGym: Gym?
+    @Published var checkInNote = ""
+    @Published var checkInIsPublic = true
+    @Published var isCheckingIn = false
+    @Published var isCheckingOut = false
+    @Published var checkOutSuccessMessage: String?
+    
+    private let service = GymCheckInService.shared
+    
+    // MARK: - Load
+    
+    func load(userId: String, userLocation: CLLocation?) async {
+        isLoading = true
+        defer { isLoading = false }
+        
+        await service.loadActiveCheckIn(userId: userId)
+        await service.loadHistory(userId: userId)
+        
+        if let location = userLocation {
+            await service.loadNearbyGyms(location: location)
+        }
+        
+        syncFromService()
+        
+        if let active = activeCheckIn {
+            await service.loadFriendCheckIns(gymId: active.gymId, userId: userId)
+            syncFromService()
+        }
+    }
+    
+    func refreshNearby(userLocation: CLLocation) async {
+        await service.loadNearbyGyms(location: userLocation)
+        syncFromService()
+    }
+    
+    // MARK: - Check In
+    
+    func startCheckIn(gym: Gym) {
+        selectedGym = gym
+        checkInNote = ""
+        checkInIsPublic = true
+        showingCheckInSheet = true
+    }
+    
+    func confirmCheckIn(userId: String) async {
+        guard let gym = selectedGym else { return }
+        isCheckingIn = true
+        defer { isCheckingIn = false }
+        
+        do {
+            try await service.checkIn(
+                userId: userId,
+                gym: gym,
+                note: checkInNote.isEmpty ? nil : checkInNote,
+                isPublic: checkInIsPublic
+            )
+            syncFromService()
+            showingCheckInSheet = false
+            
+            // Load friends at this gym
+            await service.loadFriendCheckIns(gymId: gym.id, userId: userId)
+            syncFromService()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+    
+    // MARK: - Check Out
+    
+    func checkOut() async {
+        isCheckingOut = true
+        defer { isCheckingOut = false }
+        
+        let gymName = activeCheckIn?.gymName ?? "gym"
+        let duration = activeCheckIn?.formattedDuration ?? ""
+        
+        do {
+            try await service.checkOut()
+            syncFromService()
+            checkOutSuccessMessage = "Checked out of \(gymName) after \(duration) 💪"
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+    
+    // MARK: - Helpers
+    
+    private func syncFromService() {
+        activeCheckIn = service.activeCheckIn
+        nearbyGyms = service.nearbyGyms
+        friendCheckIns = service.friendCheckIns
+        recentCheckIns = service.recentCheckIns
+    }
+    
+    func isWithinRange(of gym: Gym, userLocation: CLLocation) -> Bool {
+        service.isWithinRange(of: gym, userLocation: userLocation)
+    }
+    
+    func distanceLabel(to gym: Gym, from userLocation: CLLocation) -> String {
+        service.formattedDistance(to: gym, from: userLocation)
+    }
+    
+    var totalWorkoutsThisMonth: Int {
+        let calendar = Calendar.current
+        let now = Date()
+        return recentCheckIns.filter {
+            calendar.isDate($0.checkedInAt, equalTo: now, toGranularity: .month)
+        }.count
+    }
+}

--- a/XomFit/Views/GymCheckIn/GymCheckInView.swift
+++ b/XomFit/Views/GymCheckIn/GymCheckInView.swift
@@ -1,0 +1,513 @@
+import SwiftUI
+import CoreLocation
+import MapKit
+
+struct GymCheckInView: View {
+    @EnvironmentObject var authService: AuthService
+    @StateObject private var viewModel = GymCheckInViewModel()
+    @StateObject private var locationService = LocationService()
+    
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Theme.background.ignoresSafeArea()
+                
+                if viewModel.isLoading && viewModel.activeCheckIn == nil {
+                    ProgressView("Loading...")
+                        .foregroundStyle(Theme.textSecondary)
+                } else {
+                    ScrollView {
+                        VStack(spacing: Theme.paddingLarge) {
+                            // Active check-in or check-in prompt
+                            activeSection
+                            
+                            // Friends at this gym
+                            if viewModel.activeCheckIn != nil && !viewModel.friendCheckIns.isEmpty {
+                                friendsSection
+                            }
+                            
+                            // Nearby gyms (when not checked in)
+                            if viewModel.activeCheckIn == nil {
+                                nearbySection
+                            }
+                            
+                            // Recent check-ins history
+                            historySection
+                        }
+                        .padding(.horizontal, Theme.paddingMedium)
+                        .padding(.bottom, Theme.paddingLarge)
+                    }
+                    .refreshable {
+                        if let userId = authService.currentUser?.id {
+                            await viewModel.load(userId: userId, userLocation: locationService.lastLocation)
+                        }
+                    }
+                }
+            }
+            .navigationTitle("Gym Check-in")
+            .navigationBarTitleDisplayMode(.large)
+            .sheet(isPresented: $viewModel.showingCheckInSheet) {
+                CheckInSheet(viewModel: viewModel)
+            }
+            .confirmationDialog("Check Out?", isPresented: $viewModel.showingCheckOutConfirm, titleVisibility: .visible) {
+                Button("Check Out", role: .destructive) {
+                    Task { await viewModel.checkOut() }
+                }
+                Button("Cancel", role: .cancel) {}
+            } message: {
+                if let dur = viewModel.activeCheckIn?.formattedDuration {
+                    Text("You've been at \(viewModel.activeCheckIn?.gymName ?? "the gym") for \(dur)")
+                }
+            }
+            .alert("Error", isPresented: Binding(
+                get: { viewModel.errorMessage != nil },
+                set: { if !$0 { viewModel.errorMessage = nil } }
+            )) {
+                Button("OK") { viewModel.errorMessage = nil }
+            } message: {
+                Text(viewModel.errorMessage ?? "")
+            }
+            .alert("Success", isPresented: Binding(
+                get: { viewModel.checkOutSuccessMessage != nil },
+                set: { if !$0 { viewModel.checkOutSuccessMessage = nil } }
+            )) {
+                Button("Nice!") { viewModel.checkOutSuccessMessage = nil }
+            } message: {
+                Text(viewModel.checkOutSuccessMessage ?? "")
+            }
+        }
+        .task {
+            if let userId = authService.currentUser?.id {
+                await viewModel.load(userId: userId, userLocation: locationService.lastLocation)
+            }
+        }
+        .onChange(of: locationService.lastLocation) { _, newLocation in
+            guard let location = newLocation else { return }
+            Task { await viewModel.refreshNearby(userLocation: location) }
+        }
+    }
+    
+    // MARK: - Active Check-In Section
+    
+    @ViewBuilder private var activeSection: some View {
+        if let checkIn = viewModel.activeCheckIn {
+            // Active check-in card
+            VStack(spacing: 16) {
+                HStack {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Label("Checked in", systemImage: "checkmark.circle.fill")
+                            .font(.system(size: 13, weight: .medium))
+                            .foregroundStyle(Theme.accent)
+                        
+                        Text(checkIn.gymName ?? "Gym")
+                            .font(Theme.fontHeadline)
+                            .foregroundStyle(Theme.textPrimary)
+                        
+                        if let addr = checkIn.gymAddress {
+                            Text(addr)
+                                .font(Theme.fontCaption)
+                                .foregroundStyle(Theme.textSecondary)
+                        }
+                    }
+                    
+                    Spacer()
+                    
+                    // Timer
+                    VStack(alignment: .trailing, spacing: 2) {
+                        Image(systemName: "timer")
+                            .font(.system(size: 20))
+                            .foregroundStyle(Theme.accent)
+                        Text(checkIn.formattedDuration)
+                            .font(.system(size: 22, weight: .bold, design: .monospaced))
+                            .foregroundStyle(Theme.textPrimary)
+                    }
+                }
+                
+                if let note = checkIn.note {
+                    HStack {
+                        Text(""\(note)"")
+                            .font(Theme.fontCaption)
+                            .foregroundStyle(Theme.textSecondary)
+                            .italic()
+                        Spacer()
+                    }
+                }
+                
+                // Friends here
+                if !viewModel.friendCheckIns.isEmpty {
+                    HStack(spacing: -8) {
+                        ForEach(viewModel.friendCheckIns.prefix(5)) { friend in
+                            AvatarBubble(name: friend.userDisplayName ?? "?")
+                        }
+                        if viewModel.friendCheckIns.count > 5 {
+                            Text("+\(viewModel.friendCheckIns.count - 5) more")
+                                .font(Theme.fontSmall)
+                                .foregroundStyle(Theme.textSecondary)
+                                .padding(.leading, 12)
+                        }
+                    }
+                }
+                
+                // Check out button
+                Button {
+                    viewModel.showingCheckOutConfirm = true
+                } label: {
+                    if viewModel.isCheckingOut {
+                        ProgressView()
+                            .tint(.black)
+                    } else {
+                        Label("Check Out", systemImage: "arrow.right.circle.fill")
+                            .font(.system(size: 16, weight: .semibold))
+                    }
+                }
+                .frame(maxWidth: .infinity)
+                .frame(height: 48)
+                .foregroundStyle(.black)
+                .background(Theme.accent)
+                .cornerRadius(Theme.cornerRadius)
+                .disabled(viewModel.isCheckingOut)
+            }
+            .padding(Theme.paddingMedium)
+            .background(
+                LinearGradient(
+                    colors: [Theme.accent.opacity(0.15), Theme.cardBackground],
+                    startPoint: .topLeading,
+                    endPoint: .bottomTrailing
+                )
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: Theme.cornerRadius)
+                    .stroke(Theme.accent.opacity(0.4), lineWidth: 1)
+            )
+            .cornerRadius(Theme.cornerRadius)
+        } else {
+            // Not checked in — prompt
+            VStack(spacing: 12) {
+                Image(systemName: "mappin.and.ellipse")
+                    .font(.system(size: 40))
+                    .foregroundStyle(Theme.accent.opacity(0.7))
+                
+                Text("Not checked in")
+                    .font(Theme.fontHeadline)
+                    .foregroundStyle(Theme.textPrimary)
+                
+                Text("Head to a gym and check in to see which friends are there with you.")
+                    .font(Theme.fontCaption)
+                    .foregroundStyle(Theme.textSecondary)
+                    .multilineTextAlignment(.center)
+                
+                if viewModel.nearbyGyms.isEmpty {
+                    Label("Looking for nearby gyms...", systemImage: "location.magnifyingglass")
+                        .font(Theme.fontCaption)
+                        .foregroundStyle(Theme.textSecondary)
+                }
+            }
+            .frame(maxWidth: .infinity)
+            .padding(Theme.paddingLarge)
+            .cardStyle()
+        }
+    }
+    
+    // MARK: - Friends Section
+    
+    @ViewBuilder private var friendsSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Also here now")
+                .font(Theme.fontHeadline)
+                .foregroundStyle(Theme.textPrimary)
+            
+            ForEach(viewModel.friendCheckIns) { friend in
+                FriendCheckInRow(checkIn: friend)
+            }
+        }
+    }
+    
+    // MARK: - Nearby Gyms Section
+    
+    @ViewBuilder private var nearbySection: some View {
+        if !viewModel.nearbyGyms.isEmpty {
+            VStack(alignment: .leading, spacing: 12) {
+                Text("Nearby Gyms")
+                    .font(Theme.fontHeadline)
+                    .foregroundStyle(Theme.textPrimary)
+                
+                ForEach(viewModel.nearbyGyms) { gym in
+                    NearbyGymRow(
+                        gym: gym,
+                        distanceLabel: locationService.lastLocation.map { loc in
+                            viewModel.distanceLabel(to: gym, from: loc)
+                        },
+                        inRange: locationService.lastLocation.map { loc in
+                            viewModel.isWithinRange(of: gym, userLocation: loc)
+                        } ?? false
+                    ) {
+                        viewModel.startCheckIn(gym: gym)
+                    }
+                }
+            }
+        }
+    }
+    
+    // MARK: - History Section
+    
+    @ViewBuilder private var historySection: some View {
+        if !viewModel.recentCheckIns.isEmpty {
+            VStack(alignment: .leading, spacing: 12) {
+                HStack {
+                    Text("Recent Check-ins")
+                        .font(Theme.fontHeadline)
+                        .foregroundStyle(Theme.textPrimary)
+                    Spacer()
+                    Text("\(viewModel.totalWorkoutsThisMonth) this month")
+                        .font(Theme.fontCaption)
+                        .foregroundStyle(Theme.accent)
+                }
+                
+                ForEach(viewModel.recentCheckIns.prefix(10)) { checkIn in
+                    CheckInHistoryRow(checkIn: checkIn)
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Check-In Sheet
+
+struct CheckInSheet: View {
+    @ObservedObject var viewModel: GymCheckInViewModel
+    @EnvironmentObject var authService: AuthService
+    @Environment(\.dismiss) private var dismiss
+    
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Theme.background.ignoresSafeArea()
+                
+                VStack(spacing: Theme.paddingLarge) {
+                    // Gym info
+                    if let gym = viewModel.selectedGym {
+                        VStack(spacing: 8) {
+                            Image(systemName: "dumbbell.fill")
+                                .font(.system(size: 40))
+                                .foregroundStyle(Theme.accent)
+                            Text(gym.name)
+                                .font(Theme.fontHeadline)
+                                .foregroundStyle(Theme.textPrimary)
+                            if let addr = gym.address {
+                                Text(addr)
+                                    .font(Theme.fontCaption)
+                                    .foregroundStyle(Theme.textSecondary)
+                            }
+                        }
+                        .frame(maxWidth: .infinity)
+                        .padding(Theme.paddingLarge)
+                        .cardStyle()
+                    }
+                    
+                    // Note
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Session Note (optional)")
+                            .font(Theme.fontCaption)
+                            .foregroundStyle(Theme.textSecondary)
+                        TextField("e.g. Leg day 🦵, PR attempt...", text: $viewModel.checkInNote, axis: .vertical)
+                            .lineLimit(2, reservesSpace: true)
+                            .padding(Theme.paddingMedium)
+                            .background(Theme.cardBackground)
+                            .cornerRadius(Theme.cornerRadius)
+                            .font(Theme.fontBody)
+                            .foregroundStyle(Theme.textPrimary)
+                    }
+                    
+                    // Privacy
+                    Toggle(isOn: $viewModel.checkInIsPublic) {
+                        HStack(spacing: 8) {
+                            Image(systemName: viewModel.checkInIsPublic ? "globe" : "lock.fill")
+                                .foregroundStyle(viewModel.checkInIsPublic ? Theme.accent : Theme.textSecondary)
+                            VStack(alignment: .leading) {
+                                Text(viewModel.checkInIsPublic ? "Public" : "Private")
+                                    .font(Theme.fontBody)
+                                    .foregroundStyle(Theme.textPrimary)
+                                Text(viewModel.checkInIsPublic ? "Friends can see you're here" : "Only visible to you")
+                                    .font(Theme.fontCaption)
+                                    .foregroundStyle(Theme.textSecondary)
+                            }
+                        }
+                    }
+                    .tint(Theme.accent)
+                    .padding(Theme.paddingMedium)
+                    .background(Theme.cardBackground)
+                    .cornerRadius(Theme.cornerRadius)
+                    
+                    Spacer()
+                    
+                    // Check in button
+                    Button {
+                        Task {
+                            guard let userId = authService.currentUser?.id else { return }
+                            await viewModel.confirmCheckIn(userId: userId)
+                        }
+                    } label: {
+                        if viewModel.isCheckingIn {
+                            ProgressView().tint(.black)
+                        } else {
+                            Label("Check In Now", systemImage: "checkmark.circle.fill")
+                                .font(.system(size: 17, weight: .semibold))
+                        }
+                    }
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 52)
+                    .foregroundStyle(.black)
+                    .background(Theme.accent)
+                    .cornerRadius(Theme.cornerRadius)
+                    .disabled(viewModel.isCheckingIn)
+                }
+                .padding(Theme.paddingMedium)
+            }
+            .navigationTitle("Check In")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button("Cancel") { dismiss() }
+                        .foregroundStyle(Theme.textSecondary)
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Supporting Views
+
+private struct AvatarBubble: View {
+    let name: String
+    var initials: String {
+        name.split(separator: " ").compactMap { $0.first }.map(String.init).joined()
+    }
+    
+    var body: some View {
+        ZStack {
+            Circle()
+                .fill(Theme.accent.opacity(0.8))
+                .frame(width: 32, height: 32)
+                .overlay(Circle().stroke(Theme.background, lineWidth: 2))
+            Text(String(initials.prefix(2)))
+                .font(.system(size: 11, weight: .bold))
+                .foregroundStyle(.black)
+        }
+    }
+}
+
+private struct FriendCheckInRow: View {
+    let checkIn: GymCheckIn
+    
+    var body: some View {
+        HStack(spacing: 12) {
+            AvatarBubble(name: checkIn.userDisplayName ?? "?")
+                .scaleEffect(1.2)
+            
+            VStack(alignment: .leading, spacing: 2) {
+                Text(checkIn.userDisplayName ?? "Friend")
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundStyle(Theme.textPrimary)
+                Text("Here for \(checkIn.formattedDuration)")
+                    .font(Theme.fontCaption)
+                    .foregroundStyle(Theme.textSecondary)
+            }
+            
+            Spacer()
+            
+            Image(systemName: "dumbbell.fill")
+                .foregroundStyle(Theme.accent.opacity(0.6))
+        }
+        .padding(Theme.paddingMedium)
+        .cardStyle()
+    }
+}
+
+private struct NearbyGymRow: View {
+    let gym: Gym
+    let distanceLabel: String?
+    let inRange: Bool
+    let onCheckIn: () -> Void
+    
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "mappin.circle.fill")
+                .font(.system(size: 28))
+                .foregroundStyle(inRange ? Theme.accent : Theme.textSecondary)
+            
+            VStack(alignment: .leading, spacing: 4) {
+                Text(gym.name)
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundStyle(Theme.textPrimary)
+                if let dist = distanceLabel {
+                    Text(dist)
+                        .font(Theme.fontCaption)
+                        .foregroundStyle(Theme.textSecondary)
+                }
+            }
+            
+            Spacer()
+            
+            if inRange {
+                Button("Check In") { onCheckIn() }
+                    .font(.system(size: 13, weight: .semibold))
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 7)
+                    .background(Theme.accent)
+                    .foregroundStyle(.black)
+                    .cornerRadius(20)
+            } else {
+                Text("Out of range")
+                    .font(Theme.fontSmall)
+                    .foregroundStyle(Theme.textSecondary)
+            }
+        }
+        .padding(Theme.paddingMedium)
+        .cardStyle()
+    }
+}
+
+private struct CheckInHistoryRow: View {
+    let checkIn: GymCheckIn
+    
+    var body: some View {
+        HStack(spacing: 12) {
+            VStack(alignment: .center, spacing: 2) {
+                Text(checkIn.checkedInAt.formatted(.dateTime.month(.abbreviated)))
+                    .font(Theme.fontSmall)
+                    .foregroundStyle(Theme.textSecondary)
+                Text(checkIn.checkedInAt.formatted(.dateTime.day()))
+                    .font(.system(size: 18, weight: .bold))
+                    .foregroundStyle(Theme.textPrimary)
+            }
+            .frame(width: 36)
+            
+            VStack(alignment: .leading, spacing: 4) {
+                Text(checkIn.gymName ?? "Gym")
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundStyle(Theme.textPrimary)
+                
+                HStack(spacing: 8) {
+                    Label(checkIn.checkedInAt.formatted(.dateTime.hour().minute()),
+                          systemImage: "clock")
+                        .font(Theme.fontCaption)
+                        .foregroundStyle(Theme.textSecondary)
+                    
+                    if !checkIn.formattedDuration.isEmpty {
+                        Text("· \(checkIn.formattedDuration)")
+                            .font(Theme.fontCaption)
+                            .foregroundStyle(Theme.accent)
+                    }
+                }
+            }
+            
+            Spacer()
+            
+            Image(systemName: "checkmark.circle.fill")
+                .foregroundStyle(Theme.accent.opacity(0.5))
+        }
+        .padding(12)
+        .background(Theme.cardBackground)
+        .cornerRadius(Theme.cornerRadiusSmall)
+    }
+}

--- a/supabase/migrations/20260228_gym_checkins.sql
+++ b/supabase/migrations/20260228_gym_checkins.sql
@@ -1,0 +1,99 @@
+-- Gyms table
+CREATE TABLE IF NOT EXISTS gyms (
+    id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name        TEXT NOT NULL,
+    address     TEXT,
+    latitude    DOUBLE PRECISION NOT NULL,
+    longitude   DOUBLE PRECISION NOT NULL,
+    logo_url    TEXT,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Spatial index for nearby gym queries
+CREATE INDEX idx_gyms_location ON gyms (latitude, longitude);
+
+-- PostGIS function for nearby gyms (uses Haversine formula)
+CREATE OR REPLACE FUNCTION nearby_gyms(lat FLOAT, lng FLOAT, radius_meters FLOAT)
+RETURNS SETOF gyms
+LANGUAGE sql STABLE AS $$
+    SELECT *
+    FROM gyms
+    WHERE (
+        6371000 * acos(
+            cos(radians(lat)) * cos(radians(latitude))
+            * cos(radians(longitude) - radians(lng))
+            + sin(radians(lat)) * sin(radians(latitude))
+        )
+    ) <= radius_meters
+    ORDER BY (
+        6371000 * acos(
+            cos(radians(lat)) * cos(radians(latitude))
+            * cos(radians(longitude) - radians(lng))
+            + sin(radians(lat)) * sin(radians(latitude))
+        )
+    );
+$$;
+
+-- Gym Check-ins table
+CREATE TABLE IF NOT EXISTS gym_checkins (
+    id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id             TEXT NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    gym_id              UUID NOT NULL REFERENCES gyms(id) ON DELETE CASCADE,
+    gym_name            TEXT,           -- Denormalized for query convenience
+    gym_address         TEXT,
+    checked_in_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+    checked_out_at      TIMESTAMPTZ,    -- NULL = currently active
+    note                TEXT,
+    is_public           BOOLEAN NOT NULL DEFAULT true,
+    
+    -- Denormalized display info (filled by trigger from profiles)
+    user_display_name   TEXT,
+    user_avatar_url     TEXT,
+    user_username       TEXT,
+    
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Indexes
+CREATE INDEX idx_gym_checkins_user         ON gym_checkins(user_id);
+CREATE INDEX idx_gym_checkins_gym_active   ON gym_checkins(gym_id) WHERE checked_out_at IS NULL;
+CREATE INDEX idx_gym_checkins_checked_in   ON gym_checkins(user_id, checked_in_at DESC);
+
+-- Row Level Security
+ALTER TABLE gym_checkins ENABLE ROW LEVEL SECURITY;
+ALTER TABLE gyms ENABLE ROW LEVEL SECURITY;
+
+-- Gyms are readable by all authenticated users
+CREATE POLICY "Gyms are publicly readable"
+    ON gyms FOR SELECT
+    TO authenticated
+    USING (true);
+
+-- Users can read their own check-ins
+CREATE POLICY "Users can view own check-ins"
+    ON gym_checkins FOR SELECT
+    USING (auth.uid()::text = user_id);
+
+-- Users can read public check-ins
+CREATE POLICY "Users can view public check-ins"
+    ON gym_checkins FOR SELECT
+    USING (is_public = true);
+
+-- Users can insert their own check-ins
+CREATE POLICY "Users can insert own check-ins"
+    ON gym_checkins FOR INSERT
+    WITH CHECK (auth.uid()::text = user_id);
+
+-- Users can update their own check-ins (e.g. check-out)
+CREATE POLICY "Users can update own check-ins"
+    ON gym_checkins FOR UPDATE
+    USING (auth.uid()::text = user_id);
+
+-- Seed some gyms (example data — replace with real gym data)
+INSERT INTO gyms (name, address, latitude, longitude) VALUES
+    ('Equinox Midtown', '1633 Broadway, New York, NY 10019', 40.7614, -73.9836),
+    ('Planet Fitness - Times Square', '234 W 42nd St, New York, NY 10036', 40.7563, -73.9888),
+    ('Crunch Fitness - Union Square', '90 E 16th St, New York, NY 10003', 40.7368, -73.9890),
+    ('NYSC - Upper West Side', '2162 Broadway, New York, NY 10024', 40.7847, -73.9814),
+    ('Barry''s Bootcamp - Flatiron', '29 W 20th St, New York, NY 10011', 40.7419, -73.9940)
+ON CONFLICT DO NOTHING;


### PR DESCRIPTION
Closes #19

## Feature Overview

Location-based gym check-in system. Check in when you arrive at the gym, see which friends are there with you, and track your workout history.

## User Flow

1. Open Check-in tab → app detects nearby gyms within 300m
2. Tap 'Check In' on your gym → optional note + public/private setting → confirm
3. While active: timer shows session duration, see friends who are also checked in
4. Tap 'Check Out' → success toast with total session time
5. History tab shows all past check-ins with date, duration, gym

## Friend Visibility

- Public check-ins appear to followers at the same gym
- Avatar bubbles show up to 5 friends in the active check-in card
- Friend rows show how long they've been there

## Files

```
XomFit/Models/GymCheckIn.swift          — Gym + GymCheckIn models + mock data
XomFit/Services/GymCheckInService.swift — Supabase CRUD, nearby_gyms RPC, friend query
XomFit/Services/LocationService.swift   — CLLocationManager wrapper (@MainActor safe)
XomFit/ViewModels/GymCheckInViewModel.swift — Full state management
XomFit/Views/GymCheckIn/GymCheckInView.swift — Complete UI
supabase/migrations/20260228_gym_checkins.sql — Tables + RLS + Haversine function
```

## Database

- `gyms` table with `nearby_gyms(lat, lng, radius_meters)` SQL function (Haversine)
- `gym_checkins` table with RLS: own check-ins + public check-ins visible
- Spatial indexes for performance
- 5 NYC seed gyms for dev

## Required

- Add `NSLocationWhenInUseUsageDescription` to `Info.plist`
- Run `supabase/migrations/20260228_gym_checkins.sql`