### PR TITLE
Pre-fill weight and reps from previous workout

### DIFF
--- a/Xomfit/ViewModels/WorkoutLoggerViewModel.swift
+++ b/Xomfit/ViewModels/WorkoutLoggerViewModel.swift
@@ -76,13 +76,39 @@ final class WorkoutLoggerViewModel {
     // MARK: - Exercise Management
 
     func addExercise(_ exercise: Exercise) {
+        // Look up last workout's weight/reps for this exercise
+        let lastSet = lastSetForExercise(exercise.id)
+
+        let firstSet = WorkoutSet(
+            id: UUID().uuidString,
+            exerciseId: exercise.id,
+            weight: lastSet?.weight ?? 0,
+            reps: lastSet?.reps ?? 0,
+            rpe: nil,
+            isPersonalRecord: false,
+            completedAt: Date.distantPast
+        )
+
         let workoutExercise = WorkoutExercise(
             id: UUID().uuidString,
             exercise: exercise,
-            sets: [],
+            sets: [firstSet],
             notes: nil
         )
         exercises.append(workoutExercise)
+    }
+
+    /// Find the most recent set for an exercise from workout history.
+    private func lastSetForExercise(_ exerciseId: String) -> WorkoutSet? {
+        guard !activeUserId.isEmpty else { return nil }
+        let workouts = WorkoutService.shared.fetchWorkoutsFromCache(userId: activeUserId)
+        for workout in workouts {
+            if let workoutExercise = workout.exercises.first(where: { $0.exercise.id == exerciseId }),
+               let bestSet = workoutExercise.sets.last {
+                return bestSet
+            }
+        }
+        return nil
     }
 
     func removeExercise(at index: Int) {


### PR DESCRIPTION
## Summary
- When adding an exercise, auto-creates first set pre-filled with weight/reps from the last workout for that exercise
- Uses sync cache lookup for instant access, no loading state needed
- Falls back to 0/0 if no history exists (same behavior as before)

Closes #104

## Test plan
- [ ] Add an exercise you've done before — first set shows previous weight/reps
- [ ] Add a new exercise with no history — first set shows empty (0)
- [ ] Add additional sets — still pre-fills from the last set in current workout
- [ ] Values are editable (just type over them)

🤖 Generated with [Claude Code](https://claude.com/claude-code)