### PR TITLE
Fix friends errors — schema mismatch and self-search

### DIFF
--- a/Xomfit/Services/FriendsService.swift
+++ b/Xomfit/Services/FriendsService.swift
@@ -5,15 +5,15 @@ import Supabase
 
 struct FriendRow: Codable, Identifiable {
     let id: String
-    let userId: String
-    let friendId: String
+    let requesterId: String
+    let addresseeId: String
     let status: String
     let createdAt: String
 
     enum CodingKeys: String, CodingKey {
         case id
-        case userId = "user_id"
-        case friendId = "friend_id"
+        case requesterId = "requester_id"
+        case addresseeId = "addressee_id"
         case status
         case createdAt = "created_at"
     }
@@ -23,8 +23,8 @@ struct FriendRow: Codable, Identifiable {
 
 private struct FriendshipInsert: Encodable {
     let id: String
-    let user_id: String
-    let friend_id: String
+    let requester_id: String
+    let addressee_id: String
     let status: String
 }
 
@@ -43,13 +43,25 @@ final class FriendsService {
     // MARK: - Fetch Friends
 
     func fetchFriends(userId: String) async throws -> [FriendRow] {
-        let rows: [FriendRow] = try await supabase
+        // Friends where I'm the requester
+        let sent: [FriendRow] = try await supabase
             .from("friendships")
             .select()
-            .eq("user_id", value: userId)
+            .eq("requester_id", value: userId)
+            .eq("status", value: "accepted")
             .execute()
             .value
-        return rows
+
+        // Friends where I'm the addressee
+        let received: [FriendRow] = try await supabase
+            .from("friendships")
+            .select()
+            .eq("addressee_id", value: userId)
+            .eq("status", value: "accepted")
+            .execute()
+            .value
+
+        return sent + received
     }
 
     // MARK: - Fetch Pending Requests (requests sent TO this user)
@@ -58,7 +70,7 @@ final class FriendsService {
         let rows: [FriendRow] = try await supabase
             .from("friendships")
             .select()
-            .eq("friend_id", value: userId)
+            .eq("addressee_id", value: userId)
             .eq("status", value: "pending")
             .execute()
             .value
@@ -70,8 +82,8 @@ final class FriendsService {
     func sendFriendRequest(fromUserId: String, toUserId: String) async throws {
         let insert = FriendshipInsert(
             id: UUID().uuidString,
-            user_id: fromUserId,
-            friend_id: toUserId,
+            requester_id: fromUserId,
+            addressee_id: toUserId,
             status: "pending"
         )
         try await supabase
@@ -83,7 +95,7 @@ final class FriendsService {
     // MARK: - Accept Friend Request
 
     func acceptFriendRequest(friendshipId: String) async throws {
-        let update = FriendshipStatusUpdate(status: "mutual")
+        let update = FriendshipStatusUpdate(status: "accepted")
         try await supabase
             .from("friendships")
             .update(update)
@@ -111,15 +123,19 @@ final class FriendsService {
 
     // MARK: - Search Users
 
-    func searchUsers(query: String) async throws -> [ProfileRow] {
+    func searchUsers(query: String, excludeUserId: String? = nil) async throws -> [ProfileRow] {
         guard !query.isEmpty else { return [] }
-        let rows: [ProfileRow] = try await supabase
+        var request = supabase
             .from("profiles")
             .select()
             .ilike("username", value: "%\(query)%")
             .limit(20)
-            .execute()
-            .value
+
+        if let excludeId = excludeUserId {
+            request = request.neq("id", value: excludeId)
+        }
+
+        let rows: [ProfileRow] = try await request.execute().value
         return rows
     }
 }

--- a/Xomfit/ViewModels/ProfileViewModel.swift
+++ b/Xomfit/ViewModels/ProfileViewModel.swift
@@ -251,12 +251,11 @@ final class ProfileViewModel {
     private func loadFriends(userId: String) async {
         do {
             let allFriends = try await FriendsService.shared.fetchFriends(userId: userId)
-            let mutualFriends = allFriends.filter { $0.status == "mutual" }
-            friends = mutualFriends
-            friendCount = mutualFriends.count
+            friends = allFriends
+            friendCount = allFriends.count
 
             // Batch-load friend profiles for display names
-            let friendIds = mutualFriends.map { $0.friendId }
+            let friendIds = allFriends.map { $0.requesterId == userId ? $0.addresseeId : $0.requesterId }
             for friendId in friendIds {
                 if friendProfiles[friendId] == nil {
                     if let profile = try? await ProfileService.shared.fetchProfile(userId: friendId) {
@@ -271,17 +270,13 @@ final class ProfileViewModel {
 
     private func loadFriendshipStatus(currentUserId: String, targetUserId: String) async {
         do {
-            // Check if current user sent a request to the target
-            let sentFriends = try await FriendsService.shared.fetchFriends(userId: currentUserId)
-            if let match = sentFriends.first(where: { $0.friendId == targetUserId }) {
-                friendshipStatus = match.status == "mutual" ? .friends : .pending
-                return
-            }
-
-            // Check if target sent a request to current user
-            let receivedFriends = try await FriendsService.shared.fetchFriends(userId: targetUserId)
-            if let match = receivedFriends.first(where: { $0.friendId == currentUserId }) {
-                friendshipStatus = match.status == "mutual" ? .friends : .pending
+            let allFriendships = try await FriendsService.shared.fetchFriends(userId: currentUserId)
+            let match = allFriendships.first(where: {
+                ($0.requesterId == currentUserId && $0.addresseeId == targetUserId) ||
+                ($0.requesterId == targetUserId && $0.addresseeId == currentUserId)
+            })
+            if let match {
+                friendshipStatus = match.status == "accepted" ? .friends : .pending
                 return
             }
 

--- a/Xomfit/Views/Friends/FriendsView.swift
+++ b/Xomfit/Views/Friends/FriendsView.swift
@@ -198,7 +198,7 @@ struct FriendsView: View {
     private func performSearch(query: String) async {
         isSearching = true
         do {
-            searchResults = try await FriendsService.shared.searchUsers(query: query)
+            searchResults = try await FriendsService.shared.searchUsers(query: query, excludeUserId: userId)
         } catch {
             searchResults = []
         }
@@ -326,7 +326,7 @@ private struct PendingRequestRow: View {
                 Text("Friend Request")
                     .font(.system(size: 14, weight: .semibold))
                     .foregroundColor(Theme.textPrimary)
-                Text("from \(request.userId)")
+                Text("from \(request.requesterId)")
                     .font(Theme.fontCaption)
                     .foregroundColor(Theme.textSecondary)
                     .lineLimit(1)
@@ -379,11 +379,11 @@ private struct FriendListRow: View {
             }
 
             VStack(alignment: .leading, spacing: 2) {
-                Text(friend.friendId)
+                Text(friend.requesterId == userId ? friend.addresseeId : friend.requesterId)
                     .font(.system(size: 14, weight: .semibold))
                     .foregroundColor(Theme.textPrimary)
                     .lineLimit(1)
-                Text(friend.status == "mutual" ? "Friends" : "Following")
+                Text(friend.status == "accepted" ? "Friends" : "Pending")
                     .font(Theme.fontCaption)
                     .foregroundColor(Theme.textSecondary)
             }

--- a/Xomfit/Views/Profile/ProfileFriendsView.swift
+++ b/Xomfit/Views/Profile/ProfileFriendsView.swift
@@ -3,6 +3,11 @@ import SwiftUI
 struct ProfileFriendsView: View {
     let friends: [FriendRow]
     let friendProfiles: [String: ProfileRow]
+    let currentUserId: String
+
+    private func otherUserId(_ friend: FriendRow) -> String {
+        friend.requesterId == currentUserId ? friend.addresseeId : friend.requesterId
+    }
 
     var body: some View {
         if friends.isEmpty {
@@ -11,7 +16,7 @@ struct ProfileFriendsView: View {
             LazyVStack(spacing: 0) {
                 ForEach(friends) { friend in
                     NavigationLink {
-                        ProfileView(userId: friend.friendId)
+                        ProfileView(userId: otherUserId(friend))
                     } label: {
                         friendRow(friend: friend)
                     }
@@ -33,8 +38,8 @@ struct ProfileFriendsView: View {
     // MARK: - Friend Row
 
     private func friendRow(friend: FriendRow) -> some View {
-        let profile = friendProfiles[friend.friendId]
-        let name = profile?.displayName ?? friend.friendId
+        let profile = friendProfiles[otherUserId(friend)]
+        let name = profile?.displayName ?? otherUserId(friend)
         let username = profile?.username ?? ""
         let initials = friendInitials(name: name, fallback: username)
 

--- a/Xomfit/Views/Profile/ProfileView.swift
+++ b/Xomfit/Views/Profile/ProfileView.swift
@@ -136,7 +136,8 @@ struct ProfileView: View {
         case .friends:
             ProfileFriendsView(
                 friends: viewModel.friends,
-                friendProfiles: viewModel.friendProfiles
+                friendProfiles: viewModel.friendProfiles,
+                currentUserId: resolvedUserId
             )
         }
     }


### PR DESCRIPTION
## Summary
Root cause: FriendsService used `user_id`/`friend_id` columns but Supabase schema has `requester_id`/`addressee_id`. Also status used `'mutual'` but DB uses `'accepted'`.

- Fix FriendRow column mapping (requesterId/addresseeId)
- Fix insert payload column names
- Fix accept status to 'accepted'
- Fetch friends from both sides of the relationship
- Exclude current user from search results
- Resolve "other user" ID from friendship direction in all views

Closes #127