### PR TITLE
Add rest timer between sets

### DIFF
--- a/Xomfit/ViewModels/WorkoutLoggerViewModel.swift
+++ b/Xomfit/ViewModels/WorkoutLoggerViewModel.swift
@@ -10,6 +10,11 @@ final class WorkoutLoggerViewModel {
     var isSaving = false
     var errorMessage: String?
 
+    // Rest timer
+    var restTimeRemaining: Double = 0
+    var restDuration: Double = 0
+    var isRestTimerActive: Bool = false
+
     // PR celebration — set when a completed set beats the user's record
     var newPR: PersonalRecord? = nil
     var showPRCelebration: Bool = false
@@ -54,6 +59,7 @@ final class WorkoutLoggerViewModel {
         activeUserId = userId
         newPR = nil
         showPRCelebration = false
+        skipRestTimer()
     }
 
     func discardWorkout() {
@@ -64,6 +70,7 @@ final class WorkoutLoggerViewModel {
         errorMessage = nil
         newPR = nil
         showPRCelebration = false
+        skipRestTimer()
     }
 
     // MARK: - Exercise Management
@@ -120,6 +127,9 @@ final class WorkoutLoggerViewModel {
             exercises[exerciseIndex].sets[setIndex].isPersonalRecord = false
         } else {
             exercises[exerciseIndex].sets[setIndex].completedAt = Date()
+            // Start rest timer
+            let exerciseCategory = exercises[exerciseIndex].exercise.category
+            startRestTimer(for: exerciseCategory)
             // Fire PR check asynchronously — non-blocking
             let set = exercises[exerciseIndex].sets[setIndex]
             let exercise = exercises[exerciseIndex].exercise
@@ -138,6 +148,38 @@ final class WorkoutLoggerViewModel {
         guard exercises.indices.contains(exerciseIndex),
               exercises[exerciseIndex].sets.indices.contains(setIndex) else { return }
         exercises[exerciseIndex].sets.remove(at: setIndex)
+    }
+
+    // MARK: - Rest Timer
+
+    func startRestTimer(for category: ExerciseCategory) {
+        let duration: Double = switch category {
+        case .compound: 90
+        case .isolation: 60
+        case .cardio, .stretching: 30
+        }
+        restDuration = duration
+        restTimeRemaining = duration
+        isRestTimerActive = true
+    }
+
+    func tickRestTimer() {
+        guard isRestTimerActive, restTimeRemaining > 0 else { return }
+        restTimeRemaining -= 1
+        if restTimeRemaining <= 0 {
+            restTimeRemaining = 0
+            isRestTimerActive = false
+        }
+    }
+
+    func skipRestTimer() {
+        restTimeRemaining = 0
+        isRestTimerActive = false
+    }
+
+    func extendRestTimer(_ seconds: Double = 30) {
+        restTimeRemaining += seconds
+        restDuration += seconds
     }
 
     // MARK: - PR Detection

--- a/Xomfit/Views/Workout/ActiveWorkoutView.swift
+++ b/Xomfit/Views/Workout/ActiveWorkoutView.swift
@@ -21,6 +21,19 @@ struct ActiveWorkoutView: View {
                     // Header bar
                     headerBar
 
+                    // Rest timer
+                    if viewModel.isRestTimerActive {
+                        RestTimerView(
+                            restTimeRemaining: viewModel.restTimeRemaining,
+                            restDuration: viewModel.restDuration,
+                            onSkip: { viewModel.skipRestTimer() },
+                            onExtend: { viewModel.extendRestTimer() }
+                        )
+                        .padding(.horizontal, Theme.paddingMedium)
+                        .padding(.vertical, Theme.paddingSmall)
+                        .transition(.move(edge: .top).combined(with: .opacity))
+                    }
+
                     // Exercise list
                     if viewModel.exercises.isEmpty {
                         emptyState
@@ -40,6 +53,7 @@ struct ActiveWorkoutView: View {
                         }
                     }
                 }
+                .animation(.easeInOut(duration: 0.3), value: viewModel.isRestTimerActive)
 
                 // Floating Add Exercise button
                 VStack {
@@ -81,7 +95,13 @@ struct ActiveWorkoutView: View {
             viewModel.startWorkout(name: workoutName, userId: userId)
         }
         .onReceive(timer) { _ in
-            // Trigger a view refresh every second to update the timer label
+            viewModel.tickRestTimer()
+            // Haptic when rest timer completes
+            if !viewModel.isRestTimerActive && viewModel.restDuration > 0 && viewModel.restTimeRemaining <= 0 {
+                viewModel.restDuration = 0
+                let generator = UINotificationFeedbackGenerator()
+                generator.notificationOccurred(.success)
+            }
         }
         .sheet(isPresented: $showExercisePicker) {
             ExercisePickerView { exercise in

--- a/Xomfit/Views/Workout/RestTimerView.swift
+++ b/Xomfit/Views/Workout/RestTimerView.swift
@@ -1,0 +1,92 @@
+import SwiftUI
+
+/// Horizontal rest timer banner shown between sets.
+/// Circular countdown ring on the left, time display and controls on the right.
+struct RestTimerView: View {
+    let restTimeRemaining: Double
+    let restDuration: Double
+    let onSkip: () -> Void
+    let onExtend: () -> Void
+
+    private var progress: Double {
+        guard restDuration > 0 else { return 0 }
+        return 1 - (restTimeRemaining / restDuration)
+    }
+
+    private var timeString: String {
+        let total = max(0, Int(restTimeRemaining))
+        let mins = total / 60
+        let secs = total % 60
+        return String(format: "%d:%02d", mins, secs)
+    }
+
+    var body: some View {
+        HStack(spacing: Theme.paddingMedium) {
+            // Circular countdown ring
+            ZStack {
+                Circle()
+                    .stroke(
+                        Theme.textSecondary.opacity(0.3),
+                        lineWidth: 5
+                    )
+
+                Circle()
+                    .trim(from: 0, to: progress)
+                    .stroke(
+                        Theme.accent,
+                        style: StrokeStyle(lineWidth: 5, lineCap: .round)
+                    )
+                    .rotationEffect(.degrees(-90))
+                    .animation(.linear(duration: 1), value: progress)
+
+                Text(timeString)
+                    .font(.system(size: 16, weight: .bold, design: .monospaced))
+                    .monospacedDigit()
+                    .foregroundStyle(Theme.accent)
+            }
+            .frame(width: 64, height: 64)
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel("Rest timer, \(timeString) remaining")
+
+            // Label + controls
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Rest")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(Theme.textSecondary)
+
+                HStack(spacing: 10) {
+                    Button {
+                        onSkip()
+                    } label: {
+                        Text("Skip")
+                            .font(.system(size: 13, weight: .bold))
+                            .foregroundStyle(Theme.textPrimary)
+                            .padding(.horizontal, 14)
+                            .padding(.vertical, 7)
+                            .background(Theme.textSecondary.opacity(0.2))
+                            .clipShape(.capsule)
+                    }
+                    .accessibilityLabel("Skip rest timer")
+
+                    Button {
+                        onExtend()
+                    } label: {
+                        Text("+30s")
+                            .font(.system(size: 13, weight: .bold))
+                            .foregroundStyle(Theme.accent)
+                            .padding(.horizontal, 14)
+                            .padding(.vertical, 7)
+                            .background(Theme.accent.opacity(0.12))
+                            .clipShape(.capsule)
+                    }
+                    .accessibilityLabel("Add 30 seconds to rest timer")
+                }
+            }
+
+            Spacer()
+        }
+        .padding(Theme.paddingMedium)
+        .background(Theme.cardBackground)
+        .clipShape(.rect(cornerRadius: Theme.cornerRadius))
+    }
+}


### PR DESCRIPTION
## Summary
- New `RestTimerView` with circular countdown ring, skip and +30s controls
- Auto-starts on set completion: 90s for compounds, 60s isolation, 30s cardio
- Timer banner animates in/out between header and exercise list
- Haptic notification when rest period completes

Closes #103

## Test plan
- [ ] Complete a set on a compound exercise — timer starts at 1:30
- [ ] Complete a set on an isolation exercise — timer starts at 1:00
- [ ] Skip button dismisses timer immediately
- [ ] +30s button extends timer
- [ ] Timer auto-dismisses and haptic fires at 0:00
- [ ] Discard workout clears timer
- [ ] Timer doesn't block exercise list scrolling

🤖 Generated with [Claude Code](https://claude.com/claude-code)