### PR TITLE
Add branded loading animations — paint, pulse, spin

### DIFF
--- a/Xomfit/Views/Common/XomFitLoader.swift
+++ b/Xomfit/Views/Common/XomFitLoader.swift
@@ -1,0 +1,129 @@
+import SwiftUI
+
+// MARK: - XStroke
+
+private struct XStroke: Shape {
+    let topLeft: Bool
+
+    func path(in rect: CGRect) -> Path {
+        var path = Path()
+        let inset = rect.width * 0.1
+        if topLeft {
+            path.move(to: CGPoint(x: inset, y: inset))
+            path.addQuadCurve(
+                to: CGPoint(x: rect.width - inset, y: rect.height - inset),
+                control: CGPoint(x: rect.midX + rect.width * 0.05, y: rect.midY - rect.height * 0.05)
+            )
+        } else {
+            path.move(to: CGPoint(x: rect.width - inset, y: inset))
+            path.addQuadCurve(
+                to: CGPoint(x: inset, y: rect.height - inset),
+                control: CGPoint(x: rect.midX - rect.width * 0.05, y: rect.midY - rect.height * 0.05)
+            )
+        }
+        return path
+    }
+}
+
+// MARK: - Paint (splash / long loads)
+
+struct XomFitLoaderPaint: View {
+    var size: CGFloat = 60
+
+    @State private var stroke1: CGFloat = 0
+    @State private var stroke2: CGFloat = 0
+    @State private var opacity: Double = 1
+
+    var body: some View {
+        Image("XomFitLogo")
+            .resizable()
+            .scaledToFit()
+            .frame(width: size, height: size)
+            .mask {
+                ZStack {
+                    XStroke(topLeft: true)
+                        .trim(from: 0, to: stroke1)
+                        .stroke(style: StrokeStyle(lineWidth: size * 0.35, lineCap: .round))
+                    XStroke(topLeft: false)
+                        .trim(from: 0, to: stroke2)
+                        .stroke(style: StrokeStyle(lineWidth: size * 0.35, lineCap: .round))
+                }
+            }
+            .opacity(opacity)
+            .onAppear { animate() }
+            .accessibilityLabel("Loading")
+    }
+
+    private func animate() {
+        stroke1 = 0; stroke2 = 0; opacity = 1
+        withAnimation(.easeOut(duration: 0.5)) { stroke1 = 1 }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+            withAnimation(.easeOut(duration: 0.5)) { stroke2 = 1 }
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.3) {
+            withAnimation(.easeIn(duration: 0.4)) { opacity = 0 }
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) { animate() }
+    }
+}
+
+// MARK: - Pulse (medium loads)
+
+struct XomFitLoaderPulse: View {
+    var size: CGFloat = 40
+
+    @State private var isPulsing = false
+
+    var body: some View {
+        Image("XomFitLogo")
+            .resizable()
+            .scaledToFit()
+            .frame(width: size, height: size)
+            .scaleEffect(isPulsing ? 1.15 : 0.85)
+            .opacity(isPulsing ? 1 : 0.5)
+            .animation(.easeInOut(duration: 0.8).repeatForever(autoreverses: true), value: isPulsing)
+            .onAppear { isPulsing = true }
+            .accessibilityLabel("Loading")
+    }
+}
+
+// MARK: - Spin (quick loads)
+
+struct XomFitLoaderSpin: View {
+    var size: CGFloat = 36
+
+    @State private var rotation: Double = 0
+
+    var body: some View {
+        Image("XomFitLogo")
+            .resizable()
+            .scaledToFit()
+            .frame(width: size, height: size)
+            .rotationEffect(.degrees(rotation))
+            .animation(.linear(duration: 1.2).repeatForever(autoreverses: false), value: rotation)
+            .onAppear { rotation = 360 }
+            .accessibilityLabel("Loading")
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    ZStack {
+        Theme.background.ignoresSafeArea()
+        VStack(spacing: 40) {
+            VStack(spacing: 8) {
+                XomFitLoaderPaint(size: 80)
+                Text("Paint").font(Theme.fontCaption).foregroundStyle(Theme.textSecondary)
+            }
+            VStack(spacing: 8) {
+                XomFitLoaderPulse(size: 60)
+                Text("Pulse").font(Theme.fontCaption).foregroundStyle(Theme.textSecondary)
+            }
+            VStack(spacing: 8) {
+                XomFitLoaderSpin(size: 50)
+                Text("Spin").font(Theme.fontCaption).foregroundStyle(Theme.textSecondary)
+            }
+        }
+    }
+}

--- a/Xomfit/Views/Feed/FeedView.swift
+++ b/Xomfit/Views/Feed/FeedView.swift
@@ -14,8 +14,7 @@ struct FeedView: View {
                 Theme.background.ignoresSafeArea()
 
                 if viewModel.isLoading {
-                    ProgressView()
-                        .tint(Theme.accent)
+                    XomFitLoaderPulse()
                 } else if let error = viewModel.errorMessage {
                     errorView(message: error)
                 } else if viewModel.feedItems.isEmpty {

--- a/Xomfit/Views/Profile/ProfileView.swift
+++ b/Xomfit/Views/Profile/ProfileView.swift
@@ -36,8 +36,7 @@ struct ProfileView: View {
             Theme.background.ignoresSafeArea()
 
             if viewModel.isLoading {
-                ProgressView()
-                    .tint(Theme.accent)
+                XomFitLoaderPulse()
             } else if !viewModel.isOwnProfile && viewModel.isPrivate && viewModel.friendshipStatus != .friends {
                 PrivateProfileView(
                     displayName: viewModel.displayName,

--- a/Xomfit/Views/Progress/XomProgressView.swift
+++ b/Xomfit/Views/Progress/XomProgressView.swift
@@ -15,8 +15,7 @@ struct XomProgressView: View {
                 Theme.background.ignoresSafeArea()
 
                 if viewModel.isLoading {
-                    ProgressView()
-                        .tint(Theme.accent)
+                    XomFitLoaderPulse()
                 } else if viewModel.totalWorkouts == 0 {
                     emptyState
                 } else {

--- a/Xomfit/XomfitApp.swift
+++ b/Xomfit/XomfitApp.swift
@@ -15,8 +15,7 @@ struct XomFitApp: App {
                                 .resizable()
                                 .scaledToFit()
                                 .frame(height: 80)
-                            ProgressView()
-                                .tint(Theme.accent)
+                            XomFitLoaderPaint(size: 60)
                         }
                     }
                 } else if authService.isAuthenticated {


### PR DESCRIPTION
## Summary
3 branded loader variants replacing the default iOS spinner:
- **Paint** — X strokes reveal the logo via mask animation (splash screen, long loads)
- **Pulse** — scale + opacity pulse on logo (profile, feed, progress loading)
- **Spin** — continuous 360 rotation (available for quick loads)

Replaced default ProgressView in splash, profile, progress, and feed full-screen loading states.

Closes #129

## Test plan
- [ ] Splash screen shows paint animation on app launch
- [ ] Profile tab loading shows pulse animation
- [ ] Progress tab loading shows pulse animation
- [ ] Feed tab loading shows pulse animation
- [ ] Xcode preview shows all 3 variants side by side
- [ ] Inline button spinners (login, save) still use default ProgressView

🤖 Generated with [Claude Code](https://claude.com/claude-code)