### PR TITLE
Complete profile setup after OAuth sign-in

### DIFF
--- a/Xomfit/Services/AuthService.swift
+++ b/Xomfit/Services/AuthService.swift
@@ -7,6 +7,7 @@ import Supabase
 @Observable
 final class AuthService {
     var isAuthenticated = false
+    var needsProfileCompletion = false
     var currentSession: Session?
     var currentUser: User?
     var isLoading = true
@@ -24,10 +25,34 @@ final class AuthService {
             self.currentSession = session
             self.currentUser = session?.user
             self.isAuthenticated = session != nil
+            if session != nil {
+                await checkProfileCompleteness()
+            }
             if event == .initialSession {
                 self.isLoading = false
             }
         }
+    }
+
+    // MARK: - Profile Completion
+
+    func checkProfileCompleteness() async {
+        guard let userId = currentUser?.id.uuidString else { return }
+        do {
+            let profile = try await ProfileService.shared.fetchProfile(userId: userId)
+            let email = currentUser?.email ?? ""
+            let emailPrefix = email.components(separatedBy: "@").first ?? ""
+            needsProfileCompletion = profile.username.isEmpty
+                || profile.username == profile.id
+                || profile.username == emailPrefix
+        } catch {
+            // Profile doesn't exist or fetch failed — needs completion
+            needsProfileCompletion = true
+        }
+    }
+
+    func profileCompleted() {
+        needsProfileCompletion = false
     }
 
     // MARK: - Email Auth

--- a/Xomfit/Views/Auth/ProfileCompletionView.swift
+++ b/Xomfit/Views/Auth/ProfileCompletionView.swift
@@ -1,0 +1,200 @@
+import SwiftUI
+import Supabase
+
+struct ProfileCompletionView: View {
+    @Environment(AuthService.self) private var authService
+    @State private var displayName = ""
+    @State private var username = ""
+    @State private var bio = ""
+    @State private var isSaving = false
+    @State private var errorMessage: String?
+    @State private var usernameError: String?
+    @State private var isCheckingUsername = false
+    @State private var usernameCheckTask: Task<Void, Never>?
+
+    private var userId: String {
+        authService.currentUser?.id.uuidString ?? ""
+    }
+
+    private var isFormValid: Bool {
+        !displayName.trimmingCharacters(in: .whitespaces).isEmpty
+            && !username.trimmingCharacters(in: .whitespaces).isEmpty
+            && usernameError == nil
+            && !isCheckingUsername
+    }
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Theme.background.ignoresSafeArea()
+
+                Form {
+                    displayNameSection
+                    usernameSection
+                    bioSection
+                    submitSection
+                }
+                .scrollContentBackground(.hidden)
+            }
+            .navigationTitle("Complete Your Profile")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbarColorScheme(.dark, for: .navigationBar)
+        }
+    }
+
+    // MARK: - Display Name
+
+    private var displayNameSection: some View {
+        Section("Display Name") {
+            TextField("Your name", text: $displayName)
+                .textContentType(.name)
+                .listRowBackground(Theme.cardBackground)
+                .foregroundStyle(Theme.textPrimary)
+                .accessibilityLabel("Display name")
+        }
+    }
+
+    // MARK: - Username
+
+    private var usernameSection: some View {
+        Section {
+            HStack(spacing: 4) {
+                Text("@")
+                    .foregroundStyle(Theme.textSecondary)
+                TextField("username", text: $username)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+                    .foregroundStyle(Theme.textPrimary)
+                    .accessibilityLabel("Username")
+                    .onChange(of: username) { _, newValue in
+                        debouncedUsernameCheck(newValue)
+                    }
+
+                if isCheckingUsername {
+                    ProgressView()
+                        .tint(Theme.accent)
+                        .controlSize(.small)
+                }
+            }
+            .listRowBackground(Theme.cardBackground)
+
+            if let usernameError {
+                Text(usernameError)
+                    .font(Theme.fontSmall)
+                    .foregroundStyle(Theme.destructive)
+                    .listRowBackground(Theme.cardBackground)
+            }
+        } header: {
+            Text("Username")
+        }
+    }
+
+    // MARK: - Bio
+
+    private var bioSection: some View {
+        Section("Bio (optional)") {
+            TextField("Tell people about yourself", text: $bio, axis: .vertical)
+                .lineLimit(3...5)
+                .listRowBackground(Theme.cardBackground)
+                .foregroundStyle(Theme.textPrimary)
+                .accessibilityLabel("Bio")
+        }
+    }
+
+    // MARK: - Submit
+
+    private var submitSection: some View {
+        Section {
+            Button {
+                Task { await saveProfile() }
+            } label: {
+                HStack {
+                    Spacer()
+                    if isSaving {
+                        ProgressView()
+                            .tint(.black)
+                    } else {
+                        Text("Continue")
+                            .font(.system(size: 17, weight: .semibold))
+                    }
+                    Spacer()
+                }
+                .padding(.vertical, Theme.paddingSmall)
+            }
+            .disabled(!isFormValid || isSaving)
+            .listRowBackground(isFormValid && !isSaving ? Theme.accent : Theme.accent.opacity(0.4))
+            .foregroundStyle(.black)
+            .accessibilityLabel("Continue")
+            .accessibilityHint("Saves your profile information")
+
+            if let errorMessage {
+                Text(errorMessage)
+                    .font(Theme.fontSmall)
+                    .foregroundStyle(Theme.destructive)
+                    .listRowBackground(Theme.cardBackground)
+            }
+        }
+    }
+
+    // MARK: - Username Validation
+
+    private func debouncedUsernameCheck(_ value: String) {
+        usernameCheckTask?.cancel()
+        usernameError = nil
+
+        let trimmed = value.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else { return }
+
+        isCheckingUsername = true
+        usernameCheckTask = Task {
+            try? await Task.sleep(for: .milliseconds(300))
+
+            guard !Task.isCancelled else { return }
+
+            do {
+                let existing: [ProfileRow] = try await supabase
+                    .from("profiles")
+                    .select("id")
+                    .eq("username", value: trimmed)
+                    .neq("id", value: userId)
+                    .limit(1)
+                    .execute()
+                    .value
+
+                guard !Task.isCancelled else { return }
+
+                if !existing.isEmpty {
+                    usernameError = "Username already taken"
+                }
+            } catch {
+                guard !Task.isCancelled else { return }
+                // Network error during check — don't block the user
+            }
+
+            isCheckingUsername = false
+        }
+    }
+
+    // MARK: - Save
+
+    private func saveProfile() async {
+        isSaving = true
+        errorMessage = nil
+
+        do {
+            try await ProfileService.shared.upsertProfile(
+                userId: userId,
+                username: username.trimmingCharacters(in: .whitespaces),
+                displayName: displayName.trimmingCharacters(in: .whitespaces),
+                bio: bio.trimmingCharacters(in: .whitespaces),
+                avatarURL: nil,
+                isPrivate: false
+            )
+            authService.profileCompleted()
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+
+        isSaving = false
+    }
+}

--- a/Xomfit/XomfitApp.swift
+++ b/Xomfit/XomfitApp.swift
@@ -11,10 +11,10 @@ struct XomFitApp: App {
                     ZStack {
                         Theme.background.ignoresSafeArea()
                         VStack(spacing: Theme.paddingMedium) {
-                            Text("XOMFIT")
-                                .font(.system(size: 42, weight: .black))
-                                .foregroundColor(Theme.accent)
-                                .tracking(4)
+                            Image("XomFitBanner")
+                                .resizable()
+                                .scaledToFit()
+                                .frame(height: 80)
                             ProgressView()
                                 .tint(Theme.accent)
                         }
@@ -22,6 +22,11 @@ struct XomFitApp: App {
                 } else if authService.isAuthenticated {
                     MainTabView()
                         .environment(authService)
+                        .sheet(isPresented: Bindable(authService).needsProfileCompletion) {
+                            ProfileCompletionView()
+                                .environment(authService)
+                                .interactiveDismissDisabled()
+                        }
                 } else {
                     LoginView()
                         .environment(authService)


### PR DESCRIPTION
## Summary
- Detect incomplete profile after OAuth sign-in (empty/auto-generated username)
- Show non-dismissable ProfileCompletionView to collect display name, username, bio
- Username uniqueness check against Supabase with 300ms debounce
- Saves via existing ProfileService.upsertProfile
- Only shows once — skips if profile already has a real username
- Bonus: loading splash now uses XomFitBanner image

Closes #106

## Test plan
- [ ] Sign in with Apple — profile completion sheet appears
- [ ] Sign in with Google — profile completion sheet appears
- [ ] Enter taken username — shows "Username already taken" inline
- [ ] Enter valid username + display name — Continue button enables
- [ ] Submit — profile saves, sheet dismisses, app loads normally
- [ ] Sign in again — sheet does NOT appear (profile already complete)
- [ ] Email signup — sheet does NOT appear (username collected during signup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)