### PR TITLE
Workout templates — quick-start from saved routines

### DIFF
--- a/Xomfit/Services/TemplateService.swift
+++ b/Xomfit/Services/TemplateService.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+@MainActor
+final class TemplateService {
+    static let shared = TemplateService()
+
+    private let key = "xomfit_custom_templates"
+
+    private init() {}
+
+    // MARK: - Public
+
+    func allTemplates() -> [WorkoutTemplate] {
+        let custom = loadCustom()
+        let all = WorkoutTemplate.builtIn + custom
+        return all.sorted { lhs, rhs in
+            if lhs.category.rawValue != rhs.category.rawValue {
+                return lhs.category.rawValue < rhs.category.rawValue
+            }
+            return lhs.name < rhs.name
+        }
+    }
+
+    func saveCustomTemplate(_ template: WorkoutTemplate) {
+        var custom = loadCustom()
+        var t = template
+        t.isCustom = true
+        if let idx = custom.firstIndex(where: { $0.id == t.id }) {
+            custom[idx] = t
+        } else {
+            custom.append(t)
+        }
+        encode(custom)
+    }
+
+    func deleteCustomTemplate(id: String) {
+        var custom = loadCustom()
+        custom.removeAll { $0.id == id }
+        encode(custom)
+    }
+
+    // MARK: - Private
+
+    private func loadCustom() -> [WorkoutTemplate] {
+        guard let data = UserDefaults.standard.data(forKey: key) else { return [] }
+        return (try? JSONDecoder().decode([WorkoutTemplate].self, from: data)) ?? []
+    }
+
+    private func encode(_ templates: [WorkoutTemplate]) {
+        if let data = try? JSONEncoder().encode(templates) {
+            UserDefaults.standard.set(data, forKey: key)
+        }
+    }
+}

--- a/Xomfit/ViewModels/WorkoutLoggerViewModel.swift
+++ b/Xomfit/ViewModels/WorkoutLoggerViewModel.swift
@@ -73,6 +73,38 @@ final class WorkoutLoggerViewModel {
         skipRestTimer()
     }
 
+    func startFromTemplate(_ template: WorkoutTemplate, userId: String) {
+        startWorkout(name: template.name, userId: userId)
+
+        var builtExercises: [WorkoutExercise] = []
+        for templateExercise in template.exercises {
+            let lastSet = lastSetForExercise(templateExercise.exercise.id)
+            let prefillWeight = lastSet?.weight ?? 0
+            let prefillReps = lastSet?.reps ?? 0
+
+            var sets: [WorkoutSet] = []
+            for _ in 0..<templateExercise.targetSets {
+                sets.append(WorkoutSet(
+                    id: UUID().uuidString,
+                    exerciseId: templateExercise.exercise.id,
+                    weight: prefillWeight,
+                    reps: prefillReps,
+                    rpe: nil,
+                    isPersonalRecord: false,
+                    completedAt: Date.distantPast
+                ))
+            }
+
+            builtExercises.append(WorkoutExercise(
+                id: UUID().uuidString,
+                exercise: templateExercise.exercise,
+                sets: sets,
+                notes: templateExercise.notes
+            ))
+        }
+        exercises = builtExercises
+    }
+
     // MARK: - Exercise Management
 
     func addExercise(_ exercise: Exercise) {

--- a/Xomfit/Views/Workout/ActiveWorkoutView.swift
+++ b/Xomfit/Views/Workout/ActiveWorkoutView.swift
@@ -11,6 +11,7 @@ struct ActiveWorkoutView: View {
 
     // Passed in from WorkoutView
     let workoutName: String
+    var template: WorkoutTemplate? = nil
 
     var body: some View {
         NavigationStack {
@@ -92,7 +93,11 @@ struct ActiveWorkoutView: View {
         }
         .onAppear {
             let userId = authService.currentUser?.id.uuidString ?? ""
-            viewModel.startWorkout(name: workoutName, userId: userId)
+            if let template {
+                viewModel.startFromTemplate(template, userId: userId)
+            } else {
+                viewModel.startWorkout(name: workoutName, userId: userId)
+            }
         }
         .onReceive(timer) { _ in
             viewModel.tickRestTimer()

--- a/Xomfit/Views/Workout/TemplateCardView.swift
+++ b/Xomfit/Views/Workout/TemplateCardView.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+
+struct TemplateCardView: View {
+    let template: WorkoutTemplate
+    let onSelect: () -> Void
+
+    var body: some View {
+        Button(action: onSelect) {
+            VStack(alignment: .leading, spacing: Theme.paddingSmall) {
+                // Category icon
+                Image(systemName: template.category.icon)
+                    .font(.system(size: 22))
+                    .foregroundStyle(Theme.accent)
+                    .frame(width: 36, height: 36)
+                    .background(Theme.accent.opacity(0.15))
+                    .clipShape(.rect(cornerRadius: Theme.cornerRadiusSmall))
+
+                Spacer(minLength: 4)
+
+                // Name
+                Text(template.name)
+                    .font(.system(size: 14, weight: .bold))
+                    .foregroundStyle(Theme.textPrimary)
+                    .lineLimit(1)
+
+                // Details
+                HStack(spacing: 4) {
+                    Text("\(template.exercises.count) exercises")
+                    Text("~\(template.estimatedDuration)m")
+                        .foregroundStyle(Theme.accent)
+                }
+                .font(Theme.fontSmall)
+                .foregroundStyle(Theme.textSecondary)
+            }
+            .padding(Theme.paddingMedium)
+            .frame(width: 160, alignment: .leading)
+            .background(Theme.cardBackground)
+            .clipShape(.rect(cornerRadius: Theme.cornerRadius))
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("\(template.name) template, \(template.exercises.count) exercises, about \(template.estimatedDuration) minutes")
+        .accessibilityAddTraits(.isButton)
+    }
+}

--- a/Xomfit/Views/Workout/TemplateListView.swift
+++ b/Xomfit/Views/Workout/TemplateListView.swift
@@ -1,0 +1,114 @@
+import SwiftUI
+
+struct TemplateListView: View {
+    @Environment(\.dismiss) private var dismiss
+
+    let onSelect: (WorkoutTemplate) -> Void
+
+    @State private var templates: [WorkoutTemplate] = []
+
+    private var groupedTemplates: [(WorkoutTemplate.TemplateCategory, [WorkoutTemplate])] {
+        let grouped = Dictionary(grouping: templates, by: \.category)
+        return WorkoutTemplate.TemplateCategory.allCases.compactMap { category in
+            guard let items = grouped[category], !items.isEmpty else { return nil }
+            return (category, items)
+        }
+    }
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Theme.background.ignoresSafeArea()
+
+                List {
+                    ForEach(groupedTemplates, id: \.0) { category, items in
+                        Section {
+                            ForEach(items) { template in
+                                templateRow(template)
+                                    .listRowBackground(Theme.cardBackground)
+                                    .listRowSeparator(.hidden)
+                            }
+                            .onDelete { indexSet in
+                                deleteCustom(from: items, at: indexSet)
+                            }
+                        } header: {
+                            HStack(spacing: 6) {
+                                Image(systemName: category.icon)
+                                    .foregroundStyle(Theme.accent)
+                                Text(category.displayName)
+                                    .foregroundStyle(Theme.textPrimary)
+                            }
+                            .font(.system(size: 14, weight: .bold))
+                        }
+                    }
+                }
+                .listStyle(.plain)
+                .scrollContentBackground(.hidden)
+            }
+            .navigationTitle("Templates")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbarColorScheme(.dark, for: .navigationBar)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button("Close") { dismiss() }
+                        .foregroundStyle(Theme.accent)
+                }
+            }
+        }
+        .onAppear { templates = TemplateService.shared.allTemplates() }
+    }
+
+    // MARK: - Row
+
+    private func templateRow(_ template: WorkoutTemplate) -> some View {
+        Button {
+            onSelect(template)
+            dismiss()
+        } label: {
+            HStack(spacing: Theme.paddingMedium) {
+                Image(systemName: template.category.icon)
+                    .font(.system(size: 18))
+                    .foregroundStyle(Theme.accent)
+                    .frame(width: 36, height: 36)
+                    .background(Theme.accent.opacity(0.15))
+                    .clipShape(.rect(cornerRadius: Theme.cornerRadiusSmall))
+
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(template.name)
+                        .font(.system(size: 15, weight: .bold))
+                        .foregroundStyle(Theme.textPrimary)
+                    Text(template.description)
+                        .font(Theme.fontCaption)
+                        .foregroundStyle(Theme.textSecondary)
+                        .lineLimit(1)
+                }
+
+                Spacer()
+
+                VStack(alignment: .trailing, spacing: 3) {
+                    Text("\(template.exercises.count) exercises")
+                        .font(Theme.fontSmall)
+                        .foregroundStyle(Theme.textSecondary)
+                    Text("~\(template.estimatedDuration)m")
+                        .font(Theme.fontSmall)
+                        .foregroundStyle(Theme.accent)
+                }
+            }
+            .padding(.vertical, 4)
+        }
+        .buttonStyle(.plain)
+        .deleteDisabled(!template.isCustom)
+        .accessibilityLabel("\(template.name), \(template.description), \(template.exercises.count) exercises, about \(template.estimatedDuration) minutes")
+    }
+
+    // MARK: - Delete
+
+    private func deleteCustom(from items: [WorkoutTemplate], at indexSet: IndexSet) {
+        for idx in indexSet {
+            let template = items[idx]
+            guard template.isCustom else { continue }
+            TemplateService.shared.deleteCustomTemplate(id: template.id)
+        }
+        templates = TemplateService.shared.allTemplates()
+    }
+}

--- a/Xomfit/Views/Workout/WorkoutView.swift
+++ b/Xomfit/Views/Workout/WorkoutView.swift
@@ -7,6 +7,8 @@ struct WorkoutView: View {
     @State private var showActiveWorkout = false
     @State private var showNameEntry = false
     @State private var pendingWorkoutName = ""
+    @State private var selectedTemplate: WorkoutTemplate?
+    @State private var showTemplateList = false
 
     private var userId: String {
         authService.currentUser?.id.uuidString ?? ""
@@ -37,6 +39,9 @@ struct WorkoutView: View {
                     .padding(.horizontal, Theme.paddingMedium)
                     .padding(.top, Theme.paddingMedium)
                     .padding(.bottom, Theme.paddingSmall)
+
+                    // Quick Start templates
+                    templateSection
 
                     // Workout history
                     if workouts.isEmpty {
@@ -88,10 +93,56 @@ struct WorkoutView: View {
             Button("Start") { showActiveWorkout = true }
             Button("Cancel", role: .cancel) {}
         }
-        .fullScreenCover(isPresented: $showActiveWorkout, onDismiss: { Task { await loadWorkouts() } }) {
-            ActiveWorkoutView(workoutName: pendingWorkoutName.isEmpty ? "Workout" : pendingWorkoutName)
-                .environment(authService)
+        .fullScreenCover(isPresented: $showActiveWorkout, onDismiss: {
+            selectedTemplate = nil
+            Task { await loadWorkouts() }
+        }) {
+            ActiveWorkoutView(
+                workoutName: selectedTemplate?.name ?? (pendingWorkoutName.isEmpty ? "Workout" : pendingWorkoutName),
+                template: selectedTemplate
+            )
+            .environment(authService)
         }
+        .sheet(isPresented: $showTemplateList) {
+            TemplateListView { template in
+                selectedTemplate = template
+                showActiveWorkout = true
+            }
+        }
+    }
+
+    // MARK: - Templates
+
+    private var templateSection: some View {
+        VStack(alignment: .leading, spacing: Theme.paddingSmall) {
+            HStack {
+                Text("Quick Start")
+                    .font(.system(size: 16, weight: .bold))
+                    .foregroundStyle(Theme.textPrimary)
+                Spacer()
+                Button {
+                    showTemplateList = true
+                } label: {
+                    Text("See All")
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundStyle(Theme.accent)
+                }
+            }
+            .padding(.horizontal, Theme.paddingMedium)
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: Theme.paddingSmall) {
+                    ForEach(TemplateService.shared.allTemplates().prefix(6)) { template in
+                        TemplateCardView(template: template) {
+                            selectedTemplate = template
+                            showActiveWorkout = true
+                        }
+                    }
+                }
+                .padding(.horizontal, Theme.paddingMedium)
+            }
+        }
+        .padding(.vertical, Theme.paddingSmall)
     }
 
     private func loadWorkouts() async {

--- a/docs/features/105-workout-templates/PLAN.md
+++ b/docs/features/105-workout-templates/PLAN.md
@@ -1,0 +1,109 @@
+# Plan: Workout Templates
+
+**Status**: Ready
+**Created**: 2026-03-30
+**Last updated**: 2026-03-30
+**Issue**: #105
+**Branch**: `feature/105-workout-templates`
+
+## Summary
+Let users start workouts from saved templates instead of building from scratch every time. The `WorkoutTemplate` model already exists with 4 built-in templates. This plan adds a template browsing UI to WorkoutView, a TemplateService for persistence, and wires template selection into the existing ActiveWorkoutView flow. Success = user can tap a template card and land in ActiveWorkoutView with all exercises and sets pre-loaded.
+
+## Approach
+Minimal v1: browse built-in templates, start workout from template, persist custom templates in UserDefaults. No template editor UI -- custom templates come from a future "Save as Template" feature. The existing `addExercise()` pattern in WorkoutLoggerViewModel already pre-fills weight/reps from history, so `startFromTemplate()` will reuse that logic per exercise.
+
+## Affected Files / Components
+
+| File / Component | Change | Why |
+|-----------------|--------|-----|
+| `Xomfit/Services/TemplateService.swift` | **New** -- singleton service for template CRUD | Owns template persistence (UserDefaults) and merges built-in + custom |
+| `Xomfit/Views/Workout/TemplateCardView.swift` | **New** -- reusable template card component | Used in both the horizontal scroll on WorkoutView and TemplateListView |
+| `Xomfit/Views/Workout/TemplateListView.swift` | **New** -- full list of all templates | Sheet showing all templates grouped by category, swipe-to-delete on custom |
+| `Xomfit/Views/Workout/WorkoutView.swift` | **Edit** -- add template section below Start button | Horizontal scroll of template cards + "See All" that opens TemplateListView |
+| `Xomfit/ViewModels/WorkoutLoggerViewModel.swift` | **Edit** -- add `startFromTemplate(_:userId:)` | Creates WorkoutExercise array from template, pre-fills sets using existing `lastSetForExercise` |
+| `Xomfit/Views/Workout/ActiveWorkoutView.swift` | **Edit** -- accept optional template, call new start method | Routes template starts through `startFromTemplate()` instead of `startWorkout()` |
+
+## Implementation Steps
+
+- [ ] **Step 1 -- Create TemplateService** (`Xomfit/Services/TemplateService.swift`)
+  - `@MainActor final class TemplateService` with `static let shared`
+  - `private let key = "xomfit_custom_templates"`
+  - `func allTemplates() -> [WorkoutTemplate]` -- returns `WorkoutTemplate.builtIn + loadCustom()`, sorted by category then name
+  - `func saveCustomTemplate(_ template: WorkoutTemplate)` -- encodes to UserDefaults
+  - `func deleteCustomTemplate(id: String)` -- removes by id, no-op for built-in
+  - Private `loadCustom() -> [WorkoutTemplate]` that decodes from UserDefaults
+  - All custom templates get `isCustom = true` enforced on save
+
+- [ ] **Step 2 -- Add `startFromTemplate` to WorkoutLoggerViewModel** (`Xomfit/ViewModels/WorkoutLoggerViewModel.swift`)
+  - New method: `func startFromTemplate(_ template: WorkoutTemplate, userId: String)`
+  - Calls `startWorkout(name: template.name, userId: userId)` first to reset state
+  - Iterates `template.exercises`, for each:
+    - Looks up last set via existing `lastSetForExercise(exerciseId)`
+    - Creates `WorkoutExercise` with `targetSets` number of `WorkoutSet` entries
+    - Pre-fills weight/reps from history (fallback: 0/0 like current behavior)
+    - Copies `TemplateExercise.notes` to `WorkoutExercise.notes`
+  - Assigns built exercises array to `self.exercises`
+
+- [ ] **Step 3 -- Create TemplateCardView** (`Xomfit/Views/Workout/TemplateCardView.swift`)
+  - Compact card showing: category icon, template name, exercise count, estimated duration
+  - Dark theme: `Theme.cardBackground` background, `Theme.accent` icon tint
+  - Fixed width (~160pt) for horizontal scroll, full-width variant for list
+  - Tap callback via `onSelect: () -> Void`
+
+- [ ] **Step 4 -- Create TemplateListView** (`Xomfit/Views/Workout/TemplateListView.swift`)
+  - Presented as a sheet from WorkoutView
+  - Shows all templates from `TemplateService.shared.allTemplates()`
+  - Grouped by `TemplateCategory` using `Section` headers
+  - Each row: TemplateCardView (full-width variant) or inline row with name, description, exercise count, duration
+  - Tap selects template and dismisses sheet
+  - Swipe-to-delete on custom templates only (check `isCustom`)
+  - Returns selected template via binding or callback
+
+- [ ] **Step 5 -- Update WorkoutView** (`Xomfit/Views/Workout/WorkoutView.swift`)
+  - Add `@State private var selectedTemplate: WorkoutTemplate?`
+  - Add `@State private var showTemplateList = false`
+  - Below the "Start Workout" button, add a section:
+    - Section header: "Quick Start" label + "See All" button (opens TemplateListView)
+    - Horizontal `ScrollView(.horizontal)` with `TemplateCardView` for each template (limit to ~6 for quick picks)
+    - Tap on card sets `selectedTemplate` and triggers `showActiveWorkout = true`
+  - Update `.fullScreenCover` to pass `selectedTemplate` to ActiveWorkoutView
+  - On template list dismiss, if a template was selected, trigger workout start
+
+- [ ] **Step 6 -- Update ActiveWorkoutView** (`Xomfit/Views/Workout/ActiveWorkoutView.swift`)
+  - Add `var template: WorkoutTemplate? = nil` parameter (default nil for backward compat)
+  - In `.onAppear`, branch:
+    - If `template != nil`: call `viewModel.startFromTemplate(template!, userId: userId)`
+    - Else: call `viewModel.startWorkout(name: workoutName, userId: userId)` (existing behavior)
+  - Update the `workoutName` parameter to be optional or derive from template name
+
+- [ ] **Step 7 -- Smoke test the full flow**
+  - Verify: WorkoutView shows template cards on load
+  - Verify: Tapping a template opens ActiveWorkoutView with exercises pre-loaded
+  - Verify: Each exercise has the correct number of sets from `targetSets`
+  - Verify: Weight/reps are pre-filled from workout history when available
+  - Verify: "Start Workout" blank flow still works unchanged
+  - Verify: "See All" opens TemplateListView with all 4 built-in templates
+  - Verify: Template notes appear on exercises
+
+## Out of Scope
+- Template editor UI (create/edit custom templates)
+- "Save as Template" from completed workout
+- Supabase persistence for templates (UserDefaults only for v1)
+- Template sharing between users
+- Reordering exercises within a template
+- Template search/filter
+
+## Risks / Tradeoffs
+- **UserDefaults size limit**: Not a concern for v1 -- custom templates are small JSON. If users accumulate hundreds, migrate to a local SQLite/SwiftData store later.
+- **`lastSetForExercise` is synchronous cache lookup**: Works fine since `WorkoutService` already caches. If cache is empty (first launch, no history), sets default to 0/0 which is acceptable.
+- **No template versioning**: If built-in templates change between app updates, in-progress workouts started from old templates are unaffected (template data is copied at start time, not referenced).
+- **Compact card width**: Fixed 160pt may not look ideal on smaller devices. Use `adaptiveFrame` or test on iPhone SE.
+
+## Open Questions
+- [ ] Should template cards show on WorkoutView even when there's workout history (list could feel crowded)? Recommendation: yes, templates section stays visible above the history list.
+- [ ] Should tapping a template skip the name entry alert (auto-use template name)? Recommendation: yes, skip the alert -- template name becomes workout name.
+
+## Skills / Agents to Use
+- **ios-standards**: Reference for Swift/SwiftUI conventions, `@Observable` patterns, accessibility requirements
+- **Coder agent**: Execute steps 1-6 sequentially, one file per step
+- **Tester agent**: Step 7 verification -- build and run through the simulator flow


### PR DESCRIPTION
## Summary
- New TemplateService (UserDefaults-backed) for template persistence
- Quick Start section on Workout tab with horizontal template cards
- TemplateListView sheet for browsing all templates by category
- `startFromTemplate()` pre-fills exercises + sets with weight history
- Tapping a template skips name alert, opens workout directly
- 4 built-in templates: Push Day, Pull Day, Leg Day, Full Body

Closes #105

## Test plan
- [ ] Workout tab shows Quick Start template cards on load
- [ ] Tapping a template opens ActiveWorkoutView with exercises pre-loaded
- [ ] Each exercise has correct number of sets from targetSets
- [ ] Weight/reps pre-filled from workout history
- [ ] "See All" opens TemplateListView grouped by category
- [ ] "Start Workout" blank flow still works unchanged
- [ ] Swipe-to-delete works on custom templates only (built-ins protected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)