### PR TITLE
Build Progress tab — charts, streaks, workout analytics

### DIFF
--- a/.claude/prompts/ci-triage.md
+++ b/.claude/prompts/ci-triage.md
@@ -1,0 +1,53 @@
+You are a triage bot. Keep it light — a developer will do deep analysis later via /work-issue.
+
+Read the project's CLAUDE.md to find the `## Project Config` block. Use it for:
+- `base_branch` — which branch to create feature branches from
+- `pm_tool` — whether to create a Notion task
+- Notion field IDs (datasource, project, goal, pillar, assignee) — for task creation
+
+DO NOT:
+- Write or modify any source code
+- Create pull requests or commit code
+- Do deep codebase analysis (no reading file contents, no line numbers)
+- Read source files — just use Glob to confirm files exist
+
+DO:
+1. Read the issue — understand what's being reported (bug, feature, question)
+2. Read CLAUDE.md to get Project Config values
+3. Use Glob to find the likely files involved (just paths, don't read them)
+4. Classify: bug, enhancement, or documentation
+5. Estimate scope: small (1-2 files), medium (3-5 files), large (5+ files)
+6. Add labels using: gh issue edit <number> --add-label <label>
+   - Type: bug, enhancement, or documentation
+   - Priority: P1-critical, P2-high, P3-medium, or P4-low
+7. Create a branch off {base_branch} from Project Config:
+   - Format: {type}/{issue#}-{short-desc}
+   - Types: feature, fix, chore, docs, refactor
+   - Commands: git fetch origin {base_branch} && git checkout -b {branch} origin/{base_branch} && git push origin {branch}
+8. If Notion MCP tools are available AND pm_tool is "notion", create a task:
+   - Use mcp__notion__API-post-page with parent database from Project Config
+   - Set properties from Project Config: Name, Status, Priority, Assignee, Project, Goal, Pillar
+   - Content: brief summary + file list
+   - If permission error, skip and note N/A
+
+Your output is posted as a GitHub issue comment. Use emojis and clean formatting:
+
+### Triage: [issue title]
+
+| | |
+|---|---|
+| **Type** | bug / enhancement / docs |
+| **Priority** | P1-P4 |
+| **Scope** | small / medium / large |
+| **Branch** | `{type}/{issue#}-{short-desc}` |
+| **PM Task** | [task link] or N/A |
+
+**Summary:** [1-2 sentences — what the issue is, not how to fix it]
+
+**Files likely involved:**
+- `path/to/file`
+
+**Recommended approach:** `/fix` / `/plan` / `/brainstorm` — [one line why]
+
+---
+*Auto-triaged. Run `/work-issue {number}` to start.*

--- a/.github/workflows/claude-issues.yml
+++ b/.github/workflows/claude-issues.yml
@@ -1,0 +1,119 @@
+name: Claude Issue Triage
+
+on:
+  issues:
+    types: [opened]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: write
+  issues: write
+  id-token: write
+
+jobs:
+  triage:
+    if: |
+      (github.event_name == 'issues') ||
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          # CONFIGURE: set to your base branch (main or develop)
+          ref: main
+          fetch-depth: 0
+
+      - name: Install Claude Code and Notion MCP
+        run: |
+          npm install -g @anthropic-ai/claude-code@latest
+          npm install -g @notionhq/notion-mcp-server
+
+      - name: Set up Notion MCP config
+        env:
+          NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}
+        run: |
+          if [ -z "$NOTION_TOKEN" ]; then
+            echo "NOTION_TOKEN not set, skipping MCP config"
+            exit 0
+          fi
+          cat > /tmp/mcp-config.json << 'MCPEOF'
+          {
+            "mcpServers": {
+              "notion": {
+                "command": "notion-mcp-server",
+                "env": {
+                  "NOTION_TOKEN": "PLACEHOLDER"
+                }
+              }
+            }
+          }
+          MCPEOF
+          sed -i "s|PLACEHOLDER|${NOTION_TOKEN}|g" /tmp/mcp-config.json
+
+      - name: Acknowledge trigger
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ "${{ github.event_name }}" = "issue_comment" ]; then
+            gh api repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}/reactions -f content=eyes
+          else
+            gh api repos/${{ github.repository }}/issues/${{ github.event.issue.number }}/reactions -f content=eyes
+          fi
+
+      - name: Get issue info
+        id: issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          NUMBER=${{ github.event.issue.number }}
+          TITLE=$(gh issue view $NUMBER --json title -q .title)
+          BODY=$(gh issue view $NUMBER --json body -q .body)
+          echo "number=$NUMBER" >> $GITHUB_OUTPUT
+          echo "title=$TITLE" >> $GITHUB_OUTPUT
+          echo "$BODY" > /tmp/issue-body.txt
+
+      - name: Run Claude triage
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.DEV_ANTHROPIC_API_KEY }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}
+        run: |
+          ISSUE_BODY=$(cat /tmp/issue-body.txt)
+          SYSTEM_PROMPT=$(cat .claude/prompts/ci-triage.md)
+
+          # Build MCP flag if config exists
+          MCP_FLAG=""
+          if [ -f /tmp/mcp-config.json ]; then
+            MCP_FLAG="--mcp-config /tmp/mcp-config.json"
+          fi
+
+          # Write the user prompt to a file (avoids ENAMETOOLONG)
+          cat > /tmp/triage-prompt.txt << PROMPTEOF
+          Triage issue #${{ steps.issue.outputs.number }}: ${{ steps.issue.outputs.title }}
+
+          Issue body:
+          $ISSUE_BODY
+
+          Repository is checked out at $(pwd). Analyze the codebase, then:
+          1. Analyze and produce your triage report
+          2. Add labels with: gh issue edit ${{ steps.issue.outputs.number }} --add-label <label>
+          3. Create a branch off the base branch (read from Project Config in CLAUDE.md)
+          4. Create a PM task if Notion MCP is available (read IDs from Project Config in CLAUDE.md)
+          PROMPTEOF
+
+          claude -p "$(cat /tmp/triage-prompt.txt)" \
+            --print \
+            --model claude-sonnet-4-6 \
+            --system-prompt "$SYSTEM_PROMPT" \
+            --max-turns 15 \
+            --allowedTools "Read,Glob,Grep,Bash(git fetch:*),Bash(git checkout:*),Bash(git push:*),Bash(git branch:*),Bash(gh issue edit:*),Bash(gh label create:*),mcp__notion__API-post-page,mcp__notion__API-post-search,mcp__notion__API-retrieve-a-database,mcp__notion__API-query-data-source,mcp__notion__API-retrieve-a-page,mcp__notion__API-patch-page" \
+            $MCP_FLAG > /tmp/triage-output.md
+
+      - name: Comment on issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue comment ${{ steps.issue.outputs.number }} --body-file /tmp/triage-output.md

--- a/Xomfit/ViewModels/ProgressViewModel.swift
+++ b/Xomfit/ViewModels/ProgressViewModel.swift
@@ -1,0 +1,177 @@
+import Foundation
+
+@MainActor
+@Observable
+final class ProgressViewModel {
+
+    // MARK: - State
+
+    var isLoading = false
+    var errorMessage: String?
+
+    // Summary
+    var totalWorkouts = 0
+    var currentStreak = 0
+    var totalVolume: Double = 0
+    var totalPRs = 0
+
+    // Charts
+    var strengthDataPoints: [StrengthDataPoint] = []
+    var weeklyVolumes: [(label: String, volume: Double)] = []
+    var muscleGroupSets: [(group: String, sets: Int)] = []
+
+    // Exercise picker
+    var availableExercises: [String] = []
+    var selectedExercise: String = ""
+
+    // Recent PRs
+    var recentPRs: [PersonalRecord] = []
+
+    // MARK: - Computed
+
+    var filteredStrengthData: [StrengthDataPoint] {
+        strengthDataPoints.filter { $0.exerciseName == selectedExercise }
+    }
+
+    var formattedTotalVolume: String {
+        if totalVolume >= 1_000_000 {
+            return String(format: "%.1fM", totalVolume / 1_000_000)
+        } else if totalVolume >= 1000 {
+            return String(format: "%.1fk", totalVolume / 1000)
+        }
+        return "\(Int(totalVolume))"
+    }
+
+    // MARK: - Load
+
+    func loadData(userId: String) async {
+        guard !userId.isEmpty else { return }
+        isLoading = true
+        errorMessage = nil
+
+        let workouts = WorkoutService.shared.fetchWorkouts(userId: userId)
+
+        var prs: [PersonalRecord] = []
+        do {
+            prs = try await PRService.shared.fetchPRs(userId: userId)
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+
+        computeSummary(workouts: workouts, prs: prs)
+        computeStrengthData(workouts: workouts)
+        computeWeeklyVolume(workouts: workouts)
+        computeMuscleGroups(workouts: workouts)
+
+        recentPRs = Array(prs.prefix(5))
+        isLoading = false
+    }
+
+    // MARK: - Private Compute
+
+    private func computeSummary(workouts: [Workout], prs: [PersonalRecord]) {
+        totalWorkouts = workouts.count
+        totalVolume = workouts.reduce(0) { $0 + $1.totalVolume }
+        totalPRs = prs.count
+
+        // Streak: consecutive calendar days with workouts looking back from today
+        let calendar = Calendar.current
+        let today = calendar.startOfDay(for: Date())
+        let workoutDays = Set(workouts.map { calendar.startOfDay(for: $0.startTime) })
+
+        var streak = 0
+        for offset in 0..<365 {
+            guard let day = calendar.date(byAdding: .day, value: -offset, to: today) else { break }
+            if workoutDays.contains(day) {
+                streak += 1
+            } else if offset == 0 {
+                // Today doesn't have a workout yet -- check from yesterday
+                continue
+            } else {
+                break
+            }
+        }
+        currentStreak = streak
+    }
+
+    private func computeStrengthData(workouts: [Workout]) {
+        // For each exercise in each workout, find the best estimated 1RM
+        var exerciseFrequency: [String: Int] = [:]
+        var dataPoints: [StrengthDataPoint] = []
+
+        for workout in workouts {
+            for workoutExercise in workout.exercises {
+                let name = workoutExercise.exercise.name
+                exerciseFrequency[name, default: 0] += 1
+
+                guard let bestSet = workoutExercise.sets.max(by: { $0.estimated1RM < $1.estimated1RM }) else {
+                    continue
+                }
+
+                dataPoints.append(
+                    StrengthDataPoint(
+                        date: workout.startTime,
+                        value: bestSet.weight,
+                        reps: bestSet.reps,
+                        exerciseName: name
+                    )
+                )
+            }
+        }
+
+        strengthDataPoints = dataPoints.sorted { $0.date < $1.date }
+        availableExercises = exerciseFrequency
+            .sorted { $0.value > $1.value }
+            .map(\.key)
+
+        if selectedExercise.isEmpty || !availableExercises.contains(selectedExercise) {
+            selectedExercise = availableExercises.first ?? ""
+        }
+    }
+
+    private func computeWeeklyVolume(workouts: [Workout]) {
+        let calendar = Calendar.current
+        let today = calendar.startOfDay(for: Date())
+
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "MMM d"
+
+        var buckets: [(label: String, volume: Double)] = []
+
+        for weekOffset in stride(from: 7, through: 0, by: -1) {
+            guard let weekStart = calendar.date(byAdding: .weekOfYear, value: -weekOffset, to: today) else {
+                continue
+            }
+            let startOfWeek = calendar.dateInterval(of: .weekOfYear, for: weekStart)?.start ?? weekStart
+            guard let endOfWeek = calendar.date(byAdding: .day, value: 7, to: startOfWeek) else {
+                continue
+            }
+
+            let weekWorkouts = workouts.filter {
+                $0.startTime >= startOfWeek && $0.startTime < endOfWeek
+            }
+            let volume = weekWorkouts.reduce(0.0) { $0 + $1.totalVolume }
+            let label = dateFormatter.string(from: startOfWeek)
+            buckets.append((label: label, volume: volume))
+        }
+
+        weeklyVolumes = buckets
+    }
+
+    private func computeMuscleGroups(workouts: [Workout]) {
+        var groupSets: [MuscleGroup: Int] = [:]
+
+        for workout in workouts {
+            for workoutExercise in workout.exercises {
+                let setCount = workoutExercise.sets.count
+                for muscle in workoutExercise.exercise.muscleGroups {
+                    groupSets[muscle, default: 0] += setCount
+                }
+            }
+        }
+
+        muscleGroupSets = groupSets
+            .sorted { $0.value > $1.value }
+            .map { (group: $0.key.displayName, sets: $0.value) }
+    }
+}

--- a/Xomfit/Views/Profile/ProfileView.swift
+++ b/Xomfit/Views/Profile/ProfileView.swift
@@ -266,36 +266,6 @@ struct ProfileView: View {
     }
 }
 
-// MARK: - PR Badge Row
-
-private struct PRBadgeRow: View {
-    let pr: PersonalRecord
-
-    var body: some View {
-        HStack {
-            Image(systemName: "trophy.fill")
-                .foregroundColor(Theme.prGold)
-                .font(.system(size: 14))
-
-            Text(pr.exerciseName)
-                .font(.system(size: 14, weight: .semibold))
-                .foregroundColor(Theme.textPrimary)
-
-            Spacer()
-
-            Text("\(pr.weight.formattedWeight) × \(pr.reps)")
-                .font(.system(size: 14, weight: .bold))
-                .foregroundColor(Theme.accent)
-
-            if let imp = pr.improvementString {
-                Text(imp)
-                    .font(Theme.fontSmall)
-                    .foregroundColor(Theme.prGold)
-            }
-        }
-    }
-}
-
 // MARK: - Edit Profile Sheet
 
 private struct EditProfileSheet: View {

--- a/Xomfit/Views/Progress/XomProgressView.swift
+++ b/Xomfit/Views/Progress/XomProgressView.swift
@@ -1,16 +1,324 @@
 import SwiftUI
+import Charts
 
 struct XomProgressView: View {
+    @Environment(AuthService.self) private var authService
+    @State private var viewModel = ProgressViewModel()
+
+    private var userId: String {
+        authService.currentUser?.id.uuidString ?? ""
+    }
+
     var body: some View {
         NavigationStack {
             ZStack {
                 Theme.background.ignoresSafeArea()
-                Text("Progress")
-                    .font(Theme.fontTitle)
-                    .foregroundColor(Theme.textPrimary)
+
+                if viewModel.isLoading {
+                    ProgressView()
+                        .tint(Theme.accent)
+                } else if viewModel.totalWorkouts == 0 {
+                    emptyState
+                } else {
+                    contentView
+                }
             }
             .navigationTitle("Progress")
             .toolbarColorScheme(.dark, for: .navigationBar)
+        }
+        .task {
+            await viewModel.loadData(userId: userId)
+        }
+    }
+
+    // MARK: - Empty State
+
+    private var emptyState: some View {
+        VStack(spacing: Theme.paddingMedium) {
+            Image(systemName: "chart.line.uptrend.xyaxis")
+                .font(.system(size: 48))
+                .foregroundStyle(Theme.textSecondary)
+
+            Text("Log your first workout to see progress here")
+                .font(Theme.fontBody)
+                .foregroundStyle(Theme.textSecondary)
+                .multilineTextAlignment(.center)
+        }
+        .padding(Theme.paddingLarge)
+    }
+
+    // MARK: - Content
+
+    private var contentView: some View {
+        ScrollView {
+            VStack(spacing: Theme.paddingMedium) {
+                summaryCards
+                liftProgressionSection
+                weeklyVolumeSection
+                muscleGroupSection
+                recentPRsSection
+            }
+            .padding(Theme.paddingMedium)
+        }
+    }
+}
+
+// MARK: - Summary Cards
+
+private struct SummaryCardsView: View {
+    let totalWorkouts: Int
+    let currentStreak: Int
+    let formattedVolume: String
+    let totalPRs: Int
+
+    private let columns = [
+        GridItem(.flexible(), spacing: Theme.paddingSmall),
+        GridItem(.flexible(), spacing: Theme.paddingSmall),
+    ]
+
+    var body: some View {
+        LazyVGrid(columns: columns, spacing: Theme.paddingSmall) {
+            StatCard(icon: "dumbbell.fill", value: "\(totalWorkouts)", label: "Workouts")
+            StatCard(icon: "flame.fill", value: "\(currentStreak)", label: "Day Streak")
+            StatCard(icon: "scalemass.fill", value: formattedVolume, label: "Volume")
+            StatCard(icon: "trophy.fill", value: "\(totalPRs)", label: "PRs")
+        }
+    }
+}
+
+private struct StatCard: View {
+    let icon: String
+    let value: String
+    let label: String
+
+    var body: some View {
+        VStack(spacing: 6) {
+            Image(systemName: icon)
+                .font(.system(size: 18))
+                .foregroundStyle(Theme.accent)
+
+            Text(value)
+                .font(.system(size: 22, weight: .bold))
+                .foregroundStyle(Theme.textPrimary)
+
+            Text(label)
+                .font(Theme.fontSmall)
+                .foregroundStyle(Theme.textSecondary)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, Theme.paddingMedium)
+        .cardStyle()
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(label): \(value)")
+    }
+}
+
+// MARK: - Lift Progression
+
+private struct LiftProgressionChart: View {
+    let dataPoints: [StrengthDataPoint]
+    let exercises: [String]
+    @Binding var selectedExercise: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Theme.paddingSmall) {
+            HStack {
+                Text("Strength Over Time")
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundStyle(Theme.textPrimary)
+
+                Spacer()
+
+                if exercises.count > 1 {
+                    Menu {
+                        ForEach(exercises, id: \.self) { exercise in
+                            Button(exercise) {
+                                selectedExercise = exercise
+                            }
+                        }
+                    } label: {
+                        HStack(spacing: 4) {
+                            Text(selectedExercise)
+                                .font(Theme.fontCaption)
+                            Image(systemName: "chevron.up.chevron.down")
+                                .font(.system(size: 10))
+                        }
+                        .foregroundStyle(Theme.accent)
+                    }
+                }
+            }
+
+            if dataPoints.isEmpty {
+                Text("No data for this exercise")
+                    .font(Theme.fontCaption)
+                    .foregroundStyle(Theme.textSecondary)
+                    .frame(maxWidth: .infinity, minHeight: 150, alignment: .center)
+            } else {
+                Chart(dataPoints) { point in
+                    LineMark(
+                        x: .value("Date", point.date),
+                        y: .value("Est. 1RM", point.estimated1RM)
+                    )
+                    .foregroundStyle(Theme.accent)
+                    .interpolationMethod(.catmullRom)
+
+                    PointMark(
+                        x: .value("Date", point.date),
+                        y: .value("Est. 1RM", point.estimated1RM)
+                    )
+                    .foregroundStyle(Theme.accent)
+                    .symbolSize(30)
+                }
+                .chartYAxisLabel("Est. 1RM (lbs)", position: .leading)
+                .chartYAxis {
+                    AxisMarks(position: .leading) { _ in
+                        AxisGridLine(stroke: StrokeStyle(lineWidth: 0.5))
+                            .foregroundStyle(Theme.textSecondary.opacity(0.3))
+                        AxisValueLabel()
+                            .foregroundStyle(Theme.textSecondary)
+                    }
+                }
+                .chartXAxis {
+                    AxisMarks { _ in
+                        AxisGridLine(stroke: StrokeStyle(lineWidth: 0.5))
+                            .foregroundStyle(Theme.textSecondary.opacity(0.3))
+                        AxisValueLabel()
+                            .foregroundStyle(Theme.textSecondary)
+                    }
+                }
+                .frame(height: 200)
+            }
+        }
+        .cardStyle()
+    }
+}
+
+// MARK: - Weekly Volume
+
+private struct WeeklyVolumeChart: View {
+    let data: [(label: String, volume: Double)]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Theme.paddingSmall) {
+            Text("Weekly Volume")
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundStyle(Theme.textPrimary)
+
+            Chart {
+                ForEach(Array(data.enumerated()), id: \.offset) { _, item in
+                    BarMark(
+                        x: .value("Week", item.label),
+                        y: .value("Volume", item.volume)
+                    )
+                    .foregroundStyle(Theme.accent)
+                    .cornerRadius(4)
+                }
+            }
+            .chartYAxis {
+                AxisMarks(position: .leading) { _ in
+                    AxisGridLine(stroke: StrokeStyle(lineWidth: 0.5))
+                        .foregroundStyle(Theme.textSecondary.opacity(0.3))
+                    AxisValueLabel()
+                        .foregroundStyle(Theme.textSecondary)
+                }
+            }
+            .chartXAxis {
+                AxisMarks { _ in
+                    AxisValueLabel()
+                        .foregroundStyle(Theme.textSecondary)
+                }
+            }
+            .frame(height: 180)
+        }
+        .cardStyle()
+    }
+}
+
+// MARK: - Muscle Group Breakdown
+
+private struct MuscleGroupChart: View {
+    let data: [(group: String, sets: Int)]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Theme.paddingSmall) {
+            Text("Muscle Groups")
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundStyle(Theme.textPrimary)
+
+            Chart {
+                ForEach(Array(data.enumerated()), id: \.offset) { _, item in
+                    BarMark(
+                        x: .value("Sets", item.sets),
+                        y: .value("Muscle", item.group)
+                    )
+                    .foregroundStyle(Theme.accent)
+                    .cornerRadius(4)
+                }
+            }
+            .chartXAxis {
+                AxisMarks { _ in
+                    AxisGridLine(stroke: StrokeStyle(lineWidth: 0.5))
+                        .foregroundStyle(Theme.textSecondary.opacity(0.3))
+                    AxisValueLabel()
+                        .foregroundStyle(Theme.textSecondary)
+                }
+            }
+            .chartYAxis {
+                AxisMarks { _ in
+                    AxisValueLabel()
+                        .foregroundStyle(Theme.textSecondary)
+                }
+            }
+            .frame(height: CGFloat(max(data.count, 1)) * 32)
+        }
+        .cardStyle()
+    }
+}
+
+// MARK: - XomProgressView Extensions
+
+extension XomProgressView {
+    fileprivate var summaryCards: some View {
+        SummaryCardsView(
+            totalWorkouts: viewModel.totalWorkouts,
+            currentStreak: viewModel.currentStreak,
+            formattedVolume: viewModel.formattedTotalVolume,
+            totalPRs: viewModel.totalPRs
+        )
+    }
+
+    fileprivate var liftProgressionSection: some View {
+        LiftProgressionChart(
+            dataPoints: viewModel.filteredStrengthData,
+            exercises: viewModel.availableExercises,
+            selectedExercise: Bindable(viewModel).selectedExercise
+        )
+    }
+
+    fileprivate var weeklyVolumeSection: some View {
+        WeeklyVolumeChart(data: viewModel.weeklyVolumes)
+    }
+
+    @ViewBuilder
+    fileprivate var muscleGroupSection: some View {
+        if !viewModel.muscleGroupSets.isEmpty {
+            MuscleGroupChart(data: viewModel.muscleGroupSets)
+        }
+    }
+
+    @ViewBuilder
+    fileprivate var recentPRsSection: some View {
+        if !viewModel.recentPRs.isEmpty {
+            VStack(alignment: .leading, spacing: Theme.paddingSmall) {
+                Text("Recent PRs")
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundStyle(Theme.textPrimary)
+
+                ForEach(viewModel.recentPRs) { pr in
+                    PRBadgeRow(pr: pr)
+                }
+            }
+            .cardStyle()
         }
     }
 }

--- a/Xomfit/Views/Shared/PRBadgeRow.swift
+++ b/Xomfit/Views/Shared/PRBadgeRow.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+
+struct PRBadgeRow: View {
+    let pr: PersonalRecord
+
+    var body: some View {
+        HStack {
+            Image(systemName: "trophy.fill")
+                .foregroundStyle(Theme.prGold)
+                .font(.system(size: 14))
+
+            Text(pr.exerciseName)
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(Theme.textPrimary)
+
+            Spacer()
+
+            Text("\(pr.weight.formattedWeight) \u{00D7} \(pr.reps)")
+                .font(.system(size: 14, weight: .bold))
+                .foregroundStyle(Theme.accent)
+
+            if let imp = pr.improvementString {
+                Text(imp)
+                    .font(Theme.fontSmall)
+                    .foregroundStyle(Theme.prGold)
+            }
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(pr.exerciseName), \(pr.weight.formattedWeight) pounds for \(pr.reps) reps\(pr.improvementString.map { ", \($0)" } ?? "")")
+    }
+}

--- a/docs/features/101-progress-tab/PLAN.md
+++ b/docs/features/101-progress-tab/PLAN.md
@@ -1,0 +1,70 @@
+# Plan: Progress Tab
+
+**Status**: Ready
+**Created**: 2026-03-30
+**Last updated**: 2026-03-30
+
+## Summary
+Build out the Progress tab (`XomProgressView`) from its current placeholder state into a full analytics dashboard. The tab will show workout summary stats, lift progression charts, weekly volume trends, muscle group breakdown, and recent PRs. All data comes from existing `WorkoutService` (local) and `PRService` (Supabase) -- no new services needed. Success = a useful, chart-driven progress view that matches the app's dark theme and MVVM patterns.
+
+## Approach
+Single ViewModel (`ProgressViewModel`) computes all derived stats from raw workout and PR data. The view uses Swift Charts (`LineMark`, `BarMark`) for visualizations. No new models needed -- `StrengthDataPoint` and related types in `AdvancedStats.swift` already exist. `PRBadgeRow` is currently `private` in `ProfileView.swift`, so we'll extract it to a shared component to avoid duplication.
+
+## Affected Files / Components
+| File / Component | Change | Why |
+|-----------------|--------|-----|
+| `Xomfit/ViewModels/ProgressViewModel.swift` | **New file** | @Observable VM -- loads workouts + PRs, computes summary stats, strength data points, weekly volume, muscle group sets |
+| `Xomfit/Views/Progress/XomProgressView.swift` | **Rewrite** | Replace placeholder with full ScrollView layout: summary cards, lift chart, volume chart, muscle breakdown, recent PRs |
+| `Xomfit/Views/Shared/PRBadgeRow.swift` | **New file** (extracted) | Move `PRBadgeRow` out of `ProfileView.swift` so both Progress and Profile can use it |
+| `Xomfit/Views/Profile/ProfileView.swift` | **Minor edit** | Remove private `PRBadgeRow` struct, import shared version |
+
+## Implementation Steps
+- [ ] **Step 1** -- Extract `PRBadgeRow` to `Xomfit/Views/Shared/PRBadgeRow.swift`. Remove the `private` copy from `ProfileView.swift`. Verify ProfileView still builds.
+- [ ] **Step 2** -- Create `Xomfit/ViewModels/ProgressViewModel.swift` with:
+  - `@Observable @MainActor final class ProgressViewModel`
+  - Properties: `isLoading`, `errorMessage`, `totalWorkouts`, `currentStreak`, `totalVolume`, `totalPRs`, `recentPRs: [PersonalRecord]`, `strengthDataPoints: [StrengthDataPoint]`, `weeklyVolumes: [(label: String, volume: Double)]`, `muscleGroupSets: [(group: String, sets: Int)]`, `availableExercises: [String]`, `selectedExercise: String`
+  - `func loadData(userId: String) async` -- fetches workouts from `WorkoutService.shared.fetchWorkouts(userId:)` and PRs from `PRService.shared.fetchPRs(userId:)`, then calls private compute methods
+  - `private func computeSummary(workouts:prs:)` -- total workouts, total volume, total PRs, current streak (consecutive calendar days with workouts looking back from today, max 7)
+  - `private func computeStrengthData(workouts:)` -- for each exercise that appears in workouts, extract best estimated 1RM per workout date as `StrengthDataPoint`. Populate `availableExercises` sorted by frequency desc. Default `selectedExercise` to the most frequent exercise.
+  - `private func computeWeeklyVolume(workouts:)` -- bucket workouts into calendar weeks (last 8 weeks), sum `totalVolume` per week. Label format: "Mar 24" (month + day of week start).
+  - `private func computeMuscleGroups(workouts:)` -- iterate all exercises in all workouts, count total completed sets per `MuscleGroup`. Sort desc by set count.
+  - `var filteredStrengthData: [StrengthDataPoint]` -- computed property filtering `strengthDataPoints` to `selectedExercise`
+- [ ] **Step 3** -- Rewrite `Xomfit/Views/Progress/XomProgressView.swift`:
+  - `@Environment(AuthService.self) private var authService`
+  - `@State private var viewModel = ProgressViewModel()`
+  - `userId` computed from `authService.currentUser?.id.uuidString ?? ""`
+  - `NavigationStack` > `ZStack` with `Theme.background.ignoresSafeArea()` > conditional on `viewModel.isLoading` / empty / content
+  - Loading: `ProgressView().tint(Theme.accent)`
+  - Empty (0 workouts): centered message "Log your first workout to see progress here"
+  - Content: `ScrollView` > `VStack(spacing: Theme.paddingMedium)` with sections:
+    1. **Summary cards** -- `LazyVGrid(columns: 2)` with 4 stat cards (icon, value, label). Total Workouts (dumbbell), Streak (flame), Volume (scalemass), PRs (trophy). Each card uses `.cardStyle()`.
+    2. **Lift progression** -- section header "Strength Over Time", `Picker` for exercise (segmented or menu style), `Chart` with `LineMark` + `PointMark` for `filteredStrengthData`. X = date, Y = estimated1RM. Foreground: `Theme.accent`. Wrapped in `.cardStyle()`.
+    3. **Weekly volume** -- section header "Weekly Volume", `Chart` with `BarMark`. X = week label, Y = volume. Foreground: `Theme.accent`. Wrapped in `.cardStyle()`.
+    4. **Muscle group breakdown** -- section header "Muscle Groups", `Chart` with horizontal `BarMark`. X = sets, Y = muscle group name. Foreground: `Theme.accent`. Wrapped in `.cardStyle()`.
+    5. **Recent PRs** -- section header "Recent PRs", `ForEach` over `viewModel.recentPRs` with `PRBadgeRow`. Wrapped in `.cardStyle()`.
+  - `.task { await viewModel.loadData(userId: userId) }`
+  - `.navigationTitle("Progress")`, `.toolbarColorScheme(.dark, for: .navigationBar)`
+- [ ] **Step 4** -- Add `Xomfit/Views/Shared/` group to the Xcode project if not already present (verify the folder exists in the file system).
+- [ ] **Step 5** -- Build and test in simulator. Verify: loads with no workouts (empty state), loads with workout data (all charts render), exercise picker switches lift chart, scrolling is smooth.
+
+## Out of Scope
+- Backend analytics endpoints or server-side aggregation
+- Date range picker / time period filtering (can be added later)
+- Export or share functionality
+- Workout frequency heatmap (calendar grid) -- future enhancement
+- Muscle balance / imbalance analysis
+- Animations or transitions between chart states
+
+## Risks / Tradeoffs
+- **Performance with large workout history**: All computation is on-device from UserDefaults. For users with hundreds of workouts, the strength data computation could be slow. Mitigation: compute once on load, not on every view update. If needed later, cache computed results.
+- **PRBadgeRow extraction**: Changing `ProfileView.swift` introduces a small regression risk. Mitigation: it's a straightforward extraction of a self-contained view -- verify Profile tab still renders.
+- **Streak calculation simplicity**: "Consecutive days looking back from today" is simple but won't show historical streaks. Accepted tradeoff for v1.
+- **Chart readability on small data sets**: Charts with 1-2 data points look sparse. Accepted -- the tab gets more useful as the user logs more workouts.
+
+## Open Questions
+- [x] Exercise picker: **Menu** (compact, supports 10+ exercises)
+- [x] Volume formatting: reuse `formattedVolume` pattern from `Workout` — "12.5k" for 1000+, "1.2M" for 1M+
+
+## Skills / Agents to Use
+- **Code agent**: Execute steps 1-4 (extraction, ViewModel, View rewrite)
+- **iOS standards skill**: Reference for Swift Charts API usage and @Observable patterns


### PR DESCRIPTION
## Summary
- Build out the Progress tab from empty placeholder to full analytics dashboard
- Add `ProgressViewModel` with stat computation from WorkoutService + PRService
- Swift Charts: lift progression (LineMark), weekly volume (BarMark), muscle group breakdown (horizontal BarMark)
- Summary cards grid: total workouts, day streak, volume, PRs
- Extract `PRBadgeRow` to shared component for reuse across Profile and Progress

Closes #101

## Test plan
- [ ] Open Progress tab with no workouts — empty state renders
- [ ] Log a workout, return to Progress — all charts populate
- [ ] Exercise picker switches lift chart data
- [ ] ProfileView still renders PRs correctly (shared PRBadgeRow)
- [ ] Scroll performance is smooth with multiple charts

🤖 Generated with [Claude Code](https://claude.com/claude-code)