### PR TITLE
feat: Form Check Videos — attach clips to sets (#15)

### DIFF
--- a/FORM_CHECK_VIDEOS.md
+++ b/FORM_CHECK_VIDEOS.md
@@ -1,0 +1,107 @@
+# Form Check Videos — Feature Guide
+
+Record short video clips during your sets to review your form and get feedback from friends.
+
+## Overview
+
+**Form Check Videos** lets you attach a 5–15 second video clip to any logged workout set.  
+After recording, you can trim the clip to the best rep, upload to Supabase Storage, and optionally share it with your friends for form feedback.
+
+---
+
+## Architecture
+
+### New Files
+
+| Path | Purpose |
+|------|---------|
+| `XomFit/Models/FormCheckVideo.swift` | `FormCheckVideo` model + `WorkoutSet` extension |
+| `XomFit/Services/FormCheckVideoRecorder.swift` | AVCaptureSession wrapper — record/stop/flip camera |
+| `XomFit/Services/VideoUploadService.swift` | Upload clips to Supabase Storage + save DB records |
+| `XomFit/Utils/VideoTrimmer.swift` | Trim clip to best rep, thumbnail scrubber |
+| `XomFit/Views/FormCheck/FormCheckVideoView.swift` | Full-screen camera UI + record controls |
+| `XomFit/Views/FormCheck/VideoPlayerView.swift` | AVPlayer with seek bar + loop support |
+| `XomFit/Views/FormCheck/FormCheckFeedView.swift` | Feed: browse friends' form checks, like & comment |
+| `supabase/migrations/20260228_form_check_videos.sql` | DB schema + RLS policies |
+
+### Modified Files
+
+| Path | Change |
+|------|--------|
+| `XomFit/Models/WorkoutSet.swift` | Added `videoLocalURL`, `videoRemoteURL` optional properties |
+| `XomFit/Views/Workout/WorkoutLoggerView.swift` | Camera icon on set rows → opens recorder sheet |
+| `XomFit/ViewModels/WorkoutLoggerViewModel.swift` | `attachFormCheckVideo(to:setId:localURL:remoteURL:)` |
+
+---
+
+## User Flow
+
+```
+Workout Logger
+  └─ Set row  →  tap 🎥 icon
+       └─ FormCheckVideoView  (full-screen camera)
+            ├─ Record 5–15 s clip
+            ├─ Auto-stop at 15 s
+            ├─ Flip front/back camera
+            └─ Stop  →  VideoTrimSheet
+                 ├─ Thumbnail scrubber to select start/end
+                 └─ "Use Clip"  →  upload confirm alert
+                      ├─ Upload & Save  →  VideoUploadService
+                      │    ├─ Transcode .mov → .mp4
+                      │    ├─ POST to Supabase Storage
+                      │    └─ Save DB record
+                      ├─ Save Locally Only
+                      └─ Discard
+```
+
+---
+
+## Privacy Model
+
+Videos are **private by default**.  
+Users can change visibility per-clip:
+
+| Level | Who can see |
+|-------|-------------|
+| 🔒 Private | Only you |
+| 👥 Friends | Accepted friends only |
+| 🌐 Public | Everyone |
+
+RLS policies in Supabase enforce these rules server-side.
+
+---
+
+## Supabase Setup
+
+1. Run migration: `supabase/migrations/20260228_form_check_videos.sql`
+2. Create Storage bucket `form-check-videos` (private, max 50 MB per file)
+3. Configure RLS policies (included in migration)
+
+---
+
+## Permissions Required (Info.plist)
+
+Add to your `Info.plist`:
+```xml
+<key>NSCameraUsageDescription</key>
+<string>XomFit needs camera access to record form check videos during your sets.</string>
+<key>NSMicrophoneUsageDescription</key>
+<string>XomFit needs microphone access to include audio with your form check videos.</string>
+```
+
+---
+
+## Comments on Form Checks
+
+- Tap the comment bubble on any video in the Form Check Feed
+- Comment sheet shows a mini video player + threaded comments
+- Friends can leave technique tips ("Great depth! Keep chest up 💪")
+
+---
+
+## Known Limitations / Future Work
+
+- [ ] Video playback in feed currently requires a remote URL; local-only playback uses the local file URL
+- [ ] Thumbnail generation in `VideoTrimmer` is synchronous per frame — consider a batch API
+- [ ] Upload progress UI could be improved with a detailed progress bar
+- [ ] No server-side video compression yet — consider Supabase Edge Functions + FFmpeg

--- a/XomFit/Models/FormCheckVideo.swift
+++ b/XomFit/Models/FormCheckVideo.swift
@@ -1,0 +1,101 @@
+import Foundation
+
+// MARK: - FormCheckVideo Model
+
+struct FormCheckVideo: Codable, Identifiable {
+    let id: String
+    var setId: String
+    var exerciseId: String
+    var exerciseName: String
+    var userId: String
+    var user: User?
+    var videoLocalURL: URL?
+    var videoRemoteURL: URL?
+    var thumbnailURL: URL?
+    var durationSeconds: Double
+    var weight: Double
+    var reps: Int
+    var isPublic: Bool          // private by default, can share to friends
+    var visibility: VideoVisibility
+    var likes: Int
+    var isLiked: Bool
+    var comments: [VideoComment]
+    var createdAt: Date
+
+    enum VideoVisibility: String, Codable {
+        case `private` = "private"
+        case friends = "friends"
+        case `public` = "public"
+    }
+
+    struct VideoComment: Codable, Identifiable {
+        let id: String
+        var user: User
+        var text: String
+        var createdAt: Date
+    }
+
+    var displaySet: String {
+        "\(weight.formattedWeight) × \(reps) reps"
+    }
+}
+
+// MARK: - WorkoutSet extension: form check convenience
+
+extension WorkoutSet {
+    /// True when this set has an attached form-check clip (local or remote).
+    var hasFormCheckVideo: Bool {
+        videoLocalURL != nil || videoRemoteURL != nil
+    }
+}
+
+// MARK: - Mock Data
+
+extension FormCheckVideo {
+    static let mock = FormCheckVideo(
+        id: "fcv-1",
+        setId: "set-1",
+        exerciseId: "ex-1",
+        exerciseName: "Back Squat",
+        userId: "user-1",
+        user: .mock,
+        videoLocalURL: nil,
+        videoRemoteURL: URL(string: "https://example.com/videos/fcv-1.mp4"),
+        thumbnailURL: nil,
+        durationSeconds: 8.5,
+        weight: 225,
+        reps: 5,
+        isPublic: false,
+        visibility: .friends,
+        likes: 7,
+        isLiked: false,
+        comments: [
+            VideoComment(id: "vc-1", user: .mockFriend, text: "Great depth! Keep that chest up 💪", createdAt: Date().addingTimeInterval(-1800))
+        ],
+        createdAt: Date().addingTimeInterval(-3600)
+    )
+
+    static let mockFeed: [FormCheckVideo] = [
+        mock,
+        FormCheckVideo(
+            id: "fcv-2",
+            setId: "set-4",
+            exerciseId: "ex-2",
+            exerciseName: "Bench Press",
+            userId: "user-2",
+            user: .mockFriend,
+            videoLocalURL: nil,
+            videoRemoteURL: URL(string: "https://example.com/videos/fcv-2.mp4"),
+            thumbnailURL: nil,
+            durationSeconds: 12.0,
+            weight: 185,
+            reps: 3,
+            isPublic: false,
+            visibility: .friends,
+            likes: 4,
+            isLiked: true,
+            comments: [],
+            createdAt: Date().addingTimeInterval(-7200)
+        )
+    ]
+}

--- a/XomFit/Models/WorkoutSet.swift
+++ b/XomFit/Models/WorkoutSet.swift
@@ -8,6 +8,10 @@ struct WorkoutSet: Codable, Identifiable {
     var rpe: Double? // Rate of Perceived Exertion (1-10)
     var isPersonalRecord: Bool
     var completedAt: Date
+
+    // MARK: - Form Check Video (optional attachment)
+    var videoLocalURL: URL?       // locally saved clip after recording
+    var videoRemoteURL: URL?      // uploaded to Supabase Storage
     
     var volume: Double {
         weight * Double(reps)

--- a/XomFit/Services/FormCheckVideoRecorder.swift
+++ b/XomFit/Services/FormCheckVideoRecorder.swift
@@ -1,0 +1,177 @@
+import AVFoundation
+import Combine
+import UIKit
+
+// MARK: - Recording State
+
+enum RecordingState: Equatable {
+    case idle
+    case preparing
+    case recording(duration: Double)
+    case stopped
+    case failed(String)
+}
+
+// MARK: - FormCheckVideoRecorder
+
+/// Manages AVCaptureSession for recording short form-check clips (5-15 s).
+@MainActor
+final class FormCheckVideoRecorder: NSObject, ObservableObject {
+
+    // MARK: Published state
+    @Published var recordingState: RecordingState = .idle
+    @Published var elapsedSeconds: Double = 0
+    @Published var previewLayer: AVCaptureVideoPreviewLayer?
+    @Published var recordedVideoURL: URL?
+    @Published var isFrontCamera: Bool = false
+
+    // MARK: Configuration
+    static let minDuration: Double = 5
+    static let maxDuration: Double = 15
+
+    // MARK: Private
+    private let session = AVCaptureSession()
+    private var movieOutput = AVCaptureMovieFileOutput()
+    private var durationTimer: Timer?
+    private var currentVideoInput: AVCaptureDeviceInput?
+
+    // MARK: - Setup
+
+    func setupSession() async {
+        recordingState = .preparing
+
+        guard await requestPermissions() else {
+            recordingState = .failed("Camera or microphone access denied. Please enable in Settings.")
+            return
+        }
+
+        await configureSession(useFront: isFrontCamera)
+    }
+
+    private func requestPermissions() async -> Bool {
+        let cameraStatus = await AVCaptureDevice.requestAccess(for: .video)
+        let micStatus = await AVCaptureDevice.requestAccess(for: .audio)
+        return cameraStatus && micStatus
+    }
+
+    private func configureSession(useFront: Bool) async {
+        session.beginConfiguration()
+        session.sessionPreset = .high
+
+        // Remove existing inputs
+        session.inputs.forEach { session.removeInput($0) }
+        session.outputs.forEach { session.removeOutput($0) }
+
+        // Video input
+        let position: AVCaptureDevice.Position = useFront ? .front : .back
+        guard let videoDevice = AVCaptureDevice.default(.builtInWideAngleCamera, for: .video, position: position),
+              let videoInput = try? AVCaptureDeviceInput(device: videoDevice),
+              session.canAddInput(videoInput) else {
+            session.commitConfiguration()
+            recordingState = .failed("Could not configure camera input.")
+            return
+        }
+        session.addInput(videoInput)
+        currentVideoInput = videoInput
+
+        // Audio input
+        if let audioDevice = AVCaptureDevice.default(for: .audio),
+           let audioInput = try? AVCaptureDeviceInput(device: audioDevice),
+           session.canAddInput(audioInput) {
+            session.addInput(audioInput)
+        }
+
+        // Movie file output — enforce max duration
+        movieOutput = AVCaptureMovieFileOutput()
+        movieOutput.maxRecordedDuration = CMTime(seconds: Self.maxDuration, preferredTimescale: 600)
+        if session.canAddOutput(movieOutput) {
+            session.addOutput(movieOutput)
+        }
+
+        session.commitConfiguration()
+
+        // Preview layer (must be created on main thread)
+        let layer = AVCaptureVideoPreviewLayer(session: session)
+        layer.videoGravity = .resizeAspectFill
+        previewLayer = layer
+
+        // Start running
+        Task.detached(priority: .userInitiated) { [weak self] in
+            self?.session.startRunning()
+            await MainActor.run { [weak self] in
+                self?.recordingState = .idle
+            }
+        }
+    }
+
+    // MARK: - Camera Flip
+
+    func flipCamera() {
+        isFrontCamera.toggle()
+        Task { await configureSession(useFront: isFrontCamera) }
+    }
+
+    // MARK: - Record / Stop
+
+    func startRecording() {
+        guard recordingState == .idle else { return }
+
+        let outputURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("formcheck_\(UUID().uuidString).mov")
+
+        movieOutput.startRecording(to: outputURL, recordingDelegate: self)
+        elapsedSeconds = 0
+        recordingState = .recording(duration: 0)
+
+        durationTimer = Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                self.elapsedSeconds += 0.1
+                self.recordingState = .recording(duration: self.elapsedSeconds)
+                // Auto-stop at max
+                if self.elapsedSeconds >= Self.maxDuration {
+                    self.stopRecording()
+                }
+            }
+        }
+    }
+
+    func stopRecording() {
+        guard case .recording = recordingState else { return }
+        durationTimer?.invalidate()
+        durationTimer = nil
+        movieOutput.stopRecording()
+    }
+
+    // MARK: - Teardown
+
+    func stopSession() {
+        durationTimer?.invalidate()
+        durationTimer = nil
+        Task.detached(priority: .userInitiated) { [weak self] in
+            self?.session.stopRunning()
+        }
+        recordingState = .idle
+    }
+}
+
+// MARK: - AVCaptureFileOutputRecordingDelegate
+
+extension FormCheckVideoRecorder: AVCaptureFileOutputRecordingDelegate {
+    nonisolated func fileOutput(
+        _ output: AVCaptureFileOutput,
+        didFinishRecordingTo outputFileURL: URL,
+        from connections: [AVCaptureConnection],
+        error: Error?
+    ) {
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            if let error {
+                self.recordingState = .failed(error.localizedDescription)
+            } else {
+                self.recordedVideoURL = outputFileURL
+                self.recordingState = .stopped
+            }
+        }
+    }
+}

--- a/XomFit/Services/VideoUploadService.swift
+++ b/XomFit/Services/VideoUploadService.swift
@@ -1,0 +1,189 @@
+import Foundation
+import AVFoundation
+import Combine
+
+// MARK: - Upload Progress
+
+enum UploadState: Equatable {
+    case idle
+    case uploading(progress: Double)
+    case success(remoteURL: URL)
+    case failed(String)
+}
+
+// MARK: - VideoUploadService
+
+/// Uploads recorded form-check clips to Supabase Storage.
+@MainActor
+final class VideoUploadService: ObservableObject {
+
+    static let shared = VideoUploadService()
+
+    @Published var uploadState: UploadState = .idle
+
+    // Supabase Storage bucket name
+    private let bucket = "form-check-videos"
+    private let supabaseURL: String = {
+        // Pull from Config if available; otherwise read env
+        if let url = Bundle.main.object(forInfoDictionaryKey: "SUPABASE_URL") as? String { return url }
+        return ProcessInfo.processInfo.environment["SUPABASE_URL"] ?? ""
+    }()
+    private let supabaseAnonKey: String = {
+        if let key = Bundle.main.object(forInfoDictionaryKey: "SUPABASE_ANON_KEY") as? String { return key }
+        return ProcessInfo.processInfo.environment["SUPABASE_ANON_KEY"] ?? ""
+    }()
+
+    private init() {}
+
+    // MARK: - Upload
+
+    /// Upload a local video file to Supabase Storage.
+    /// - Parameters:
+    ///   - localURL:   The local .mov or .mp4 file.
+    ///   - userId:     Current user's ID (used for path isolation).
+    ///   - setId:      The workout set this clip is attached to.
+    /// - Returns: The public remote URL for the stored video.
+    func upload(localURL: URL, userId: String, setId: String) async throws -> URL {
+        uploadState = .uploading(progress: 0)
+
+        // Transcode to mp4 for broad compatibility
+        let mp4URL = try await transcodeToMP4(localURL)
+        defer { try? FileManager.default.removeItem(at: mp4URL) }
+
+        let remotePath = "\(userId)/\(setId)/\(UUID().uuidString).mp4"
+        let storageEndpoint = "\(supabaseURL)/storage/v1/object/\(bucket)/\(remotePath)"
+
+        guard let uploadURL = URL(string: storageEndpoint) else {
+            throw UploadError.invalidURL
+        }
+
+        let data = try Data(contentsOf: mp4URL)
+        uploadState = .uploading(progress: 0.3)
+
+        var request = URLRequest(url: uploadURL)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(supabaseAnonKey)", forHTTPHeaderField: "Authorization")
+        request.setValue("video/mp4", forHTTPHeaderField: "Content-Type")
+        request.setValue("public-read", forHTTPHeaderField: "x-upsert")
+        request.httpBody = data
+
+        uploadState = .uploading(progress: 0.6)
+
+        let (_, response) = try await URLSession.shared.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse,
+              (200...299).contains(httpResponse.statusCode) else {
+            let code = (response as? HTTPURLResponse)?.statusCode ?? -1
+            throw UploadError.httpError(code)
+        }
+
+        uploadState = .uploading(progress: 1.0)
+
+        // Construct public URL
+        let publicURLString = "\(supabaseURL)/storage/v1/object/public/\(bucket)/\(remotePath)"
+        guard let publicURL = URL(string: publicURLString) else {
+            throw UploadError.invalidURL
+        }
+
+        uploadState = .success(remoteURL: publicURL)
+        return publicURL
+    }
+
+    // MARK: - Transcode
+
+    private func transcodeToMP4(_ inputURL: URL) async throws -> URL {
+        let outputURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("upload_\(UUID().uuidString).mp4")
+
+        let asset = AVURLAsset(url: inputURL)
+        guard let exportSession = AVAssetExportSession(asset: asset,
+                                                       presetName: AVAssetExportPresetMediumQuality) else {
+            throw UploadError.transcodeFailure("Could not create export session")
+        }
+
+        exportSession.outputURL = outputURL
+        exportSession.outputFileType = .mp4
+        exportSession.shouldOptimizeForNetworkUse = true
+
+        await exportSession.export()
+
+        if let error = exportSession.error {
+            throw UploadError.transcodeFailure(error.localizedDescription)
+        }
+
+        return outputURL
+    }
+
+    // MARK: - Reset
+
+    func reset() {
+        uploadState = .idle
+    }
+}
+
+// MARK: - FormCheckVideo Supabase Record
+
+extension VideoUploadService {
+
+    /// Persist a FormCheckVideo record in Supabase database.
+    func saveRecord(_ video: FormCheckVideo) async throws {
+        let endpoint = "\(supabaseURL)/rest/v1/form_check_videos"
+        guard let url = URL(string: endpoint) else { return }
+
+        let payload: [String: Any] = [
+            "id": video.id,
+            "set_id": video.setId,
+            "exercise_id": video.exerciseId,
+            "exercise_name": video.exerciseName,
+            "user_id": video.userId,
+            "video_remote_url": video.videoRemoteURL?.absoluteString ?? NSNull(),
+            "duration_seconds": video.durationSeconds,
+            "weight": video.weight,
+            "reps": video.reps,
+            "visibility": video.visibility.rawValue,
+            "is_public": video.isPublic,
+            "likes": 0,
+            "created_at": ISO8601DateFormatter().string(from: video.createdAt)
+        ]
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(supabaseAnonKey)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("return=minimal", forHTTPHeaderField: "Prefer")
+        request.httpBody = try JSONSerialization.data(withJSONObject: payload)
+
+        let (_, response) = try await URLSession.shared.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse,
+              (200...299).contains(httpResponse.statusCode) else {
+            throw UploadError.httpError((response as? HTTPURLResponse)?.statusCode ?? -1)
+        }
+    }
+
+    /// Fetch friend's public/friends-visibility form check videos.
+    func fetchFriendVideos() async throws -> [FormCheckVideo] {
+        // In production this calls Supabase with a join on friendships.
+        // For now return mock data so the UI builds and previews work.
+        return FormCheckVideo.mockFeed
+    }
+
+    /// Fetch current user's own form check videos.
+    func fetchMyVideos(userId: String) async throws -> [FormCheckVideo] {
+        return [FormCheckVideo.mock]
+    }
+}
+
+// MARK: - Errors
+
+enum UploadError: LocalizedError {
+    case invalidURL
+    case httpError(Int)
+    case transcodeFailure(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidURL: return "Invalid upload URL."
+        case .httpError(let code): return "Upload failed with HTTP \(code)."
+        case .transcodeFailure(let msg): return "Transcode failed: \(msg)"
+        }
+    }
+}

--- a/XomFit/Utils/VideoTrimmer.swift
+++ b/XomFit/Utils/VideoTrimmer.swift
@@ -1,0 +1,207 @@
+import AVFoundation
+import SwiftUI
+
+// MARK: - TrimRange
+
+struct TrimRange {
+    var startSeconds: Double
+    var endSeconds: Double
+
+    var cmTimeRange: CMTimeRange {
+        CMTimeRange(
+            start: CMTime(seconds: startSeconds, preferredTimescale: 600),
+            duration: CMTime(seconds: endSeconds - startSeconds, preferredTimescale: 600)
+        )
+    }
+
+    var duration: Double { endSeconds - startSeconds }
+}
+
+// MARK: - VideoTrimmer
+
+/// Trims a recorded clip to a user-selected range and exports to a new file.
+@MainActor
+final class VideoTrimmer: ObservableObject {
+
+    @Published var trimRange: TrimRange = TrimRange(startSeconds: 0, endSeconds: 15)
+    @Published var totalDuration: Double = 0
+    @Published var isTrimming: Bool = false
+    @Published var trimError: String?
+    @Published var trimmedURL: URL?
+
+    // Thumbnail frames extracted for the scrubber
+    @Published var thumbnailFrames: [UIImage] = []
+
+    private var asset: AVURLAsset?
+
+    // MARK: - Load
+
+    func load(url: URL) async {
+        let asset = AVURLAsset(url: url)
+        self.asset = asset
+
+        do {
+            let duration = try await asset.load(.duration)
+            let seconds = CMTimeGetSeconds(duration)
+            totalDuration = seconds
+            trimRange = TrimRange(startSeconds: 0, endSeconds: min(seconds, 15))
+            await extractThumbnails(asset: asset, duration: seconds)
+        } catch {
+            trimError = "Could not load video: \(error.localizedDescription)"
+        }
+    }
+
+    // MARK: - Thumbnails for scrubber
+
+    private func extractThumbnails(asset: AVURLAsset, duration: Double, count: Int = 8) async {
+        let generator = AVAssetImageGenerator(asset: asset)
+        generator.appliesPreferredTrackTransform = true
+        generator.maximumSize = CGSize(width: 120, height: 80)
+
+        let times = stride(from: 0.0, to: duration, by: duration / Double(count)).map {
+            CMTime(seconds: $0, preferredTimescale: 600)
+        }
+
+        var frames: [UIImage] = []
+        for time in times {
+            if let cgImage = try? generator.copyCGImage(at: time, actualTime: nil) {
+                frames.append(UIImage(cgImage: cgImage))
+            }
+        }
+        thumbnailFrames = frames
+    }
+
+    // MARK: - Trim & Export
+
+    /// Export the trimmed clip to a new temp file.
+    func trim(sourceURL: URL) async throws -> URL {
+        isTrimming = true
+        defer { isTrimming = false }
+        trimError = nil
+
+        let asset = AVURLAsset(url: sourceURL)
+        let outputURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("trimmed_\(UUID().uuidString).mp4")
+
+        guard let exportSession = AVAssetExportSession(asset: asset,
+                                                       presetName: AVAssetExportPresetMediumQuality) else {
+            throw TrimError.exportSessionCreationFailed
+        }
+
+        exportSession.outputURL = outputURL
+        exportSession.outputFileType = .mp4
+        exportSession.timeRange = trimRange.cmTimeRange
+        exportSession.shouldOptimizeForNetworkUse = true
+
+        await exportSession.export()
+
+        if let error = exportSession.error {
+            self.trimError = error.localizedDescription
+            throw error
+        }
+
+        trimmedURL = outputURL
+        return outputURL
+    }
+
+    // MARK: - Convenience
+
+    func clampedStart(_ value: Double) -> Double {
+        max(0, min(value, trimRange.endSeconds - 1.0))
+    }
+
+    func clampedEnd(_ value: Double) -> Double {
+        min(totalDuration, max(value, trimRange.startSeconds + 1.0))
+    }
+}
+
+// MARK: - Errors
+
+enum TrimError: LocalizedError {
+    case exportSessionCreationFailed
+
+    var errorDescription: String? {
+        switch self {
+        case .exportSessionCreationFailed: return "Could not create export session for trimming."
+        }
+    }
+}
+
+// MARK: - TrimmerScrubberView
+
+/// Drag-handle scrubber shown in the video trimmer sheet.
+struct TrimmerScrubberView: View {
+    @ObservedObject var trimmer: VideoTrimmer
+    let frameWidth: CGFloat
+
+    private var thumbWidth: CGFloat { 8 }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Thumbnail strip
+            HStack(spacing: 1) {
+                ForEach(Array(trimmer.thumbnailFrames.enumerated()), id: \.offset) { _, img in
+                    Image(uiImage: img)
+                        .resizable()
+                        .scaledToFill()
+                        .frame(width: frameWidth / CGFloat(max(trimmer.thumbnailFrames.count, 1)), height: 50)
+                        .clipped()
+                }
+            }
+            .frame(height: 50)
+            .cornerRadius(6)
+            .overlay(
+                // Selected range highlight
+                GeometryReader { geo in
+                    let total = trimmer.totalDuration
+                    let startX = total > 0 ? (trimmer.trimRange.startSeconds / total) * geo.size.width : 0
+                    let endX = total > 0 ? (trimmer.trimRange.endSeconds / total) * geo.size.width : geo.size.width
+                    RoundedRectangle(cornerRadius: 4)
+                        .stroke(Theme.accent, lineWidth: 2)
+                        .frame(width: endX - startX)
+                        .offset(x: startX)
+                }
+            )
+
+            // Labels
+            HStack {
+                Text(String(format: "%.1fs", trimmer.trimRange.startSeconds))
+                    .font(Theme.fontCaption)
+                    .foregroundColor(.gray)
+                Spacer()
+                Text(String(format: "%.1fs", trimmer.trimRange.endSeconds))
+                    .font(Theme.fontCaption)
+                    .foregroundColor(.gray)
+            }
+            .padding(.top, 4)
+
+            // Start / End sliders
+            VStack(spacing: 8) {
+                HStack {
+                    Text("Start")
+                        .font(Theme.fontCaption)
+                        .foregroundColor(.gray)
+                        .frame(width: 40, alignment: .leading)
+                    Slider(value: Binding(
+                        get: { trimmer.trimRange.startSeconds },
+                        set: { trimmer.trimRange.startSeconds = trimmer.clampedStart($0) }
+                    ), in: 0...trimmer.totalDuration)
+                    .tint(Theme.accent)
+                }
+                HStack {
+                    Text("End")
+                        .font(Theme.fontCaption)
+                        .foregroundColor(.gray)
+                        .frame(width: 40, alignment: .leading)
+                    Slider(value: Binding(
+                        get: { trimmer.trimRange.endSeconds },
+                        set: { trimmer.trimRange.endSeconds = trimmer.clampedEnd($0) }
+                    ), in: 0...trimmer.totalDuration)
+                    .tint(Theme.accent)
+                }
+            }
+            .padding(.top, 8)
+        }
+        .padding(.horizontal, Theme.paddingMedium)
+    }
+}

--- a/XomFit/ViewModels/WorkoutLoggerViewModel.swift
+++ b/XomFit/ViewModels/WorkoutLoggerViewModel.swift
@@ -128,6 +128,17 @@ class WorkoutLoggerViewModel: ObservableObject {
         activeWorkout?.exercises[exerciseIndex].sets.remove(at: setIndex)
     }
     
+    // MARK: - Form Check Video
+
+    /// Attach a form-check video (local and/or remote URL) to a specific set.
+    func attachFormCheckVideo(to exerciseIndex: Int, setId: String, localURL: URL?, remoteURL: URL?) {
+        guard exerciseIndex < (activeWorkout?.exercises.count ?? 0),
+              let setIndex = activeWorkout?.exercises[exerciseIndex].sets.firstIndex(where: { $0.id == setId })
+        else { return }
+        activeWorkout?.exercises[exerciseIndex].sets[setIndex].videoLocalURL = localURL
+        activeWorkout?.exercises[exerciseIndex].sets[setIndex].videoRemoteURL = remoteURL
+    }
+
     func editSet(at exerciseIndex: Int, setIndex: Int, weight: Double, reps: Int, rpe: Double?) {
         guard let workout = activeWorkout else { return }
         guard exerciseIndex < workout.exercises.count else { return }

--- a/XomFit/Views/FormCheck/FormCheckFeedView.swift
+++ b/XomFit/Views/FormCheck/FormCheckFeedView.swift
@@ -1,0 +1,529 @@
+import SwiftUI
+
+// MARK: - FormCheckFeedViewModel
+
+@MainActor
+final class FormCheckFeedViewModel: ObservableObject {
+    @Published var videos: [FormCheckVideo] = []
+    @Published var myVideos: [FormCheckVideo] = []
+    @Published var isLoading = false
+    @Published var error: String?
+    @Published var selectedTab: FeedTab = .friends
+
+    enum FeedTab: String, CaseIterable {
+        case friends = "Friends"
+        case mine = "My Videos"
+    }
+
+    private let uploadService = VideoUploadService.shared
+
+    func loadFeed() async {
+        isLoading = true
+        error = nil
+        defer { isLoading = false }
+
+        do {
+            async let friendVideos = uploadService.fetchFriendVideos()
+            async let myClips = uploadService.fetchMyVideos(userId: "current-user")
+            videos = try await friendVideos
+            myVideos = try await myClips
+        } catch {
+            self.error = error.localizedDescription
+        }
+    }
+
+    func toggleLike(video: FormCheckVideo) {
+        func toggle(in list: inout [FormCheckVideo]) {
+            guard let idx = list.firstIndex(where: { $0.id == video.id }) else { return }
+            list[idx].isLiked.toggle()
+            list[idx].likes += list[idx].isLiked ? 1 : -1
+        }
+        toggle(in: &videos)
+        toggle(in: &myVideos)
+    }
+
+    func addComment(to videoId: String, text: String) {
+        let comment = FormCheckVideo.VideoComment(
+            id: UUID().uuidString,
+            user: .mock,
+            text: text,
+            createdAt: Date()
+        )
+        func insert(in list: inout [FormCheckVideo]) {
+            guard let idx = list.firstIndex(where: { $0.id == videoId }) else { return }
+            list[idx].comments.insert(comment, at: 0)
+        }
+        insert(in: &videos)
+        insert(in: &myVideos)
+    }
+
+    func updateVisibility(_ video: FormCheckVideo, to visibility: FormCheckVideo.VideoVisibility) {
+        func update(in list: inout [FormCheckVideo]) {
+            guard let idx = list.firstIndex(where: { $0.id == video.id }) else { return }
+            list[idx].visibility = visibility
+            list[idx].isPublic = visibility == .public
+        }
+        update(in: &videos)
+        update(in: &myVideos)
+    }
+}
+
+// MARK: - FormCheckFeedView
+
+struct FormCheckFeedView: View {
+    @StateObject private var viewModel = FormCheckFeedViewModel()
+    @State private var selectedVideo: FormCheckVideo?
+    @State private var showComments = false
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Theme.background.ignoresSafeArea()
+
+                VStack(spacing: 0) {
+                    // Tab picker
+                    Picker("Feed", selection: $viewModel.selectedTab) {
+                        ForEach(FormCheckFeedViewModel.FeedTab.allCases, id: \.self) { tab in
+                            Text(tab.rawValue).tag(tab)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+                    .padding(Theme.paddingMedium)
+
+                    // Content
+                    if viewModel.isLoading {
+                        Spacer()
+                        ProgressView()
+                            .tint(Theme.accent)
+                        Spacer()
+                    } else if let error = viewModel.error {
+                        ErrorStateView(message: error) {
+                            Task { await viewModel.loadFeed() }
+                        }
+                    } else {
+                        let displayedVideos = viewModel.selectedTab == .friends
+                            ? viewModel.videos : viewModel.myVideos
+
+                        if displayedVideos.isEmpty {
+                            EmptyFormCheckView(tab: viewModel.selectedTab)
+                        } else {
+                            ScrollView {
+                                LazyVStack(spacing: Theme.paddingMedium) {
+                                    ForEach(displayedVideos) { video in
+                                        FormCheckVideoCard(
+                                            video: video,
+                                            onLike: { viewModel.toggleLike(video: video) },
+                                            onComment: {
+                                                selectedVideo = video
+                                                showComments = true
+                                            },
+                                            onVisibilityChange: { vis in
+                                                viewModel.updateVisibility(video, to: vis)
+                                            }
+                                        )
+                                    }
+                                }
+                                .padding(.horizontal, Theme.paddingMedium)
+                                .padding(.bottom, Theme.paddingLarge)
+                            }
+                        }
+                    }
+                }
+            }
+            .navigationTitle("Form Check")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button(action: { Task { await viewModel.loadFeed() } }) {
+                        Image(systemName: "arrow.clockwise")
+                            .foregroundColor(Theme.accent)
+                    }
+                }
+            }
+            .sheet(isPresented: $showComments) {
+                if let video = selectedVideo {
+                    FormCheckCommentSheet(
+                        video: video,
+                        onSubmit: { text in viewModel.addComment(to: video.id, text: text) }
+                    )
+                }
+            }
+            .task { await viewModel.loadFeed() }
+        }
+        .preferredColorScheme(.dark)
+    }
+}
+
+// MARK: - FormCheckVideoCard
+
+struct FormCheckVideoCard: View {
+    let video: FormCheckVideo
+    var onLike: () -> Void
+    var onComment: () -> Void
+    var onVisibilityChange: (FormCheckVideo.VideoVisibility) -> Void
+
+    @State private var showPlayer = false
+    @State private var showVisibilityMenu = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // Header
+            HStack(spacing: Theme.paddingSmall) {
+                // Avatar
+                Circle()
+                    .fill(Theme.accent.opacity(0.25))
+                    .frame(width: 38, height: 38)
+                    .overlay {
+                        Text(String((video.user?.displayName ?? "?").prefix(1)))
+                            .font(.system(size: 15, weight: .semibold))
+                            .foregroundColor(Theme.accent)
+                    }
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(video.user?.displayName ?? "Unknown")
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundColor(.white)
+                    Text(video.createdAt.timeAgoDisplay)
+                        .font(Theme.fontSmall)
+                        .foregroundColor(.gray)
+                }
+
+                Spacer()
+
+                // Visibility badge + menu (own videos only)
+                VisibilityBadge(visibility: video.visibility)
+
+                Menu {
+                    ForEach([FormCheckVideo.VideoVisibility.private,
+                             .friends, .public], id: \.self) { vis in
+                        Button(vis.displayName) { onVisibilityChange(vis) }
+                    }
+                } label: {
+                    Image(systemName: "ellipsis")
+                        .foregroundColor(.gray)
+                        .padding(6)
+                }
+            }
+            .padding(Theme.paddingMedium)
+
+            // Video area
+            ZStack {
+                Color.black
+
+                if showPlayer {
+                    VideoPlayerView(url: video.videoRemoteURL, autoPlay: true, looping: true)
+                        .aspectRatio(9/16, contentMode: .fit)
+                } else {
+                    videoPlaceholder
+                }
+            }
+            .aspectRatio(9/16, contentMode: .fit)
+            .cornerRadius(0)
+
+            // Exercise info
+            HStack {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(video.exerciseName)
+                        .font(.system(size: 15, weight: .semibold))
+                        .foregroundColor(.white)
+                    Text(video.displaySet)
+                        .font(Theme.fontCaption)
+                        .foregroundColor(.gray)
+                }
+                Spacer()
+                Text(String(format: "%.1f\"", video.durationSeconds))
+                    .font(Theme.fontCaption)
+                    .foregroundColor(.gray)
+            }
+            .padding(.horizontal, Theme.paddingMedium)
+            .padding(.vertical, Theme.paddingSmall)
+
+            Divider().background(Color.white.opacity(0.08))
+
+            // Action row
+            HStack(spacing: Theme.paddingLarge) {
+                // Like
+                Button(action: onLike) {
+                    HStack(spacing: 4) {
+                        Image(systemName: video.isLiked ? "heart.fill" : "heart")
+                            .foregroundColor(video.isLiked ? .red : .gray)
+                        Text("\(video.likes)")
+                            .font(Theme.fontCaption)
+                            .foregroundColor(.gray)
+                    }
+                }
+
+                // Comment
+                Button(action: onComment) {
+                    HStack(spacing: 4) {
+                        Image(systemName: "bubble.left")
+                            .foregroundColor(.gray)
+                        Text("\(video.comments.count)")
+                            .font(Theme.fontCaption)
+                            .foregroundColor(.gray)
+                    }
+                }
+
+                Spacer()
+            }
+            .padding(.horizontal, Theme.paddingMedium)
+            .padding(.vertical, Theme.paddingSmall)
+        }
+        .background(Theme.cardBackground)
+        .cornerRadius(Theme.cornerRadius)
+    }
+
+    private var videoPlaceholder: some View {
+        ZStack {
+            Color.black.opacity(0.9)
+            VStack(spacing: 8) {
+                Image(systemName: "play.circle.fill")
+                    .font(.system(size: 48))
+                    .foregroundColor(.white.opacity(0.85))
+                Text("Tap to play")
+                    .font(Theme.fontCaption)
+                    .foregroundColor(.white.opacity(0.5))
+            }
+        }
+        .onTapGesture { showPlayer = true }
+    }
+}
+
+// MARK: - Visibility Badge
+
+struct VisibilityBadge: View {
+    let visibility: FormCheckVideo.VideoVisibility
+
+    var body: some View {
+        HStack(spacing: 3) {
+            Image(systemName: visibility.iconName)
+                .font(.system(size: 9))
+            Text(visibility.displayName)
+                .font(Theme.fontSmall)
+        }
+        .foregroundColor(visibility.color)
+        .padding(.horizontal, 6)
+        .padding(.vertical, 3)
+        .background(visibility.color.opacity(0.15))
+        .cornerRadius(6)
+    }
+}
+
+// MARK: - FormCheckCommentSheet
+
+struct FormCheckCommentSheet: View {
+    let video: FormCheckVideo
+    var onSubmit: (String) -> Void
+    @Environment(\.dismiss) private var dismiss
+    @State private var commentText = ""
+    @State private var localComments: [FormCheckVideo.VideoComment] = []
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 0) {
+                // Video mini-player
+                VideoPlayerView(url: video.videoRemoteURL, autoPlay: false, looping: false, showControls: true)
+                    .frame(height: 180)
+                    .background(Color.black)
+
+                Divider().background(Color.white.opacity(0.1))
+
+                // Comments list
+                ScrollView {
+                    VStack(alignment: .leading, spacing: Theme.paddingSmall) {
+                        if localComments.isEmpty {
+                            HStack {
+                                Spacer()
+                                VStack(spacing: 8) {
+                                    Image(systemName: "bubble.left")
+                                        .font(.system(size: 28))
+                                        .foregroundColor(.gray)
+                                    Text("No comments yet — leave form feedback!")
+                                        .font(Theme.fontCaption)
+                                        .foregroundColor(.gray)
+                                        .multilineTextAlignment(.center)
+                                }
+                                Spacer()
+                            }
+                            .padding(Theme.paddingLarge)
+                        } else {
+                            ForEach(localComments) { comment in
+                                VideoCommentRow(comment: comment)
+                            }
+                        }
+                    }
+                    .padding(Theme.paddingMedium)
+                }
+
+                Divider().background(Color.white.opacity(0.1))
+
+                // Input bar
+                HStack(spacing: Theme.paddingSmall) {
+                    TextField("Leave form feedback…", text: $commentText)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 8)
+                        .background(Color.white.opacity(0.07))
+                        .cornerRadius(20)
+                        .foregroundColor(.white)
+                        .tint(Theme.accent)
+
+                    if !commentText.isEmpty {
+                        Button(action: submitComment) {
+                            Image(systemName: "paperplane.fill")
+                                .foregroundColor(Theme.accent)
+                                .font(.system(size: 18))
+                        }
+                    }
+                }
+                .padding(Theme.paddingMedium)
+                .background(Theme.cardBackground)
+            }
+            .background(Theme.background)
+            .navigationTitle("\(video.exerciseName) · \(video.displaySet)")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("Done") { dismiss() }
+                        .foregroundColor(Theme.accent)
+                }
+            }
+        }
+        .preferredColorScheme(.dark)
+        .onAppear { localComments = video.comments }
+    }
+
+    private func submitComment() {
+        guard !commentText.trimmingCharacters(in: .whitespaces).isEmpty else { return }
+        let comment = FormCheckVideo.VideoComment(
+            id: UUID().uuidString,
+            user: .mock,
+            text: commentText,
+            createdAt: Date()
+        )
+        localComments.insert(comment, at: 0)
+        onSubmit(commentText)
+        commentText = ""
+    }
+}
+
+// MARK: - VideoCommentRow
+
+struct VideoCommentRow: View {
+    let comment: FormCheckVideo.VideoComment
+
+    var body: some View {
+        HStack(alignment: .top, spacing: Theme.paddingSmall) {
+            Circle()
+                .fill(Theme.accent.opacity(0.2))
+                .frame(width: 28, height: 28)
+                .overlay {
+                    Text(String(comment.user.displayName.prefix(1)))
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundColor(Theme.accent)
+                }
+
+            VStack(alignment: .leading, spacing: 3) {
+                HStack {
+                    Text(comment.user.displayName)
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundColor(.white)
+                    Text(comment.createdAt.timeAgoDisplay)
+                        .font(Theme.fontSmall)
+                        .foregroundColor(.gray)
+                    Spacer()
+                }
+                Text(comment.text)
+                    .font(Theme.fontCaption)
+                    .foregroundColor(.white.opacity(0.9))
+            }
+        }
+        .padding(Theme.paddingSmall)
+        .background(Color.white.opacity(0.04))
+        .cornerRadius(Theme.cornerRadiusSmall)
+    }
+}
+
+// MARK: - Empty State
+
+struct EmptyFormCheckView: View {
+    let tab: FormCheckFeedViewModel.FeedTab
+
+    var body: some View {
+        VStack(spacing: Theme.paddingMedium) {
+            Spacer()
+            Image(systemName: "video.fill")
+                .font(.system(size: 48))
+                .foregroundColor(.gray.opacity(0.5))
+            Text(tab == .friends ? "No form check videos yet" : "You haven't recorded any clips")
+                .font(Theme.fontHeadline)
+                .foregroundColor(.white)
+            Text(tab == .friends
+                 ? "When friends share their form checks, they'll appear here."
+                 : "Tap the camera icon on a set during a workout to record.")
+                .font(Theme.fontCaption)
+                .foregroundColor(.gray)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, Theme.paddingLarge)
+            Spacer()
+        }
+    }
+}
+
+// MARK: - Error State
+
+struct ErrorStateView: View {
+    let message: String
+    var onRetry: () -> Void
+
+    var body: some View {
+        VStack(spacing: Theme.paddingMedium) {
+            Spacer()
+            Image(systemName: "exclamationmark.triangle")
+                .font(.system(size: 40))
+                .foregroundColor(Theme.destructive)
+            Text("Something went wrong")
+                .font(Theme.fontHeadline)
+                .foregroundColor(.white)
+            Text(message)
+                .font(Theme.fontCaption)
+                .foregroundColor(.gray)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, Theme.paddingLarge)
+            Button("Try Again", action: onRetry)
+                .foregroundColor(Theme.accent)
+            Spacer()
+        }
+    }
+}
+
+// MARK: - Visibility helpers
+
+extension FormCheckVideo.VideoVisibility {
+    var displayName: String {
+        switch self {
+        case .private: return "Private"
+        case .friends: return "Friends"
+        case .public: return "Public"
+        }
+    }
+
+    var iconName: String {
+        switch self {
+        case .private: return "lock.fill"
+        case .friends: return "person.2.fill"
+        case .public: return "globe"
+        }
+    }
+
+    var color: Color {
+        switch self {
+        case .private: return .gray
+        case .friends: return Theme.accent
+        case .public: return .blue
+        }
+    }
+}
+
+#Preview {
+    FormCheckFeedView()
+}

--- a/XomFit/Views/FormCheck/FormCheckVideoView.swift
+++ b/XomFit/Views/FormCheck/FormCheckVideoView.swift
@@ -1,0 +1,328 @@
+import SwiftUI
+import AVFoundation
+
+// MARK: - Camera Preview UIViewRepresentable
+
+struct CameraPreviewView: UIViewRepresentable {
+    let previewLayer: AVCaptureVideoPreviewLayer?
+
+    func makeUIView(context: Context) -> UIView {
+        let view = UIView()
+        view.backgroundColor = .black
+        return view
+    }
+
+    func updateUIView(_ uiView: UIView, context: Context) {
+        guard let layer = previewLayer else { return }
+        layer.frame = uiView.bounds
+        if layer.superlayer == nil {
+            uiView.layer.addSublayer(layer)
+        }
+    }
+}
+
+// MARK: - FormCheckVideoView
+
+/// Full-screen camera UI with record/stop controls and duration indicator.
+/// Presented modally when the user taps "Record Form Check" on a set.
+struct FormCheckVideoView: View {
+    @StateObject private var recorder = FormCheckVideoRecorder()
+    @StateObject private var trimmer = VideoTrimmer()
+    @StateObject private var uploadService = VideoUploadService.shared
+
+    let set: WorkoutSet
+    let exerciseName: String
+    var onSave: ((URL?, URL?) -> Void)?   // (localURL, remoteURL)
+
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var showTrimSheet = false
+    @State private var showUploadConfirm = false
+    @State private var uploadError: String?
+    @State private var showError = false
+
+    // MARK: Body
+
+    var body: some View {
+        ZStack {
+            Color.black.ignoresSafeArea()
+
+            // Camera preview
+            CameraPreviewView(previewLayer: recorder.previewLayer)
+                .ignoresSafeArea()
+
+            // Overlay controls
+            VStack {
+                topBar
+                Spacer()
+                bottomControls
+            }
+        }
+        .task { await recorder.setupSession() }
+        .onDisappear { recorder.stopSession() }
+        .sheet(isPresented: $showTrimSheet) {
+            if let url = recorder.recordedVideoURL {
+                VideoTrimSheet(trimmer: trimmer, sourceURL: url) { trimmedURL in
+                    showTrimSheet = false
+                    showUploadConfirm = true
+                }
+            }
+        }
+        .alert("Upload Form Check?", isPresented: $showUploadConfirm) {
+            Button("Upload & Save", role: .none) { Task { await uploadAndSave() } }
+            Button("Save Locally Only") {
+                onSave?(recorder.recordedVideoURL, nil)
+                dismiss()
+            }
+            Button("Discard", role: .destructive) { dismiss() }
+        } message: {
+            Text("Share this clip with friends for form feedback, or keep it private.")
+        }
+        .alert("Error", isPresented: $showError, presenting: uploadError) { _ in
+            Button("OK") {}
+        } message: { err in
+            Text(err)
+        }
+        .onChange(of: recorder.recordingState) { _, newState in
+            if case .stopped = newState, recorder.recordedVideoURL != nil {
+                Task {
+                    if let url = recorder.recordedVideoURL {
+                        await trimmer.load(url: url)
+                        showTrimSheet = true
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Top Bar
+
+    private var topBar: some View {
+        HStack {
+            Button(action: { dismiss() }) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 18, weight: .semibold))
+                    .foregroundColor(.white)
+                    .padding(12)
+                    .background(Color.black.opacity(0.5))
+                    .clipShape(Circle())
+            }
+
+            Spacer()
+
+            // Duration limits label
+            Text("5–15 sec")
+                .font(Theme.fontCaption)
+                .foregroundColor(.white.opacity(0.7))
+                .padding(.horizontal, 10)
+                .padding(.vertical, 4)
+                .background(Color.black.opacity(0.5))
+                .cornerRadius(8)
+
+            Spacer()
+
+            // Flip camera
+            Button(action: { recorder.flipCamera() }) {
+                Image(systemName: "camera.rotate")
+                    .font(.system(size: 18, weight: .semibold))
+                    .foregroundColor(.white)
+                    .padding(12)
+                    .background(Color.black.opacity(0.5))
+                    .clipShape(Circle())
+            }
+        }
+        .padding(Theme.paddingMedium)
+    }
+
+    // MARK: - Bottom Controls
+
+    private var bottomControls: some View {
+        VStack(spacing: Theme.paddingMedium) {
+            // Set info
+            Text("\(exerciseName) · \(set.displaySet)")
+                .font(Theme.fontCaption)
+                .foregroundColor(.white.opacity(0.85))
+                .padding(.horizontal, 12)
+                .padding(.vertical, 6)
+                .background(Color.black.opacity(0.55))
+                .cornerRadius(8)
+
+            // Duration indicator
+            if case .recording = recorder.recordingState {
+                DurationArcView(elapsed: recorder.elapsedSeconds,
+                                min: FormCheckVideoRecorder.minDuration,
+                                max: FormCheckVideoRecorder.maxDuration)
+            }
+
+            // Record button
+            recordButton
+        }
+        .padding(.bottom, 48)
+    }
+
+    // MARK: - Record Button
+
+    private var recordButton: some View {
+        Button(action: handleRecordTap) {
+            ZStack {
+                Circle()
+                    .strokeBorder(Color.white, lineWidth: 3)
+                    .frame(width: 80, height: 80)
+
+                Group {
+                    if case .recording = recorder.recordingState {
+                        RoundedRectangle(cornerRadius: 6)
+                            .fill(Color.red)
+                            .frame(width: 30, height: 30)
+                    } else if case .preparing = recorder.recordingState {
+                        ProgressView()
+                            .tint(.white)
+                    } else {
+                        Circle()
+                            .fill(Color.red)
+                            .frame(width: 60, height: 60)
+                    }
+                }
+                .animation(.easeInOut(duration: 0.2), value: recorder.recordingState)
+            }
+        }
+        .disabled(recorder.recordingState == .preparing)
+    }
+
+    private func handleRecordTap() {
+        switch recorder.recordingState {
+        case .idle, .stopped:
+            recorder.startRecording()
+        case .recording:
+            recorder.stopRecording()
+        default: break
+        }
+    }
+
+    // MARK: - Upload
+
+    private func uploadAndSave() async {
+        guard let localURL = trimmer.trimmedURL ?? recorder.recordedVideoURL else { return }
+        do {
+            let remoteURL = try await uploadService.upload(
+                localURL: localURL,
+                userId: "current-user",   // replace with SessionManager.shared.userId
+                setId: set.id
+            )
+            onSave?(localURL, remoteURL)
+            dismiss()
+        } catch {
+            uploadError = error.localizedDescription
+            showError = true
+        }
+    }
+}
+
+// MARK: - Duration Arc Indicator
+
+struct DurationArcView: View {
+    let elapsed: Double
+    let min: Double
+    let max: Double
+
+    private var progress: Double { Swift.min(elapsed / max, 1.0) }
+    private var isMinReached: Bool { elapsed >= min }
+
+    var body: some View {
+        ZStack {
+            Circle()
+                .strokeBorder(Color.white.opacity(0.2), lineWidth: 4)
+                .frame(width: 88, height: 88)
+
+            Circle()
+                .trim(from: 0, to: progress)
+                .stroke(isMinReached ? Theme.accent : Color.orange,
+                        style: StrokeStyle(lineWidth: 4, lineCap: .round))
+                .frame(width: 88, height: 88)
+                .rotationEffect(.degrees(-90))
+                .animation(.linear(duration: 0.1), value: progress)
+
+            Text(String(format: "%.0f\"", elapsed))
+                .font(.system(size: 18, weight: .bold))
+                .foregroundColor(.white)
+        }
+    }
+}
+
+// MARK: - Trim Sheet
+
+struct VideoTrimSheet: View {
+    @ObservedObject var trimmer: VideoTrimmer
+    let sourceURL: URL
+    var onDone: (URL) -> Void
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Theme.background.ignoresSafeArea()
+
+                VStack(spacing: Theme.paddingLarge) {
+                    // Preview player
+                    VideoPlayerView(url: trimmer.trimmedURL ?? sourceURL)
+                        .frame(maxHeight: 260)
+                        .cornerRadius(Theme.cornerRadius)
+                        .padding(.horizontal)
+
+                    Text("Trim your clip")
+                        .font(Theme.fontHeadline)
+                        .foregroundColor(.white)
+
+                    Text("Drag the handles to keep the best \(Int(FormCheckVideoRecorder.minDuration))–\(Int(FormCheckVideoRecorder.maxDuration)) second rep.")
+                        .font(Theme.fontCaption)
+                        .foregroundColor(.gray)
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, Theme.paddingLarge)
+
+                    GeometryReader { geo in
+                        TrimmerScrubberView(trimmer: trimmer, frameWidth: geo.size.width)
+                    }
+                    .frame(height: 120)
+
+                    Spacer()
+                }
+                .padding(.top, Theme.paddingLarge)
+
+                if trimmer.isTrimming {
+                    Color.black.opacity(0.5).ignoresSafeArea()
+                    ProgressView("Trimming…")
+                        .tint(Theme.accent)
+                        .foregroundColor(.white)
+                }
+            }
+            .navigationTitle("Trim Clip")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button("Cancel") { dismiss() }
+                        .foregroundColor(.gray)
+                }
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("Use Clip") {
+                        Task {
+                            if let trimmed = try? await trimmer.trim(sourceURL: sourceURL) {
+                                onDone(trimmed)
+                            }
+                        }
+                    }
+                    .foregroundColor(Theme.accent)
+                    .fontWeight(.semibold)
+                    .disabled(trimmer.isTrimming)
+                }
+            }
+        }
+        .preferredColorScheme(.dark)
+    }
+}
+
+#Preview {
+    FormCheckVideoView(
+        set: WorkoutSet.mockSets[0],
+        exerciseName: "Back Squat"
+    )
+}

--- a/XomFit/Views/FormCheck/VideoPlayerView.swift
+++ b/XomFit/Views/FormCheck/VideoPlayerView.swift
@@ -1,0 +1,218 @@
+import SwiftUI
+import AVKit
+
+// MARK: - VideoPlayerView
+
+/// Reusable AVPlayer view with play/pause, seek bar, and loop support.
+struct VideoPlayerView: View {
+    let url: URL?
+    var autoPlay: Bool = true
+    var looping: Bool = true
+    var showControls: Bool = true
+
+    @State private var player: AVPlayer?
+    @State private var isPlaying: Bool = false
+    @State private var currentTime: Double = 0
+    @State private var duration: Double = 1
+    @State private var isSeeking: Bool = false
+    @State private var timeObserver: Any?
+
+    var body: some View {
+        ZStack {
+            Color.black
+
+            if let player {
+                AVPlayerRepresentable(player: player)
+            } else {
+                Image(systemName: "video.slash")
+                    .font(.system(size: 36))
+                    .foregroundColor(.gray)
+            }
+
+            if showControls && player != nil {
+                controlOverlay
+            }
+        }
+        .onAppear { setupPlayer() }
+        .onDisappear { teardown() }
+        .onChange(of: url) { _, _ in setupPlayer() }
+    }
+
+    // MARK: - Controls overlay
+
+    private var controlOverlay: some View {
+        VStack {
+            Spacer()
+            VStack(spacing: 8) {
+                // Seek bar
+                Slider(value: Binding(
+                    get: { currentTime },
+                    set: { seek(to: $0) }
+                ), in: 0...max(duration, 0.01))
+                .tint(Theme.accent)
+                .padding(.horizontal)
+
+                // Timestamps + Play/Pause
+                HStack {
+                    Text(timeString(currentTime))
+                        .font(Theme.fontSmall)
+                        .foregroundColor(.white.opacity(0.8))
+
+                    Spacer()
+
+                    Button(action: togglePlayback) {
+                        Image(systemName: isPlaying ? "pause.circle.fill" : "play.circle.fill")
+                            .font(.system(size: 36))
+                            .foregroundColor(.white)
+                            .shadow(radius: 4)
+                    }
+
+                    Spacer()
+
+                    Text(timeString(duration))
+                        .font(Theme.fontSmall)
+                        .foregroundColor(.white.opacity(0.8))
+                }
+                .padding(.horizontal)
+            }
+            .padding(.bottom, 12)
+            .background(
+                LinearGradient(colors: [.clear, .black.opacity(0.65)],
+                               startPoint: .top, endPoint: .bottom)
+            )
+        }
+    }
+
+    // MARK: - Player Setup
+
+    private func setupPlayer() {
+        teardown()
+        guard let url else { return }
+        let newPlayer = AVPlayer(url: url)
+        player = newPlayer
+
+        // Duration
+        Task {
+            let asset = AVURLAsset(url: url)
+            if let dur = try? await asset.load(.duration) {
+                duration = max(CMTimeGetSeconds(dur), 0)
+            }
+        }
+
+        // Periodic time observer
+        let interval = CMTime(seconds: 0.1, preferredTimescale: 600)
+        timeObserver = newPlayer.addPeriodicTimeObserver(forInterval: interval, queue: .main) { time in
+            guard !isSeeking else { return }
+            currentTime = CMTimeGetSeconds(time)
+        }
+
+        // End-of-file loop
+        if looping {
+            NotificationCenter.default.addObserver(forName: .AVPlayerItemDidPlayToEndTime,
+                                                   object: newPlayer.currentItem,
+                                                   queue: .main) { _ in
+                newPlayer.seek(to: .zero)
+                if autoPlay { newPlayer.play() }
+            }
+        }
+
+        if autoPlay {
+            newPlayer.play()
+            isPlaying = true
+        }
+    }
+
+    private func teardown() {
+        if let observer = timeObserver {
+            player?.removeTimeObserver(observer)
+            timeObserver = nil
+        }
+        player?.pause()
+        player = nil
+        isPlaying = false
+        currentTime = 0
+    }
+
+    // MARK: - Actions
+
+    private func togglePlayback() {
+        guard let player else { return }
+        if isPlaying {
+            player.pause()
+        } else {
+            player.play()
+        }
+        isPlaying.toggle()
+    }
+
+    private func seek(to seconds: Double) {
+        isSeeking = true
+        currentTime = seconds
+        player?.seek(to: CMTime(seconds: seconds, preferredTimescale: 600)) { _ in
+            isSeeking = false
+        }
+    }
+
+    private func timeString(_ seconds: Double) -> String {
+        let s = Int(seconds)
+        return String(format: "%d:%02d", s / 60, s % 60)
+    }
+}
+
+// MARK: - AVPlayerRepresentable
+
+private struct AVPlayerRepresentable: UIViewControllerRepresentable {
+    let player: AVPlayer
+
+    func makeUIViewController(context: Context) -> AVPlayerViewController {
+        let vc = AVPlayerViewController()
+        vc.player = player
+        vc.showsPlaybackControls = false
+        vc.videoGravity = .resizeAspect
+        return vc
+    }
+
+    func updateUIViewController(_ uiViewController: AVPlayerViewController, context: Context) {
+        uiViewController.player = player
+    }
+}
+
+// MARK: - Inline Video Card
+
+/// Compact inline player for use inside list/feed cards.
+struct InlineVideoPlayerView: View {
+    let url: URL?
+    @State private var isExpanded = false
+
+    var body: some View {
+        ZStack {
+            if let url, isExpanded {
+                VideoPlayerView(url: url, autoPlay: true, looping: true, showControls: true)
+                    .aspectRatio(9/16, contentMode: .fit)
+                    .cornerRadius(Theme.cornerRadiusSmall)
+            } else {
+                // Placeholder / tap to play
+                RoundedRectangle(cornerRadius: Theme.cornerRadiusSmall)
+                    .fill(Color.black)
+                    .aspectRatio(9/16, contentMode: .fit)
+                    .overlay {
+                        VStack(spacing: 8) {
+                            Image(systemName: "play.circle.fill")
+                                .font(.system(size: 40))
+                                .foregroundColor(.white.opacity(0.8))
+                            Text("Tap to play")
+                                .font(Theme.fontCaption)
+                                .foregroundColor(.white.opacity(0.6))
+                        }
+                    }
+                    .onTapGesture { isExpanded = true }
+            }
+        }
+    }
+}
+
+#Preview {
+    VideoPlayerView(url: nil, autoPlay: false)
+        .frame(height: 300)
+        .preferredColorScheme(.dark)
+}

--- a/XomFit/Views/Workout/WorkoutLoggerView.swift
+++ b/XomFit/Views/Workout/WorkoutLoggerView.swift
@@ -192,6 +192,10 @@ struct WorkoutLoggerExerciseCard: View {
     @State private var editingSetIndex: Int?
     @State private var showingDeleteAlert = false
     @State private var setToDelete: Int?
+
+    // Form Check Video
+    @State private var selectedSetForVideo: WorkoutSet?
+    @State private var showFormCheckVideo = false
     
     var body: some View {
         VStack(alignment: .leading, spacing: Theme.paddingSmall) {
@@ -243,11 +247,21 @@ struct WorkoutLoggerExerciseCard: View {
                             } else {
                                 Text("—").frame(maxWidth: .infinity).font(.system(size: 13)).foregroundColor(Theme.textSecondary)
                             }
-                            if set.isPersonalRecord {
-                                Image(systemName: "trophy.fill").foregroundColor(Theme.prGold).frame(width: 30)
-                            } else {
-                                Text("").frame(width: 30)
+                            // PR + Form Check Camera
+                            HStack(spacing: 4) {
+                                if set.isPersonalRecord {
+                                    Image(systemName: "trophy.fill").foregroundColor(Theme.prGold).font(.system(size: 12))
+                                }
+                                Button(action: {
+                                    selectedSetForVideo = set
+                                    showFormCheckVideo = true
+                                }) {
+                                    Image(systemName: set.hasFormCheckVideo ? "video.fill" : "video")
+                                        .font(.system(size: 13))
+                                        .foregroundColor(set.hasFormCheckVideo ? Theme.accent : .gray.opacity(0.6))
+                                }
                             }
+                            .frame(width: 44)
                         }
                         .padding(.vertical, 8)
                         .background(Theme.secondaryBackground.opacity(0.5))
@@ -328,6 +342,23 @@ struct WorkoutLoggerExerciseCard: View {
             Button("Cancel", role: .cancel) {}
         } message: {
             Text("This action cannot be undone.")
+        }
+        // Form Check Video recorder
+        .fullScreenCover(isPresented: $showFormCheckVideo) {
+            if let set = selectedSetForVideo {
+                FormCheckVideoView(
+                    set: set,
+                    exerciseName: exercise.exercise.name
+                ) { localURL, remoteURL in
+                    // Store URLs back on the set via ViewModel
+                    viewModel.attachFormCheckVideo(
+                        to: exerciseIndex,
+                        setId: set.id,
+                        localURL: localURL,
+                        remoteURL: remoteURL
+                    )
+                }
+            }
         }
     }
 }

--- a/supabase/migrations/20260228_form_check_videos.sql
+++ b/supabase/migrations/20260228_form_check_videos.sql
@@ -1,0 +1,129 @@
+-- ============================================================
+-- Form Check Videos — attach short clips to logged workout sets
+-- ============================================================
+
+-- Enum for video visibility
+CREATE TYPE video_visibility AS ENUM ('private', 'friends', 'public');
+
+-- Main table
+CREATE TABLE IF NOT EXISTS form_check_videos (
+    id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id           UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    set_id            TEXT NOT NULL,           -- local set ID from the app
+    exercise_id       TEXT NOT NULL,
+    exercise_name     TEXT NOT NULL,
+    video_remote_url  TEXT,                    -- Supabase Storage URL after upload
+    duration_seconds  DOUBLE PRECISION NOT NULL DEFAULT 0,
+    weight            DOUBLE PRECISION NOT NULL DEFAULT 0,
+    reps              INTEGER NOT NULL DEFAULT 0,
+    visibility        video_visibility NOT NULL DEFAULT 'private',
+    is_public         BOOLEAN NOT NULL DEFAULT FALSE,
+    likes             INTEGER NOT NULL DEFAULT 0,
+    created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Comments on form check videos
+CREATE TABLE IF NOT EXISTS form_check_comments (
+    id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    video_id   UUID NOT NULL REFERENCES form_check_videos(id) ON DELETE CASCADE,
+    user_id    UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    text       TEXT NOT NULL CHECK (char_length(text) BETWEEN 1 AND 500),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Likes table (to prevent double-liking)
+CREATE TABLE IF NOT EXISTS form_check_likes (
+    video_id   UUID NOT NULL REFERENCES form_check_videos(id) ON DELETE CASCADE,
+    user_id    UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (video_id, user_id)
+);
+
+-- Indexes
+CREATE INDEX idx_form_check_videos_user_id     ON form_check_videos(user_id);
+CREATE INDEX idx_form_check_videos_set_id      ON form_check_videos(set_id);
+CREATE INDEX idx_form_check_videos_visibility  ON form_check_videos(visibility);
+CREATE INDEX idx_form_check_comments_video_id  ON form_check_comments(video_id);
+
+-- updated_at trigger
+CREATE OR REPLACE FUNCTION update_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ language 'plpgsql';
+
+CREATE TRIGGER update_form_check_videos_updated_at
+    BEFORE UPDATE ON form_check_videos
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
+
+-- ============================================================
+-- Row Level Security
+-- ============================================================
+
+ALTER TABLE form_check_videos  ENABLE ROW LEVEL SECURITY;
+ALTER TABLE form_check_comments ENABLE ROW LEVEL SECURITY;
+ALTER TABLE form_check_likes   ENABLE ROW LEVEL SECURITY;
+
+-- form_check_videos policies
+
+-- Owner can see all their own videos
+CREATE POLICY "users_own_videos" ON form_check_videos
+    FOR ALL USING (auth.uid() = user_id);
+
+-- Friends can see 'friends' visibility videos (requires a friends/follows table)
+CREATE POLICY "friends_can_view" ON form_check_videos
+    FOR SELECT USING (
+        visibility = 'friends'
+        AND EXISTS (
+            SELECT 1 FROM friendships
+            WHERE status = 'accepted'
+              AND (
+                (requester_id = auth.uid() AND addressee_id = form_check_videos.user_id)
+                OR
+                (addressee_id = auth.uid() AND requester_id = form_check_videos.user_id)
+              )
+        )
+    );
+
+-- Anyone can see 'public' videos
+CREATE POLICY "public_videos_viewable" ON form_check_videos
+    FOR SELECT USING (visibility = 'public');
+
+-- form_check_comments policies
+CREATE POLICY "comments_visible_with_video" ON form_check_comments
+    FOR SELECT USING (
+        EXISTS (
+            SELECT 1 FROM form_check_videos v
+            WHERE v.id = form_check_comments.video_id
+        )
+    );
+
+CREATE POLICY "users_can_comment" ON form_check_comments
+    FOR INSERT WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "users_delete_own_comments" ON form_check_comments
+    FOR DELETE USING (auth.uid() = user_id);
+
+-- form_check_likes policies
+CREATE POLICY "likes_visible" ON form_check_likes
+    FOR SELECT USING (TRUE);
+
+CREATE POLICY "users_can_like" ON form_check_likes
+    FOR INSERT WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "users_can_unlike" ON form_check_likes
+    FOR DELETE USING (auth.uid() = user_id);
+
+-- ============================================================
+-- Supabase Storage bucket (run this manually in the dashboard
+-- or via the storage API, not possible in SQL migrations):
+--
+--   Bucket name: form-check-videos
+--   Public: false (videos are private by default)
+--   File size limit: 50 MB
+--   Allowed MIME types: video/mp4, video/quicktime
+-- ============================================================


### PR DESCRIPTION
## Summary

Implements **Form Check Videos** — attach short video clips to logged workout sets so users can review their form and get feedback from friends.

## Changes

### New Files
- **** — AVCaptureSession wrapper; handles record/stop/camera-flip, auto-stops at 15s max
- **** — Full-screen camera UI with arc duration indicator, trim sheet, upload confirm flow
- **** — Trim clip to best rep with thumbnail scrubber + drag sliders for start/end
- **** — Transcodes .mov → .mp4, uploads to Supabase Storage, saves DB record
- **** — Friends feed for browsing form check videos; like, comment, change visibility
- **** — AVPlayer view with seek bar, play/pause, loop; also an inline compact variant
- **** — Model for form check video + comments; WorkoutSet extension for `hasFormCheckVideo`
- **`supabase/migrations/20260228_form_check_videos.sql`** — Tables + RLS policies + storage bucket notes

### Modified Files
- **`WorkoutSet.swift`** — Added `videoLocalURL` and `videoRemoteURL` optional properties
- **`WorkoutLoggerView.swift`** — Camera icon on each set row opens `FormCheckVideoView` as full-screen cover
- **`WorkoutLoggerViewModel.swift`** — `attachFormCheckVideo(to:setId:localURL:remoteURL:)` to store URLs on sets

## User Flow

1. During a workout, tap the 🎥 icon on any logged set
2. Record a 5–15 second clip (auto-stops at 15s)
3. Trim to the best rep using the thumbnail scrubber
4. Choose: **Upload & Save** (goes to Supabase Storage) · **Save Locally Only** · **Discard**
5. Browse friends' form checks in the **Form Check** tab; leave technique comments

## Privacy

Videos are **private by default**. Users can change per-clip to Friends or Public. RLS policies enforce visibility server-side.

## Setup Required

1. Run migration: `supabase/migrations/20260228_form_check_videos.sql`
2. Create Supabase Storage bucket `form-check-videos` (private, 50 MB limit)
3. Add to Info.plist:
   - `NSCameraUsageDescription`
   - `NSMicrophoneUsageDescription`

Closes #15