### PR TITLE
Fix EstimatedOneRMChart averageScaled calculation bug

### DIFF
--- a/XomFit/ViewModels/AnalyticsViewModel.swift
+++ b/XomFit/ViewModels/AnalyticsViewModel.swift
@@ -199,7 +199,8 @@ struct WorkoutFrequencyDataPoint {
     let count: Int
 }
 
-struct OneRMTrendDataPoint {
+struct OneRMTrendDataPoint: Identifiable {
+    let id = UUID()
     let date: Date
     let estimatedOneRM: Double
 }

--- a/XomFit/Views/Analytics/EstimatedOneRMChart.swift
+++ b/XomFit/Views/Analytics/EstimatedOneRMChart.swift
@@ -98,9 +98,10 @@ struct TrendLineChartView: View {
             
             // Draw grid lines and average line
             var gridPath = Path()
-            let averageScaled = CGFloat((averageOneRM - (data.min(by: { $0.estimatedOneRM < $1.estimatedOneRM })?.estimatedOneRM ?? 0)) / 
-                                        (data.max(by: { $0.estimatedOneRM < $1.estimatedOneRM })?.estimatedOneRM ?? 0) - 
-                                        (data.min(by: { $0.estimatedOneRM < $1.estimatedOneRM })?.estimatedOneRM ?? 0))
+            let minOneRM = data.min(by: { $0.estimatedOneRM < $1.estimatedOneRM })?.estimatedOneRM ?? 0
+            let maxOneRM = data.max(by: { $0.estimatedOneRM < $1.estimatedOneRM })?.estimatedOneRM ?? 0
+            let oneRMRange = maxOneRM - minOneRM
+            let averageScaled = oneRMRange > 0 ? CGFloat((averageOneRM - minOneRM) / oneRMRange) : 0.5
             
             for i in 0...4 {
                 let y = padding + (CGFloat(i) / 4.0) * chartHeight


### PR DESCRIPTION
## Problem
The `averageScaled` variable in `TrendLineChartView` had a parenthesization bug causing incorrect calculation:

```swift
// Before (broken): divides by max, then subtracts min
(averageOneRM - min) / max - min

// After (correct): divides by the range
(averageOneRM - min) / (max - min)
```

This caused a build failure due to the compiler being unable to type-check the malformed expression within the allowed time.

## Fix
- Extract min/max/range into named local variables for clarity
- Add division-by-zero guard (falls back to 0.5 when all data points are equal)
- Make `OneRMTrendDataPoint` conform to `Identifiable`