### PR TITLE
feat: Push Notifications — APNs, preferences, workout reminders, deep links

### DIFF
--- a/XomFit/Models/NotificationTypes.swift
+++ b/XomFit/Models/NotificationTypes.swift
@@ -1,0 +1,157 @@
+import Foundation
+
+// MARK: - Notification Categories
+enum NotificationCategory: String, CaseIterable {
+    case friendActivity = "friend_activity"
+    case personalRecords = "personal_records"
+    case workoutReminders = "workout_reminders"
+    case challenges = "challenges"
+    case social = "social"
+    case system = "system"
+    
+    var displayName: String {
+        switch self {
+        case .friendActivity: return "Friend Activity"
+        case .personalRecords: return "Personal Records"
+        case .workoutReminders: return "Workout Reminders"
+        case .challenges: return "Challenges"
+        case .social: return "Social"
+        case .system: return "System"
+        }
+    }
+    
+    var description: String {
+        switch self {
+        case .friendActivity: return "When friends hit PRs, complete workouts, or check in"
+        case .personalRecords: return "When you set a new personal record"
+        case .workoutReminders: return "Daily workout reminders at your scheduled time"
+        case .challenges: return "Challenge updates, completions, and leaderboard changes"
+        case .social: return "Comments, reactions, and mentions on your posts"
+        case .system: return "App updates and important announcements"
+        }
+    }
+    
+    var systemImage: String {
+        switch self {
+        case .friendActivity: return "figure.strengthtraining.traditional"
+        case .personalRecords: return "trophy.fill"
+        case .workoutReminders: return "alarm.fill"
+        case .challenges: return "flag.fill"
+        case .social: return "bubble.left.and.bubble.right.fill"
+        case .system: return "bell.fill"
+        }
+    }
+}
+
+// MARK: - Notification Types
+enum NotificationType: String {
+    // Friend activity
+    case friendPR = "friend_pr"
+    case friendWorkoutComplete = "friend_workout_complete"
+    case friendCheckIn = "friend_check_in"
+    
+    // Personal records
+    case newPR = "new_pr"
+    case PRStreakMilestone = "pr_streak_milestone"
+    
+    // Workout reminders
+    case workoutReminder = "workout_reminder"
+    case missedWorkoutStreak = "missed_workout_streak"
+    case streakCelebration = "streak_celebration"
+    
+    // Challenges
+    case challengeInvite = "challenge_invite"
+    case challengeUpdate = "challenge_update"
+    case challengeComplete = "challenge_complete"
+    case leaderboardChange = "leaderboard_change"
+    
+    // Social
+    case comment = "comment"
+    case reaction = "reaction"
+    case mention = "mention"
+    case friendRequest = "friend_request"
+    case friendRequestAccepted = "friend_request_accepted"
+    
+    var category: NotificationCategory {
+        switch self {
+        case .friendPR, .friendWorkoutComplete, .friendCheckIn: return .friendActivity
+        case .newPR, .PRStreakMilestone: return .personalRecords
+        case .workoutReminder, .missedWorkoutStreak, .streakCelebration: return .workoutReminders
+        case .challengeInvite, .challengeUpdate, .challengeComplete, .leaderboardChange: return .challenges
+        case .comment, .reaction, .mention, .friendRequest, .friendRequestAccepted: return .social
+        }
+    }
+}
+
+// MARK: - Notification Preferences
+struct NotificationPreferences: Codable {
+    var userId: String
+    var isEnabled: Bool
+    
+    // Category toggles
+    var friendActivity: Bool
+    var personalRecords: Bool
+    var workoutReminders: Bool
+    var challenges: Bool
+    var social: Bool
+    
+    // Workout reminder time
+    var reminderHour: Int    // 0-23
+    var reminderMinute: Int  // 0-59
+    var reminderDays: [Int]  // 0=Sun...6=Sat
+    
+    enum CodingKeys: String, CodingKey {
+        case userId = "user_id"
+        case isEnabled = "is_enabled"
+        case friendActivity = "friend_activity"
+        case personalRecords = "personal_records"
+        case workoutReminders = "workout_reminders"
+        case challenges
+        case social
+        case reminderHour = "reminder_hour"
+        case reminderMinute = "reminder_minute"
+        case reminderDays = "reminder_days"
+    }
+    
+    static func defaultPrefs(userId: String) -> NotificationPreferences {
+        NotificationPreferences(
+            userId: userId,
+            isEnabled: true,
+            friendActivity: true,
+            personalRecords: true,
+            workoutReminders: true,
+            challenges: true,
+            social: true,
+            reminderHour: 8,
+            reminderMinute: 0,
+            reminderDays: [1, 2, 3, 4, 5]  // Mon-Fri
+        )
+    }
+    
+    func isEnabled(for category: NotificationCategory) -> Bool {
+        switch category {
+        case .friendActivity: return friendActivity
+        case .personalRecords: return personalRecords
+        case .workoutReminders: return workoutReminders
+        case .challenges: return challenges
+        case .social: return social
+        case .system: return true  // Always enabled
+        }
+    }
+    
+    var reminderTimeDescription: String {
+        let hour = reminderHour
+        let min = reminderMinute
+        let amPm = hour < 12 ? "AM" : "PM"
+        let displayHour = hour == 0 ? 12 : (hour > 12 ? hour - 12 : hour)
+        return String(format: "%d:%02d %@", displayHour, min, amPm)
+    }
+    
+    var reminderDaysDescription: String {
+        let dayNames = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
+        if reminderDays == [0, 1, 2, 3, 4, 5, 6] { return "Every day" }
+        if reminderDays == [1, 2, 3, 4, 5] { return "Weekdays" }
+        if reminderDays == [0, 6] { return "Weekends" }
+        return reminderDays.map { dayNames[$0] }.joined(separator: ", ")
+    }
+}

--- a/XomFit/Services/NotificationService.swift
+++ b/XomFit/Services/NotificationService.swift
@@ -1,0 +1,272 @@
+import Foundation
+import UserNotifications
+import UIKit
+import OSLog
+import Supabase
+
+private let logger = Logger(subsystem: "com.xomware.xomfit", category: "Notifications")
+
+@MainActor
+final class NotificationService: NSObject, ObservableObject {
+    static let shared = NotificationService()
+    
+    // MARK: - Published State
+    @Published var authStatus: UNAuthorizationStatus = .notDetermined
+    @Published var preferences: NotificationPreferences?
+    @Published var isLoading = false
+    
+    private override init() {
+        super.init()
+        UNUserNotificationCenter.current().delegate = self
+        Task { await checkAuthStatus() }
+    }
+    
+    // MARK: - Permission
+    
+    /// Request push notification permission from the user
+    func requestPermission() async -> Bool {
+        do {
+            let granted = try await UNUserNotificationCenter.current()
+                .requestAuthorization(options: [.alert, .badge, .sound])
+            
+            authStatus = granted ? .authorized : .denied
+            
+            if granted {
+                await registerForRemoteNotifications()
+            }
+            
+            logger.info("Notification permission: \(granted ? "granted" : "denied")")
+            return granted
+        } catch {
+            logger.error("Failed to request notification permission: \(error)")
+            return false
+        }
+    }
+    
+    func checkAuthStatus() async {
+        let settings = await UNUserNotificationCenter.current().notificationSettings()
+        authStatus = settings.authorizationStatus
+    }
+    
+    // MARK: - Device Token Registration
+    
+    @MainActor
+    func registerForRemoteNotifications() async {
+        await MainActor.run {
+            UIApplication.shared.registerForRemoteNotifications()
+        }
+    }
+    
+    /// Called from AppDelegate/SceneDelegate after APNs returns a device token
+    func registerDeviceToken(_ tokenData: Data, userId: String) async {
+        let tokenString = tokenData.map { String(format: "%02.2hhx", $0) }.joined()
+        logger.info("Registering device token for user \(userId): \(tokenString.prefix(20))...")
+        
+        do {
+            try await supabase
+                .from("push_tokens")
+                .upsert([
+                    "user_id": userId,
+                    "token": tokenString,
+                    "platform": "ios",
+                    "app_version": Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown",
+                    "updated_at": ISO8601DateFormatter().string(from: Date())
+                ], onConflict: "user_id,token")
+                .execute()
+            
+            logger.info("Device token registered successfully")
+        } catch {
+            logger.error("Failed to register device token: \(error)")
+        }
+    }
+    
+    /// Remove device token on sign-out
+    func unregisterDeviceToken(_ token: String, userId: String) async {
+        do {
+            try await supabase
+                .from("push_tokens")
+                .delete()
+                .eq("user_id", value: userId)
+                .eq("token", value: token)
+                .execute()
+        } catch {
+            logger.error("Failed to unregister device token: \(error)")
+        }
+    }
+    
+    // MARK: - Preferences
+    
+    func loadPreferences(userId: String) async {
+        isLoading = true
+        defer { isLoading = false }
+        
+        do {
+            let prefs: [NotificationPreferences] = try await supabase
+                .from("notification_preferences")
+                .select()
+                .eq("user_id", value: userId)
+                .limit(1)
+                .execute()
+                .value
+            
+            if let pref = prefs.first {
+                preferences = pref
+            } else {
+                // Create default preferences
+                let defaults = NotificationPreferences.defaultPrefs(userId: userId)
+                preferences = defaults
+                try await savePreferences(defaults)
+            }
+        } catch {
+            logger.error("Failed to load notification preferences: \(error)")
+            preferences = NotificationPreferences.defaultPrefs(userId: userId)
+        }
+    }
+    
+    func savePreferences(_ prefs: NotificationPreferences) async throws {
+        try await supabase
+            .from("notification_preferences")
+            .upsert(prefs, onConflict: "user_id")
+            .execute()
+        
+        preferences = prefs
+        
+        // Reschedule local workout reminders
+        if prefs.workoutReminders && prefs.isEnabled {
+            scheduleWorkoutReminders(prefs)
+        } else {
+            cancelWorkoutReminders()
+        }
+        
+        logger.info("Saved notification preferences for user \(prefs.userId)")
+    }
+    
+    // MARK: - Local Workout Reminders
+    
+    func scheduleWorkoutReminders(_ prefs: NotificationPreferences) {
+        cancelWorkoutReminders()
+        
+        guard prefs.isEnabled && prefs.workoutReminders else { return }
+        
+        let content = UNMutableNotificationContent()
+        content.title = "Time to train 💪"
+        content.body = "Keep your streak alive. Your gym session awaits."
+        content.sound = .default
+        content.badge = 1
+        
+        for dayIndex in prefs.reminderDays {
+            var dateComponents = DateComponents()
+            dateComponents.hour = prefs.reminderHour
+            dateComponents.minute = prefs.reminderMinute
+            dateComponents.weekday = dayIndex + 1  // Calendar uses 1=Sun
+            
+            let trigger = UNCalendarNotificationTrigger(
+                dateMatching: dateComponents,
+                repeats: true
+            )
+            
+            let request = UNNotificationRequest(
+                identifier: "workout_reminder_day_\(dayIndex)",
+                content: content,
+                trigger: trigger
+            )
+            
+            UNUserNotificationCenter.current().add(request) { error in
+                if let error {
+                    logger.error("Failed to schedule reminder for day \(dayIndex): \(error)")
+                }
+            }
+        }
+        
+        logger.info("Scheduled workout reminders for \(prefs.reminderDays.count) days")
+    }
+    
+    func cancelWorkoutReminders() {
+        let ids = (0...6).map { "workout_reminder_day_\($0)" }
+        UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: ids)
+    }
+    
+    // MARK: - Deep Link Handling
+    
+    /// Parse a push notification payload into a deep link destination
+    func deepLinkDestination(from userInfo: [AnyHashable: Any]) -> NotificationDeepLink? {
+        guard let type = userInfo["type"] as? String,
+              let notifType = NotificationType(rawValue: type) else { return nil }
+        
+        switch notifType {
+        case .friendPR, .friendWorkoutComplete:
+            if let userId = userInfo["user_id"] as? String {
+                return .profile(userId: userId)
+            }
+        case .newPR, .PRStreakMilestone:
+            if let exerciseId = userInfo["exercise_id"] as? String {
+                return .exercise(exerciseId: exerciseId)
+            }
+        case .comment, .reaction, .mention:
+            if let workoutId = userInfo["workout_id"] as? String {
+                return .workout(workoutId: workoutId)
+            }
+        case .friendRequest, .friendRequestAccepted:
+            if let userId = userInfo["user_id"] as? String {
+                return .profile(userId: userId)
+            }
+        case .challengeInvite, .challengeUpdate, .challengeComplete:
+            if let challengeId = userInfo["challenge_id"] as? String {
+                return .challenge(challengeId: challengeId)
+            }
+        default:
+            break
+        }
+        
+        return nil
+    }
+}
+
+// MARK: - Deep Link Destination
+
+enum NotificationDeepLink {
+    case profile(userId: String)
+    case workout(workoutId: String)
+    case exercise(exerciseId: String)
+    case challenge(challengeId: String)
+    case checkIn
+}
+
+// MARK: - UNUserNotificationCenterDelegate
+
+extension NotificationService: UNUserNotificationCenterDelegate {
+    
+    /// Called when notification arrives while app is in foreground
+    nonisolated func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification
+    ) async -> UNNotificationPresentationOptions {
+        logger.debug("Received foreground notification: \(notification.request.identifier)")
+        return [.banner, .sound, .badge]
+    }
+    
+    /// Called when user taps a notification
+    nonisolated func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse
+    ) async {
+        let userInfo = response.notification.request.content.userInfo
+        logger.debug("User tapped notification with type: \(userInfo["type"] as? String ?? "unknown")")
+        
+        // Post deep link notification for the app to handle
+        await MainActor.run {
+            NotificationCenter.default.post(
+                name: .notificationDeepLink,
+                object: nil,
+                userInfo: userInfo
+            )
+        }
+    }
+}
+
+// MARK: - Notification Name Extension
+
+extension Notification.Name {
+    static let notificationDeepLink = Notification.Name("XomFitNotificationDeepLink")
+    static let deviceTokenReceived = Notification.Name("XomFitDeviceTokenReceived")
+}

--- a/XomFit/Views/Settings/NotificationSettingsView.swift
+++ b/XomFit/Views/Settings/NotificationSettingsView.swift
@@ -1,0 +1,410 @@
+import SwiftUI
+import UserNotifications
+
+struct NotificationSettingsView: View {
+    @EnvironmentObject var authService: AuthService
+    @StateObject private var notifService = NotificationService.shared
+    @State private var showingTimePicker = false
+    @State private var isSaving = false
+    @State private var saveError: String?
+    
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Theme.background.ignoresSafeArea()
+                
+                if notifService.isLoading {
+                    ProgressView("Loading settings...")
+                        .foregroundStyle(Theme.textSecondary)
+                } else {
+                    ScrollView {
+                        VStack(spacing: Theme.paddingLarge) {
+                            // Permission status
+                            permissionSection
+                            
+                            if notifService.authStatus == .authorized,
+                               let prefs = notifService.preferences {
+                                // Master toggle
+                                masterToggleSection(prefs: prefs)
+                                
+                                if prefs.isEnabled {
+                                    // Category toggles
+                                    categorySection(prefs: prefs)
+                                    
+                                    // Workout reminder schedule
+                                    reminderSection(prefs: prefs)
+                                }
+                            }
+                        }
+                        .padding(.horizontal, Theme.paddingMedium)
+                        .padding(.bottom, Theme.paddingLarge)
+                    }
+                }
+            }
+            .navigationTitle("Notifications")
+            .navigationBarTitleDisplayMode(.large)
+            .alert("Error", isPresented: Binding(
+                get: { saveError != nil },
+                set: { if !$0 { saveError = nil } }
+            )) {
+                Button("OK") { saveError = nil }
+            } message: {
+                Text(saveError ?? "")
+            }
+        }
+        .task {
+            await notifService.checkAuthStatus()
+            if let userId = authService.currentUser?.id {
+                await notifService.loadPreferences(userId: userId)
+            }
+        }
+    }
+    
+    // MARK: - Permission Section
+    
+    @ViewBuilder private var permissionSection: some View {
+        switch notifService.authStatus {
+        case .authorized:
+            // All good — no banner needed
+            EmptyView()
+            
+        case .denied:
+            HStack(spacing: 12) {
+                Image(systemName: "bell.slash.fill")
+                    .font(.title2)
+                    .foregroundStyle(Theme.destructive)
+                
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Notifications Disabled")
+                        .font(.system(size: 15, weight: .semibold))
+                        .foregroundStyle(Theme.textPrimary)
+                    Text("Enable in Settings to receive alerts")
+                        .font(Theme.fontCaption)
+                        .foregroundStyle(Theme.textSecondary)
+                }
+                
+                Spacer()
+                
+                Button("Open Settings") {
+                    if let url = URL(string: UIApplication.openSettingsURLString) {
+                        UIApplication.shared.open(url)
+                    }
+                }
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(Theme.accent)
+            }
+            .padding(Theme.paddingMedium)
+            .background(Theme.destructive.opacity(0.1))
+            .cornerRadius(Theme.cornerRadius)
+            
+        case .notDetermined:
+            VStack(spacing: 12) {
+                Image(systemName: "bell.badge.fill")
+                    .font(.system(size: 40))
+                    .foregroundStyle(Theme.accent)
+                
+                Text("Stay in the loop")
+                    .font(Theme.fontHeadline)
+                    .foregroundStyle(Theme.textPrimary)
+                
+                Text("Get notified when friends hit PRs, when it's time to train, and more.")
+                    .font(Theme.fontCaption)
+                    .foregroundStyle(Theme.textSecondary)
+                    .multilineTextAlignment(.center)
+                
+                Button {
+                    Task { await notifService.requestPermission() }
+                } label: {
+                    Text("Enable Notifications")
+                        .font(.system(size: 16, weight: .semibold))
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 48)
+                        .foregroundStyle(.black)
+                        .background(Theme.accent)
+                        .cornerRadius(Theme.cornerRadius)
+                }
+            }
+            .padding(Theme.paddingLarge)
+            .cardStyle()
+            
+        default:
+            EmptyView()
+        }
+    }
+    
+    // MARK: - Master Toggle
+    
+    @ViewBuilder private func masterToggleSection(prefs: NotificationPreferences) -> some View {
+        Toggle(isOn: Binding(
+            get: { prefs.isEnabled },
+            set: { newVal in
+                guard var updated = notifService.preferences else { return }
+                updated = NotificationPreferences(
+                    userId: updated.userId,
+                    isEnabled: newVal,
+                    friendActivity: updated.friendActivity,
+                    personalRecords: updated.personalRecords,
+                    workoutReminders: updated.workoutReminders,
+                    challenges: updated.challenges,
+                    social: updated.social,
+                    reminderHour: updated.reminderHour,
+                    reminderMinute: updated.reminderMinute,
+                    reminderDays: updated.reminderDays
+                )
+                save(updated)
+            }
+        )) {
+            HStack(spacing: 10) {
+                Image(systemName: "bell.fill")
+                    .foregroundStyle(Theme.accent)
+                Text("All Notifications")
+                    .font(.system(size: 16, weight: .medium))
+                    .foregroundStyle(Theme.textPrimary)
+            }
+        }
+        .tint(Theme.accent)
+        .padding(Theme.paddingMedium)
+        .background(Theme.cardBackground)
+        .cornerRadius(Theme.cornerRadius)
+    }
+    
+    // MARK: - Category Section
+    
+    @ViewBuilder private func categorySection(prefs: NotificationPreferences) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Notification Types")
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(Theme.textSecondary)
+                .textCase(.uppercase)
+                .tracking(0.5)
+            
+            VStack(spacing: 0) {
+                ForEach(Array(NotificationCategory.allCases.enumerated()), id: \.element) { idx, category in
+                    if category != .system {
+                        CategoryToggleRow(
+                            category: category,
+                            isEnabled: prefs.isEnabled(for: category)
+                        ) { newValue in
+                            guard var updated = notifService.preferences else { return }
+                            switch category {
+                            case .friendActivity: updated = mutate(updated, friendActivity: newValue)
+                            case .personalRecords: updated = mutate(updated, personalRecords: newValue)
+                            case .workoutReminders: updated = mutate(updated, workoutReminders: newValue)
+                            case .challenges: updated = mutate(updated, challenges: newValue)
+                            case .social: updated = mutate(updated, social: newValue)
+                            case .system: break
+                            }
+                            save(updated)
+                        }
+                        
+                        if idx < NotificationCategory.allCases.count - 2 {
+                            Divider()
+                                .background(Theme.background)
+                        }
+                    }
+                }
+            }
+            .background(Theme.cardBackground)
+            .cornerRadius(Theme.cornerRadius)
+        }
+    }
+    
+    // MARK: - Reminder Schedule
+    
+    @ViewBuilder private func reminderSection(prefs: NotificationPreferences) -> some View {
+        if prefs.workoutReminders {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Workout Reminder Schedule")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(Theme.textSecondary)
+                    .textCase(.uppercase)
+                    .tracking(0.5)
+                
+                VStack(spacing: 0) {
+                    // Time
+                    NavigationLink {
+                        ReminderTimePickerView(
+                            hour: prefs.reminderHour,
+                            minute: prefs.reminderMinute
+                        ) { h, m in
+                            guard var updated = notifService.preferences else { return }
+                            updated = mutate(updated, reminderHour: h, reminderMinute: m)
+                            save(updated)
+                        }
+                    } label: {
+                        HStack {
+                            Label("Time", systemImage: "clock.fill")
+                                .foregroundStyle(Theme.textPrimary)
+                                .font(Theme.fontBody)
+                            Spacer()
+                            Text(prefs.reminderTimeDescription)
+                                .foregroundStyle(Theme.accent)
+                                .font(Theme.fontBody)
+                            Image(systemName: "chevron.right")
+                                .font(.caption)
+                                .foregroundStyle(Theme.textSecondary)
+                        }
+                        .padding(Theme.paddingMedium)
+                    }
+                    
+                    Divider().background(Theme.background)
+                    
+                    // Days
+                    VStack(alignment: .leading, spacing: 10) {
+                        Label("Days", systemImage: "calendar")
+                            .foregroundStyle(Theme.textPrimary)
+                            .font(Theme.fontBody)
+                        
+                        HStack(spacing: 8) {
+                            ForEach(0..<7, id: \.self) { day in
+                                let dayNames = ["S", "M", "T", "W", "T", "F", "S"]
+                                let isSelected = prefs.reminderDays.contains(day)
+                                
+                                Button {
+                                    guard var updated = notifService.preferences else { return }
+                                    var days = updated.reminderDays
+                                    if isSelected { days.removeAll { $0 == day } } else { days.append(day) }
+                                    days.sort()
+                                    updated = mutate(updated, reminderDays: days)
+                                    save(updated)
+                                } label: {
+                                    Text(dayNames[day])
+                                        .font(.system(size: 13, weight: .semibold))
+                                        .frame(width: 36, height: 36)
+                                        .background(isSelected ? Theme.accent : Theme.secondaryBackground)
+                                        .foregroundStyle(isSelected ? .black : Theme.textSecondary)
+                                        .cornerRadius(18)
+                                }
+                            }
+                        }
+                        
+                        Text(prefs.reminderDaysDescription)
+                            .font(Theme.fontCaption)
+                            .foregroundStyle(Theme.textSecondary)
+                    }
+                    .padding(Theme.paddingMedium)
+                }
+                .background(Theme.cardBackground)
+                .cornerRadius(Theme.cornerRadius)
+            }
+        }
+    }
+    
+    // MARK: - Helpers
+    
+    private func save(_ prefs: NotificationPreferences) {
+        Task {
+            isSaving = true
+            do {
+                try await notifService.savePreferences(prefs)
+            } catch {
+                saveError = error.localizedDescription
+            }
+            isSaving = false
+        }
+    }
+    
+    private func mutate(
+        _ p: NotificationPreferences,
+        friendActivity: Bool? = nil,
+        personalRecords: Bool? = nil,
+        workoutReminders: Bool? = nil,
+        challenges: Bool? = nil,
+        social: Bool? = nil,
+        reminderHour: Int? = nil,
+        reminderMinute: Int? = nil,
+        reminderDays: [Int]? = nil
+    ) -> NotificationPreferences {
+        NotificationPreferences(
+            userId: p.userId,
+            isEnabled: p.isEnabled,
+            friendActivity: friendActivity ?? p.friendActivity,
+            personalRecords: personalRecords ?? p.personalRecords,
+            workoutReminders: workoutReminders ?? p.workoutReminders,
+            challenges: challenges ?? p.challenges,
+            social: social ?? p.social,
+            reminderHour: reminderHour ?? p.reminderHour,
+            reminderMinute: reminderMinute ?? p.reminderMinute,
+            reminderDays: reminderDays ?? p.reminderDays
+        )
+    }
+}
+
+// MARK: - Category Toggle Row
+
+private struct CategoryToggleRow: View {
+    let category: NotificationCategory
+    let isEnabled: Bool
+    let onToggle: (Bool) -> Void
+    
+    var body: some View {
+        Toggle(isOn: Binding(get: { isEnabled }, set: onToggle)) {
+            HStack(spacing: 12) {
+                Image(systemName: category.systemImage)
+                    .foregroundStyle(Theme.accent)
+                    .frame(width: 22)
+                
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(category.displayName)
+                        .font(.system(size: 15, weight: .medium))
+                        .foregroundStyle(Theme.textPrimary)
+                    Text(category.description)
+                        .font(Theme.fontSmall)
+                        .foregroundStyle(Theme.textSecondary)
+                        .lineLimit(2)
+                }
+            }
+        }
+        .tint(Theme.accent)
+        .padding(Theme.paddingMedium)
+    }
+}
+
+// MARK: - Reminder Time Picker View
+
+struct ReminderTimePickerView: View {
+    @State var hour: Int
+    @State var minute: Int
+    let onSave: (Int, Int) -> Void
+    @Environment(\.dismiss) private var dismiss
+    
+    private var selectedDate: Binding<Date> {
+        Binding(
+            get: {
+                Calendar.current.date(
+                    bySettingHour: hour, minute: minute, second: 0, of: Date()
+                ) ?? Date()
+            },
+            set: { newDate in
+                hour = Calendar.current.component(.hour, from: newDate)
+                minute = Calendar.current.component(.minute, from: newDate)
+            }
+        )
+    }
+    
+    var body: some View {
+        ZStack {
+            Theme.background.ignoresSafeArea()
+            VStack(spacing: Theme.paddingLarge) {
+                DatePicker("Reminder Time", selection: selectedDate, displayedComponents: .hourAndMinute)
+                    .datePickerStyle(.wheel)
+                    .labelsHidden()
+                    .tint(Theme.accent)
+                
+                Button("Save") {
+                    onSave(hour, minute)
+                    dismiss()
+                }
+                .font(.system(size: 17, weight: .semibold))
+                .frame(maxWidth: .infinity)
+                .frame(height: 52)
+                .foregroundStyle(.black)
+                .background(Theme.accent)
+                .cornerRadius(Theme.cornerRadius)
+                .padding(.horizontal, Theme.paddingMedium)
+            }
+        }
+        .navigationTitle("Reminder Time")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}

--- a/supabase/migrations/20260228_push_notifications.sql
+++ b/supabase/migrations/20260228_push_notifications.sql
@@ -1,0 +1,118 @@
+-- Push Tokens table
+-- Stores APNs device tokens for push notification delivery
+CREATE TABLE IF NOT EXISTS push_tokens (
+    id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id     TEXT NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    token       TEXT NOT NULL,
+    platform    TEXT NOT NULL DEFAULT 'ios',   -- 'ios', 'android', 'web'
+    app_version TEXT,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    
+    UNIQUE(user_id, token)
+);
+
+CREATE INDEX idx_push_tokens_user ON push_tokens(user_id);
+
+-- Notification Preferences table
+CREATE TABLE IF NOT EXISTS notification_preferences (
+    id                  UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id             TEXT NOT NULL UNIQUE REFERENCES auth.users(id) ON DELETE CASCADE,
+    is_enabled          BOOLEAN NOT NULL DEFAULT true,
+    
+    -- Category toggles
+    friend_activity     BOOLEAN NOT NULL DEFAULT true,
+    personal_records    BOOLEAN NOT NULL DEFAULT true,
+    workout_reminders   BOOLEAN NOT NULL DEFAULT true,
+    challenges          BOOLEAN NOT NULL DEFAULT true,
+    social              BOOLEAN NOT NULL DEFAULT true,
+    
+    -- Reminder schedule
+    reminder_hour       INTEGER NOT NULL DEFAULT 8   CHECK (reminder_hour BETWEEN 0 AND 23),
+    reminder_minute     INTEGER NOT NULL DEFAULT 0   CHECK (reminder_minute BETWEEN 0 AND 59),
+    reminder_days       INTEGER[] NOT NULL DEFAULT '{1,2,3,4,5}',  -- 0=Sun, 6=Sat
+    
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at          TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Notification Events log (for analytics and debugging)
+CREATE TABLE IF NOT EXISTS notification_events (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id         TEXT NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    type            TEXT NOT NULL,  -- NotificationType rawValue
+    payload         JSONB,
+    sent_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
+    delivered       BOOLEAN,
+    opened          BOOLEAN DEFAULT false,
+    opened_at       TIMESTAMPTZ
+);
+
+CREATE INDEX idx_notification_events_user ON notification_events(user_id, sent_at DESC);
+
+-- RLS
+ALTER TABLE push_tokens ENABLE ROW LEVEL SECURITY;
+ALTER TABLE notification_preferences ENABLE ROW LEVEL SECURITY;
+ALTER TABLE notification_events ENABLE ROW LEVEL SECURITY;
+
+-- Push tokens
+CREATE POLICY "Users can manage own push tokens"
+    ON push_tokens FOR ALL
+    USING (auth.uid()::text = user_id)
+    WITH CHECK (auth.uid()::text = user_id);
+
+-- Notification preferences
+CREATE POLICY "Users can manage own preferences"
+    ON notification_preferences FOR ALL
+    USING (auth.uid()::text = user_id)
+    WITH CHECK (auth.uid()::text = user_id);
+
+-- Notification events (read-only for users)
+CREATE POLICY "Users can view own notification events"
+    ON notification_events FOR SELECT
+    USING (auth.uid()::text = user_id);
+
+-- Auto-update updated_at
+CREATE OR REPLACE FUNCTION update_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = now();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER push_tokens_updated_at
+    BEFORE UPDATE ON push_tokens
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+CREATE TRIGGER notification_preferences_updated_at
+    BEFORE UPDATE ON notification_preferences
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+-- Helper function: get active push tokens for a user
+-- Used by backend notification service
+CREATE OR REPLACE FUNCTION get_user_push_tokens(target_user_id TEXT)
+RETURNS TABLE(token TEXT, platform TEXT) AS $$
+    SELECT token, platform
+    FROM push_tokens
+    WHERE user_id = target_user_id
+    ORDER BY updated_at DESC;
+$$ LANGUAGE sql SECURITY DEFINER;
+
+-- Helper function: check if user has a notification type enabled
+CREATE OR REPLACE FUNCTION user_has_notif_enabled(target_user_id TEXT, category TEXT)
+RETURNS BOOLEAN AS $$
+    SELECT 
+        is_enabled AND (
+            CASE category
+                WHEN 'friend_activity' THEN friend_activity
+                WHEN 'personal_records' THEN personal_records
+                WHEN 'workout_reminders' THEN workout_reminders
+                WHEN 'challenges' THEN challenges
+                WHEN 'social' THEN social
+                ELSE true
+            END
+        )
+    FROM notification_preferences
+    WHERE user_id = target_user_id;
+$$ LANGUAGE sql SECURITY DEFINER;


### PR DESCRIPTION
Closes #17

## Feature Overview

Full push notification infrastructure: APNs device token registration, per-category preferences UI, local workout reminders, and deep link routing from notification taps.

## Notification Types (15 types, 6 categories)

| Category | Types |
|---|---|
| Friend Activity | Friend PR, Workout Complete, Gym Check-in |
| Personal Records | New PR, PR Streak Milestone |
| Workout Reminders | Daily reminder, Missed streak, Streak celebration |
| Challenges | Invite, Update, Complete, Leaderboard change |
| Social | Comment, Reaction, Mention, Friend request/accepted |

## Settings UI

- Permission request flow with native system prompt
- Disabled state → deep link to iOS Settings
- Master on/off toggle
- Per-category toggles with descriptions
- Workout reminder schedule: time picker + day-of-week grid
- Shows friendly labels (e.g., 'Weekdays', 'Every day')

## Technical

- `NotificationService` is a singleton registered as `UNUserNotificationCenterDelegate`
- APNs token stored in Supabase `push_tokens` table (upsert on conflict)
- Preferences synced to `notification_preferences` table
- Local reminders use `UNCalendarNotificationTrigger` (one per day of week, repeating)
- Deep links posted via `NotificationCenter` for app-level routing

## Integration Required

1. Add `UIBackgroundModes: [remote-notification]` to Info.plist
2. Enable 'Push Notifications' capability in Xcode
3. Connect `didRegisterForRemoteNotificationsWithDeviceToken` to `NotificationService.registerDeviceToken()`
4. Run `supabase/migrations/20260228_push_notifications.sql`
5. Link `NotificationSettingsView` from Profile → Settings screen