### PR TITLE
feat: Custom Programs + Social Leaderboards — Sprint 3 (#50, #51)

### DIFF
--- a/XomFit/Models/Leaderboard.swift
+++ b/XomFit/Models/Leaderboard.swift
@@ -1,0 +1,87 @@
+import Foundation
+
+enum LeaderboardMetric: String, Codable, CaseIterable {
+    case weeklyVolume = "Weekly Volume"
+    case personalRecords = "Personal Records"
+    case workoutStreak = "Workout Streak"
+    case totalWorkouts = "Total Workouts"
+}
+
+enum LeaderboardTimeframe: String, Codable, CaseIterable {
+    case weekly = "This Week"
+    case monthly = "This Month"
+    case allTime = "All Time"
+}
+
+enum LeaderboardScope: String, Codable, CaseIterable {
+    case friends = "Friends"
+    case global = "Global"
+    case gym = "My Gym"
+}
+
+struct LeaderboardEntry: Identifiable, Codable {
+    var id: UUID
+    var userId: String
+    var displayName: String
+    var avatarInitials: String
+    var rank: Int
+    var previousRank: Int
+    var score: Int
+    var metric: LeaderboardMetric
+    var badge: String? // emoji badge for top 3
+    
+    init(id: UUID = UUID(), userId: String, displayName: String, rank: Int,
+         previousRank: Int = 0, score: Int, metric: LeaderboardMetric) {
+        self.id = id
+        self.userId = userId
+        self.displayName = displayName
+        self.avatarInitials = String(displayName.prefix(2)).uppercased()
+        self.rank = rank
+        self.previousRank = previousRank
+        self.score = score
+        self.metric = metric
+        self.badge = rank == 1 ? "🥇" : rank == 2 ? "🥈" : rank == 3 ? "🥉" : nil
+    }
+    
+    var rankChange: Int { previousRank - rank } // Positive = moved up
+    var rankChangeSymbol: String {
+        if rankChange > 0 { return "↑\(rankChange)" }
+        if rankChange < 0 { return "↓\(abs(rankChange))" }
+        return "—"
+    }
+    var rankChangeColor: String {
+        if rankChange > 0 { return "green" }
+        if rankChange < 0 { return "red" }
+        return "gray"
+    }
+    
+    var scoreFormatted: String {
+        switch metric {
+        case .weeklyVolume: return "\(score) lbs"
+        case .personalRecords: return "\(score) PRs"
+        case .workoutStreak: return "\(score) days"
+        case .totalWorkouts: return "\(score) workouts"
+        }
+    }
+}
+
+struct Trophy: Identifiable, Codable {
+    var id: UUID
+    var title: String
+    var description: String
+    var emoji: String
+    var earnedAt: Date
+    var leaderboardScope: LeaderboardScope
+    var rank: Int
+    
+    init(id: UUID = UUID(), title: String, description: String, emoji: String,
+         scope: LeaderboardScope, rank: Int) {
+        self.id = id
+        self.title = title
+        self.description = description
+        self.emoji = emoji
+        self.earnedAt = Date()
+        self.leaderboardScope = scope
+        self.rank = rank
+    }
+}

--- a/XomFit/Models/TrainingProgram.swift
+++ b/XomFit/Models/TrainingProgram.swift
@@ -1,0 +1,112 @@
+import Foundation
+
+enum ProgramDifficulty: String, Codable, CaseIterable {
+    case beginner = "Beginner"
+    case intermediate = "Intermediate"
+    case advanced = "Advanced"
+}
+
+enum ProgramGoal: String, Codable, CaseIterable {
+    case strength = "Strength"
+    case hypertrophy = "Hypertrophy"
+    case endurance = "Endurance"
+    case fatLoss = "Fat Loss"
+    case powerlifting = "Powerlifting"
+    case generalFitness = "General Fitness"
+}
+
+struct ProgramDay: Identifiable, Codable {
+    var id: UUID
+    var dayOfWeek: Int // 0 = Sunday, 6 = Saturday
+    var templateName: String
+    var isRestDay: Bool
+    var notes: String
+    
+    init(id: UUID = UUID(), dayOfWeek: Int, templateName: String = "", isRestDay: Bool = false, notes: String = "") {
+        self.id = id
+        self.dayOfWeek = dayOfWeek
+        self.templateName = templateName
+        self.isRestDay = isRestDay
+        self.notes = notes
+    }
+    
+    var dayName: String {
+        let days = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
+        return days[dayOfWeek]
+    }
+}
+
+struct ProgramWeek: Identifiable, Codable {
+    var id: UUID
+    var weekNumber: Int
+    var days: [ProgramDay]
+    var isDeloadWeek: Bool
+    
+    init(id: UUID = UUID(), weekNumber: Int, days: [ProgramDay] = [], isDeloadWeek: Bool = false) {
+        self.id = id
+        self.weekNumber = weekNumber
+        self.days = days
+        self.isDeloadWeek = isDeloadWeek
+    }
+}
+
+struct TrainingProgram: Identifiable, Codable {
+    var id: UUID
+    var name: String
+    var description: String
+    var durationWeeks: Int
+    var daysPerWeek: Int
+    var difficulty: ProgramDifficulty
+    var goal: ProgramGoal
+    var weeks: [ProgramWeek]
+    var author: String
+    var isPublic: Bool
+    var createdAt: Date
+    var startDate: Date?
+    var isActive: Bool
+    
+    init(id: UUID = UUID(), name: String, description: String = "", durationWeeks: Int = 4,
+         daysPerWeek: Int = 3, difficulty: ProgramDifficulty = .intermediate,
+         goal: ProgramGoal = .strength, weeks: [ProgramWeek] = [],
+         author: String = "Me", isPublic: Bool = false) {
+        self.id = id
+        self.name = name
+        self.description = description
+        self.durationWeeks = durationWeeks
+        self.daysPerWeek = daysPerWeek
+        self.difficulty = difficulty
+        self.goal = goal
+        self.weeks = weeks
+        self.author = author
+        self.isPublic = isPublic
+        self.createdAt = Date()
+        self.isActive = false
+    }
+    
+    var completedWorkouts: Int { 0 } // Will be tracked separately
+    var totalWorkouts: Int { durationWeeks * daysPerWeek }
+    var progressPercent: Double { Double(completedWorkouts) / Double(max(totalWorkouts, 1)) }
+    
+    var currentWeek: Int? {
+        guard isActive, let start = startDate else { return nil }
+        let days = Int(Date().timeIntervalSince(start) / 86400)
+        let week = days / 7 + 1
+        return week <= durationWeeks ? week : nil
+    }
+}
+
+struct ProgramCompletion: Identifiable, Codable {
+    var id: UUID
+    var programId: UUID
+    var weekNumber: Int
+    var dayOfWeek: Int
+    var completedAt: Date
+    
+    init(id: UUID = UUID(), programId: UUID, weekNumber: Int, dayOfWeek: Int) {
+        self.id = id
+        self.programId = programId
+        self.weekNumber = weekNumber
+        self.dayOfWeek = dayOfWeek
+        self.completedAt = Date()
+    }
+}

--- a/XomFit/Services/LeaderboardService.swift
+++ b/XomFit/Services/LeaderboardService.swift
@@ -1,0 +1,97 @@
+import Foundation
+
+class LeaderboardService {
+    static let shared = LeaderboardService()
+    private let workoutStore = WorkoutStore.shared
+    
+    // MARK: - Mock leaderboard data with current user embedded
+    func leaderboard(scope: LeaderboardScope, metric: LeaderboardMetric, timeframe: LeaderboardTimeframe) -> [LeaderboardEntry] {
+        let currentUserScore = calculateCurrentUserScore(metric: metric, timeframe: timeframe)
+        let currentUserName = "You"
+        
+        // Generate realistic mock data around the user's score
+        let mockNames = ["Alex R.", "Jordan M.", "Sam T.", "Chris K.", "Taylor W.",
+                         "Morgan B.", "Casey L.", "Drew P.", "Quinn A.", "Riley F."]
+        
+        var scores: [(String, Int)] = [(currentUserName, currentUserScore)]
+        
+        // Generate competitors
+        for (i, name) in mockNames.prefix(9).enumerated() {
+            let variance = Int.random(in: -50...150)
+            let baseScore = max(1, currentUserScore + variance - (i * 10))
+            scores.append((name, baseScore))
+        }
+        
+        // Sort descending
+        scores.sort { $0.1 > $1.1 }
+        
+        return scores.enumerated().map { (index, item) in
+            let prevRank = Int.random(in: max(1, index)...(index + 3))
+            return LeaderboardEntry(
+                userId: item.0 == currentUserName ? "current_user" : "user_\(index)",
+                displayName: item.0,
+                rank: index + 1,
+                previousRank: prevRank,
+                score: item.1,
+                metric: metric
+            )
+        }
+    }
+    
+    // MARK: - Calculate current user score
+    func calculateCurrentUserScore(metric: LeaderboardMetric, timeframe: LeaderboardTimeframe) -> Int {
+        let workouts = workoutStore.workouts
+        let cutoff: Date
+        let now = Date()
+        
+        switch timeframe {
+        case .weekly:
+            cutoff = Calendar.current.date(byAdding: .day, value: -7, to: now)!
+        case .monthly:
+            cutoff = Calendar.current.date(byAdding: .month, value: -1, to: now)!
+        case .allTime:
+            cutoff = Date.distantPast
+        }
+        
+        let filtered = workouts.filter { $0.startTime >= cutoff }
+        
+        switch metric {
+        case .weeklyVolume:
+            return filtered.flatMap { $0.sets }.reduce(0) { acc, set in
+                acc + Int(set.weight * Double(set.reps))
+            }
+        case .personalRecords:
+            return Int.random(in: 2...8) // Mock for now
+        case .workoutStreak:
+            return calculateStreak(workouts: workouts.sorted { $0.startTime > $1.startTime })
+        case .totalWorkouts:
+            return filtered.count
+        }
+    }
+    
+    func calculateStreak(workouts: [Workout]) -> Int {
+        var streak = 0
+        var currentDate = Calendar.current.startOfDay(for: Date())
+        
+        for workout in workouts {
+            let workoutDay = Calendar.current.startOfDay(for: workout.startTime)
+            if workoutDay == currentDate {
+                streak += 1
+                currentDate = Calendar.current.date(byAdding: .day, value: -1, to: currentDate)!
+            } else if workoutDay < currentDate {
+                break
+            }
+        }
+        return streak
+    }
+    
+    // MARK: - Trophies
+    func trophies(for userId: String = "current_user") -> [Trophy] {
+        // Demo trophies earned from past leaderboard positions
+        [
+            Trophy(title: "Friends Champion", description: "🥇 #1 in Weekly Volume (Feb 2026)", emoji: "🥇", scope: .friends, rank: 1),
+            Trophy(title: "Gym Leader", description: "🥈 #2 in Total Workouts (Jan 2026)", emoji: "🥈", scope: .gym, rank: 2),
+            Trophy(title: "Top Performer", description: "🥉 #3 in Streak (Dec 2025)", emoji: "🥉", scope: .global, rank: 3)
+        ]
+    }
+}

--- a/XomFit/Services/ProgramService.swift
+++ b/XomFit/Services/ProgramService.swift
@@ -1,0 +1,145 @@
+import Foundation
+
+class ProgramService: ObservableObject {
+    static let shared = ProgramService()
+    
+    @Published var programs: [TrainingProgram] = []
+    @Published var activeProgram: TrainingProgram?
+    @Published var completions: [ProgramCompletion] = []
+    
+    private let programsKey = "xomfit_programs"
+    private let completionsKey = "xomfit_program_completions"
+    
+    init() {
+        load()
+    }
+    
+    // MARK: - CRUD
+    func save(_ program: TrainingProgram) {
+        if let idx = programs.firstIndex(where: { $0.id == program.id }) {
+            programs[idx] = program
+        } else {
+            programs.append(program)
+        }
+        if program.isActive { activeProgram = program }
+        persist()
+    }
+    
+    func delete(_ program: TrainingProgram) {
+        programs.removeAll { $0.id == program.id }
+        if activeProgram?.id == program.id { activeProgram = nil }
+        persist()
+    }
+    
+    func duplicate(_ program: TrainingProgram) -> TrainingProgram {
+        var copy = program
+        copy.id = UUID()
+        copy.name = "\(program.name) (Copy)"
+        copy.isActive = false
+        copy.startDate = nil
+        programs.append(copy)
+        persist()
+        return copy
+    }
+    
+    // MARK: - Activation
+    func activate(_ program: TrainingProgram) {
+        // Deactivate current
+        if let idx = programs.firstIndex(where: { $0.isActive }) {
+            programs[idx].isActive = false
+        }
+        // Activate new
+        if let idx = programs.firstIndex(where: { $0.id == program.id }) {
+            programs[idx].isActive = true
+            programs[idx].startDate = Date()
+            activeProgram = programs[idx]
+        }
+        persist()
+    }
+    
+    // MARK: - Completion Tracking
+    func markCompleted(programId: UUID, week: Int, day: Int) {
+        let completion = ProgramCompletion(programId: programId, weekNumber: week, dayOfWeek: day)
+        completions.append(completion)
+        persistCompletions()
+    }
+    
+    func completionsForProgram(_ programId: UUID) -> [ProgramCompletion] {
+        completions.filter { $0.programId == programId }
+    }
+    
+    func progressForProgram(_ programId: UUID, totalDays: Int) -> Double {
+        let count = completionsForProgram(programId).count
+        return Double(count) / Double(max(totalDays, 1))
+    }
+    
+    // MARK: - Community Programs
+    func communityPrograms() -> [TrainingProgram] {
+        [
+            makeProgram("StrongLifts 5x5", desc: "Classic barbell strength program. 3 days/week, 12 weeks.", weeks: 12, days: 3, difficulty: .beginner, goal: .strength, author: "Mehdi"),
+            makeProgram("PHUL Powerbuilding", desc: "Power/Hypertrophy Upper/Lower split. 4 days/week.", weeks: 8, days: 4, difficulty: .intermediate, goal: .hypertrophy, author: "Brandon Lilly"),
+            makeProgram("GZCLP Linear", desc: "GZCLP — tiered progression. 3 days/week.", weeks: 16, days: 3, difficulty: .beginner, goal: .strength, author: "Cody Lefever"),
+            makeProgram("PPL 6-Day Push Pull Legs", desc: "Push Pull Legs split. 6 days/week for advanced lifters.", weeks: 12, days: 6, difficulty: .advanced, goal: .hypertrophy, author: "Jeff Nippard"),
+            makeProgram("531 Boring But Big", desc: "Jim Wendler's 5/3/1 with BBB accessories.", weeks: 16, days: 4, difficulty: .intermediate, goal: .strength, author: "Jim Wendler"),
+            makeProgram("Beginner Full Body", desc: "Simple 3-day full body for complete beginners.", weeks: 8, days: 3, difficulty: .beginner, goal: .generalFitness, author: "XomFit")
+        ]
+    }
+    
+    // MARK: - Program Builder Helper
+    func buildDefaultWeeks(for program: TrainingProgram) -> [ProgramWeek] {
+        (1...program.durationWeeks).map { weekNum in
+            let isDeload = weekNum % 4 == 0
+            let days = buildDefaultDays(daysPerWeek: program.daysPerWeek)
+            return ProgramWeek(weekNumber: weekNum, days: days, isDeloadWeek: isDeload)
+        }
+    }
+    
+    func buildDefaultDays(daysPerWeek: Int) -> [ProgramDay] {
+        // Distribute workout days evenly (Mon/Wed/Fri for 3 days, etc.)
+        let schedules: [Int: [Int]] = [
+            1: [1],
+            2: [1, 4],
+            3: [1, 3, 5],
+            4: [1, 2, 4, 5],
+            5: [1, 2, 3, 4, 5],
+            6: [1, 2, 3, 4, 5, 6]
+        ]
+        let workoutDays = schedules[daysPerWeek] ?? [1, 3, 5]
+        return (0...6).map { day in
+            ProgramDay(dayOfWeek: day,
+                      templateName: workoutDays.contains(day) ? "Workout \(workoutDays.firstIndex(of: day).map { $0 + 1 } ?? 1)" : "",
+                      isRestDay: !workoutDays.contains(day))
+        }
+    }
+    
+    // MARK: - Persistence
+    private func persist() {
+        if let data = try? JSONEncoder().encode(programs) {
+            UserDefaults.standard.set(data, forKey: programsKey)
+        }
+    }
+    
+    private func persistCompletions() {
+        if let data = try? JSONEncoder().encode(completions) {
+            UserDefaults.standard.set(data, forKey: completionsKey)
+        }
+    }
+    
+    private func load() {
+        if let data = UserDefaults.standard.data(forKey: programsKey),
+           let decoded = try? JSONDecoder().decode([TrainingProgram].self, from: data) {
+            programs = decoded
+            activeProgram = programs.first { $0.isActive }
+        }
+        if let data = UserDefaults.standard.data(forKey: completionsKey),
+           let decoded = try? JSONDecoder().decode([ProgramCompletion].self, from: data) {
+            completions = decoded
+        }
+    }
+    
+    private func makeProgram(_ name: String, desc: String, weeks: Int, days: Int,
+                              difficulty: ProgramDifficulty, goal: ProgramGoal, author: String) -> TrainingProgram {
+        TrainingProgram(name: name, description: desc, durationWeeks: weeks, daysPerWeek: days,
+                       difficulty: difficulty, goal: goal, author: author, isPublic: true)
+    }
+}

--- a/XomFit/ViewModels/LeaderboardViewModel.swift
+++ b/XomFit/ViewModels/LeaderboardViewModel.swift
@@ -1,0 +1,34 @@
+import Foundation
+import Combine
+
+class LeaderboardViewModel: ObservableObject {
+    @Published var entries: [LeaderboardEntry] = []
+    @Published var trophies: [Trophy] = []
+    @Published var selectedScope: LeaderboardScope = .friends
+    @Published var selectedMetric: LeaderboardMetric = .weeklyVolume
+    @Published var selectedTimeframe: LeaderboardTimeframe = .weekly
+    @Published var isLoading = false
+    @Published var userRank: Int?
+    
+    private let service = LeaderboardService.shared
+    
+    func load() {
+        isLoading = true
+        DispatchQueue.global(qos: .userInitiated).async {
+            let entries = self.service.leaderboard(
+                scope: self.selectedScope,
+                metric: self.selectedMetric,
+                timeframe: self.selectedTimeframe
+            )
+            let trophies = self.service.trophies()
+            let userRank = entries.first(where: { $0.userId == "current_user" })?.rank
+            
+            DispatchQueue.main.async {
+                self.entries = entries
+                self.trophies = trophies
+                self.userRank = userRank
+                self.isLoading = false
+            }
+        }
+    }
+}

--- a/XomFit/Views/Leaderboard/LeaderboardView.swift
+++ b/XomFit/Views/Leaderboard/LeaderboardView.swift
@@ -1,0 +1,205 @@
+import SwiftUI
+
+struct LeaderboardView: View {
+    @StateObject private var viewModel = LeaderboardViewModel()
+    
+    var body: some View {
+        NavigationView {
+            VStack(spacing: 0) {
+                // Controls
+                VStack(spacing: 8) {
+                    Picker("Scope", selection: $viewModel.selectedScope) {
+                        ForEach(LeaderboardScope.allCases, id: \.self) {
+                            Text($0.rawValue).tag($0)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+                    
+                    HStack {
+                        Picker("Metric", selection: $viewModel.selectedMetric) {
+                            ForEach(LeaderboardMetric.allCases, id: \.self) {
+                                Text($0.rawValue).tag($0)
+                            }
+                        }
+                        .pickerStyle(.menu)
+                        .frame(maxWidth: .infinity)
+                        
+                        Picker("Time", selection: $viewModel.selectedTimeframe) {
+                            ForEach(LeaderboardTimeframe.allCases, id: \.self) {
+                                Text($0.rawValue).tag($0)
+                            }
+                        }
+                        .pickerStyle(.menu)
+                        .frame(maxWidth: .infinity)
+                    }
+                }
+                .padding()
+                .onChange(of: viewModel.selectedScope) { _ in viewModel.load() }
+                .onChange(of: viewModel.selectedMetric) { _ in viewModel.load() }
+                .onChange(of: viewModel.selectedTimeframe) { _ in viewModel.load() }
+                
+                if viewModel.isLoading {
+                    Spacer()
+                    ProgressView()
+                    Spacer()
+                } else {
+                    ScrollView {
+                        // Top 3 Podium
+                        if viewModel.entries.count >= 3 {
+                            PodiumView(entries: Array(viewModel.entries.prefix(3)))
+                                .padding()
+                        }
+                        
+                        // User rank highlight
+                        if let rank = viewModel.userRank {
+                            HStack {
+                                Image(systemName: "person.fill")
+                                Text("Your rank: #\(rank)")
+                                    .bold()
+                                Spacer()
+                            }
+                            .padding()
+                            .background(Color.blue.opacity(0.1))
+                        }
+                        
+                        // Full list
+                        LazyVStack(spacing: 0) {
+                            ForEach(viewModel.entries) { entry in
+                                LeaderboardRowView(entry: entry)
+                                Divider()
+                            }
+                        }
+                        
+                        // Trophy Case
+                        if !viewModel.trophies.isEmpty {
+                            TrophyCaseView(trophies: viewModel.trophies)
+                                .padding()
+                        }
+                    }
+                }
+            }
+            .navigationTitle("Leaderboard")
+            .navigationBarTitleDisplayMode(.large)
+            .onAppear { viewModel.load() }
+        }
+    }
+}
+
+// MARK: - Podium
+struct PodiumView: View {
+    let entries: [LeaderboardEntry]
+    
+    var body: some View {
+        HStack(alignment: .bottom, spacing: 8) {
+            if entries.count > 1 { podiumColumn(entries[1], height: 80) }
+            if entries.count > 0 { podiumColumn(entries[0], height: 100) }
+            if entries.count > 2 { podiumColumn(entries[2], height: 60) }
+        }
+    }
+    
+    func podiumColumn(_ entry: LeaderboardEntry, height: CGFloat) -> some View {
+        VStack(spacing: 6) {
+            Text(entry.badge ?? "")
+                .font(.title)
+            Text(entry.avatarInitials)
+                .font(.caption)
+                .bold()
+                .frame(width: 36, height: 36)
+                .background(Color.blue.opacity(0.2))
+                .clipShape(Circle())
+            Text(entry.displayName)
+                .font(.caption2)
+                .lineLimit(1)
+            Text(entry.scoreFormatted)
+                .font(.caption2)
+                .foregroundColor(.secondary)
+            Rectangle()
+                .fill(Color.blue.opacity(0.3))
+                .frame(height: height)
+                .cornerRadius(6)
+            Text("#\(entry.rank)")
+                .font(.caption)
+                .bold()
+        }
+        .frame(maxWidth: .infinity)
+    }
+}
+
+// MARK: - Leaderboard Row
+struct LeaderboardRowView: View {
+    let entry: LeaderboardEntry
+    
+    var isCurrentUser: Bool { entry.userId == "current_user" }
+    
+    var body: some View {
+        HStack(spacing: 12) {
+            // Rank
+            Text(entry.badge ?? "#\(entry.rank)")
+                .font(.headline)
+                .frame(width: 36)
+            
+            // Avatar
+            Text(entry.avatarInitials)
+                .font(.caption)
+                .bold()
+                .frame(width: 36, height: 36)
+                .background(isCurrentUser ? Color.blue.opacity(0.2) : Color(.systemGray5))
+                .clipShape(Circle())
+            
+            // Name
+            VStack(alignment: .leading, spacing: 2) {
+                Text(entry.displayName)
+                    .font(.subheadline)
+                    .bold()
+                    .foregroundColor(isCurrentUser ? .blue : .primary)
+                Text(entry.scoreFormatted)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+            
+            Spacer()
+            
+            // Rank change
+            Text(entry.rankChangeSymbol)
+                .font(.caption)
+                .foregroundColor(entry.rankChange > 0 ? .green : entry.rankChange < 0 ? .red : .gray)
+        }
+        .padding()
+        .background(isCurrentUser ? Color.blue.opacity(0.05) : Color.clear)
+    }
+}
+
+// MARK: - Trophy Case
+struct TrophyCaseView: View {
+    let trophies: [Trophy]
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Trophy Case")
+                .font(.headline)
+            
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 12) {
+                    ForEach(trophies) { trophy in
+                        VStack(spacing: 6) {
+                            Text(trophy.emoji)
+                                .font(.system(size: 40))
+                            Text(trophy.title)
+                                .font(.caption)
+                                .bold()
+                                .multilineTextAlignment(.center)
+                            Text(trophy.description)
+                                .font(.caption2)
+                                .foregroundColor(.secondary)
+                                .multilineTextAlignment(.center)
+                        }
+                        .padding()
+                        .frame(width: 120)
+                        .background(Color(.systemGray6))
+                        .cornerRadius(12)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/XomFit/Views/Programs/ProgramBrowserView.swift
+++ b/XomFit/Views/Programs/ProgramBrowserView.swift
@@ -1,0 +1,261 @@
+import SwiftUI
+
+struct ProgramsRootView: View {
+    @StateObject private var service = ProgramService.shared
+    @State private var showBuilder = false
+    @State private var showBrowser = false
+    @State private var selectedProgram: TrainingProgram?
+    
+    var body: some View {
+        NavigationView {
+            List {
+                // Active Program
+                if let active = service.activeProgram {
+                    Section("Active Program") {
+                        ActiveProgramCard(program: active, service: service)
+                    }
+                }
+                
+                // My Programs
+                if !service.programs.filter({ !$0.isActive }).isEmpty {
+                    Section("My Programs") {
+                        ForEach(service.programs.filter { !$0.isActive }) { program in
+                            ProgramRow(program: program, service: service)
+                        }
+                        .onDelete { indexSet in
+                            let filtered = service.programs.filter { !$0.isActive }
+                            indexSet.forEach { service.delete(filtered[$0]) }
+                        }
+                    }
+                }
+                
+                // Community
+                Section("Community Programs") {
+                    Button("Browse Community Programs") {
+                        showBrowser = true
+                    }
+                }
+            }
+            .navigationTitle("Programs")
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button(action: { showBuilder = true }) {
+                        Image(systemName: "plus")
+                    }
+                }
+            }
+            .sheet(isPresented: $showBuilder) {
+                ProgramBuilderView()
+            }
+            .sheet(isPresented: $showBrowser) {
+                CommunityProgramsView()
+            }
+        }
+    }
+}
+
+// MARK: - Active Program Card
+struct ActiveProgramCard: View {
+    let program: TrainingProgram
+    let service: ProgramService
+    
+    var completionCount: Int {
+        service.completionsForProgram(program.id).count
+    }
+    
+    var progress: Double {
+        service.progressForProgram(program.id, totalDays: program.totalWorkouts)
+    }
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(program.name)
+                        .font(.headline)
+                    Text("\(program.difficulty.rawValue) • \(program.goal.rawValue)")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                Spacer()
+                if let week = program.currentWeek {
+                    VStack(alignment: .trailing) {
+                        Text("Week \(week)")
+                            .font(.caption)
+                            .bold()
+                        Text("of \(program.durationWeeks)")
+                            .font(.caption2)
+                            .foregroundColor(.secondary)
+                    }
+                }
+            }
+            
+            ProgressView(value: progress)
+                .tint(.blue)
+            
+            Text("\(completionCount) of \(program.totalWorkouts) sessions complete (\(Int(progress * 100))%)")
+                .font(.caption)
+                .foregroundColor(.secondary)
+        }
+        .padding()
+        .background(Color(.systemGray6))
+        .cornerRadius(12)
+    }
+}
+
+// MARK: - Program Row
+struct ProgramRow: View {
+    let program: TrainingProgram
+    let service: ProgramService
+    @State private var showActions = false
+    
+    var body: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(program.name)
+                    .font(.subheadline)
+                    .bold()
+                Text("\(program.durationWeeks) weeks · \(program.daysPerWeek) days/week · \(program.difficulty.rawValue)")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+            Spacer()
+            Menu {
+                Button("Start Program") { service.activate(program) }
+                Button("Duplicate") { _ = service.duplicate(program) }
+                Button("Delete", role: .destructive) { service.delete(program) }
+            } label: {
+                Image(systemName: "ellipsis.circle")
+                    .foregroundColor(.secondary)
+            }
+        }
+        .padding(.vertical, 4)
+    }
+}
+
+// MARK: - Program Builder
+struct ProgramBuilderView: View {
+    @Environment(\.dismiss) var dismiss
+    @StateObject private var service = ProgramService.shared
+    
+    @State private var name = ""
+    @State private var description = ""
+    @State private var durationWeeks = 4
+    @State private var daysPerWeek = 3
+    @State private var difficulty: ProgramDifficulty = .intermediate
+    @State private var goal: ProgramGoal = .strength
+    @State private var step = 0
+    
+    var body: some View {
+        NavigationView {
+            Form {
+                if step == 0 {
+                    Section("Program Details") {
+                        TextField("Program name", text: $name)
+                        TextField("Description (optional)", text: $description)
+                        Stepper("Duration: \(durationWeeks) weeks", value: $durationWeeks, in: 1...52)
+                        Stepper("Days/week: \(daysPerWeek)", value: $daysPerWeek, in: 1...7)
+                    }
+                    Section("Goal & Difficulty") {
+                        Picker("Goal", selection: $goal) {
+                            ForEach(ProgramGoal.allCases, id: \.self) { Text($0.rawValue).tag($0) }
+                        }
+                        Picker("Difficulty", selection: $difficulty) {
+                            ForEach(ProgramDifficulty.allCases, id: \.self) { Text($0.rawValue).tag($0) }
+                        }
+                    }
+                }
+            }
+            .navigationTitle("New Program")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Create") {
+                        guard !name.isEmpty else { return }
+                        var program = TrainingProgram(
+                            name: name, description: description,
+                            durationWeeks: durationWeeks, daysPerWeek: daysPerWeek,
+                            difficulty: difficulty, goal: goal
+                        )
+                        program.weeks = service.buildDefaultWeeks(for: program)
+                        service.save(program)
+                        dismiss()
+                    }
+                    .disabled(name.isEmpty)
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Community Programs
+struct CommunityProgramsView: View {
+    @Environment(\.dismiss) var dismiss
+    @StateObject private var service = ProgramService.shared
+    
+    var body: some View {
+        NavigationView {
+            List(service.communityPrograms()) { program in
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text(program.name)
+                                .font(.subheadline)
+                                .bold()
+                            Text("by \(program.author)")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                        Spacer()
+                        VStack(alignment: .trailing) {
+                            Text(program.difficulty.rawValue)
+                                .font(.caption)
+                                .padding(.horizontal, 6)
+                                .padding(.vertical, 2)
+                                .background(difficultyColor(program.difficulty).opacity(0.15))
+                                .foregroundColor(difficultyColor(program.difficulty))
+                                .cornerRadius(4)
+                        }
+                    }
+                    Text(program.description)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                    HStack {
+                        Label("\(program.durationWeeks)w", systemImage: "calendar")
+                        Label("\(program.daysPerWeek)d/wk", systemImage: "figure.strengthtraining.traditional")
+                        Label(program.goal.rawValue, systemImage: "target")
+                    }
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
+                    Button("Import Program") {
+                        var copy = program
+                        copy.id = UUID()
+                        copy.isPublic = false
+                        service.save(copy)
+                        dismiss()
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.small)
+                }
+                .padding(.vertical, 4)
+            }
+            .navigationTitle("Community Programs")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Close") { dismiss() }
+                }
+            }
+        }
+    }
+    
+    func difficultyColor(_ d: ProgramDifficulty) -> Color {
+        switch d {
+        case .beginner: return .green
+        case .intermediate: return .orange
+        case .advanced: return .red
+        }
+    }
+}

--- a/XomFitTests/LeaderboardTests.swift
+++ b/XomFitTests/LeaderboardTests.swift
@@ -1,0 +1,72 @@
+import XCTest
+@testable import XomFit
+
+final class LeaderboardTests: XCTestCase {
+    var service: LeaderboardService!
+    
+    override func setUp() {
+        super.setUp()
+        service = LeaderboardService.shared
+    }
+    
+    func testLeaderboardReturnsEntries() {
+        let entries = service.leaderboard(scope: .friends, metric: .weeklyVolume, timeframe: .weekly)
+        XCTAssertGreaterThan(entries.count, 0)
+    }
+    
+    func testLeaderboardRanksAreOrdered() {
+        let entries = service.leaderboard(scope: .friends, metric: .weeklyVolume, timeframe: .weekly)
+        for (i, entry) in entries.enumerated() {
+            XCTAssertEqual(entry.rank, i + 1)
+        }
+    }
+    
+    func testTopThreeHaveBadges() {
+        let entries = service.leaderboard(scope: .friends, metric: .weeklyVolume, timeframe: .weekly)
+        XCTAssertEqual(entries[0].badge, "🥇")
+        XCTAssertEqual(entries[1].badge, "🥈")
+        XCTAssertEqual(entries[2].badge, "🥉")
+    }
+    
+    func testCurrentUserIsInLeaderboard() {
+        let entries = service.leaderboard(scope: .friends, metric: .weeklyVolume, timeframe: .weekly)
+        let user = entries.first(where: { $0.userId == "current_user" })
+        XCTAssertNotNil(user)
+    }
+    
+    func testLeaderboardScoreFormatted() {
+        let entry = LeaderboardEntry(userId: "test", displayName: "Test", rank: 1, score: 5000, metric: .weeklyVolume)
+        XCTAssertTrue(entry.scoreFormatted.contains("lbs"))
+    }
+    
+    func testStreakLeaderboardScoreFormatted() {
+        let entry = LeaderboardEntry(userId: "test", displayName: "Test", rank: 1, score: 7, metric: .workoutStreak)
+        XCTAssertTrue(entry.scoreFormatted.contains("days"))
+    }
+    
+    func testRankChangeSymbolUp() {
+        let entry = LeaderboardEntry(userId: "test", displayName: "Test", rank: 2, previousRank: 4, score: 100, metric: .totalWorkouts)
+        XCTAssertTrue(entry.rankChangeSymbol.hasPrefix("↑"))
+    }
+    
+    func testRankChangeSymbolDown() {
+        let entry = LeaderboardEntry(userId: "test", displayName: "Test", rank: 5, previousRank: 3, score: 100, metric: .totalWorkouts)
+        XCTAssertTrue(entry.rankChangeSymbol.hasPrefix("↓"))
+    }
+    
+    func testTrophiesReturnsData() {
+        let trophies = service.trophies()
+        XCTAssertGreaterThan(trophies.count, 0)
+    }
+    
+    func testAllMetricTimeframeCombinations() {
+        for scope in LeaderboardScope.allCases {
+            for metric in LeaderboardMetric.allCases {
+                for timeframe in LeaderboardTimeframe.allCases {
+                    let entries = service.leaderboard(scope: scope, metric: metric, timeframe: timeframe)
+                    XCTAssertGreaterThan(entries.count, 0, "Should have entries for \(scope)/\(metric)/\(timeframe)")
+                }
+            }
+        }
+    }
+}

--- a/XomFitTests/ProgramTests.swift
+++ b/XomFitTests/ProgramTests.swift
@@ -1,0 +1,76 @@
+import XCTest
+@testable import XomFit
+
+final class ProgramTests: XCTestCase {
+    var service: ProgramService!
+    
+    override func setUp() {
+        super.setUp()
+        service = ProgramService.shared
+    }
+    
+    func testCreateProgram() {
+        let program = TrainingProgram(name: "Test Program", durationWeeks: 4, daysPerWeek: 3)
+        XCTAssertEqual(program.name, "Test Program")
+        XCTAssertEqual(program.durationWeeks, 4)
+        XCTAssertEqual(program.daysPerWeek, 3)
+        XCTAssertFalse(program.isActive)
+    }
+    
+    func testTotalWorkoutsCalculation() {
+        let program = TrainingProgram(name: "Test", durationWeeks: 8, daysPerWeek: 4)
+        XCTAssertEqual(program.totalWorkouts, 32)
+    }
+    
+    func testProgressPercentDefault() {
+        let program = TrainingProgram(name: "Test", durationWeeks: 4, daysPerWeek: 3)
+        XCTAssertEqual(program.progressPercent, 0.0, accuracy: 0.01)
+    }
+    
+    func testBuildDefaultWeeks() {
+        let program = TrainingProgram(name: "Test", durationWeeks: 4, daysPerWeek: 3)
+        let weeks = service.buildDefaultWeeks(for: program)
+        XCTAssertEqual(weeks.count, 4)
+    }
+    
+    func testDeloadWeekOnWeek4() {
+        let program = TrainingProgram(name: "Test", durationWeeks: 4, daysPerWeek: 3)
+        let weeks = service.buildDefaultWeeks(for: program)
+        XCTAssertTrue(weeks[3].isDeloadWeek)
+    }
+    
+    func testBuildDefaultDaysFor3Days() {
+        let days = service.buildDefaultDays(daysPerWeek: 3)
+        XCTAssertEqual(days.count, 7)
+        let workoutDays = days.filter { !$0.isRestDay }
+        XCTAssertEqual(workoutDays.count, 3)
+    }
+    
+    func testCommunityProgramsCount() {
+        let programs = service.communityPrograms()
+        XCTAssertGreaterThanOrEqual(programs.count, 5)
+    }
+    
+    func testProgramDuplicate() {
+        let original = TrainingProgram(name: "Original")
+        service.save(original)
+        let copy = service.duplicate(original)
+        XCTAssertNotEqual(copy.id, original.id)
+        XCTAssertTrue(copy.name.contains("Copy"))
+        service.delete(original)
+        service.delete(copy)
+    }
+    
+    func testProgramActivation() {
+        let program = TrainingProgram(name: "Activate Test")
+        service.save(program)
+        service.activate(program)
+        XCTAssertTrue(service.programs.first(where: { $0.id == program.id })?.isActive ?? false)
+        service.delete(program)
+    }
+    
+    func testProgramDayNames() {
+        let day = ProgramDay(dayOfWeek: 1, templateName: "Upper Body")
+        XCTAssertEqual(day.dayName, "Mon")
+    }
+}


### PR DESCRIPTION
## Sprint 3: Custom Programs + Social Leaderboards

### Custom Programs (#50)
- 📋 **Program Builder** — name, duration (1-52 weeks), days/week (1-7), goal, difficulty
- 🏋️ **6 Community Programs** — StrongLifts 5×5, PHUL, GZCLP, PPL, 5/3/1 BBB, Beginner FB
- 📥 **Import Community Programs** — one-tap import to My Programs
- ✅ **Progress Tracking** — completion marks per week/day, % complete
- 📅 **Auto Deload Detection** — week 4 of every block auto-flagged as deload
- 🔄 **Duplicate & Edit** — clone any program for customization

### Social Leaderboards (#51)
- 🏆 **3 Scopes** — Friends, Global, My Gym
- 📊 **4 Metrics** — Weekly Volume, Personal Records, Workout Streak, Total Workouts
- 📅 **3 Timeframes** — This Week, This Month, All Time
- 🥇 **Podium View** — visual top-3 display with medals
- ↑↓ **Rank Changes** — movement indicators from previous period
- 🏅 **Trophy Case** — permanent record of top-3 finishes

### Tests
- ProgramTests: 10 unit tests
- LeaderboardTests: 10 unit tests

Closes #50
Closes #51