### PR TITLE
feat: implement Auth (Phase 2) and Workout Core (Phase 3)

### DIFF
--- a/Xomfit/Services/AuthService.swift
+++ b/Xomfit/Services/AuthService.swift
@@ -1,0 +1,63 @@
+import Foundation
+import Supabase
+
+@MainActor
+@Observable
+final class AuthService {
+    var isAuthenticated = false
+    var currentSession: Session?
+    var currentUser: User?
+    var isLoading = true
+    var errorMessage: String?
+
+    init() {
+        Task { await listenForAuthChanges() }
+    }
+
+    private func listenForAuthChanges() async {
+        for await (event, session) in supabase.auth.authStateChanges {
+            self.currentSession = session
+            self.currentUser = session?.user
+            self.isAuthenticated = session != nil
+            if event == .initialSession {
+                self.isLoading = false
+            }
+        }
+    }
+
+    func signIn(email: String, password: String) async throws {
+        errorMessage = nil
+        let session = try await supabase.auth.signIn(
+            email: email,
+            password: password
+        )
+        self.currentSession = session
+        self.currentUser = session.user
+        self.isAuthenticated = true
+    }
+
+    func signUp(email: String, password: String) async throws {
+        errorMessage = nil
+        let response = try await supabase.auth.signUp(
+            email: email,
+            password: password
+        )
+        if let session = response.session {
+            self.currentSession = session
+            self.currentUser = session.user
+            self.isAuthenticated = true
+        }
+    }
+
+    func signOut() async {
+        errorMessage = nil
+        do {
+            try await supabase.auth.signOut()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+        self.currentSession = nil
+        self.currentUser = nil
+        self.isAuthenticated = false
+    }
+}

--- a/Xomfit/Services/WorkoutService.swift
+++ b/Xomfit/Services/WorkoutService.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+@MainActor
+final class WorkoutService {
+    static let shared = WorkoutService()
+
+    private let storageKey = "xomfit_workouts"
+
+    private init() {}
+
+    // MARK: - Save
+
+    func saveWorkout(_ workout: Workout) async throws {
+        var workouts = fetchWorkouts()
+        // Replace if exists, otherwise append
+        if let idx = workouts.firstIndex(where: { $0.id == workout.id }) {
+            workouts[idx] = workout
+        } else {
+            workouts.insert(workout, at: 0)
+        }
+        let data = try JSONEncoder().encode(workouts)
+        UserDefaults.standard.set(data, forKey: storageKey)
+    }
+
+    // MARK: - Fetch
+
+    func fetchWorkouts() -> [Workout] {
+        guard let data = UserDefaults.standard.data(forKey: storageKey) else { return [] }
+        let workouts = (try? JSONDecoder().decode([Workout].self, from: data)) ?? []
+        return workouts.sorted { $0.startTime > $1.startTime }
+    }
+
+    func fetchWorkouts(userId: String) -> [Workout] {
+        fetchWorkouts().filter { $0.userId == userId }
+    }
+
+    // MARK: - Delete
+
+    func deleteWorkout(id: String) {
+        var workouts = fetchWorkouts()
+        workouts.removeAll { $0.id == id }
+        let data = try? JSONEncoder().encode(workouts)
+        UserDefaults.standard.set(data, forKey: storageKey)
+    }
+}

--- a/Xomfit/ViewModels/WorkoutLoggerViewModel.swift
+++ b/Xomfit/ViewModels/WorkoutLoggerViewModel.swift
@@ -1,0 +1,157 @@
+import SwiftUI
+
+@MainActor
+@Observable
+final class WorkoutLoggerViewModel {
+    var workoutName: String = ""
+    var exercises: [WorkoutExercise] = []
+    var startTime = Date()
+    var isActive = false
+    var isSaving = false
+    var errorMessage: String?
+
+    // MARK: - Computed
+
+    var duration: TimeInterval {
+        Date().timeIntervalSince(startTime)
+    }
+
+    var durationString: String {
+        let seconds = Int(duration)
+        let minutes = seconds / 60
+        let hours = minutes / 60
+        if hours > 0 {
+            return String(format: "%d:%02d:%02d", hours, minutes % 60, seconds % 60)
+        }
+        return String(format: "%d:%02d", minutes, seconds % 60)
+    }
+
+    var totalSets: Int {
+        exercises.reduce(0) { $0 + $1.sets.count }
+    }
+
+    var completedSets: Int {
+        exercises.reduce(0) { total, ex in
+            total + ex.sets.filter { $0.completedAt != Date.distantPast }.count
+        }
+    }
+
+    // MARK: - Workout Lifecycle
+
+    func startWorkout(name: String) {
+        workoutName = name.isEmpty ? "Workout" : name
+        exercises = []
+        startTime = Date()
+        isActive = true
+        errorMessage = nil
+    }
+
+    func discardWorkout() {
+        workoutName = ""
+        exercises = []
+        isActive = false
+        isSaving = false
+        errorMessage = nil
+    }
+
+    // MARK: - Exercise Management
+
+    func addExercise(_ exercise: Exercise) {
+        let workoutExercise = WorkoutExercise(
+            id: UUID().uuidString,
+            exercise: exercise,
+            sets: [],
+            notes: nil
+        )
+        exercises.append(workoutExercise)
+    }
+
+    func removeExercise(at index: Int) {
+        guard exercises.indices.contains(index) else { return }
+        exercises.remove(at: index)
+    }
+
+    // MARK: - Set Management
+
+    func addSet(to exerciseIndex: Int) {
+        guard exercises.indices.contains(exerciseIndex) else { return }
+        let exercise = exercises[exerciseIndex]
+
+        // Pre-fill weight/reps from the last set if available
+        let lastSet = exercise.sets.last
+        let newSet = WorkoutSet(
+            id: UUID().uuidString,
+            exerciseId: exercise.exercise.id,
+            weight: lastSet?.weight ?? 0,
+            reps: lastSet?.reps ?? 0,
+            rpe: nil,
+            isPersonalRecord: false,
+            completedAt: Date.distantPast   // distantPast = not yet completed
+        )
+        exercises[exerciseIndex].sets.append(newSet)
+    }
+
+    func updateSet(exerciseIndex: Int, setIndex: Int, weight: Double, reps: Int) {
+        guard exercises.indices.contains(exerciseIndex),
+              exercises[exerciseIndex].sets.indices.contains(setIndex) else { return }
+        exercises[exerciseIndex].sets[setIndex].weight = weight
+        exercises[exerciseIndex].sets[setIndex].reps = reps
+    }
+
+    func completeSet(exerciseIndex: Int, setIndex: Int) {
+        guard exercises.indices.contains(exerciseIndex),
+              exercises[exerciseIndex].sets.indices.contains(setIndex) else { return }
+        let isCurrentlyCompleted = exercises[exerciseIndex].sets[setIndex].completedAt != Date.distantPast
+        if isCurrentlyCompleted {
+            // Toggle off
+            exercises[exerciseIndex].sets[setIndex].completedAt = Date.distantPast
+        } else {
+            exercises[exerciseIndex].sets[setIndex].completedAt = Date()
+        }
+    }
+
+    func removeSet(exerciseIndex: Int, setIndex: Int) {
+        guard exercises.indices.contains(exerciseIndex),
+              exercises[exerciseIndex].sets.indices.contains(setIndex) else { return }
+        exercises[exerciseIndex].sets.remove(at: setIndex)
+    }
+
+    // MARK: - Finish Workout
+
+    func finishWorkout(userId: String) async {
+        isSaving = true
+        errorMessage = nil
+
+        // Only keep completed sets (completedAt != distantPast) for the saved workout,
+        // but keep all exercises that have at least one set
+        let completedExercises: [WorkoutExercise] = exercises.compactMap { ex in
+            let doneSets = ex.sets.filter { $0.completedAt != Date.distantPast }
+            guard !doneSets.isEmpty else { return nil }
+            return WorkoutExercise(
+                id: ex.id,
+                exercise: ex.exercise,
+                sets: doneSets,
+                notes: ex.notes
+            )
+        }
+
+        let workout = Workout(
+            id: UUID().uuidString,
+            userId: userId,
+            name: workoutName,
+            exercises: completedExercises,
+            startTime: startTime,
+            endTime: Date(),
+            notes: nil
+        )
+
+        do {
+            try await WorkoutService.shared.saveWorkout(workout)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+
+        isSaving = false
+        discardWorkout()
+    }
+}

--- a/Xomfit/Views/Auth/LoginView.swift
+++ b/Xomfit/Views/Auth/LoginView.swift
@@ -1,0 +1,121 @@
+import SwiftUI
+
+struct LoginView: View {
+    @Environment(AuthService.self) private var authService
+
+    @State private var email = ""
+    @State private var password = ""
+    @State private var isLoading = false
+    @State private var showSignUp = false
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Theme.background.ignoresSafeArea()
+
+                ScrollView {
+                    VStack(spacing: Theme.paddingLarge) {
+                        // Logo / Header
+                        VStack(spacing: Theme.paddingSmall) {
+                            Text("XOMFIT")
+                                .font(.system(size: 42, weight: .black))
+                                .foregroundColor(Theme.accent)
+                                .tracking(4)
+                            Text("Track. Lift. Grow.")
+                                .font(Theme.fontCaption)
+                                .foregroundColor(Theme.textSecondary)
+                        }
+                        .padding(.top, 60)
+                        .padding(.bottom, Theme.paddingLarge)
+
+                        // Form
+                        VStack(spacing: Theme.paddingMedium) {
+                            VStack(alignment: .leading, spacing: 6) {
+                                Text("Email")
+                                    .font(Theme.fontCaption)
+                                    .foregroundColor(Theme.textSecondary)
+                                TextField("you@example.com", text: $email)
+                                    .keyboardType(.emailAddress)
+                                    .autocapitalization(.none)
+                                    .autocorrectionDisabled()
+                                    .padding(Theme.paddingMedium)
+                                    .background(Theme.cardBackground)
+                                    .cornerRadius(Theme.cornerRadius)
+                                    .foregroundColor(Theme.textPrimary)
+                            }
+
+                            VStack(alignment: .leading, spacing: 6) {
+                                Text("Password")
+                                    .font(Theme.fontCaption)
+                                    .foregroundColor(Theme.textSecondary)
+                                SecureField("••••••••", text: $password)
+                                    .padding(Theme.paddingMedium)
+                                    .background(Theme.cardBackground)
+                                    .cornerRadius(Theme.cornerRadius)
+                                    .foregroundColor(Theme.textPrimary)
+                            }
+
+                            if let error = authService.errorMessage {
+                                Text(error)
+                                    .font(Theme.fontCaption)
+                                    .foregroundColor(Theme.destructive)
+                                    .multilineTextAlignment(.center)
+                                    .padding(.horizontal, Theme.paddingSmall)
+                            }
+
+                            Button {
+                                signIn()
+                            } label: {
+                                ZStack {
+                                    RoundedRectangle(cornerRadius: Theme.cornerRadius)
+                                        .fill(Theme.accent)
+                                    if isLoading {
+                                        ProgressView()
+                                            .tint(.black)
+                                    } else {
+                                        Text("Sign In")
+                                            .font(.system(size: 16, weight: .bold))
+                                            .foregroundColor(.black)
+                                    }
+                                }
+                                .frame(height: 52)
+                            }
+                            .disabled(isLoading || email.isEmpty || password.isEmpty)
+                            .opacity((isLoading || email.isEmpty || password.isEmpty) ? 0.6 : 1)
+                            .padding(.top, Theme.paddingSmall)
+                        }
+                        .padding(.horizontal, Theme.paddingLarge)
+
+                        // Sign up link
+                        HStack(spacing: 4) {
+                            Text("Don't have an account?")
+                                .foregroundColor(Theme.textSecondary)
+                                .font(Theme.fontCaption)
+                            NavigationLink(destination: SignUpView()) {
+                                Text("Sign Up")
+                                    .font(.system(size: 13, weight: .semibold))
+                                    .foregroundColor(Theme.accent)
+                            }
+                        }
+                        .padding(.top, Theme.paddingSmall)
+
+                        Spacer()
+                    }
+                }
+            }
+            .navigationBarHidden(true)
+        }
+    }
+
+    private func signIn() {
+        isLoading = true
+        Task {
+            do {
+                try await authService.signIn(email: email, password: password)
+            } catch {
+                authService.errorMessage = error.localizedDescription
+            }
+            isLoading = false
+        }
+    }
+}

--- a/Xomfit/Views/Auth/SignUpView.swift
+++ b/Xomfit/Views/Auth/SignUpView.swift
@@ -1,0 +1,148 @@
+import SwiftUI
+
+struct SignUpView: View {
+    @Environment(AuthService.self) private var authService
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var email = ""
+    @State private var password = ""
+    @State private var confirmPassword = ""
+    @State private var isLoading = false
+    @State private var validationError: String?
+
+    var body: some View {
+        ZStack {
+            Theme.background.ignoresSafeArea()
+
+            ScrollView {
+                VStack(spacing: Theme.paddingLarge) {
+                    // Header
+                    VStack(spacing: Theme.paddingSmall) {
+                        Text("Create Account")
+                            .font(Theme.fontTitle)
+                            .foregroundColor(Theme.textPrimary)
+                        Text("Start your fitness journey")
+                            .font(Theme.fontCaption)
+                            .foregroundColor(Theme.textSecondary)
+                    }
+                    .padding(.top, 48)
+                    .padding(.bottom, Theme.paddingMedium)
+
+                    // Form
+                    VStack(spacing: Theme.paddingMedium) {
+                        VStack(alignment: .leading, spacing: 6) {
+                            Text("Email")
+                                .font(Theme.fontCaption)
+                                .foregroundColor(Theme.textSecondary)
+                            TextField("you@example.com", text: $email)
+                                .keyboardType(.emailAddress)
+                                .autocapitalization(.none)
+                                .autocorrectionDisabled()
+                                .padding(Theme.paddingMedium)
+                                .background(Theme.cardBackground)
+                                .cornerRadius(Theme.cornerRadius)
+                                .foregroundColor(Theme.textPrimary)
+                        }
+
+                        VStack(alignment: .leading, spacing: 6) {
+                            Text("Password")
+                                .font(Theme.fontCaption)
+                                .foregroundColor(Theme.textSecondary)
+                            SecureField("Min 8 characters", text: $password)
+                                .padding(Theme.paddingMedium)
+                                .background(Theme.cardBackground)
+                                .cornerRadius(Theme.cornerRadius)
+                                .foregroundColor(Theme.textPrimary)
+                        }
+
+                        VStack(alignment: .leading, spacing: 6) {
+                            Text("Confirm Password")
+                                .font(Theme.fontCaption)
+                                .foregroundColor(Theme.textSecondary)
+                            SecureField("Repeat password", text: $confirmPassword)
+                                .padding(Theme.paddingMedium)
+                                .background(Theme.cardBackground)
+                                .cornerRadius(Theme.cornerRadius)
+                                .foregroundColor(Theme.textPrimary)
+                        }
+
+                        // Validation / auth error
+                        let displayError = validationError ?? authService.errorMessage
+                        if let error = displayError {
+                            Text(error)
+                                .font(Theme.fontCaption)
+                                .foregroundColor(Theme.destructive)
+                                .multilineTextAlignment(.center)
+                                .padding(.horizontal, Theme.paddingSmall)
+                        }
+
+                        Button {
+                            signUp()
+                        } label: {
+                            ZStack {
+                                RoundedRectangle(cornerRadius: Theme.cornerRadius)
+                                    .fill(Theme.accent)
+                                if isLoading {
+                                    ProgressView()
+                                        .tint(.black)
+                                } else {
+                                    Text("Create Account")
+                                        .font(.system(size: 16, weight: .bold))
+                                        .foregroundColor(.black)
+                                }
+                            }
+                            .frame(height: 52)
+                        }
+                        .disabled(isLoading || email.isEmpty || password.isEmpty || confirmPassword.isEmpty)
+                        .opacity((isLoading || email.isEmpty || password.isEmpty || confirmPassword.isEmpty) ? 0.6 : 1)
+                        .padding(.top, Theme.paddingSmall)
+                    }
+                    .padding(.horizontal, Theme.paddingLarge)
+
+                    // Back to login
+                    HStack(spacing: 4) {
+                        Text("Already have an account?")
+                            .foregroundColor(Theme.textSecondary)
+                            .font(Theme.fontCaption)
+                        Button {
+                            dismiss()
+                        } label: {
+                            Text("Sign In")
+                                .font(.system(size: 13, weight: .semibold))
+                                .foregroundColor(Theme.accent)
+                        }
+                    }
+                    .padding(.top, Theme.paddingSmall)
+
+                    Spacer()
+                }
+            }
+        }
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbarColorScheme(.dark, for: .navigationBar)
+    }
+
+    private func signUp() {
+        validationError = nil
+        authService.errorMessage = nil
+
+        guard password.count >= Config.Validation.passwordMinLength else {
+            validationError = "Password must be at least \(Config.Validation.passwordMinLength) characters."
+            return
+        }
+        guard password == confirmPassword else {
+            validationError = "Passwords do not match."
+            return
+        }
+
+        isLoading = true
+        Task {
+            do {
+                try await authService.signUp(email: email, password: password)
+            } catch {
+                authService.errorMessage = error.localizedDescription
+            }
+            isLoading = false
+        }
+    }
+}

--- a/Xomfit/Views/Profile/ProfileView.swift
+++ b/Xomfit/Views/Profile/ProfileView.swift
@@ -1,16 +1,107 @@
 import SwiftUI
 
 struct ProfileView: View {
+    @Environment(AuthService.self) private var authService
+    @State private var showSignOutConfirm = false
+
+    private var userEmail: String {
+        authService.currentUser?.email ?? "—"
+    }
+
+    private var userInitials: String {
+        let email = userEmail
+        let firstChar = email.first.map { String($0).uppercased() } ?? "?"
+        return firstChar
+    }
+
     var body: some View {
         NavigationStack {
             ZStack {
                 Theme.background.ignoresSafeArea()
-                Text("Profile")
-                    .font(Theme.fontTitle)
-                    .foregroundColor(Theme.textPrimary)
+
+                List {
+                    // Avatar + email header
+                    Section {
+                        HStack(spacing: Theme.paddingMedium) {
+                            ZStack {
+                                Circle()
+                                    .fill(Theme.accent.opacity(0.2))
+                                    .frame(width: 60, height: 60)
+                                Text(userInitials)
+                                    .font(.system(size: 24, weight: .bold))
+                                    .foregroundColor(Theme.accent)
+                            }
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text(userEmail)
+                                    .font(.system(size: 15, weight: .semibold))
+                                    .foregroundColor(Theme.textPrimary)
+                                Text("Member")
+                                    .font(Theme.fontCaption)
+                                    .foregroundColor(Theme.textSecondary)
+                            }
+                        }
+                        .padding(.vertical, 8)
+                        .listRowBackground(Theme.cardBackground)
+                    }
+
+                    // Workout stats (from local storage)
+                    Section("Stats") {
+                        let workouts = WorkoutService.shared.fetchWorkouts()
+                        StatRow(label: "Total Workouts", value: "\(workouts.count)")
+                        StatRow(label: "Total Sets", value: "\(workouts.reduce(0) { $0 + $1.totalSets })")
+                        StatRow(label: "Total Volume", value: {
+                            let v = workouts.reduce(0.0) { $0 + $1.totalVolume }
+                            if v >= 1000 { return String(format: "%.1fk lbs", v / 1000) }
+                            return "\(Int(v)) lbs"
+                        }())
+                    }
+                    .listRowBackground(Theme.cardBackground)
+
+                    // Sign Out
+                    Section {
+                        Button(role: .destructive) {
+                            showSignOutConfirm = true
+                        } label: {
+                            HStack {
+                                Image(systemName: "rectangle.portrait.and.arrow.right")
+                                Text("Sign Out")
+                            }
+                            .foregroundColor(Theme.destructive)
+                        }
+                        .listRowBackground(Theme.cardBackground)
+                    }
+                }
+                .listStyle(.insetGrouped)
+                .scrollContentBackground(.hidden)
             }
             .navigationTitle("Profile")
             .toolbarColorScheme(.dark, for: .navigationBar)
+        }
+        .alert("Sign Out?", isPresented: $showSignOutConfirm) {
+            Button("Sign Out", role: .destructive) {
+                Task { await authService.signOut() }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("You will be returned to the login screen.")
+        }
+    }
+}
+
+// MARK: - Helpers
+
+private struct StatRow: View {
+    let label: String
+    let value: String
+
+    var body: some View {
+        HStack {
+            Text(label)
+                .foregroundColor(Theme.textSecondary)
+            Spacer()
+            Text(value)
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundColor(Theme.textPrimary)
         }
     }
 }

--- a/Xomfit/Views/Workout/ActiveWorkoutView.swift
+++ b/Xomfit/Views/Workout/ActiveWorkoutView.swift
@@ -1,0 +1,274 @@
+import SwiftUI
+
+struct ActiveWorkoutView: View {
+    @Environment(AuthService.self) private var authService
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var viewModel = WorkoutLoggerViewModel()
+    @State private var showExercisePicker = false
+    @State private var showDiscardAlert = false
+    @State private var timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
+
+    // Passed in from WorkoutView
+    let workoutName: String
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Theme.background.ignoresSafeArea()
+
+                VStack(spacing: 0) {
+                    // Header bar
+                    headerBar
+
+                    // Exercise list
+                    if viewModel.exercises.isEmpty {
+                        emptyState
+                    } else {
+                        ScrollView {
+                            LazyVStack(spacing: Theme.paddingMedium) {
+                                ForEach(viewModel.exercises.indices, id: \.self) { exIdx in
+                                    ExerciseCard(
+                                        exerciseIndex: exIdx,
+                                        viewModel: viewModel
+                                    )
+                                }
+                            }
+                            .padding(Theme.paddingMedium)
+                            // Bottom padding so FAB doesn't overlap last card
+                            .padding(.bottom, 80)
+                        }
+                    }
+                }
+
+                // Floating Add Exercise button
+                VStack {
+                    Spacer()
+                    Button {
+                        showExercisePicker = true
+                    } label: {
+                        HStack(spacing: 8) {
+                            Image(systemName: "plus")
+                                .font(.system(size: 16, weight: .bold))
+                            Text("Add Exercise")
+                                .font(.system(size: 15, weight: .bold))
+                        }
+                        .foregroundColor(.black)
+                        .padding(.horizontal, Theme.paddingLarge)
+                        .padding(.vertical, 14)
+                        .background(Theme.accent)
+                        .cornerRadius(28)
+                        .shadow(color: Theme.accent.opacity(0.4), radius: 8, x: 0, y: 4)
+                    }
+                    .padding(.bottom, Theme.paddingLarge)
+                }
+            }
+            .navigationBarHidden(true)
+        }
+        .onAppear {
+            viewModel.startWorkout(name: workoutName)
+        }
+        .onReceive(timer) { _ in
+            // Trigger a view refresh every second to update the timer label
+        }
+        .sheet(isPresented: $showExercisePicker) {
+            ExercisePickerView { exercise in
+                viewModel.addExercise(exercise)
+            }
+        }
+        .alert("Discard Workout?", isPresented: $showDiscardAlert) {
+            Button("Discard", role: .destructive) {
+                viewModel.discardWorkout()
+                dismiss()
+            }
+            Button("Keep Going", role: .cancel) {}
+        } message: {
+            Text("All logged sets will be lost.")
+        }
+    }
+
+    // MARK: - Header
+
+    private var headerBar: some View {
+        HStack {
+            // Discard button
+            Button {
+                showDiscardAlert = true
+            } label: {
+                Text("Discard")
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundColor(Theme.destructive)
+            }
+
+            Spacer()
+
+            // Timer
+            VStack(spacing: 2) {
+                Text(viewModel.workoutName)
+                    .font(.system(size: 15, weight: .bold))
+                    .foregroundColor(Theme.textPrimary)
+                Text(viewModel.durationString)
+                    .font(.system(size: 13, weight: .medium, design: .monospaced))
+                    .foregroundColor(Theme.accent)
+            }
+
+            Spacer()
+
+            // Finish button
+            Button {
+                finishWorkout()
+            } label: {
+                if viewModel.isSaving {
+                    ProgressView()
+                        .tint(.black)
+                        .frame(width: 70, height: 32)
+                        .background(Theme.accent)
+                        .cornerRadius(8)
+                } else {
+                    Text("Finish")
+                        .font(.system(size: 14, weight: .bold))
+                        .foregroundColor(.black)
+                        .padding(.horizontal, 16)
+                        .padding(.vertical, 8)
+                        .background(Theme.accent)
+                        .cornerRadius(8)
+                }
+            }
+            .disabled(viewModel.isSaving)
+        }
+        .padding(.horizontal, Theme.paddingMedium)
+        .padding(.vertical, Theme.paddingMedium)
+        .background(Theme.cardBackground)
+    }
+
+    // MARK: - Empty State
+
+    private var emptyState: some View {
+        VStack(spacing: Theme.paddingMedium) {
+            Spacer()
+            Image(systemName: "dumbbell")
+                .font(.system(size: 48))
+                .foregroundColor(Theme.textSecondary)
+            Text("No exercises yet")
+                .font(Theme.fontHeadline)
+                .foregroundColor(Theme.textPrimary)
+            Text("Tap \"Add Exercise\" to get started")
+                .font(Theme.fontBody)
+                .foregroundColor(Theme.textSecondary)
+            Spacer()
+            Spacer()
+        }
+    }
+
+    // MARK: - Actions
+
+    private func finishWorkout() {
+        guard let userId = authService.currentUser?.id.uuidString else { return }
+        Task {
+            await viewModel.finishWorkout(userId: userId)
+            if viewModel.errorMessage == nil {
+                dismiss()
+            }
+        }
+    }
+}
+
+// MARK: - Exercise Card
+
+private struct ExerciseCard: View {
+    let exerciseIndex: Int
+    let viewModel: WorkoutLoggerViewModel
+
+    var body: some View {
+        let exercise = viewModel.exercises[exerciseIndex]
+        VStack(alignment: .leading, spacing: Theme.paddingSmall) {
+            // Exercise header
+            HStack {
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(exercise.exercise.name)
+                        .font(.system(size: 16, weight: .bold))
+                        .foregroundColor(Theme.textPrimary)
+                    HStack(spacing: 4) {
+                        ForEach(exercise.exercise.muscleGroups.prefix(2), id: \.self) { mg in
+                            Text(mg.displayName)
+                                .font(Theme.fontSmall)
+                                .foregroundColor(Theme.accent)
+                                .padding(.horizontal, 6)
+                                .padding(.vertical, 2)
+                                .background(Theme.accent.opacity(0.15))
+                                .cornerRadius(4)
+                        }
+                    }
+                }
+                Spacer()
+                Button {
+                    viewModel.removeExercise(at: exerciseIndex)
+                } label: {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundColor(Theme.textSecondary)
+                }
+            }
+
+            // Column headers
+            if !exercise.sets.isEmpty {
+                HStack(spacing: Theme.paddingSmall) {
+                    Text("SET")
+                        .frame(width: 24)
+                    Spacer()
+                    Text("WEIGHT")
+                        .frame(maxWidth: .infinity)
+                    Text("")
+                        .frame(width: 40)
+                    Text("REPS")
+                        .frame(maxWidth: .infinity)
+                    Text("")
+                        .frame(width: 36)
+                }
+                .font(Theme.fontSmall)
+                .foregroundColor(Theme.textSecondary)
+                .padding(.horizontal, Theme.paddingMedium)
+            }
+
+            // Sets
+            ForEach(exercise.sets.indices, id: \.self) { setIdx in
+                SetRowView(
+                    setNumber: setIdx + 1,
+                    workoutSet: exercise.sets[setIdx],
+                    onWeightChange: { w in
+                        viewModel.updateSet(exerciseIndex: exerciseIndex, setIndex: setIdx, weight: w, reps: viewModel.exercises[exerciseIndex].sets[setIdx].reps)
+                    },
+                    onRepsChange: { r in
+                        viewModel.updateSet(exerciseIndex: exerciseIndex, setIndex: setIdx, weight: viewModel.exercises[exerciseIndex].sets[setIdx].weight, reps: r)
+                    },
+                    onComplete: {
+                        viewModel.completeSet(exerciseIndex: exerciseIndex, setIndex: setIdx)
+                    },
+                    onDelete: {
+                        viewModel.removeSet(exerciseIndex: exerciseIndex, setIndex: setIdx)
+                    }
+                )
+            }
+
+            // Add Set button
+            Button {
+                viewModel.addSet(to: exerciseIndex)
+            } label: {
+                HStack(spacing: 6) {
+                    Image(systemName: "plus")
+                    Text("Add Set")
+                }
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundColor(Theme.accent)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 10)
+                .background(Theme.accent.opacity(0.08))
+                .cornerRadius(Theme.cornerRadiusSmall)
+            }
+            .padding(.top, 4)
+        }
+        .padding(Theme.paddingMedium)
+        .background(Theme.cardBackground)
+        .cornerRadius(Theme.cornerRadius)
+    }
+}

--- a/Xomfit/Views/Workout/ExercisePickerView.swift
+++ b/Xomfit/Views/Workout/ExercisePickerView.swift
@@ -1,0 +1,177 @@
+import SwiftUI
+
+struct ExercisePickerView: View {
+    @Environment(\.dismiss) private var dismiss
+    let onSelect: (Exercise) -> Void
+
+    @State private var searchText = ""
+    @State private var selectedMuscleGroup: MuscleGroup? = nil
+
+    private var filtered: [Exercise] {
+        var exercises = ExerciseDatabase.all
+        if let mg = selectedMuscleGroup {
+            exercises = exercises.filter { $0.muscleGroups.contains(mg) }
+        }
+        if !searchText.isEmpty {
+            let query = searchText.lowercased()
+            exercises = exercises.filter {
+                $0.name.lowercased().contains(query) ||
+                $0.muscleGroups.map { $0.rawValue }.joined().contains(query) ||
+                $0.equipment.rawValue.contains(query)
+            }
+        }
+        return exercises.sorted { $0.name < $1.name }
+    }
+
+    private var groupedByMuscle: [(String, [Exercise])] {
+        let dict = Dictionary(grouping: filtered) { ex in
+            ex.muscleGroups.first?.displayName ?? "Other"
+        }
+        return dict.sorted { $0.key < $1.key }
+    }
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Theme.background.ignoresSafeArea()
+
+                VStack(spacing: 0) {
+                    // Search bar
+                    HStack {
+                        Image(systemName: "magnifyingglass")
+                            .foregroundColor(Theme.textSecondary)
+                        TextField("Search exercises...", text: $searchText)
+                            .foregroundColor(Theme.textPrimary)
+                            .autocorrectionDisabled()
+                        if !searchText.isEmpty {
+                            Button { searchText = "" } label: {
+                                Image(systemName: "xmark.circle.fill")
+                                    .foregroundColor(Theme.textSecondary)
+                            }
+                        }
+                    }
+                    .padding(Theme.paddingMedium)
+                    .background(Theme.cardBackground)
+                    .cornerRadius(Theme.cornerRadius)
+                    .padding(.horizontal, Theme.paddingMedium)
+                    .padding(.vertical, Theme.paddingSmall)
+
+                    // Muscle group filter chips
+                    ScrollView(.horizontal, showsIndicators: false) {
+                        HStack(spacing: Theme.paddingSmall) {
+                            FilterChip(label: "All", isSelected: selectedMuscleGroup == nil) {
+                                selectedMuscleGroup = nil
+                            }
+                            ForEach(MuscleGroup.allCases, id: \.self) { mg in
+                                FilterChip(label: mg.displayName, isSelected: selectedMuscleGroup == mg) {
+                                    selectedMuscleGroup = selectedMuscleGroup == mg ? nil : mg
+                                }
+                            }
+                        }
+                        .padding(.horizontal, Theme.paddingMedium)
+                        .padding(.vertical, Theme.paddingSmall)
+                    }
+
+                    // Exercise list
+                    List {
+                        ForEach(groupedByMuscle, id: \.0) { groupName, exercises in
+                            Section {
+                                ForEach(exercises) { exercise in
+                                    ExerciseRow(exercise: exercise) {
+                                        onSelect(exercise)
+                                        dismiss()
+                                    }
+                                    .listRowBackground(Theme.cardBackground)
+                                    .listRowSeparatorTint(Theme.textSecondary.opacity(0.2))
+                                }
+                            } header: {
+                                Text(groupName)
+                                    .font(Theme.fontCaption)
+                                    .foregroundColor(Theme.textSecondary)
+                                    .textCase(nil)
+                            }
+                        }
+                    }
+                    .listStyle(.plain)
+                    .scrollContentBackground(.hidden)
+                }
+            }
+            .navigationTitle("Add Exercise")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbarColorScheme(.dark, for: .navigationBar)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                        .foregroundColor(Theme.accent)
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Sub-views
+
+private struct FilterChip: View {
+    let label: String
+    let isSelected: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Text(label)
+                .font(Theme.fontSmall)
+                .foregroundColor(isSelected ? .black : Theme.textSecondary)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 6)
+                .background(isSelected ? Theme.accent : Theme.cardBackground)
+                .cornerRadius(20)
+        }
+    }
+}
+
+private struct ExerciseRow: View {
+    let exercise: Exercise
+    let onTap: () -> Void
+
+    var body: some View {
+        Button(action: onTap) {
+            HStack(spacing: Theme.paddingMedium) {
+                Image(systemName: exercise.muscleGroups.first?.icon ?? "dumbbell.fill")
+                    .font(.system(size: 20))
+                    .foregroundColor(Theme.accent)
+                    .frame(width: 36, height: 36)
+                    .background(Theme.accent.opacity(0.1))
+                    .cornerRadius(8)
+
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(exercise.name)
+                        .font(.system(size: 15, weight: .semibold))
+                        .foregroundColor(Theme.textPrimary)
+                    HStack(spacing: 6) {
+                        Text(exercise.equipment.displayName)
+                            .font(Theme.fontSmall)
+                            .foregroundColor(Theme.textSecondary)
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 2)
+                            .background(Theme.secondaryBackground)
+                            .cornerRadius(4)
+                        ForEach(exercise.muscleGroups.prefix(2), id: \.self) { mg in
+                            Text(mg.displayName)
+                                .font(Theme.fontSmall)
+                                .foregroundColor(Theme.textSecondary)
+                                .padding(.horizontal, 6)
+                                .padding(.vertical, 2)
+                                .background(Theme.secondaryBackground)
+                                .cornerRadius(4)
+                        }
+                    }
+                }
+                Spacer()
+                Image(systemName: "plus.circle")
+                    .foregroundColor(Theme.accent)
+            }
+            .padding(.vertical, 4)
+        }
+        .buttonStyle(.plain)
+    }
+}

--- a/Xomfit/Views/Workout/SetRowView.swift
+++ b/Xomfit/Views/Workout/SetRowView.swift
@@ -1,0 +1,110 @@
+import SwiftUI
+
+struct SetRowView: View {
+    let setNumber: Int
+    let workoutSet: WorkoutSet
+    let onWeightChange: (Double) -> Void
+    let onRepsChange: (Int) -> Void
+    let onComplete: () -> Void
+    let onDelete: () -> Void
+
+    @State private var weightText: String
+    @State private var repsText: String
+
+    private var isCompleted: Bool {
+        workoutSet.completedAt != Date.distantPast
+    }
+
+    init(
+        setNumber: Int,
+        workoutSet: WorkoutSet,
+        onWeightChange: @escaping (Double) -> Void,
+        onRepsChange: @escaping (Int) -> Void,
+        onComplete: @escaping () -> Void,
+        onDelete: @escaping () -> Void
+    ) {
+        self.setNumber = setNumber
+        self.workoutSet = workoutSet
+        self.onWeightChange = onWeightChange
+        self.onRepsChange = onRepsChange
+        self.onComplete = onComplete
+        self.onDelete = onDelete
+
+        let w = workoutSet.weight
+        let r = workoutSet.reps
+        _weightText = State(initialValue: w > 0 ? w.formattedWeight : "")
+        _repsText   = State(initialValue: r > 0 ? "\(r)" : "")
+    }
+
+    var body: some View {
+        HStack(spacing: Theme.paddingSmall) {
+            // Set number
+            Text("\(setNumber)")
+                .font(.system(size: 14, weight: .bold, design: .monospaced))
+                .foregroundColor(isCompleted ? Theme.accent : Theme.textSecondary)
+                .frame(width: 24, alignment: .center)
+
+            // Weight field
+            TextField("0", text: $weightText)
+                .keyboardType(.decimalPad)
+                .multilineTextAlignment(.center)
+                .padding(.vertical, 8)
+                .padding(.horizontal, 6)
+                .background(Theme.cardBackground)
+                .cornerRadius(Theme.cornerRadiusSmall)
+                .foregroundColor(isCompleted ? Theme.accent : Theme.textPrimary)
+                .frame(maxWidth: .infinity)
+                .onChange(of: weightText) { _, newValue in
+                    if let w = Double(newValue) {
+                        onWeightChange(w)
+                    }
+                }
+
+            Text("lbs  ×")
+                .font(Theme.fontCaption)
+                .foregroundColor(Theme.textSecondary)
+
+            // Reps field
+            TextField("0", text: $repsText)
+                .keyboardType(.numberPad)
+                .multilineTextAlignment(.center)
+                .padding(.vertical, 8)
+                .padding(.horizontal, 6)
+                .background(Theme.cardBackground)
+                .cornerRadius(Theme.cornerRadiusSmall)
+                .foregroundColor(isCompleted ? Theme.accent : Theme.textPrimary)
+                .frame(maxWidth: .infinity)
+                .onChange(of: repsText) { _, newValue in
+                    if let r = Int(newValue) {
+                        onRepsChange(r)
+                    }
+                }
+
+            // Complete checkmark button
+            Button(action: onComplete) {
+                Image(systemName: isCompleted ? "checkmark.circle.fill" : "checkmark.circle")
+                    .font(.system(size: 24))
+                    .foregroundColor(isCompleted ? Theme.accent : Theme.textSecondary)
+            }
+            .frame(width: 36)
+        }
+        .padding(.horizontal, Theme.paddingMedium)
+        .padding(.vertical, 6)
+        .background(isCompleted ? Theme.accent.opacity(0.08) : Color.clear)
+        .cornerRadius(Theme.cornerRadiusSmall)
+        .swipeActions(edge: .trailing, allowsFullSwipe: true) {
+            Button(role: .destructive, action: onDelete) {
+                Label("Delete", systemImage: "trash")
+            }
+        }
+        // Keep local text state in sync if set is reset externally
+        .onChange(of: workoutSet.weight) { _, newWeight in
+            let formatted = newWeight > 0 ? newWeight.formattedWeight : ""
+            if weightText != formatted { weightText = formatted }
+        }
+        .onChange(of: workoutSet.reps) { _, newReps in
+            let formatted = newReps > 0 ? "\(newReps)" : ""
+            if repsText != formatted { repsText = formatted }
+        }
+    }
+}

--- a/Xomfit/Views/Workout/WorkoutView.swift
+++ b/Xomfit/Views/Workout/WorkoutView.swift
@@ -1,16 +1,161 @@
 import SwiftUI
 
 struct WorkoutView: View {
+    @Environment(AuthService.self) private var authService
+
+    @State private var workouts: [Workout] = []
+    @State private var showActiveWorkout = false
+    @State private var showNameEntry = false
+    @State private var pendingWorkoutName = ""
+
+    private var userId: String {
+        authService.currentUser?.id.uuidString ?? ""
+    }
+
     var body: some View {
         NavigationStack {
             ZStack {
                 Theme.background.ignoresSafeArea()
-                Text("Workout")
-                    .font(Theme.fontTitle)
-                    .foregroundColor(Theme.textPrimary)
+
+                VStack(spacing: 0) {
+                    // Start Workout CTA
+                    Button {
+                        pendingWorkoutName = ""
+                        showNameEntry = true
+                    } label: {
+                        HStack(spacing: 10) {
+                            Image(systemName: "play.fill")
+                            Text("Start Workout")
+                                .font(.system(size: 17, weight: .bold))
+                        }
+                        .foregroundColor(.black)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 16)
+                        .background(Theme.accent)
+                        .cornerRadius(Theme.cornerRadius)
+                    }
+                    .padding(.horizontal, Theme.paddingMedium)
+                    .padding(.top, Theme.paddingMedium)
+                    .padding(.bottom, Theme.paddingSmall)
+
+                    // Workout history
+                    if workouts.isEmpty {
+                        Spacer()
+                        VStack(spacing: Theme.paddingMedium) {
+                            Image(systemName: "dumbbell")
+                                .font(.system(size: 48))
+                                .foregroundColor(Theme.textSecondary)
+                            Text("No workouts yet")
+                                .font(Theme.fontHeadline)
+                                .foregroundColor(Theme.textPrimary)
+                            Text("Start your first workout above")
+                                .font(Theme.fontBody)
+                                .foregroundColor(Theme.textSecondary)
+                        }
+                        Spacer()
+                    } else {
+                        List {
+                            ForEach(workouts) { workout in
+                                WorkoutHistoryCard(workout: workout)
+                                    .listRowBackground(Color.clear)
+                                    .listRowSeparator(.hidden)
+                                    .listRowInsets(EdgeInsets(top: 6, leading: Theme.paddingMedium, bottom: 6, trailing: Theme.paddingMedium))
+                            }
+                            .onDelete { indexSet in
+                                for index in indexSet {
+                                    WorkoutService.shared.deleteWorkout(id: workouts[index].id)
+                                }
+                                loadWorkouts()
+                            }
+                        }
+                        .listStyle(.plain)
+                        .scrollContentBackground(.hidden)
+                        .refreshable { loadWorkouts() }
+                    }
+                }
             }
             .navigationTitle("Workout")
             .toolbarColorScheme(.dark, for: .navigationBar)
+        }
+        .onAppear { loadWorkouts() }
+        .alert("Name Your Workout", isPresented: $showNameEntry) {
+            TextField("e.g. Push Day", text: $pendingWorkoutName)
+            Button("Start") { showActiveWorkout = true }
+            Button("Cancel", role: .cancel) {}
+        }
+        .fullScreenCover(isPresented: $showActiveWorkout, onDismiss: loadWorkouts) {
+            ActiveWorkoutView(workoutName: pendingWorkoutName.isEmpty ? "Workout" : pendingWorkoutName)
+                .environment(authService)
+        }
+    }
+
+    private func loadWorkouts() {
+        workouts = WorkoutService.shared.fetchWorkouts(userId: userId)
+    }
+}
+
+// MARK: - History Card
+
+private struct WorkoutHistoryCard: View {
+    let workout: Workout
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Theme.paddingSmall) {
+            HStack {
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(workout.name)
+                        .font(.system(size: 16, weight: .bold))
+                        .foregroundColor(Theme.textPrimary)
+                    Text(workout.startTime.workoutDateString)
+                        .font(Theme.fontCaption)
+                        .foregroundColor(Theme.textSecondary)
+                }
+                Spacer()
+                Text(workout.durationString)
+                    .font(.system(size: 13, weight: .semibold, design: .monospaced))
+                    .foregroundColor(Theme.accent)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 4)
+                    .background(Theme.accent.opacity(0.12))
+                    .cornerRadius(6)
+            }
+
+            HStack(spacing: Theme.paddingLarge) {
+                statPill(label: "Exercises", value: "\(workout.exercises.count)")
+                statPill(label: "Sets", value: "\(workout.totalSets)")
+                statPill(label: "Volume", value: "\(workout.formattedVolume) lbs")
+            }
+
+            // Muscle groups
+            if !workout.muscleGroups.isEmpty {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 6) {
+                        ForEach(workout.muscleGroups, id: \.self) { mg in
+                            Text(mg.displayName)
+                                .font(Theme.fontSmall)
+                                .foregroundColor(Theme.textSecondary)
+                                .padding(.horizontal, 8)
+                                .padding(.vertical, 3)
+                                .background(Theme.secondaryBackground)
+                                .cornerRadius(4)
+                        }
+                    }
+                }
+            }
+        }
+        .padding(Theme.paddingMedium)
+        .background(Theme.cardBackground)
+        .cornerRadius(Theme.cornerRadius)
+    }
+
+    private func statPill(label: String, value: String) -> some View {
+        VStack(spacing: 2) {
+            Text(value)
+                .font(.system(size: 15, weight: .bold))
+                .foregroundColor(Theme.textPrimary)
+            Text(label)
+                .font(Theme.fontSmall)
+                .foregroundColor(Theme.textSecondary)
         }
     }
 }

--- a/Xomfit/XomfitApp.swift
+++ b/Xomfit/XomfitApp.swift
@@ -2,10 +2,37 @@ import SwiftUI
 
 @main
 struct XomFitApp: App {
+    @State private var authService = AuthService()
+
     var body: some Scene {
         WindowGroup {
-            MainTabView()
-                .preferredColorScheme(.dark)
+            Group {
+                if authService.isLoading {
+                    ZStack {
+                        Theme.background.ignoresSafeArea()
+                        VStack(spacing: Theme.paddingMedium) {
+                            Text("XOMFIT")
+                                .font(.system(size: 42, weight: .black))
+                                .foregroundColor(Theme.accent)
+                                .tracking(4)
+                            ProgressView()
+                                .tint(Theme.accent)
+                        }
+                    }
+                } else if authService.isAuthenticated {
+                    MainTabView()
+                        .environment(authService)
+                } else {
+                    LoginView()
+                        .environment(authService)
+                }
+            }
+            .preferredColorScheme(.dark)
+            .onOpenURL { url in
+                Task {
+                    try? await supabase.auth.session(from: url)
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Phase 2 — Auth:
- AuthService: @Observable @MainActor, supabase-swift v2 authStateChanges AsyncStream, signIn/signUp/signOut
- LoginView: dark themed email+password form, error display, NavigationLink to SignUpView
- SignUpView: password validation (length + match), dark themed form
- XomfitApp: auth state routing (splash -> LoginView -> MainTabView), .environment(authService), onOpenURL for OAuth

Phase 3 — Workout Core:
- WorkoutService: local UserDefaults persistence with JSONEncoder/Decoder, saveWorkout/fetchWorkouts/deleteWorkout
- WorkoutLoggerViewModel: @Observable @MainActor, full exercise/set CRUD, finishWorkout saves via WorkoutService
- SetRowView: weight+reps TextFields, checkmark toggle, swipe-to-delete, green tint on completion
- ExercisePickerView: search bar, muscle group filter chips, grouped list from ExerciseDatabase.all
- ActiveWorkoutView: live timer, exercise cards with set rows, Add Exercise FAB, Finish/Discard with confirmation
- WorkoutView: Start Workout CTA with name prompt, workout history list with stats cards, pull-to-refresh
- ProfileView: user avatar/email header, workout stats from local store, Sign Out with confirmation alert

Build: ** BUILD SUCCEEDED ** (iPhone 17 Pro simulator, supabase-swift 2.41.1)