### PR TITLE
Redesign Profile — IG-style layout with feed, calendar, friends

### DIFF
--- a/Xomfit/Services/FeedService.swift
+++ b/Xomfit/Services/FeedService.swift
@@ -112,6 +112,23 @@ final class FeedService {
         }
     }
 
+    // MARK: - Fetch User Feed
+
+    func fetchUserFeed(userId: String, limit: Int = 20, offset: Int = 0) async throws -> [SocialFeedItem] {
+        let rows: [FeedItemRow] = try await supabase
+            .from("feed_items")
+            .select()
+            .eq("user_id", value: userId)
+            .order("created_at", ascending: false)
+            .range(from: offset, to: offset + limit - 1)
+            .execute()
+            .value
+
+        return rows.compactMap { row in
+            buildSocialFeedItem(from: row)
+        }
+    }
+
     // MARK: - Post Workout to Feed
 
     func postWorkoutToFeed(workout: Workout, userId: String) async throws {

--- a/Xomfit/ViewModels/ProfileViewModel.swift
+++ b/Xomfit/ViewModels/ProfileViewModel.swift
@@ -1,5 +1,44 @@
 import Foundation
 
+// MARK: - Profile Tab
+
+enum ProfileTab: String, CaseIterable, Identifiable {
+    case feed
+    case calendar
+    case stats
+    case friends
+
+    var id: String { rawValue }
+
+    var icon: String {
+        switch self {
+        case .feed: return "list.bullet"
+        case .calendar: return "calendar"
+        case .stats: return "chart.bar"
+        case .friends: return "person.2"
+        }
+    }
+
+    var label: String {
+        switch self {
+        case .feed: return "Feed"
+        case .calendar: return "Calendar"
+        case .stats: return "Stats"
+        case .friends: return "Friends"
+        }
+    }
+}
+
+// MARK: - Friendship Status (profile context)
+
+enum ProfileFriendshipStatus {
+    case none
+    case pending
+    case friends
+}
+
+// MARK: - ProfileViewModel
+
 @MainActor
 @Observable
 final class ProfileViewModel {
@@ -21,18 +60,58 @@ final class ProfileViewModel {
     var totalPRs: Int = 0
     var recentPRs: [PersonalRecord] = []
 
+    // MARK: - Tab state
+    var selectedTab: ProfileTab = .feed
+
+    // MARK: - Feed
+    var feedItems: [SocialFeedItem] = []
+
+    // MARK: - Calendar
+    var workoutDays: [Date: Int] = [:]
+
+    // MARK: - Friends
+    var friends: [FriendRow] = []
+    var friendProfiles: [String: ProfileRow] = [:]
+
+    // MARK: - Profile context
+    var isOwnProfile: Bool = true
+    var friendshipStatus: ProfileFriendshipStatus = .none
+    var friendCount: Int = 0
+    var feedItemCount: Int = 0
+
     // MARK: - State
     var isLoading: Bool = false
     var isSaving: Bool = false
     var errorMessage: String? = nil
 
-    // MARK: - Load
+    // MARK: - Computed
 
-    func loadProfile(userId: String) async {
+    var initials: String {
+        let name = displayName.isEmpty ? username : displayName
+        let parts = name.split(separator: " ")
+        if parts.count >= 2 {
+            return String(parts[0].prefix(1) + parts[1].prefix(1)).uppercased()
+        }
+        return String(name.prefix(2)).uppercased()
+    }
+
+    var formattedVolume: String {
+        if totalVolume >= 1_000_000 {
+            return String(format: "%.1fM", totalVolume / 1_000_000)
+        } else if totalVolume >= 1000 {
+            return String(format: "%.1fk", totalVolume / 1000)
+        }
+        return "\(Int(totalVolume))"
+    }
+
+    // MARK: - Load All
+
+    func loadAll(userId: String, currentUserId: String) async {
         isLoading = true
         errorMessage = nil
+        isOwnProfile = userId == currentUserId
 
-        // Fetch profile from Supabase (non-fatal if profile row doesn't exist yet)
+        // Load profile first (needed for privacy check)
         do {
             let profile = try await ProfileService.shared.fetchProfile(userId: userId)
             displayName = profile.displayName
@@ -41,20 +120,62 @@ final class ProfileViewModel {
             avatarURL = profile.avatarURL
             isPrivate = profile.isPrivate
         } catch {
-            // Profile row may not exist on first login — use email initials fallback
-            // Don't surface this as an error to the user
+            // Profile row may not exist on first login
         }
 
-        // Workout stats from local WorkoutService
+        // For other users, check friendship status
+        if !isOwnProfile {
+            await loadFriendshipStatus(currentUserId: currentUserId, targetUserId: userId)
+
+            // If private and not friends, stop here
+            if isPrivate && friendshipStatus != .friends {
+                isLoading = false
+                return
+            }
+        }
+
+        // Load remaining data in parallel
+        async let workoutsTask = WorkoutService.shared.fetchWorkouts(userId: userId)
+        async let prsTask = loadPRs(userId: userId)
+        async let feedTask = loadFeed(userId: userId)
+        async let friendsTask = loadFriends(userId: userId)
+
+        let workouts = await workoutsTask
+        totalWorkouts = workouts.count
+        totalVolume = workouts.reduce(0) { $0 + $1.totalVolume }
+        loadCalendarData(workouts: workouts)
+
+        await prsTask
+        await feedTask
+        await friendsTask
+
+        isLoading = false
+    }
+
+    // MARK: - Load Profile (legacy, kept for compatibility)
+
+    func loadProfile(userId: String) async {
+        isLoading = true
+        errorMessage = nil
+
+        do {
+            let profile = try await ProfileService.shared.fetchProfile(userId: userId)
+            displayName = profile.displayName
+            username = profile.username
+            bio = profile.bio
+            avatarURL = profile.avatarURL
+            isPrivate = profile.isPrivate
+        } catch {
+            // Profile row may not exist on first login
+        }
+
         let workouts = await WorkoutService.shared.fetchWorkouts(userId: userId)
         totalWorkouts = workouts.count
         totalVolume = workouts.reduce(0) { $0 + $1.totalVolume }
 
-        // PRs from PRService
         do {
             let prs = try await PRService.shared.fetchPRs(userId: userId)
             totalPRs = prs.count
-            // Show the 5 most recent PRs on the profile header
             recentPRs = Array(prs.prefix(5))
         } catch {
             // Non-fatal
@@ -77,7 +198,6 @@ final class ProfileViewModel {
                 avatarURL: avatarURL,
                 isPrivate: editIsPrivate
             )
-            // Commit edits to live fields
             displayName = editDisplayName.isEmpty ? displayName : editDisplayName
             bio = editBio
             isPrivate = editIsPrivate
@@ -93,5 +213,91 @@ final class ProfileViewModel {
         editDisplayName = displayName
         editBio = bio
         editIsPrivate = isPrivate
+    }
+
+    // MARK: - Friend Request
+
+    func sendFriendRequest(fromUserId: String, toUserId: String) async {
+        do {
+            try await FriendsService.shared.sendFriendRequest(fromUserId: fromUserId, toUserId: toUserId)
+            friendshipStatus = .pending
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    // MARK: - Private Helpers
+
+    private func loadPRs(userId: String) async {
+        do {
+            let prs = try await PRService.shared.fetchPRs(userId: userId)
+            totalPRs = prs.count
+            recentPRs = Array(prs.prefix(5))
+        } catch {
+            // Non-fatal
+        }
+    }
+
+    private func loadFeed(userId: String) async {
+        do {
+            let items = try await FeedService.shared.fetchUserFeed(userId: userId)
+            feedItems = items
+            feedItemCount = items.count
+        } catch {
+            // Non-fatal
+        }
+    }
+
+    private func loadFriends(userId: String) async {
+        do {
+            let allFriends = try await FriendsService.shared.fetchFriends(userId: userId)
+            let mutualFriends = allFriends.filter { $0.status == "mutual" }
+            friends = mutualFriends
+            friendCount = mutualFriends.count
+
+            // Batch-load friend profiles for display names
+            let friendIds = mutualFriends.map { $0.friendId }
+            for friendId in friendIds {
+                if friendProfiles[friendId] == nil {
+                    if let profile = try? await ProfileService.shared.fetchProfile(userId: friendId) {
+                        friendProfiles[friendId] = profile
+                    }
+                }
+            }
+        } catch {
+            // Non-fatal
+        }
+    }
+
+    private func loadFriendshipStatus(currentUserId: String, targetUserId: String) async {
+        do {
+            // Check if current user sent a request to the target
+            let sentFriends = try await FriendsService.shared.fetchFriends(userId: currentUserId)
+            if let match = sentFriends.first(where: { $0.friendId == targetUserId }) {
+                friendshipStatus = match.status == "mutual" ? .friends : .pending
+                return
+            }
+
+            // Check if target sent a request to current user
+            let receivedFriends = try await FriendsService.shared.fetchFriends(userId: targetUserId)
+            if let match = receivedFriends.first(where: { $0.friendId == currentUserId }) {
+                friendshipStatus = match.status == "mutual" ? .friends : .pending
+                return
+            }
+
+            friendshipStatus = .none
+        } catch {
+            friendshipStatus = .none
+        }
+    }
+
+    func loadCalendarData(workouts: [Workout]) {
+        let calendar = Calendar.current
+        var days: [Date: Int] = [:]
+        for workout in workouts {
+            let day = calendar.startOfDay(for: workout.startTime)
+            days[day, default: 0] += 1
+        }
+        workoutDays = days
     }
 }

--- a/Xomfit/Views/Profile/EditProfileSheet.swift
+++ b/Xomfit/Views/Profile/EditProfileSheet.swift
@@ -1,0 +1,66 @@
+import SwiftUI
+
+struct EditProfileSheet: View {
+    let viewModel: ProfileViewModel
+    let userId: String
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Theme.background.ignoresSafeArea()
+
+                Form {
+                    Section("Display Name") {
+                        TextField("Your name", text: Bindable(viewModel).editDisplayName)
+                            .listRowBackground(Theme.cardBackground)
+                            .foregroundStyle(Theme.textPrimary)
+                    }
+
+                    Section("Bio") {
+                        TextField("Tell people about yourself", text: Bindable(viewModel).editBio, axis: .vertical)
+                            .lineLimit(3...5)
+                            .listRowBackground(Theme.cardBackground)
+                            .foregroundStyle(Theme.textPrimary)
+                    }
+
+                    Section {
+                        Toggle("Private Account", isOn: Bindable(viewModel).editIsPrivate)
+                            .tint(Theme.accent)
+                            .listRowBackground(Theme.cardBackground)
+                            .foregroundStyle(Theme.textPrimary)
+                    } footer: {
+                        Text("Only friends can see your activity when your account is private.")
+                            .foregroundStyle(Theme.textSecondary)
+                    }
+                }
+                .scrollContentBackground(.hidden)
+            }
+            .navigationTitle("Edit Profile")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbarColorScheme(.dark, for: .navigationBar)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button("Cancel") { dismiss() }
+                        .foregroundStyle(Theme.textSecondary)
+                }
+                ToolbarItem(placement: .topBarTrailing) {
+                    if viewModel.isSaving {
+                        ProgressView().tint(Theme.accent)
+                    } else {
+                        Button("Save") {
+                            Task {
+                                await viewModel.updateProfile(userId: userId)
+                                if viewModel.errorMessage == nil {
+                                    dismiss()
+                                }
+                            }
+                        }
+                        .font(.system(size: 15, weight: .semibold))
+                        .foregroundStyle(Theme.accent)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Xomfit/Views/Profile/PrivateProfileView.swift
+++ b/Xomfit/Views/Profile/PrivateProfileView.swift
@@ -1,0 +1,82 @@
+import SwiftUI
+
+struct PrivateProfileView: View {
+    let displayName: String
+    let username: String
+    let initials: String
+    let friendshipStatus: ProfileFriendshipStatus
+    let onSendRequest: () -> Void
+
+    var body: some View {
+        VStack(spacing: Theme.paddingLarge) {
+            Spacer()
+
+            // Avatar
+            ZStack {
+                Circle()
+                    .fill(Theme.accent.opacity(0.2))
+                    .frame(width: 70, height: 70)
+                Text(initials)
+                    .font(.system(size: 24, weight: .bold))
+                    .foregroundStyle(Theme.accent)
+            }
+
+            // Name
+            VStack(spacing: 4) {
+                if !displayName.isEmpty {
+                    Text(displayName)
+                        .font(.system(size: 20, weight: .bold))
+                        .foregroundStyle(Theme.textPrimary)
+                }
+                if !username.isEmpty {
+                    Text("@\(username)")
+                        .font(Theme.fontCaption)
+                        .foregroundStyle(Theme.textSecondary)
+                }
+            }
+
+            // Lock icon + message
+            VStack(spacing: Theme.paddingSmall) {
+                Image(systemName: "lock.fill")
+                    .font(.system(size: 28))
+                    .foregroundStyle(Theme.textSecondary)
+
+                Text("This account is private")
+                    .font(Theme.fontBody)
+                    .foregroundStyle(Theme.textSecondary)
+
+                Text("Send a friend request to see their activity.")
+                    .font(Theme.fontCaption)
+                    .foregroundStyle(Theme.textSecondary)
+                    .multilineTextAlignment(.center)
+            }
+
+            // Action button
+            if friendshipStatus == .none {
+                Button(action: onSendRequest) {
+                    Text("Send Friend Request")
+                        .font(.system(size: 15, weight: .semibold))
+                        .foregroundStyle(Theme.background)
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 44)
+                        .background(Theme.accent)
+                        .clipShape(.rect(cornerRadius: Theme.cornerRadius))
+                }
+                .padding(.horizontal, Theme.paddingLarge)
+                .accessibilityLabel("Send friend request to \(displayName)")
+            } else if friendshipStatus == .pending {
+                Text("Friend Request Sent")
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundStyle(Theme.textSecondary)
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 44)
+                    .background(Theme.cardBackground)
+                    .clipShape(.rect(cornerRadius: Theme.cornerRadius))
+                    .padding(.horizontal, Theme.paddingLarge)
+            }
+
+            Spacer()
+        }
+        .frame(maxWidth: .infinity)
+    }
+}

--- a/Xomfit/Views/Profile/ProfileCalendarView.swift
+++ b/Xomfit/Views/Profile/ProfileCalendarView.swift
@@ -1,0 +1,180 @@
+import SwiftUI
+
+struct ProfileCalendarView: View {
+    let workoutDays: [Date: Int]
+
+    @State private var displayedMonth: Date = Date()
+
+    private let calendar = Calendar.current
+    private let dayOfWeekHeaders = ["S", "M", "T", "W", "T", "F", "S"]
+    private let columns = Array(repeating: GridItem(.flexible(), spacing: 4), count: 7)
+
+    var body: some View {
+        VStack(spacing: Theme.paddingMedium) {
+            monthNavigator
+            dayOfWeekHeader
+            calendarGrid
+        }
+        .padding(Theme.paddingMedium)
+        .background(Theme.cardBackground)
+        .clipShape(.rect(cornerRadius: Theme.cornerRadius))
+        .padding(.horizontal, Theme.paddingMedium)
+    }
+
+    // MARK: - Month Navigator
+
+    private var monthNavigator: some View {
+        HStack {
+            Button {
+                navigateMonth(by: -1)
+            } label: {
+                Image(systemName: "chevron.left")
+                    .font(.system(size: 16, weight: .semibold))
+                    .foregroundStyle(Theme.accent)
+                    .frame(width: 44, height: 44)
+            }
+            .accessibilityLabel("Previous month")
+
+            Spacer()
+
+            Text(monthYearString)
+                .font(.system(size: 16, weight: .bold))
+                .foregroundStyle(Theme.textPrimary)
+
+            Spacer()
+
+            Button {
+                navigateMonth(by: 1)
+            } label: {
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 16, weight: .semibold))
+                    .foregroundStyle(canGoForward ? Theme.accent : Theme.textSecondary.opacity(0.3))
+                    .frame(width: 44, height: 44)
+            }
+            .disabled(!canGoForward)
+            .accessibilityLabel("Next month")
+        }
+    }
+
+    // MARK: - Day of Week Header
+
+    private var dayOfWeekHeader: some View {
+        LazyVGrid(columns: columns, spacing: 4) {
+            ForEach(dayOfWeekHeaders, id: \.self) { day in
+                Text(day)
+                    .font(Theme.fontSmall)
+                    .foregroundStyle(Theme.textSecondary)
+                    .frame(maxWidth: .infinity)
+            }
+        }
+    }
+
+    // MARK: - Calendar Grid
+
+    private var calendarGrid: some View {
+        let days = daysInMonth()
+        return LazyVGrid(columns: columns, spacing: 4) {
+            ForEach(Array(days.enumerated()), id: \.offset) { _, date in
+                if let date {
+                    dayCell(for: date)
+                } else {
+                    Color.clear
+                        .aspectRatio(1, contentMode: .fit)
+                }
+            }
+        }
+    }
+
+    private func dayCell(for date: Date) -> some View {
+        let dayNumber = calendar.component(.day, from: date)
+        let count = workoutCount(for: date)
+        let isToday = calendar.isDateInToday(date)
+
+        return Text("\(dayNumber)")
+            .font(.system(size: 13, weight: count > 0 ? .bold : .regular))
+            .foregroundStyle(cellForeground(count: count, isToday: isToday))
+            .frame(maxWidth: .infinity)
+            .aspectRatio(1, contentMode: .fit)
+            .background(cellBackground(count: count, isToday: isToday))
+            .clipShape(.rect(cornerRadius: 6))
+            .accessibilityLabel(dayCellAccessibilityLabel(dayNumber: dayNumber, count: count))
+    }
+
+    // MARK: - Cell Styling
+
+    private func cellForeground(count: Int, isToday: Bool) -> Color {
+        if count > 0 { return Theme.background }
+        if isToday { return Theme.accent }
+        return Theme.textSecondary
+    }
+
+    private func cellBackground(count: Int, isToday: Bool) -> Color {
+        if count >= 2 { return Theme.accent }
+        if count == 1 { return Theme.accent.opacity(0.4) }
+        if isToday { return Theme.accent.opacity(0.1) }
+        return .clear
+    }
+
+    // MARK: - Helpers
+
+    private var monthYearString: String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMMM yyyy"
+        return formatter.string(from: displayedMonth)
+    }
+
+    private var canGoForward: Bool {
+        let now = Date()
+        let currentMonthStart = calendar.date(from: calendar.dateComponents([.year, .month], from: now))
+        let displayedMonthStart = calendar.date(from: calendar.dateComponents([.year, .month], from: displayedMonth))
+        guard let current = currentMonthStart, let displayed = displayedMonthStart else { return false }
+        return displayed < current
+    }
+
+    private func navigateMonth(by value: Int) {
+        if let newMonth = calendar.date(byAdding: .month, value: value, to: displayedMonth) {
+            withAnimation(.easeInOut(duration: 0.2)) {
+                displayedMonth = newMonth
+            }
+        }
+    }
+
+    private func daysInMonth() -> [Date?] {
+        guard let monthStart = calendar.date(from: calendar.dateComponents([.year, .month], from: displayedMonth)),
+              let range = calendar.range(of: .day, in: .month, for: monthStart) else {
+            return []
+        }
+
+        let firstWeekday = calendar.component(.weekday, from: monthStart)
+        let leadingBlanks = firstWeekday - calendar.firstWeekday
+        let adjustedBlanks = leadingBlanks < 0 ? leadingBlanks + 7 : leadingBlanks
+
+        var days: [Date?] = Array(repeating: nil, count: adjustedBlanks)
+
+        for day in range {
+            if let date = calendar.date(byAdding: .day, value: day - 1, to: monthStart) {
+                days.append(date)
+            }
+        }
+
+        // Pad to fill the last row
+        let remainder = days.count % 7
+        if remainder > 0 {
+            days.append(contentsOf: Array(repeating: nil as Date?, count: 7 - remainder))
+        }
+
+        return days
+    }
+
+    private func workoutCount(for date: Date) -> Int {
+        let startOfDay = calendar.startOfDay(for: date)
+        return workoutDays[startOfDay] ?? 0
+    }
+
+    private func dayCellAccessibilityLabel(dayNumber: Int, count: Int) -> String {
+        if count > 0 {
+            return "Day \(dayNumber), \(count) workout\(count == 1 ? "" : "s")"
+        }
+        return "Day \(dayNumber)"
+    }
+}

--- a/Xomfit/Views/Profile/ProfileFeedView.swift
+++ b/Xomfit/Views/Profile/ProfileFeedView.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+struct ProfileFeedView: View {
+    let feedItems: [SocialFeedItem]
+
+    var body: some View {
+        if feedItems.isEmpty {
+            emptyState
+        } else {
+            LazyVStack(spacing: Theme.paddingSmall) {
+                ForEach(feedItems) { item in
+                    FeedItemCard(
+                        item: item,
+                        onLike: { /* Like handled at feed level */ },
+                        onComment: { /* Comment handled at feed level */ }
+                    )
+                }
+            }
+            .padding(.horizontal, Theme.paddingMedium)
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: Theme.paddingSmall) {
+            Image(systemName: "text.page")
+                .font(.system(size: 36))
+                .foregroundStyle(Theme.textSecondary)
+            Text("No posts yet")
+                .font(Theme.fontBody)
+                .foregroundStyle(Theme.textSecondary)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 60)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("No posts yet")
+    }
+}

--- a/Xomfit/Views/Profile/ProfileFriendsView.swift
+++ b/Xomfit/Views/Profile/ProfileFriendsView.swift
@@ -1,0 +1,102 @@
+import SwiftUI
+
+struct ProfileFriendsView: View {
+    let friends: [FriendRow]
+    let friendProfiles: [String: ProfileRow]
+
+    var body: some View {
+        if friends.isEmpty {
+            emptyState
+        } else {
+            LazyVStack(spacing: 0) {
+                ForEach(friends) { friend in
+                    NavigationLink {
+                        ProfileView(userId: friend.friendId)
+                    } label: {
+                        friendRow(friend: friend)
+                    }
+                    .buttonStyle(.plain)
+
+                    if friend.id != friends.last?.id {
+                        Divider()
+                            .background(Theme.textSecondary.opacity(0.2))
+                            .padding(.leading, 60)
+                    }
+                }
+            }
+            .background(Theme.cardBackground)
+            .clipShape(.rect(cornerRadius: Theme.cornerRadius))
+            .padding(.horizontal, Theme.paddingMedium)
+        }
+    }
+
+    // MARK: - Friend Row
+
+    private func friendRow(friend: FriendRow) -> some View {
+        let profile = friendProfiles[friend.friendId]
+        let name = profile?.displayName ?? friend.friendId
+        let username = profile?.username ?? ""
+        let initials = friendInitials(name: name, fallback: username)
+
+        return HStack(spacing: Theme.paddingMedium) {
+            ZStack {
+                Circle()
+                    .fill(Theme.accent.opacity(0.2))
+                    .frame(width: 40, height: 40)
+                Text(initials)
+                    .font(.system(size: 14, weight: .bold))
+                    .foregroundStyle(Theme.accent)
+            }
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(name)
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundStyle(Theme.textPrimary)
+                if !username.isEmpty {
+                    Text("@\(username)")
+                        .font(Theme.fontCaption)
+                        .foregroundStyle(Theme.textSecondary)
+                }
+            }
+
+            Spacer()
+
+            Image(systemName: "chevron.right")
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(Theme.textSecondary)
+        }
+        .padding(Theme.paddingMedium)
+        .frame(minHeight: 44)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(name)\(username.isEmpty ? "" : ", @\(username)")")
+        .accessibilityAddTraits(.isButton)
+    }
+
+    // MARK: - Empty State
+
+    private var emptyState: some View {
+        VStack(spacing: Theme.paddingSmall) {
+            Image(systemName: "person.2")
+                .font(.system(size: 36))
+                .foregroundStyle(Theme.textSecondary)
+            Text("No friends yet")
+                .font(Theme.fontBody)
+                .foregroundStyle(Theme.textSecondary)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 60)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("No friends yet")
+    }
+
+    // MARK: - Helpers
+
+    private func friendInitials(name: String, fallback: String) -> String {
+        let source = name.isEmpty ? fallback : name
+        let parts = source.split(separator: " ")
+        if parts.count >= 2 {
+            return String(parts[0].prefix(1) + parts[1].prefix(1)).uppercased()
+        }
+        return String(source.prefix(2)).uppercased()
+    }
+}

--- a/Xomfit/Views/Profile/ProfileHeaderView.swift
+++ b/Xomfit/Views/Profile/ProfileHeaderView.swift
@@ -1,0 +1,154 @@
+import SwiftUI
+
+struct ProfileHeaderView: View {
+    let displayName: String
+    let username: String
+    let bio: String
+    let initials: String
+    let isPrivate: Bool
+    let isOwnProfile: Bool
+    let feedItemCount: Int
+    let friendCount: Int
+    let prCount: Int
+    let friendshipStatus: ProfileFriendshipStatus
+    let onStatTapped: (ProfileTab) -> Void
+    let onActionTapped: () -> Void
+
+    var body: some View {
+        VStack(spacing: Theme.paddingMedium) {
+            // Top row: avatar + stats
+            HStack(alignment: .center, spacing: Theme.paddingLarge) {
+                avatarCircle
+
+                Spacer()
+
+                statColumn(value: feedItemCount, label: "Posts") {
+                    onStatTapped(.feed)
+                }
+                statColumn(value: friendCount, label: "Friends") {
+                    onStatTapped(.friends)
+                }
+                statColumn(value: prCount, label: "PRs") {
+                    onStatTapped(.stats)
+                }
+
+                Spacer()
+            }
+            .padding(.horizontal, Theme.paddingSmall)
+
+            // Name + username + bio
+            VStack(alignment: .leading, spacing: 4) {
+                if !displayName.isEmpty {
+                    Text(displayName)
+                        .font(.system(size: 16, weight: .bold))
+                        .foregroundStyle(Theme.textPrimary)
+                }
+
+                if !username.isEmpty {
+                    Text("@\(username)")
+                        .font(Theme.fontCaption)
+                        .foregroundStyle(Theme.textSecondary)
+                }
+
+                if !bio.isEmpty {
+                    Text(bio)
+                        .font(Theme.fontBody)
+                        .foregroundStyle(Theme.textSecondary)
+                        .padding(.top, 2)
+                }
+
+                if isPrivate && isOwnProfile {
+                    HStack(spacing: 4) {
+                        Image(systemName: "lock.fill")
+                            .font(.system(size: 11))
+                        Text("Private Account")
+                            .font(Theme.fontSmall)
+                    }
+                    .foregroundStyle(Theme.textSecondary)
+                    .padding(.top, 2)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            // Action button
+            actionButton
+        }
+        .padding(Theme.paddingMedium)
+    }
+
+    // MARK: - Avatar
+
+    private var avatarCircle: some View {
+        ZStack {
+            Circle()
+                .fill(Theme.accent.opacity(0.2))
+                .frame(width: 70, height: 70)
+            Text(initials)
+                .font(.system(size: 24, weight: .bold))
+                .foregroundStyle(Theme.accent)
+        }
+        .accessibilityLabel("Profile avatar")
+    }
+
+    // MARK: - Stat Column
+
+    private func statColumn(value: Int, label: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            VStack(spacing: 2) {
+                Text("\(value)")
+                    .font(.system(size: 18, weight: .bold))
+                    .foregroundStyle(Theme.textPrimary)
+                Text(label)
+                    .font(Theme.fontSmall)
+                    .foregroundStyle(Theme.textSecondary)
+            }
+            .frame(minWidth: 44, minHeight: 44)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("\(value) \(label)")
+        .accessibilityAddTraits(.isButton)
+    }
+
+    // MARK: - Action Button
+
+    private var actionButton: some View {
+        Button(action: onActionTapped) {
+            Text(actionButtonLabel)
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(actionButtonForeground)
+                .frame(maxWidth: .infinity)
+                .frame(height: 34)
+                .background(actionButtonBackground)
+                .clipShape(.rect(cornerRadius: Theme.cornerRadiusSmall))
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(actionButtonLabel)
+    }
+
+    private var actionButtonLabel: String {
+        if isOwnProfile { return "Edit Profile" }
+        switch friendshipStatus {
+        case .none: return "Add Friend"
+        case .pending: return "Requested"
+        case .friends: return "Friends"
+        }
+    }
+
+    private var actionButtonForeground: Color {
+        if isOwnProfile { return Theme.textPrimary }
+        switch friendshipStatus {
+        case .none: return Theme.background
+        case .pending: return Theme.textSecondary
+        case .friends: return Theme.accent
+        }
+    }
+
+    private var actionButtonBackground: some ShapeStyle {
+        if isOwnProfile { return AnyShapeStyle(Theme.cardBackground) }
+        switch friendshipStatus {
+        case .none: return AnyShapeStyle(Theme.accent)
+        case .pending: return AnyShapeStyle(Theme.cardBackground)
+        case .friends: return AnyShapeStyle(Theme.accent.opacity(0.15))
+        }
+    }
+}

--- a/Xomfit/Views/Profile/ProfileStatsView.swift
+++ b/Xomfit/Views/Profile/ProfileStatsView.swift
@@ -1,0 +1,82 @@
+import SwiftUI
+
+struct ProfileStatsView: View {
+    let totalWorkouts: Int
+    let totalVolume: String
+    let totalPRs: Int
+    let recentPRs: [PersonalRecord]
+
+    var body: some View {
+        VStack(spacing: Theme.paddingSmall) {
+            statsCards
+            prSection
+        }
+        .padding(.horizontal, Theme.paddingMedium)
+    }
+
+    // MARK: - Stats Cards
+
+    private var statsCards: some View {
+        HStack(spacing: Theme.paddingSmall) {
+            statCard(icon: "dumbbell.fill", value: "\(totalWorkouts)", label: "Workouts", color: Theme.accent)
+            statCard(icon: "scalemass.fill", value: totalVolume, label: "Volume", color: Theme.accent)
+            statCard(icon: "trophy.fill", value: "\(totalPRs)", label: "PRs", color: Theme.prGold)
+        }
+    }
+
+    private func statCard(icon: String, value: String, label: String, color: Color) -> some View {
+        VStack(spacing: 6) {
+            Image(systemName: icon)
+                .font(.system(size: 18))
+                .foregroundStyle(color)
+            Text(value)
+                .font(.system(size: 18, weight: .bold))
+                .foregroundStyle(Theme.textPrimary)
+            Text(label)
+                .font(Theme.fontSmall)
+                .foregroundStyle(Theme.textSecondary)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, Theme.paddingMedium)
+        .background(Theme.cardBackground)
+        .clipShape(.rect(cornerRadius: Theme.cornerRadius))
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(value) \(label)")
+    }
+
+    // MARK: - PR Section
+
+    @ViewBuilder
+    private var prSection: some View {
+        if recentPRs.isEmpty {
+            emptyState
+        } else {
+            VStack(alignment: .leading, spacing: Theme.paddingSmall) {
+                Text("Recent PRs")
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundStyle(Theme.textSecondary)
+                    .padding(.horizontal, Theme.paddingSmall)
+
+                ForEach(recentPRs) { pr in
+                    PRBadgeRow(pr: pr)
+                }
+            }
+            .cardStyle()
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: Theme.paddingSmall) {
+            Image(systemName: "trophy")
+                .font(.system(size: 36))
+                .foregroundStyle(Theme.textSecondary)
+            Text("No PRs yet")
+                .font(Theme.fontBody)
+                .foregroundStyle(Theme.textSecondary)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 60)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("No personal records yet")
+    }
+}

--- a/Xomfit/Views/Profile/ProfileTabPicker.swift
+++ b/Xomfit/Views/Profile/ProfileTabPicker.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+
+struct ProfileTabPicker: View {
+    @Binding var selectedTab: ProfileTab
+    @Namespace private var underline
+
+    var body: some View {
+        HStack(spacing: 0) {
+            ForEach(ProfileTab.allCases) { tab in
+                Button {
+                    withAnimation(.easeInOut(duration: 0.25)) {
+                        selectedTab = tab
+                    }
+                } label: {
+                    VStack(spacing: Theme.paddingSmall) {
+                        Image(systemName: tab.icon)
+                            .font(.system(size: 18))
+                            .foregroundStyle(selectedTab == tab ? Theme.accent : Theme.textSecondary)
+                            .frame(height: 24)
+
+                        Text(tab.label)
+                            .font(Theme.fontSmall)
+                            .foregroundStyle(selectedTab == tab ? Theme.accent : Theme.textSecondary)
+                    }
+                    .frame(maxWidth: .infinity)
+                    .frame(minHeight: 44)
+                    .overlay(alignment: .bottom) {
+                        if selectedTab == tab {
+                            Rectangle()
+                                .fill(Theme.accent)
+                                .frame(height: 2)
+                                .matchedGeometryEffect(id: "underline", in: underline)
+                        }
+                    }
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("\(tab.label) tab")
+                .accessibilityAddTraits(selectedTab == tab ? .isSelected : [])
+            }
+        }
+        .padding(.top, Theme.paddingSmall)
+        .overlay(alignment: .bottom) {
+            Divider()
+                .background(Theme.textSecondary.opacity(0.3))
+        }
+    }
+}

--- a/Xomfit/Views/Profile/ProfileView.swift
+++ b/Xomfit/Views/Profile/ProfileView.swift
@@ -4,331 +4,155 @@ struct ProfileView: View {
     @Environment(AuthService.self) private var authService
     @State private var viewModel = ProfileViewModel()
     @State private var showEditSheet = false
-    @State private var showSignOutConfirm = false
 
-    private var userId: String {
+    /// Pass a userId to view another user's profile. nil = current user (tab root).
+    var userId: String? = nil
+
+    private var resolvedUserId: String {
+        userId ?? authService.currentUser?.id.uuidString ?? ""
+    }
+
+    private var currentUserId: String {
         authService.currentUser?.id.uuidString ?? ""
     }
 
-    private var userEmail: String {
-        authService.currentUser?.email ?? ""
-    }
-
-    private var initials: String {
-        let name = viewModel.displayName.isEmpty ? userEmail : viewModel.displayName
-        let parts = name.split(separator: " ")
-        if parts.count >= 2 {
-            return String(parts[0].prefix(1) + parts[1].prefix(1)).uppercased()
-        }
-        return String(name.prefix(2)).uppercased()
-    }
-
     var body: some View {
-        NavigationStack {
-            ZStack {
-                Theme.background.ignoresSafeArea()
-
-                if viewModel.isLoading {
-                    ProgressView()
-                        .tint(Theme.accent)
-                } else {
-                    ScrollView {
-                        VStack(spacing: Theme.paddingMedium) {
-                            avatarHeader
-                            statsGrid
-                            recentPRsSection
-                            navigationLinks
-                            signOutSection
-                        }
-                        .padding(Theme.paddingMedium)
-                    }
-                }
+        // Tab root (own profile) gets its own NavigationStack.
+        // Pushed profiles (userId != nil) are already inside a NavigationStack.
+        if userId == nil {
+            NavigationStack {
+                profileContent
+                    .toolbar { ownProfileToolbar }
             }
-            .navigationTitle("Profile")
-            .toolbarColorScheme(.dark, for: .navigationBar)
-            .toolbar {
-                ToolbarItem(placement: .topBarTrailing) {
-                    Button {
-                        viewModel.beginEditing()
-                        showEditSheet = true
-                    } label: {
-                        Image(systemName: "pencil")
-                            .foregroundColor(Theme.accent)
+        } else {
+            profileContent
+        }
+    }
+
+    // MARK: - Profile Content
+
+    private var profileContent: some View {
+        ZStack {
+            Theme.background.ignoresSafeArea()
+
+            if viewModel.isLoading {
+                ProgressView()
+                    .tint(Theme.accent)
+            } else if !viewModel.isOwnProfile && viewModel.isPrivate && viewModel.friendshipStatus != .friends {
+                PrivateProfileView(
+                    displayName: viewModel.displayName,
+                    username: viewModel.username,
+                    initials: viewModel.initials,
+                    friendshipStatus: viewModel.friendshipStatus,
+                    onSendRequest: {
+                        Task {
+                            await viewModel.sendFriendRequest(
+                                fromUserId: currentUserId,
+                                toUserId: resolvedUserId
+                            )
+                        }
                     }
-                }
+                )
+            } else {
+                mainScrollContent
             }
         }
-        .onAppear {
-            Task { await viewModel.loadProfile(userId: userId) }
+        .navigationTitle(viewModel.isOwnProfile ? "Profile" : viewModel.displayName)
+        .navigationBarTitleDisplayMode(viewModel.isOwnProfile ? .large : .inline)
+        .toolbarColorScheme(.dark, for: .navigationBar)
+        .task {
+            await viewModel.loadAll(userId: resolvedUserId, currentUserId: currentUserId)
         }
         .sheet(isPresented: $showEditSheet) {
-            EditProfileSheet(viewModel: viewModel, userId: userId)
-        }
-        .alert("Sign Out?", isPresented: $showSignOutConfirm) {
-            Button("Sign Out", role: .destructive) {
-                Task { await authService.signOut() }
-            }
-            Button("Cancel", role: .cancel) {}
-        } message: {
-            Text("You will be returned to the login screen.")
+            EditProfileSheet(viewModel: viewModel, userId: resolvedUserId)
         }
     }
 
-    // MARK: - Avatar Header
+    // MARK: - Main Scroll Content
 
-    private var avatarHeader: some View {
-        VStack(spacing: Theme.paddingSmall) {
-            ZStack {
-                Circle()
-                    .fill(Theme.accent.opacity(0.2))
-                    .frame(width: 80, height: 80)
-                Text(initials)
-                    .font(.system(size: 28, weight: .bold))
-                    .foregroundColor(Theme.accent)
-            }
+    private var mainScrollContent: some View {
+        ScrollView {
+            LazyVStack(spacing: 0, pinnedViews: [.sectionHeaders]) {
+                // Header (not pinned)
+                ProfileHeaderView(
+                    displayName: viewModel.displayName,
+                    username: viewModel.username,
+                    bio: viewModel.bio,
+                    initials: viewModel.initials,
+                    isPrivate: viewModel.isPrivate,
+                    isOwnProfile: viewModel.isOwnProfile,
+                    feedItemCount: viewModel.feedItemCount,
+                    friendCount: viewModel.friendCount,
+                    prCount: viewModel.totalPRs,
+                    friendshipStatus: viewModel.friendshipStatus,
+                    onStatTapped: { tab in
+                        withAnimation(.easeInOut(duration: 0.25)) {
+                            viewModel.selectedTab = tab
+                        }
+                    },
+                    onActionTapped: {
+                        if viewModel.isOwnProfile {
+                            viewModel.beginEditing()
+                            showEditSheet = true
+                        } else if viewModel.friendshipStatus == .none {
+                            Task {
+                                await viewModel.sendFriendRequest(
+                                    fromUserId: currentUserId,
+                                    toUserId: resolvedUserId
+                                )
+                            }
+                        }
+                    }
+                )
 
-            if !viewModel.displayName.isEmpty {
-                Text(viewModel.displayName)
-                    .font(.system(size: 20, weight: .bold))
-                    .foregroundColor(Theme.textPrimary)
-            }
-
-            if !viewModel.username.isEmpty {
-                Text("@\(viewModel.username)")
-                    .font(Theme.fontCaption)
-                    .foregroundColor(Theme.textSecondary)
-            }
-
-            if !viewModel.bio.isEmpty {
-                Text(viewModel.bio)
-                    .font(Theme.fontBody)
-                    .foregroundColor(Theme.textSecondary)
-                    .multilineTextAlignment(.center)
-            }
-
-            if viewModel.isPrivate {
-                HStack(spacing: 4) {
-                    Image(systemName: "lock.fill")
-                        .font(.system(size: 11))
-                    Text("Private Account")
-                        .font(Theme.fontSmall)
+                // Tab picker (pinned) + tab content
+                Section {
+                    tabContent
+                        .padding(.top, Theme.paddingSmall)
+                } header: {
+                    ProfileTabPicker(selectedTab: Bindable(viewModel).selectedTab)
+                        .background(Theme.background)
                 }
-                .foregroundColor(Theme.textSecondary)
             }
         }
-        .frame(maxWidth: .infinity)
-        .padding(Theme.paddingLarge)
-        .background(Theme.cardBackground)
-        .cornerRadius(Theme.cornerRadius)
     }
 
-    // MARK: - Stats Grid
-
-    private var statsGrid: some View {
-        HStack(spacing: 1) {
-            statCell(
-                value: "\(viewModel.totalWorkouts)",
-                label: "Workouts",
-                icon: "dumbbell.fill"
-            )
-            Divider()
-                .background(Theme.background)
-                .frame(width: 1)
-            statCell(
-                value: formattedVolume,
-                label: "Volume",
-                icon: "scalemass.fill"
-            )
-            Divider()
-                .background(Theme.background)
-                .frame(width: 1)
-            statCell(
-                value: "\(viewModel.totalPRs)",
-                label: "PRs",
-                icon: "trophy.fill"
-            )
-        }
-        .background(Theme.cardBackground)
-        .cornerRadius(Theme.cornerRadius)
-    }
-
-    private func statCell(value: String, label: String, icon: String) -> some View {
-        VStack(spacing: 6) {
-            Image(systemName: icon)
-                .font(.system(size: 18))
-                .foregroundColor(Theme.accent)
-            Text(value)
-                .font(.system(size: 20, weight: .bold))
-                .foregroundColor(Theme.textPrimary)
-            Text(label)
-                .font(Theme.fontSmall)
-                .foregroundColor(Theme.textSecondary)
-        }
-        .frame(maxWidth: .infinity)
-        .padding(.vertical, Theme.paddingMedium)
-    }
-
-    private var formattedVolume: String {
-        if viewModel.totalVolume >= 1_000_000 {
-            return String(format: "%.1fM", viewModel.totalVolume / 1_000_000)
-        } else if viewModel.totalVolume >= 1000 {
-            return String(format: "%.1fk", viewModel.totalVolume / 1000)
-        }
-        return "\(Int(viewModel.totalVolume))"
-    }
-
-    // MARK: - Recent PRs
+    // MARK: - Tab Content
 
     @ViewBuilder
-    private var recentPRsSection: some View {
-        if !viewModel.recentPRs.isEmpty {
-            VStack(alignment: .leading, spacing: Theme.paddingSmall) {
-                Text("Recent PRs")
-                    .font(.system(size: 15, weight: .semibold))
-                    .foregroundColor(Theme.textSecondary)
-
-                ForEach(viewModel.recentPRs) { pr in
-                    PRBadgeRow(pr: pr)
-                }
-            }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(Theme.paddingMedium)
-            .background(Theme.cardBackground)
-            .cornerRadius(Theme.cornerRadius)
+    private var tabContent: some View {
+        switch viewModel.selectedTab {
+        case .feed:
+            ProfileFeedView(feedItems: viewModel.feedItems)
+        case .calendar:
+            ProfileCalendarView(workoutDays: viewModel.workoutDays)
+        case .stats:
+            ProfileStatsView(
+                totalWorkouts: viewModel.totalWorkouts,
+                totalVolume: viewModel.formattedVolume,
+                totalPRs: viewModel.totalPRs,
+                recentPRs: viewModel.recentPRs
+            )
+        case .friends:
+            ProfileFriendsView(
+                friends: viewModel.friends,
+                friendProfiles: viewModel.friendProfiles
+            )
         }
     }
 
-    // MARK: - Navigation Links
+    // MARK: - Toolbar
 
-    private var navigationLinks: some View {
-        VStack(spacing: 0) {
-            NavigationLink {
-                PRListView(userId: userId)
-            } label: {
-                navRow(icon: "trophy.fill", iconColor: Theme.prGold, title: "All Personal Records")
-            }
-
-            Divider()
-                .background(Theme.background)
-
+    @ToolbarContentBuilder
+    private var ownProfileToolbar: some ToolbarContent {
+        ToolbarItem(placement: .topBarTrailing) {
             NavigationLink {
                 SettingsView()
             } label: {
-                navRow(icon: "gearshape.fill", iconColor: Theme.textSecondary, title: "Settings")
+                Image(systemName: "gearshape.fill")
+                    .foregroundStyle(Theme.textSecondary)
             }
-
-            Divider()
-                .background(Theme.background)
-
-            NavigationLink {
-                FriendsView()
-            } label: {
-                navRow(icon: "person.2.fill", iconColor: Theme.accent, title: "Friends")
-            }
-        }
-        .background(Theme.cardBackground)
-        .cornerRadius(Theme.cornerRadius)
-    }
-
-    private func navRow(icon: String, iconColor: Color, title: String) -> some View {
-        HStack(spacing: Theme.paddingMedium) {
-            Image(systemName: icon)
-                .frame(width: 24)
-                .foregroundColor(iconColor)
-            Text(title)
-                .font(.system(size: 15, weight: .medium))
-                .foregroundColor(Theme.textPrimary)
-            Spacer()
-            Image(systemName: "chevron.right")
-                .font(.system(size: 13, weight: .semibold))
-                .foregroundColor(Theme.textSecondary)
-        }
-        .padding(Theme.paddingMedium)
-    }
-
-    // MARK: - Sign Out
-
-    private var signOutSection: some View {
-        Button(role: .destructive) {
-            showSignOutConfirm = true
-        } label: {
-            HStack {
-                Image(systemName: "rectangle.portrait.and.arrow.right")
-                Text("Sign Out")
-                    .font(.system(size: 15, weight: .semibold))
-            }
-            .foregroundColor(Theme.destructive)
-            .frame(maxWidth: .infinity)
-            .padding(Theme.paddingMedium)
-            .background(Theme.cardBackground)
-            .cornerRadius(Theme.cornerRadius)
-        }
-    }
-}
-
-// MARK: - Edit Profile Sheet
-
-private struct EditProfileSheet: View {
-    let viewModel: ProfileViewModel
-    let userId: String
-    @Environment(\.dismiss) private var dismiss
-
-    var body: some View {
-        NavigationStack {
-            ZStack {
-                Theme.background.ignoresSafeArea()
-
-                Form {
-                    Section("Display Name") {
-                        TextField("Your name", text: Bindable(viewModel).editDisplayName)
-                            .listRowBackground(Theme.cardBackground)
-                            .foregroundColor(Theme.textPrimary)
-                    }
-
-                    Section("Bio") {
-                        TextField("Tell people about yourself", text: Bindable(viewModel).editBio, axis: .vertical)
-                            .lineLimit(3...5)
-                            .listRowBackground(Theme.cardBackground)
-                            .foregroundColor(Theme.textPrimary)
-                    }
-
-                    Section {
-                        Toggle("Private Account", isOn: Bindable(viewModel).editIsPrivate)
-                            .tint(Theme.accent)
-                            .listRowBackground(Theme.cardBackground)
-                            .foregroundColor(Theme.textPrimary)
-                    } footer: {
-                        Text("Only friends can see your activity when your account is private.")
-                            .foregroundColor(Theme.textSecondary)
-                    }
-                }
-                .scrollContentBackground(.hidden)
-            }
-            .navigationTitle("Edit Profile")
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbarColorScheme(.dark, for: .navigationBar)
-            .toolbar {
-                ToolbarItem(placement: .topBarLeading) {
-                    Button("Cancel") { dismiss() }
-                        .foregroundColor(Theme.textSecondary)
-                }
-                ToolbarItem(placement: .topBarTrailing) {
-                    if viewModel.isSaving {
-                        ProgressView().tint(Theme.accent)
-                    } else {
-                        Button("Save") {
-                            Task {
-                                await viewModel.updateProfile(userId: userId)
-                                if viewModel.errorMessage == nil {
-                                    dismiss()
-                                }
-                            }
-                        }
-                        .font(.system(size: 15, weight: .semibold))
-                        .foregroundColor(Theme.accent)
-                    }
-                }
-            }
+            .accessibilityLabel("Settings")
         }
     }
 }

--- a/docs/features/122-profile-redesign/PLAN.md
+++ b/docs/features/122-profile-redesign/PLAN.md
@@ -1,0 +1,81 @@
+# Plan: Profile Redesign (IG-Style)
+
+**Status**: Ready
+**Created**: 2026-03-30
+**Last updated**: 2026-03-30
+
+## Summary
+Redesign the XomFit ProfileView from a settings-like page into an Instagram-style profile with a header, stats row, custom tab picker, and tabbed content (Feed, Calendar, Stats, Friends). The same view must work for the current user and for viewing other users' profiles. Sign out and settings move to the gear icon toolbar item, which already links to the existing SettingsView.
+
+## Approach
+Full rewrite of ProfileView with extracted subviews. The existing ProfileViewModel expands to manage tab state, feed items, calendar data, and friends. FeedService gets one new method (`fetchUserFeed`). No new services needed -- all data sources already exist.
+
+## Affected Files / Components
+| File / Component | Change | Why |
+|-----------------|--------|-----|
+| `Xomfit/Views/Profile/ProfileView.swift` | Rewrite: header + tab picker + tab content container. Accept optional `userId` param. Remove sign out, nav links, stats grid, recent PRs. Extract EditProfileSheet to own file. | Core of the redesign |
+| `Xomfit/Views/Profile/ProfileHeaderView.swift` | **New** -- avatar, display name, username, bio, IG-style stats row, action button (Edit Profile / Add Friend) | Extracted header component |
+| `Xomfit/Views/Profile/ProfileTabPicker.swift` | **New** -- custom horizontal tab bar with underline indicator (Feed / Calendar / Stats / Friends) | IG-style tab UI |
+| `Xomfit/Views/Profile/ProfileFeedView.swift` | **New** -- LazyVStack of FeedItemCard for the user's feed items | Feed tab content |
+| `Xomfit/Views/Profile/ProfileCalendarView.swift` | **New** -- heatmap calendar grid (last ~12 weeks, LazyVGrid 7 cols, green intensity) | Calendar tab content |
+| `Xomfit/Views/Profile/ProfileStatsView.swift` | **New** -- PRs list + volume summary. Reuses PRBadgeRow. | Stats tab content |
+| `Xomfit/Views/Profile/ProfileFriendsView.swift` | **New** -- friend list with avatars within profile | Friends tab content |
+| `Xomfit/Views/Profile/EditProfileSheet.swift` | **Extract** -- move existing EditProfileSheet from ProfileView to its own file (no logic changes) | Clean separation |
+| `Xomfit/ViewModels/ProfileViewModel.swift` | Expand: add selectedTab enum, feedItems array, calendarData, friends list, `isOwnProfile` flag, `loadAll(userId:currentUserId:)`, fetchUserFeed, group workouts by day for calendar | Drives all new tab content |
+| `Xomfit/Services/FeedService.swift` | Add `fetchUserFeed(userId:limit:offset:)` -- filter by `user_id` | Per-user feed data |
+| `Xomfit/Views/Profile/PrivateProfileView.swift` | **New** -- lock icon + "This account is private" message | Shown for private non-friend profiles |
+
+## Implementation Steps
+
+### Phase 1: Service + ViewModel Foundation
+- [ ] Step 1 -- Add `fetchUserFeed(userId:limit:offset:)` to `FeedService`. Copy `fetchFeed` but add `.eq("user_id", value: userId)` filter.
+- [ ] Step 2 -- Define `ProfileTab` enum (feed, calendar, stats, friends) in ProfileViewModel.
+- [ ] Step 3 -- Expand ProfileViewModel: add `selectedTab`, `feedItems: [SocialFeedItem]`, `friends: [FriendRow]`, `workoutsByDay: [Date: Int]` (for calendar), `isOwnProfile: Bool`, `isFriend: Bool`, `friendCount: Int`, `feedItemCount: Int`.
+- [ ] Step 4 -- Add `loadAll(userId:currentUserId:)` to ProfileViewModel. Loads profile, stats, feed items, friends, and calendar data in parallel with `async let`. Sets `isOwnProfile` based on whether `userId == currentUserId`.
+- [ ] Step 5 -- Add `loadCalendarData(workouts:)` helper to ProfileViewModel. Groups workouts by calendar day (stripping time) into `workoutsByDay` dictionary.
+
+### Phase 2: Extracted / New Subviews
+- [ ] Step 6 -- Extract `EditProfileSheet` from ProfileView into `Xomfit/Views/Profile/EditProfileSheet.swift`. No logic changes.
+- [ ] Step 7 -- Create `ProfileHeaderView`. Props: displayName, username, bio, avatarURL, initials, isPrivate, isOwnProfile, feedItemCount, friendCount, prCount, onStatTapped (closure that sets selectedTab), onActionTapped (edit or add friend). Use Theme colors. Avatar: 80pt circle with initials or AsyncImage.
+- [ ] Step 8 -- Create `ProfileTabPicker`. Binding<ProfileTab>, custom HStack with underline indicator animated with `.matchedGeometryEffect`. Icons: list.bullet (feed), calendar (calendar), chart.bar (stats), person.2 (friends).
+- [ ] Step 9 -- Create `ProfileFeedView`. Takes `[SocialFeedItem]`, renders in LazyVStack using existing FeedItemCard. Show empty state if no items.
+- [ ] Step 10 -- Create `ProfileCalendarView`. Takes `workoutsByDay: [Date: Int]`. LazyVGrid with 7 columns, ~12 weeks of cells. Color: `Theme.cardBackground` for empty, `Theme.accent.opacity(0.4)` for 1 workout, `Theme.accent` for 2+. Day-of-week header row (S M T W T F S).
+- [ ] Step 11 -- Create `ProfileStatsView`. Takes `[PersonalRecord]`, shows total PRs header + ForEach with PRBadgeRow. Add volume stat card at top.
+- [ ] Step 12 -- Create `ProfileFriendsView`. Takes `[FriendRow]` (will need profile lookups for display names/avatars). List rows with avatar circle + display name. Tap navigates to that user's profile.
+- [ ] Step 13 -- Create `PrivateProfileView`. Lock icon + message + "Send Friend Request" button.
+
+### Phase 3: Rewrite ProfileView
+- [ ] Step 14 -- Rewrite `ProfileView`. Accept optional `userId: String?` parameter (nil = current user). Compose: ProfileHeaderView + ProfileTabPicker + switch on selectedTab for content views. Toolbar: gear icon (NavigationLink to SettingsView) for own profile only, pencil icon triggers EditProfileSheet for own profile.
+- [ ] Step 15 -- Handle other-user flow: if `userId != nil && userId != currentUserId`, set `isOwnProfile = false`. If profile is private and not friends, show PrivateProfileView instead of tabs.
+- [ ] Step 16 -- Wire stats row taps: tapping Posts/Friends/PRs in the header switches `selectedTab` to .feed/.friends/.stats respectively.
+
+### Phase 4: Integration + Polish
+- [ ] Step 17 -- Update any navigation that pushes to ProfileView (feed user taps, friend list taps) to pass `userId` parameter.
+- [ ] Step 18 -- Remove sign out button and nav links from ProfileView (already in SettingsView).
+- [ ] Step 19 -- Test own-profile flow: load, edit, tab switching, calendar rendering.
+- [ ] Step 20 -- Test other-user flow: view public profile, view private profile (locked), add friend action.
+- [ ] Step 21 -- Verify accessibility: Dynamic Type on all text, VoiceOver labels on tab picker and stats row, 44pt touch targets on all interactive elements.
+
+## Out of Scope
+- Avatar image upload (just initials/placeholder for now -- avatarURL field exists but upload flow is separate)
+- Pull-to-refresh on profile
+- Infinite scroll / pagination on profile feed (load first 20, paginate later)
+- Workout detail drill-down from calendar cells
+- Friend request accept/reject from within profile (that lives in FriendsView)
+- Real-time feed updates via Supabase subscriptions
+
+## Risks / Tradeoffs
+- **FeedItemCard reuse in profile context**: FeedItemCard (348 LOC) was built for the main feed. It may show user info redundantly when used in a profile. Mitigation: check if it has a compact mode or plan a fast follow to add one.
+- **Calendar data volume**: Loading all workouts to build the calendar could be slow for heavy users. Mitigation: limit to last 90 days in the query.
+- **Friends list in profile needs profile lookups**: FriendsService returns FriendRow (IDs only). Displaying names/avatars requires batch profile fetches. Mitigation: add a `fetchProfiles(userIds:)` batch method to ProfileService, or accept N+1 for now with small friend counts.
+- **Tab picker sticky behavior**: SwiftUI ScrollView doesn't natively support sticky headers. Mitigation: use `LazyVStack(pinnedViews: [.sectionHeaders])` with the tab picker as a section header.
+
+## Open Questions
+- [x] ProfileFriendsView navigates to other user's profile (recursive push, IG pattern)
+- [x] Calendar should look like a real calendar with month/day headers, not just a heatmap grid
+- [x] Add Friend button handles all states: "Add Friend" (none), "Requested" (pending), "Friends" (accepted)
+
+## Skills / Agents to Use
+- **Coder agent**: Execute phases 1-3 sequentially. Each phase is independent enough for a focused coding pass.
+- **ios-standards skill**: Reference before writing any new SwiftUI views to ensure conventions (foregroundStyle vs foregroundColor, clipShape, etc.).
+- **Reviewer agent**: After phase 3 to check MVVM compliance, verify no view-to-service calls, and catch accessibility gaps.


### PR DESCRIPTION
## Summary
Complete rewrite of ProfileView into an Instagram-style profile:
- **Header**: avatar, display name, @username, bio, tappable stats row (Posts/Friends/PRs)
- **Tab picker**: animated underline tabs (Feed/Calendar/Stats/Friends)
- **Feed tab**: user's workout posts via FeedItemCard
- **Calendar tab**: real month-based calendar with workout day heatmap, month navigation
- **Stats tab**: PR list + volume summary
- **Friends tab**: friend list with recursive navigation to other profiles
- **Other users**: ProfileView(userId:) for viewing any profile, Add Friend with status handling
- **Private profiles**: lock screen with friend request button
- Settings/sign out moved to gear icon → SettingsView

12 files changed, 9 new components.

Closes #122

## Test plan
- [ ] Profile tab loads with header, stats, tabs
- [ ] Stats row taps switch to corresponding tab
- [ ] Feed tab shows user's posts (or empty state)
- [ ] Calendar shows current month with workout days highlighted
- [ ] Calendar month navigation works (arrows)
- [ ] Stats tab shows PRs
- [ ] Friends tab shows friend list
- [ ] Tap friend → navigates to their profile
- [ ] Gear icon → opens SettingsView
- [ ] Edit profile sheet still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)