### PR TITLE
Batch fix: 19 issues (#138-#157) — workout, profile, feed, friends

### DIFF
--- a/Xomfit/Models/WorkoutSet.swift
+++ b/Xomfit/Models/WorkoutSet.swift
@@ -1,5 +1,10 @@
 import Foundation
 
+enum WeightMode: String, Codable {
+    case total      // default: weight is total (both hands on barbell)
+    case perSide    // weight is per arm/leg (e.g., 25lb each arm)
+}
+
 struct WorkoutSet: Codable, Identifiable, Hashable {
     static func == (lhs: WorkoutSet, rhs: WorkoutSet) -> Bool { lhs.id == rhs.id }
     func hash(into hasher: inout Hasher) { hasher.combine(id) }
@@ -10,13 +15,15 @@ struct WorkoutSet: Codable, Identifiable, Hashable {
     var rpe: Double? // Rate of Perceived Exertion (1-10)
     var isPersonalRecord: Bool
     var completedAt: Date
+    var weightMode: WeightMode = .total
 
     // MARK: - Form Check Video (optional attachment)
     var videoLocalURL: URL?       // locally saved clip after recording
     var videoRemoteURL: URL?      // uploaded to Supabase Storage
-    
+
     var volume: Double {
-        weight * Double(reps)
+        let multiplier: Double = weightMode == .perSide ? 2 : 1
+        return weight * Double(reps) * multiplier
     }
     
     var estimated1RM: Double {

--- a/Xomfit/Services/FeedService.swift
+++ b/Xomfit/Services/FeedService.swift
@@ -11,6 +11,7 @@ struct FeedItemRow: Codable {
     let payload: String       // JSON-encoded payload blob stored as text
     let visibility: String
     let createdAt: String
+    let profiles: ProfileRow?
 
     enum CodingKeys: String, CodingKey {
         case id
@@ -20,6 +21,7 @@ struct FeedItemRow: Codable {
         case payload
         case visibility
         case createdAt = "created_at"
+        case profiles
     }
 }
 
@@ -101,7 +103,7 @@ final class FeedService {
     func fetchFeed(userId: String, limit: Int = 20, offset: Int = 0) async throws -> [SocialFeedItem] {
         let rows: [FeedItemRow] = try await supabase
             .from("feed_items")
-            .select()
+            .select("*, profiles!feed_items_user_id_fkey(*)")
             .order("created_at", ascending: false)
             .range(from: offset, to: offset + limit - 1)
             .execute()
@@ -117,7 +119,7 @@ final class FeedService {
     func fetchUserFeed(userId: String, limit: Int = 20, offset: Int = 0) async throws -> [SocialFeedItem] {
         let rows: [FeedItemRow] = try await supabase
             .from("feed_items")
-            .select()
+            .select("*, profiles!feed_items_user_id_fkey(*)")
             .eq("user_id", value: userId)
             .order("created_at", ascending: false)
             .range(from: offset, to: offset + limit - 1)
@@ -257,6 +259,40 @@ final class FeedService {
             .execute()
     }
 
+    // MARK: - Delete Feed Items for Workout
+
+    /// Deletes feed items associated with a workout.
+    /// Finds workout-type feed items for the given user and checks the payload for a matching workoutId.
+    func deleteFeedItemsForWorkout(workoutId: String, userId: String) async throws {
+        // Fetch all workout-type feed items for this user (no profile join needed)
+        let rows: [FeedItemRow] = try await supabase
+            .from("feed_items")
+            .select("*, profiles!feed_items_user_id_fkey(*)")
+            .eq("user_id", value: userId)
+            .eq("activity_type", value: ActivityType.workout.rawValue)
+            .execute()
+            .value
+
+        // Find rows whose payload contains the matching workoutId
+        let matchingIds = rows.compactMap { row -> String? in
+            guard let data = row.payload.data(using: .utf8),
+                  let activity = try? jsonDecoder.decode(WorkoutActivity.self, from: data),
+                  activity.workoutId == workoutId else {
+                return nil
+            }
+            return row.id
+        }
+
+        // Delete matching feed items
+        for feedItemId in matchingIds {
+            try await supabase
+                .from("feed_items")
+                .delete()
+                .eq("id", value: feedItemId)
+                .execute()
+        }
+    }
+
     // MARK: - Private Helpers
 
     private func buildSocialFeedItem(from row: FeedItemRow) -> SocialFeedItem? {
@@ -282,31 +318,52 @@ final class FeedService {
             streakActivity = try? jsonDecoder.decode(StreakActivity.self, from: payloadData)
         }
 
-        // Build a placeholder AppUser — full profile join is a future enhancement
-        let placeholderUser = AppUser(
-            id: row.userId,
-            username: "",
-            displayName: "User",
-            avatarURL: nil,
-            bio: "",
-            stats: AppUser.UserStats(
-                totalWorkouts: 0,
-                totalVolume: 0,
-                totalPRs: 0,
-                currentStreak: 0,
-                longestStreak: 0,
-                favoriteExercise: nil
-            ),
-            isPrivate: false,
-            createdAt: Date()
-        )
+        // Build AppUser from joined profile data, falling back to placeholder
+        let user: AppUser
+        if let profile = row.profiles {
+            user = AppUser(
+                id: profile.id,
+                username: profile.username,
+                displayName: profile.displayName,
+                avatarURL: profile.avatarURL,
+                bio: profile.bio,
+                stats: AppUser.UserStats(
+                    totalWorkouts: 0,
+                    totalVolume: 0,
+                    totalPRs: 0,
+                    currentStreak: 0,
+                    longestStreak: 0,
+                    favoriteExercise: nil
+                ),
+                isPrivate: profile.isPrivate,
+                createdAt: Date()
+            )
+        } else {
+            user = AppUser(
+                id: row.userId,
+                username: "",
+                displayName: "User",
+                avatarURL: nil,
+                bio: "",
+                stats: AppUser.UserStats(
+                    totalWorkouts: 0,
+                    totalVolume: 0,
+                    totalPRs: 0,
+                    currentStreak: 0,
+                    longestStreak: 0,
+                    favoriteExercise: nil
+                ),
+                isPrivate: false,
+                createdAt: Date()
+            )
+        }
 
         return SocialFeedItem(
             id: row.id,
             userId: row.userId,
             activityType: activityType,
             createdAt: createdAt,
-            user: placeholderUser,
+            user: user,
             likes: 0,          // Like counts fetched separately / via DB view
             isLiked: false,
             comments: [],

--- a/Xomfit/Services/WorkoutService.swift
+++ b/Xomfit/Services/WorkoutService.swift
@@ -190,10 +190,14 @@ final class WorkoutService {
     // MARK: - Delete
 
     func deleteWorkout(id: String) async {
-        // Delete locally first
-        var workouts = loadAllFromCache()
-        workouts.removeAll { $0.id == id }
-        let data = try? JSONEncoder().encode(workouts)
+        // Grab the userId from cache before deleting (needed for feed cleanup)
+        let workouts = loadAllFromCache()
+        let workoutUserId = workouts.first(where: { $0.id == id })?.userId
+
+        // Delete locally
+        var updatedWorkouts = workouts
+        updatedWorkouts.removeAll { $0.id == id }
+        let data = try? JSONEncoder().encode(updatedWorkouts)
         UserDefaults.standard.set(data, forKey: storageKey)
 
         // Delete from Supabase (cascade handles exercises + sets)
@@ -201,6 +205,15 @@ final class WorkoutService {
             try await deleteFromSupabase(id: id)
         } catch {
             print("[WorkoutService] Supabase delete failed: \(error.localizedDescription)")
+        }
+
+        // Delete associated feed items
+        if let userId = workoutUserId {
+            do {
+                try await FeedService.shared.deleteFeedItemsForWorkout(workoutId: id, userId: userId)
+            } catch {
+                print("[WorkoutService] Feed item cleanup failed: \(error.localizedDescription)")
+            }
         }
     }
 

--- a/Xomfit/ViewModels/ProfileViewModel.swift
+++ b/Xomfit/ViewModels/ProfileViewModel.swift
@@ -50,6 +50,7 @@ final class ProfileViewModel {
     var isPrivate: Bool = false
 
     // MARK: - Edit buffer (populated when the edit sheet opens)
+    var editUsername: String = ""
     var editDisplayName: String = ""
     var editBio: String = ""
     var editIsPrivate: Bool = false
@@ -59,6 +60,10 @@ final class ProfileViewModel {
     var totalVolume: Double = 0
     var totalPRs: Int = 0
     var recentPRs: [PersonalRecord] = []
+
+    // MARK: - Muscle Group Heatmap
+    var muscleGroupSetsThisWeek: [String: Int] = [:]
+    var muscleGroupSetsThisMonth: [String: Int] = [:]
 
     // MARK: - Tab state
     var selectedTab: ProfileTab = .feed
@@ -144,6 +149,7 @@ final class ProfileViewModel {
         totalWorkouts = workouts.count
         totalVolume = workouts.reduce(0) { $0 + $1.totalVolume }
         loadCalendarData(workouts: workouts)
+        computeMuscleGroupSets(workouts: workouts)
 
         await prsTask
         await feedTask
@@ -172,6 +178,7 @@ final class ProfileViewModel {
         let workouts = await WorkoutService.shared.fetchWorkouts(userId: userId)
         totalWorkouts = workouts.count
         totalVolume = workouts.reduce(0) { $0 + $1.totalVolume }
+        computeMuscleGroupSets(workouts: workouts)
 
         do {
             let prs = try await PRService.shared.fetchPRs(userId: userId)
@@ -190,14 +197,16 @@ final class ProfileViewModel {
         isSaving = true
         errorMessage = nil
         do {
+            let savedUsername = editUsername.isEmpty ? (username.isEmpty ? userId : username) : editUsername
             try await ProfileService.shared.upsertProfile(
                 userId: userId,
-                username: username.isEmpty ? userId : username,
+                username: savedUsername,
                 displayName: editDisplayName.isEmpty ? displayName : editDisplayName,
                 bio: editBio,
                 avatarURL: avatarURL,
                 isPrivate: editIsPrivate
             )
+            username = savedUsername
             displayName = editDisplayName.isEmpty ? displayName : editDisplayName
             bio = editBio
             isPrivate = editIsPrivate
@@ -210,6 +219,7 @@ final class ProfileViewModel {
     // MARK: - Edit sheet helpers
 
     func beginEditing() {
+        editUsername = username
         editDisplayName = displayName
         editBio = bio
         editIsPrivate = isPrivate
@@ -284,6 +294,37 @@ final class ProfileViewModel {
         } catch {
             friendshipStatus = .none
         }
+    }
+
+    func computeMuscleGroupSets(workouts: [Workout]) {
+        let calendar = Calendar.current
+        let now = Date()
+        let oneWeekAgo = calendar.date(byAdding: .weekOfYear, value: -1, to: now) ?? now
+        let oneMonthAgo = calendar.date(byAdding: .month, value: -1, to: now) ?? now
+
+        var weekSets: [String: Int] = [:]
+        var monthSets: [String: Int] = [:]
+
+        for workout in workouts {
+            let isThisWeek = workout.startTime >= oneWeekAgo
+            let isThisMonth = workout.startTime >= oneMonthAgo
+
+            guard isThisMonth else { continue }
+
+            for exercise in workout.exercises {
+                let setCount = exercise.sets.count
+                for muscleGroup in exercise.exercise.muscleGroups {
+                    let name = muscleGroup.displayName
+                    if isThisWeek {
+                        weekSets[name, default: 0] += setCount
+                    }
+                    monthSets[name, default: 0] += setCount
+                }
+            }
+        }
+
+        muscleGroupSetsThisWeek = weekSets
+        muscleGroupSetsThisMonth = monthSets
     }
 
     func loadCalendarData(workouts: [Workout]) {

--- a/Xomfit/ViewModels/WorkoutLoggerViewModel.swift
+++ b/Xomfit/ViewModels/WorkoutLoggerViewModel.swift
@@ -19,6 +19,16 @@ final class WorkoutLoggerViewModel {
     var newPR: PersonalRecord? = nil
     var showPRCelebration: Bool = false
 
+    // Next exercise prompt — shown when all sets of an exercise are complete
+    var nextExerciseSuggestion: String? = nil
+    var completedExerciseName: String? = nil
+    var showNextExercisePrompt: Bool = false
+
+    // Focus mode — large gym-floor view
+    var focusMode: Bool = false
+    var focusExerciseIndex: Int = 0
+    var focusSetIndex: Int = 0
+
     // Stored so completeSet can fire PR checks without needing the caller to pass it
     private(set) var activeUserId: String = ""
 
@@ -59,6 +69,12 @@ final class WorkoutLoggerViewModel {
         activeUserId = userId
         newPR = nil
         showPRCelebration = false
+        nextExerciseSuggestion = nil
+        completedExerciseName = nil
+        showNextExercisePrompt = false
+        focusMode = false
+        focusExerciseIndex = 0
+        focusSetIndex = 0
         skipRestTimer()
     }
 
@@ -70,6 +86,12 @@ final class WorkoutLoggerViewModel {
         errorMessage = nil
         newPR = nil
         showPRCelebration = false
+        nextExerciseSuggestion = nil
+        completedExerciseName = nil
+        showNextExercisePrompt = false
+        focusMode = false
+        focusExerciseIndex = 0
+        focusSetIndex = 0
         skipRestTimer()
     }
 
@@ -110,21 +132,27 @@ final class WorkoutLoggerViewModel {
     func addExercise(_ exercise: Exercise) {
         // Look up last workout's weight/reps for this exercise
         let lastSet = lastSetForExercise(exercise.id)
+        let prefillWeight = lastSet?.weight ?? 0
+        let prefillReps = lastSet?.reps ?? 0
 
-        let firstSet = WorkoutSet(
-            id: UUID().uuidString,
-            exerciseId: exercise.id,
-            weight: lastSet?.weight ?? 0,
-            reps: lastSet?.reps ?? 0,
-            rpe: nil,
-            isPersonalRecord: false,
-            completedAt: Date.distantPast
-        )
+        let defaultSetCount = 3
+        var sets: [WorkoutSet] = []
+        for _ in 0..<defaultSetCount {
+            sets.append(WorkoutSet(
+                id: UUID().uuidString,
+                exerciseId: exercise.id,
+                weight: prefillWeight,
+                reps: prefillReps,
+                rpe: nil,
+                isPersonalRecord: false,
+                completedAt: Date.distantPast
+            ))
+        }
 
         let workoutExercise = WorkoutExercise(
             id: UUID().uuidString,
             exercise: exercise,
-            sets: [firstSet],
+            sets: sets,
             notes: nil
         )
         exercises.append(workoutExercise)
@@ -146,6 +174,13 @@ final class WorkoutLoggerViewModel {
     func removeExercise(at index: Int) {
         guard exercises.indices.contains(index) else { return }
         exercises.remove(at: index)
+    }
+
+    func moveExercise(from source: Int, direction: Int) {
+        let destination = source + direction
+        guard exercises.indices.contains(source),
+              exercises.indices.contains(destination) else { return }
+        exercises.swapAt(source, destination)
     }
 
     // MARK: - Set Management
@@ -199,6 +234,21 @@ final class WorkoutLoggerViewModel {
                     setIndex: setIndex
                 )
             }
+
+            // Check if all sets in this exercise are now complete
+            let allDone = exercises[exerciseIndex].sets.allSatisfy { $0.completedAt != Date.distantPast }
+            if allDone {
+                completedExerciseName = exercises[exerciseIndex].exercise.name
+                let nextIndex = exercises.indices.first { idx in
+                    idx > exerciseIndex && exercises[idx].sets.contains { $0.completedAt == Date.distantPast }
+                }
+                if let nextIdx = nextIndex {
+                    nextExerciseSuggestion = exercises[nextIdx].exercise.name
+                } else {
+                    nextExerciseSuggestion = nil
+                }
+                showNextExercisePrompt = true
+            }
         }
     }
 
@@ -206,6 +256,63 @@ final class WorkoutLoggerViewModel {
         guard exercises.indices.contains(exerciseIndex),
               exercises[exerciseIndex].sets.indices.contains(setIndex) else { return }
         exercises[exerciseIndex].sets.remove(at: setIndex)
+    }
+
+    func toggleWeightMode(exerciseIndex: Int, setIndex: Int) {
+        guard exercises.indices.contains(exerciseIndex),
+              exercises[exerciseIndex].sets.indices.contains(setIndex) else { return }
+        exercises[exerciseIndex].sets[setIndex].weightMode =
+            exercises[exerciseIndex].sets[setIndex].weightMode == .total ? .perSide : .total
+    }
+
+    // MARK: - Focus Mode Navigation
+
+    /// The exercise currently in focus, if valid.
+    var focusExercise: WorkoutExercise? {
+        exercises.indices.contains(focusExerciseIndex) ? exercises[focusExerciseIndex] : nil
+    }
+
+    /// The set currently in focus, if valid.
+    var focusSet: WorkoutSet? {
+        guard let ex = focusExercise,
+              ex.sets.indices.contains(focusSetIndex) else { return nil }
+        return ex.sets[focusSetIndex]
+    }
+
+    /// Advance to the next incomplete set. If the current exercise is done, move to the next exercise.
+    func focusAdvance() {
+        guard exercises.indices.contains(focusExerciseIndex) else { return }
+        let ex = exercises[focusExerciseIndex]
+
+        // Try next set in the same exercise
+        if focusSetIndex + 1 < ex.sets.count {
+            focusSetIndex += 1
+            return
+        }
+
+        // Move to next exercise, first set
+        if focusExerciseIndex + 1 < exercises.count {
+            focusExerciseIndex += 1
+            focusSetIndex = 0
+        }
+    }
+
+    func focusPreviousExercise() {
+        guard focusExerciseIndex > 0 else { return }
+        focusExerciseIndex -= 1
+        focusSetIndex = 0
+    }
+
+    func focusNextExercise() {
+        guard focusExerciseIndex + 1 < exercises.count else { return }
+        focusExerciseIndex += 1
+        focusSetIndex = 0
+    }
+
+    /// Complete the focused set and auto-advance.
+    func completeFocusedSet() {
+        completeSet(exerciseIndex: focusExerciseIndex, setIndex: focusSetIndex)
+        focusAdvance()
     }
 
     // MARK: - Rest Timer
@@ -222,12 +329,8 @@ final class WorkoutLoggerViewModel {
     }
 
     func tickRestTimer() {
-        guard isRestTimerActive, restTimeRemaining > 0 else { return }
+        guard isRestTimerActive else { return }
         restTimeRemaining -= 1
-        if restTimeRemaining <= 0 {
-            restTimeRemaining = 0
-            isRestTimerActive = false
-        }
     }
 
     func skipRestTimer() {
@@ -304,11 +407,12 @@ final class WorkoutLoggerViewModel {
             try await WorkoutService.shared.saveWorkout(workout)
             // Auto-post to feed after saving
             try await FeedService.shared.postWorkoutToFeed(workout: workout, userId: userId)
+            // Only discard local state after successful save
+            isSaving = false
+            discardWorkout()
         } catch {
             errorMessage = error.localizedDescription
+            isSaving = false
         }
-
-        isSaving = false
-        discardWorkout()
     }
 }

--- a/Xomfit/Views/Common/UserSearchView.swift
+++ b/Xomfit/Views/Common/UserSearchView.swift
@@ -1,0 +1,200 @@
+import SwiftUI
+
+struct UserSearchView: View {
+    @Environment(AuthService.self) private var authService
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var query = ""
+    @State private var results: [ProfileRow] = []
+    @State private var isSearching = false
+    @State private var searchTask: Task<Void, Never>?
+
+    private var currentUserId: String {
+        authService.currentUser?.id.uuidString ?? ""
+    }
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Theme.background.ignoresSafeArea()
+
+                VStack(spacing: 0) {
+                    searchBar
+                        .padding(.horizontal, Theme.paddingMedium)
+                        .padding(.vertical, Theme.paddingSmall)
+
+                    if isSearching {
+                        Spacer()
+                        ProgressView()
+                            .tint(Theme.accent)
+                        Spacer()
+                    } else if results.isEmpty && !query.isEmpty {
+                        Spacer()
+                        noResultsView
+                        Spacer()
+                    } else if results.isEmpty {
+                        Spacer()
+                        emptyState
+                        Spacer()
+                    } else {
+                        resultsList
+                    }
+                }
+            }
+            .navigationTitle("Search Users")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbarColorScheme(.dark, for: .navigationBar)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button("Cancel") { dismiss() }
+                        .foregroundStyle(Theme.textSecondary)
+                }
+            }
+        }
+    }
+
+    // MARK: - Search Bar
+
+    private var searchBar: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "magnifyingglass")
+                .foregroundStyle(Theme.textSecondary)
+                .font(.system(size: 16))
+
+            TextField("Search by username", text: $query)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+                .foregroundStyle(Theme.textPrimary)
+
+            if !query.isEmpty {
+                Button {
+                    query = ""
+                    results = []
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(Theme.textSecondary)
+                }
+            }
+        }
+        .padding(12)
+        .background(Theme.cardBackground)
+        .clipShape(.rect(cornerRadius: Theme.cornerRadiusSmall))
+        .onChange(of: query) { _, newValue in
+            searchTask?.cancel()
+            guard !newValue.isEmpty else {
+                results = []
+                isSearching = false
+                return
+            }
+            searchTask = Task {
+                try? await Task.sleep(for: .milliseconds(300))
+                guard !Task.isCancelled else { return }
+                await performSearch(newValue)
+            }
+        }
+    }
+
+    // MARK: - Results List
+
+    private var resultsList: some View {
+        List {
+            ForEach(results, id: \.id) { profile in
+                NavigationLink {
+                    ProfileView(userId: profile.id)
+                } label: {
+                    userRow(profile)
+                }
+                .listRowBackground(Theme.cardBackground)
+                .listRowSeparatorTint(Theme.textSecondary.opacity(0.2))
+            }
+        }
+        .listStyle(.plain)
+        .scrollContentBackground(.hidden)
+    }
+
+    // MARK: - User Row
+
+    private func userRow(_ profile: ProfileRow) -> some View {
+        HStack(spacing: 12) {
+            // Avatar circle with initials
+            initialsAvatar(profile)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(profile.displayName.isEmpty ? profile.username : profile.displayName)
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundStyle(Theme.textPrimary)
+                Text("@\(profile.username)")
+                    .font(Theme.fontCaption)
+                    .foregroundStyle(Theme.textSecondary)
+            }
+
+            Spacer()
+        }
+        .padding(.vertical, 4)
+        .accessibilityElement(children: .combine)
+    }
+
+    private func initialsAvatar(_ profile: ProfileRow) -> some View {
+        let name = profile.displayName.isEmpty ? profile.username : profile.displayName
+        let parts = name.split(separator: " ")
+        let initials: String
+        if parts.count >= 2 {
+            initials = String(parts[0].prefix(1) + parts[1].prefix(1)).uppercased()
+        } else {
+            initials = String(name.prefix(2)).uppercased()
+        }
+
+        return Text(initials)
+            .font(.system(size: 14, weight: .bold))
+            .foregroundStyle(Theme.accent)
+            .frame(width: 40, height: 40)
+            .background(Theme.accent.opacity(0.15))
+            .clipShape(Circle())
+    }
+
+    // MARK: - Empty / No Results
+
+    private var emptyState: some View {
+        VStack(spacing: Theme.paddingSmall) {
+            Image(systemName: "magnifyingglass")
+                .font(.system(size: 36))
+                .foregroundStyle(Theme.textSecondary)
+            Text("Search for users by username")
+                .font(Theme.fontBody)
+                .foregroundStyle(Theme.textSecondary)
+        }
+    }
+
+    private var noResultsView: some View {
+        VStack(spacing: Theme.paddingSmall) {
+            Image(systemName: "person.slash")
+                .font(.system(size: 36))
+                .foregroundStyle(Theme.textSecondary)
+            Text("No users found")
+                .font(Theme.fontBody)
+                .foregroundStyle(Theme.textSecondary)
+        }
+    }
+
+    // MARK: - Search
+
+    private func performSearch(_ searchQuery: String) async {
+        isSearching = true
+        do {
+            let rows = try await FriendsService.shared.searchUsers(
+                query: searchQuery,
+                excludeUserId: currentUserId
+            )
+            if !Task.isCancelled {
+                results = rows
+            }
+        } catch {
+            if !Task.isCancelled {
+                results = []
+            }
+        }
+        if !Task.isCancelled {
+            isSearching = false
+        }
+    }
+}

--- a/Xomfit/Views/Feed/FeedView.swift
+++ b/Xomfit/Views/Feed/FeedView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct FeedView: View {
     @Environment(AuthService.self) private var authService
     @State private var viewModel = FeedViewModel()
+    @State private var showUserSearch = false
 
     private var userId: String {
         authService.currentUser?.id.uuidString ?? ""
@@ -27,13 +28,26 @@ struct FeedView: View {
             .toolbarColorScheme(.dark, for: .navigationBar)
             .toolbar {
                 ToolbarItem(placement: .topBarTrailing) {
-                    NavigationLink {
-                        FriendsView()
-                    } label: {
-                        Image(systemName: "person.badge.plus")
-                            .foregroundColor(Theme.accent)
+                    HStack(spacing: 16) {
+                        Button {
+                            showUserSearch = true
+                        } label: {
+                            Image(systemName: "magnifyingglass")
+                                .foregroundColor(Theme.accent)
+                        }
+                        .accessibilityLabel("Search users")
+
+                        NavigationLink {
+                            FriendsView()
+                        } label: {
+                            Image(systemName: "person.badge.plus")
+                                .foregroundColor(Theme.accent)
+                        }
                     }
                 }
+            }
+            .sheet(isPresented: $showUserSearch) {
+                UserSearchView()
             }
         }
         .onAppear {

--- a/Xomfit/Views/Friends/FriendsView.swift
+++ b/Xomfit/Views/Friends/FriendsView.swift
@@ -11,6 +11,8 @@ struct FriendsView: View {
     @State private var isLoading = false
     @State private var errorMessage: String?
     @State private var searchTask: Task<Void, Never>?
+    @State private var requesterProfiles: [String: ProfileRow] = [:]
+    @State private var friendProfiles: [String: ProfileRow] = [:]
 
     private var userId: String {
         authService.currentUser?.id.uuidString ?? ""
@@ -26,7 +28,7 @@ struct FriendsView: View {
 
                 if isLoading {
                     Spacer()
-                    ProgressView().tint(Theme.accent)
+                    XomFitLoaderPulse()
                     Spacer()
                 } else {
                     List {
@@ -112,16 +114,16 @@ struct FriendsView: View {
                     Spacer()
                 }
                 .listRowBackground(Theme.cardBackground)
-            } else if searchResults.isEmpty {
+            } else if searchResults.filter({ $0.id != userId }).isEmpty {
                 Text("No users found for \"\(searchQuery)\"")
                     .foregroundColor(Theme.textSecondary)
                     .font(Theme.fontBody)
                     .listRowBackground(Theme.cardBackground)
             } else {
-                ForEach(searchResults, id: \.id) { profile in
+                ForEach(searchResults.filter { $0.id != userId }, id: \.id) { profile in
                     SearchResultRow(
                         profile: profile,
-                        isCurrentUser: profile.id == userId
+                        isCurrentUser: false
                     ) {
                         sendRequest(toUserId: profile.id)
                     }
@@ -142,6 +144,7 @@ struct FriendsView: View {
             ForEach(pendingRequests, id: \.id) { request in
                 PendingRequestRow(
                     request: request,
+                    requesterProfile: requesterProfiles[request.requesterId],
                     onAccept: { acceptRequest(request) },
                     onDecline: { declineRequest(request) }
                 )
@@ -165,7 +168,12 @@ struct FriendsView: View {
                     .listRowBackground(Theme.cardBackground)
             } else {
                 ForEach(friends, id: \.id) { friend in
-                    FriendListRow(friend: friend, currentUserId: userId) {
+                    let friendId = friend.requesterId == userId ? friend.addresseeId : friend.requesterId
+                    FriendListRow(
+                        friend: friend,
+                        currentUserId: userId,
+                        friendProfile: friendProfiles[friendId]
+                    ) {
                         removeFriend(friend)
                     }
                     .listRowBackground(Theme.cardBackground)
@@ -189,6 +197,25 @@ struct FriendsView: View {
                 async let friendsResult = FriendsService.shared.fetchFriends(userId: userId)
                 async let pendingResult = FriendsService.shared.fetchPendingRequests(userId: userId)
                 (friends, pendingRequests) = try await (friendsResult, pendingResult)
+
+                // Fetch profiles for pending request senders
+                for request in pendingRequests {
+                    if requesterProfiles[request.requesterId] == nil {
+                        if let profile = try? await ProfileService.shared.fetchProfile(userId: request.requesterId) {
+                            requesterProfiles[request.requesterId] = profile
+                        }
+                    }
+                }
+
+                // Fetch profiles for friends
+                for friend in friends {
+                    let friendId = friend.requesterId == userId ? friend.addresseeId : friend.requesterId
+                    if friendProfiles[friendId] == nil {
+                        if let profile = try? await ProfileService.shared.fetchProfile(userId: friendId) {
+                            friendProfiles[friendId] = profile
+                        }
+                    }
+                }
             } catch {
                 errorMessage = error.localizedDescription
             }
@@ -310,8 +337,25 @@ private struct SearchResultRow: View {
 
 private struct PendingRequestRow: View {
     let request: FriendRow
+    let requesterProfile: ProfileRow?
     let onAccept: () -> Void
     let onDecline: () -> Void
+
+    private var requesterName: String {
+        if let profile = requesterProfile {
+            return profile.displayName.isEmpty ? profile.username : profile.displayName
+        }
+        return String(request.requesterId.prefix(8))
+    }
+
+    private var requesterInitials: String {
+        let name = requesterName
+        let parts = name.split(separator: " ")
+        if parts.count >= 2 {
+            return String(parts[0].prefix(1) + parts[1].prefix(1)).uppercased()
+        }
+        return String(name.prefix(2)).uppercased()
+    }
 
     var body: some View {
         HStack(spacing: Theme.paddingMedium) {
@@ -319,18 +363,21 @@ private struct PendingRequestRow: View {
                 Circle()
                     .fill(Theme.accent.opacity(0.2))
                     .frame(width: 40, height: 40)
-                Image(systemName: "person.fill")
+                Text(requesterInitials)
+                    .font(.system(size: 14, weight: .bold))
                     .foregroundColor(Theme.accent)
             }
 
             VStack(alignment: .leading, spacing: 2) {
-                Text("Friend Request")
+                Text(requesterName)
                     .font(.system(size: 14, weight: .semibold))
                     .foregroundColor(Theme.textPrimary)
-                Text("from \(request.requesterId)")
-                    .font(Theme.fontCaption)
-                    .foregroundColor(Theme.textSecondary)
-                    .lineLimit(1)
+                if let profile = requesterProfile {
+                    Text("@\(profile.username)")
+                        .font(Theme.fontCaption)
+                        .foregroundColor(Theme.textSecondary)
+                        .lineLimit(1)
+                }
             }
 
             Spacer()
@@ -368,7 +415,25 @@ private struct PendingRequestRow: View {
 private struct FriendListRow: View {
     let friend: FriendRow
     let currentUserId: String
+    let friendProfile: ProfileRow?
     let onRemove: () -> Void
+
+    private var friendName: String {
+        if let profile = friendProfile {
+            return profile.displayName.isEmpty ? profile.username : profile.displayName
+        }
+        let friendId = friend.requesterId == currentUserId ? friend.addresseeId : friend.requesterId
+        return String(friendId.prefix(8))
+    }
+
+    private var friendInitials: String {
+        let name = friendName
+        let parts = name.split(separator: " ")
+        if parts.count >= 2 {
+            return String(parts[0].prefix(1) + parts[1].prefix(1)).uppercased()
+        }
+        return String(name.prefix(2)).uppercased()
+    }
 
     var body: some View {
         HStack(spacing: Theme.paddingMedium) {
@@ -376,18 +441,25 @@ private struct FriendListRow: View {
                 Circle()
                     .fill(Theme.accent.opacity(0.2))
                     .frame(width: 40, height: 40)
-                Image(systemName: "person.fill")
+                Text(friendInitials)
+                    .font(.system(size: 14, weight: .bold))
                     .foregroundColor(Theme.accent)
             }
 
             VStack(alignment: .leading, spacing: 2) {
-                Text(friend.requesterId == currentUserId ? friend.addresseeId : friend.requesterId)
+                Text(friendName)
                     .font(.system(size: 14, weight: .semibold))
                     .foregroundColor(Theme.textPrimary)
                     .lineLimit(1)
-                Text(friend.status == "accepted" ? "Friends" : "Pending")
-                    .font(Theme.fontCaption)
-                    .foregroundColor(Theme.textSecondary)
+                if let profile = friendProfile {
+                    Text("@\(profile.username)")
+                        .font(Theme.fontCaption)
+                        .foregroundColor(Theme.textSecondary)
+                } else {
+                    Text(friend.status == "accepted" ? "Friends" : "Pending")
+                        .font(Theme.fontCaption)
+                        .foregroundColor(Theme.textSecondary)
+                }
             }
 
             Spacer()

--- a/Xomfit/Views/Profile/BodyHeatmapView.swift
+++ b/Xomfit/Views/Profile/BodyHeatmapView.swift
@@ -1,0 +1,124 @@
+import SwiftUI
+
+// MARK: - Time Filter
+
+enum HeatmapTimeFilter: String, CaseIterable, Identifiable {
+    case week = "Week"
+    case month = "Month"
+
+    var id: String { rawValue }
+}
+
+// MARK: - Body Heatmap View
+
+struct BodyHeatmapView: View {
+    let muscleGroupSets: [String: Int]
+
+    private static let frontMuscles = ["Chest", "Shoulders", "Biceps", "Abs", "Quads"]
+    private static let backMuscles = ["Traps", "Back", "Lats", "Triceps", "Glutes", "Hamstrings", "Calves"]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Theme.paddingSmall) {
+            HStack(alignment: .top, spacing: Theme.paddingSmall) {
+                // Front column
+                VStack(spacing: Theme.paddingSmall) {
+                    Text("Front")
+                        .font(.system(size: 13, weight: .bold))
+                        .foregroundStyle(Theme.textSecondary)
+
+                    ForEach(Self.frontMuscles, id: \.self) { muscle in
+                        muscleCell(name: muscle, sets: muscleGroupSets[muscle] ?? 0)
+                    }
+                }
+                .frame(maxWidth: .infinity)
+
+                // Back column
+                VStack(spacing: Theme.paddingSmall) {
+                    Text("Back")
+                        .font(.system(size: 13, weight: .bold))
+                        .foregroundStyle(Theme.textSecondary)
+
+                    ForEach(Self.backMuscles, id: \.self) { muscle in
+                        muscleCell(name: muscle, sets: muscleGroupSets[muscle] ?? 0)
+                    }
+                }
+                .frame(maxWidth: .infinity)
+            }
+
+            // Legend
+            heatmapLegend
+                .padding(.top, Theme.paddingSmall)
+        }
+    }
+
+    // MARK: - Muscle Cell
+
+    private func muscleCell(name: String, sets: Int) -> some View {
+        HStack {
+            Text(name)
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(sets > 0 ? Theme.textPrimary : Theme.textSecondary)
+
+            Spacer()
+
+            Text("\(sets)")
+                .font(.system(size: 13, weight: .bold, design: .monospaced))
+                .foregroundStyle(sets > 0 ? Theme.textPrimary : Theme.textSecondary)
+        }
+        .padding(.horizontal, Theme.paddingSmall)
+        .padding(.vertical, 10)
+        .background(heatColor(for: sets))
+        .clipShape(.rect(cornerRadius: Theme.cornerRadiusSmall))
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(name): \(sets) sets")
+    }
+
+    // MARK: - Heat Color
+
+    /// Maps set count to intensity color:
+    /// 0 = card background (not hit), 1-3 = green (light), 4-8 = yellow, 9-15 = orange, 16+ = red
+    private func heatColor(for sets: Int) -> Color {
+        switch sets {
+        case 0:
+            return Theme.cardBackground
+        case 1...3:
+            return Theme.accent.opacity(0.3)
+        case 4...8:
+            return Color.yellow.opacity(0.3)
+        case 9...15:
+            return Color.orange.opacity(0.3)
+        default:
+            return Theme.destructive.opacity(0.3)
+        }
+    }
+
+    // MARK: - Legend
+
+    private var heatmapLegend: some View {
+        HStack(spacing: Theme.paddingSmall) {
+            legendItem(color: Theme.cardBackground, label: "None")
+            legendItem(color: Theme.accent.opacity(0.3), label: "Light")
+            legendItem(color: Color.yellow.opacity(0.3), label: "Some")
+            legendItem(color: Color.orange.opacity(0.3), label: "Moderate")
+            legendItem(color: Theme.destructive.opacity(0.3), label: "Heavy")
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private func legendItem(color: Color, label: String) -> some View {
+        VStack(spacing: 2) {
+            RoundedRectangle(cornerRadius: 3)
+                .fill(color)
+                .frame(width: 20, height: 12)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 3)
+                        .stroke(Theme.textSecondary.opacity(0.2), lineWidth: 0.5)
+                )
+            Text(label)
+                .font(.system(size: 9, weight: .medium))
+                .foregroundStyle(Theme.textSecondary)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(label) intensity")
+    }
+}

--- a/Xomfit/Views/Profile/EditProfileSheet.swift
+++ b/Xomfit/Views/Profile/EditProfileSheet.swift
@@ -11,6 +11,14 @@ struct EditProfileSheet: View {
                 Theme.background.ignoresSafeArea()
 
                 Form {
+                    Section("Username") {
+                        TextField("username", text: Bindable(viewModel).editUsername)
+                            .textInputAutocapitalization(.never)
+                            .autocorrectionDisabled()
+                            .listRowBackground(Theme.cardBackground)
+                            .foregroundStyle(Theme.textPrimary)
+                    }
+
                     Section("Display Name") {
                         TextField("Your name", text: Bindable(viewModel).editDisplayName)
                             .listRowBackground(Theme.cardBackground)

--- a/Xomfit/Views/Profile/PRListView.swift
+++ b/Xomfit/Views/Profile/PRListView.swift
@@ -20,8 +20,7 @@ struct PRListView: View {
             Theme.background.ignoresSafeArea()
 
             if isLoading {
-                ProgressView()
-                    .tint(Theme.accent)
+                XomFitLoaderPulse()
             } else if prs.isEmpty {
                 emptyState
             } else {

--- a/Xomfit/Views/Profile/ProfileStatsView.swift
+++ b/Xomfit/Views/Profile/ProfileStatsView.swift
@@ -5,10 +5,22 @@ struct ProfileStatsView: View {
     let totalVolume: String
     let totalPRs: Int
     let recentPRs: [PersonalRecord]
+    let muscleGroupSetsThisWeek: [String: Int]
+    let muscleGroupSetsThisMonth: [String: Int]
+
+    @State private var heatmapFilter: HeatmapTimeFilter = .week
+
+    private var activeMuscleGroupSets: [String: Int] {
+        switch heatmapFilter {
+        case .week: return muscleGroupSetsThisWeek
+        case .month: return muscleGroupSetsThisMonth
+        }
+    }
 
     var body: some View {
         VStack(spacing: Theme.paddingSmall) {
             statsCards
+            heatmapSection
             prSection
         }
         .padding(.horizontal, Theme.paddingMedium)
@@ -42,6 +54,32 @@ struct ProfileStatsView: View {
         .clipShape(.rect(cornerRadius: Theme.cornerRadius))
         .accessibilityElement(children: .combine)
         .accessibilityLabel("\(value) \(label)")
+    }
+
+    // MARK: - Heatmap Section
+
+    private var heatmapSection: some View {
+        VStack(alignment: .leading, spacing: Theme.paddingSmall) {
+            HStack {
+                Text("Muscle Heatmap")
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundStyle(Theme.textSecondary)
+
+                Spacer()
+
+                Picker("Time Range", selection: $heatmapFilter) {
+                    ForEach(HeatmapTimeFilter.allCases) { filter in
+                        Text(filter.rawValue).tag(filter)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .frame(width: 140)
+            }
+            .padding(.horizontal, Theme.paddingSmall)
+
+            BodyHeatmapView(muscleGroupSets: activeMuscleGroupSets)
+        }
+        .cardStyle()
     }
 
     // MARK: - PR Section

--- a/Xomfit/Views/Profile/ProfileView.swift
+++ b/Xomfit/Views/Profile/ProfileView.swift
@@ -133,7 +133,9 @@ struct ProfileView: View {
                 totalWorkouts: viewModel.totalWorkouts,
                 totalVolume: viewModel.formattedVolume,
                 totalPRs: viewModel.totalPRs,
-                recentPRs: viewModel.recentPRs
+                recentPRs: viewModel.recentPRs,
+                muscleGroupSetsThisWeek: viewModel.muscleGroupSetsThisWeek,
+                muscleGroupSetsThisMonth: viewModel.muscleGroupSetsThisMonth
             )
         case .friends:
             ProfileFriendsView(
@@ -149,13 +151,24 @@ struct ProfileView: View {
     @ToolbarContentBuilder
     private var ownProfileToolbar: some ToolbarContent {
         ToolbarItem(placement: .topBarTrailing) {
-            NavigationLink {
-                SettingsView()
-            } label: {
-                Image(systemName: "gearshape.fill")
-                    .foregroundStyle(Theme.textSecondary)
+            HStack(spacing: 16) {
+                Button {
+                    viewModel.beginEditing()
+                    showEditSheet = true
+                } label: {
+                    Image(systemName: "pencil")
+                        .foregroundStyle(Theme.textSecondary)
+                }
+                .accessibilityLabel("Edit Profile")
+
+                NavigationLink {
+                    SettingsView()
+                } label: {
+                    Image(systemName: "gearshape.fill")
+                        .foregroundStyle(Theme.textSecondary)
+                }
+                .accessibilityLabel("Settings")
             }
-            .accessibilityLabel("Settings")
         }
     }
 }

--- a/Xomfit/Views/Workout/ActiveWorkoutView.swift
+++ b/Xomfit/Views/Workout/ActiveWorkoutView.swift
@@ -8,6 +8,7 @@ struct ActiveWorkoutView: View {
     @State private var showExercisePicker = false
     @State private var showDiscardAlert = false
     @State private var timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
+    @State private var restTimerHapticFired = false
 
     // Passed in from WorkoutView
     let workoutName: String
@@ -22,60 +23,72 @@ struct ActiveWorkoutView: View {
                     // Header bar
                     headerBar
 
-                    // Rest timer
-                    if viewModel.isRestTimerActive {
-                        RestTimerView(
-                            restTimeRemaining: viewModel.restTimeRemaining,
-                            restDuration: viewModel.restDuration,
-                            onSkip: { viewModel.skipRestTimer() },
-                            onExtend: { viewModel.extendRestTimer() }
-                        )
-                        .padding(.horizontal, Theme.paddingMedium)
-                        .padding(.vertical, Theme.paddingSmall)
-                        .transition(.move(edge: .top).combined(with: .opacity))
-                    }
-
-                    // Exercise list
-                    if viewModel.exercises.isEmpty {
-                        emptyState
+                    if viewModel.focusMode {
+                        // Focus mode — large gym-floor view
+                        WorkoutFocusView(viewModel: viewModel)
                     } else {
-                        ScrollView {
-                            LazyVStack(spacing: Theme.paddingMedium) {
-                                ForEach(viewModel.exercises.indices, id: \.self) { exIdx in
-                                    ExerciseCard(
-                                        exerciseIndex: exIdx,
-                                        viewModel: viewModel
-                                    )
+                        // Rest timer
+                        if viewModel.isRestTimerActive {
+                            RestTimerView(
+                                restTimeRemaining: viewModel.restTimeRemaining,
+                                restDuration: viewModel.restDuration,
+                                onSkip: {
+                                    viewModel.skipRestTimer()
+                                    restTimerHapticFired = false
+                                },
+                                onExtend: { viewModel.extendRestTimer() }
+                            )
+                            .padding(.horizontal, Theme.paddingMedium)
+                            .padding(.vertical, Theme.paddingSmall)
+                            .transition(.move(edge: .top).combined(with: .opacity))
+                        }
+
+                        // Exercise list
+                        if viewModel.exercises.isEmpty {
+                            emptyState
+                        } else {
+                            ScrollView {
+                                LazyVStack(spacing: Theme.paddingMedium) {
+                                    ForEach(viewModel.exercises.indices, id: \.self) { exIdx in
+                                        ExerciseCard(
+                                            exerciseIndex: exIdx,
+                                            viewModel: viewModel
+                                        )
+                                    }
                                 }
+                                .padding(Theme.paddingMedium)
+                                // Bottom padding so FAB doesn't overlap last card
+                                .padding(.bottom, 80)
                             }
-                            .padding(Theme.paddingMedium)
-                            // Bottom padding so FAB doesn't overlap last card
-                            .padding(.bottom, 80)
                         }
                     }
                 }
                 .animation(.easeInOut(duration: 0.3), value: viewModel.isRestTimerActive)
+                .animation(.easeInOut(duration: 0.3), value: viewModel.showNextExercisePrompt)
+                .animation(.easeInOut(duration: 0.3), value: viewModel.focusMode)
 
-                // Floating Add Exercise button
-                VStack {
-                    Spacer()
-                    Button {
-                        showExercisePicker = true
-                    } label: {
-                        HStack(spacing: 8) {
-                            Image(systemName: "plus")
-                                .font(.system(size: 16, weight: .bold))
-                            Text("Add Exercise")
-                                .font(.system(size: 15, weight: .bold))
+                // Floating Add Exercise button (hidden in focus mode)
+                if !viewModel.focusMode {
+                    VStack {
+                        Spacer()
+                        Button {
+                            showExercisePicker = true
+                        } label: {
+                            HStack(spacing: 8) {
+                                Image(systemName: "plus")
+                                    .font(.system(size: 16, weight: .bold))
+                                Text("Add Exercise")
+                                    .font(.system(size: 15, weight: .bold))
+                            }
+                            .foregroundColor(.black)
+                            .padding(.horizontal, Theme.paddingLarge)
+                            .padding(.vertical, 14)
+                            .background(Theme.accent)
+                            .cornerRadius(28)
+                            .shadow(color: Theme.accent.opacity(0.4), radius: 8, x: 0, y: 4)
                         }
-                        .foregroundColor(.black)
-                        .padding(.horizontal, Theme.paddingLarge)
-                        .padding(.vertical, 14)
-                        .background(Theme.accent)
-                        .cornerRadius(28)
-                        .shadow(color: Theme.accent.opacity(0.4), radius: 8, x: 0, y: 4)
+                        .padding(.bottom, Theme.paddingLarge)
                     }
-                    .padding(.bottom, Theme.paddingLarge)
                 }
 
                 // PR Celebration Banner
@@ -85,6 +98,26 @@ struct ActiveWorkoutView: View {
                             withAnimation { viewModel.showPRCelebration = false }
                         }
                         .transition(.move(edge: .top).combined(with: .opacity))
+                        Spacer()
+                    }
+                }
+
+                // Next Exercise Toast
+                if viewModel.showNextExercisePrompt {
+                    VStack {
+                        NextExerciseBanner(
+                            completedName: viewModel.completedExerciseName ?? "",
+                            nextName: viewModel.nextExerciseSuggestion
+                        ) {
+                            withAnimation { viewModel.showNextExercisePrompt = false }
+                        }
+                        .transition(.move(edge: .top).combined(with: .opacity))
+                        .onAppear {
+                            Task {
+                                try? await Task.sleep(for: .seconds(3))
+                                withAnimation { viewModel.showNextExercisePrompt = false }
+                            }
+                        }
                         Spacer()
                     }
                 }
@@ -101,11 +134,16 @@ struct ActiveWorkoutView: View {
         }
         .onReceive(timer) { _ in
             viewModel.tickRestTimer()
-            // Haptic when rest timer completes
-            if !viewModel.isRestTimerActive && viewModel.restDuration > 0 && viewModel.restTimeRemaining <= 0 {
-                viewModel.restDuration = 0
+            // Haptic fires once when rest timer crosses zero
+            if viewModel.isRestTimerActive && viewModel.restTimeRemaining <= 0 && !restTimerHapticFired {
+                restTimerHapticFired = true
                 let generator = UINotificationFeedbackGenerator()
                 generator.notificationOccurred(.success)
+            }
+        }
+        .onChange(of: viewModel.isRestTimerActive) { _, isActive in
+            if isActive {
+                restTimerHapticFired = false
             }
         }
         .sheet(isPresented: $showExercisePicker) {
@@ -150,6 +188,19 @@ struct ActiveWorkoutView: View {
             }
 
             Spacer()
+
+            // Focus mode toggle
+            Button {
+                withAnimation { viewModel.focusMode.toggle() }
+            } label: {
+                Image(systemName: viewModel.focusMode ? "list.bullet" : "eye")
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundStyle(viewModel.focusMode ? Theme.accent : Theme.textSecondary)
+                    .frame(width: 36, height: 36)
+                    .background(viewModel.focusMode ? Theme.accent.opacity(0.15) : Theme.textSecondary.opacity(0.15))
+                    .clipShape(Circle())
+            }
+            .accessibilityLabel(viewModel.focusMode ? "Switch to list view" : "Switch to focus view")
 
             // Finish button
             Button {
@@ -281,12 +332,46 @@ private struct ExerciseCard: View {
                     }
                 }
                 Spacer()
+
+                // Reorder buttons
+                if exerciseIndex > 0 {
+                    Button {
+                        withAnimation(.easeInOut(duration: 0.2)) {
+                            viewModel.moveExercise(from: exerciseIndex, direction: -1)
+                        }
+                    } label: {
+                        Image(systemName: "chevron.up")
+                            .font(.system(size: 13, weight: .semibold))
+                            .foregroundStyle(Theme.textSecondary)
+                            .frame(width: 44, height: 44)
+                            .contentShape(Rectangle())
+                    }
+                    .accessibilityLabel("Move \(exercise.exercise.name) up")
+                }
+
+                if exerciseIndex < viewModel.exercises.count - 1 {
+                    Button {
+                        withAnimation(.easeInOut(duration: 0.2)) {
+                            viewModel.moveExercise(from: exerciseIndex, direction: 1)
+                        }
+                    } label: {
+                        Image(systemName: "chevron.down")
+                            .font(.system(size: 13, weight: .semibold))
+                            .foregroundStyle(Theme.textSecondary)
+                            .frame(width: 44, height: 44)
+                            .contentShape(Rectangle())
+                    }
+                    .accessibilityLabel("Move \(exercise.exercise.name) down")
+                }
+
                 Button {
                     viewModel.removeExercise(at: exerciseIndex)
                 } label: {
                     Image(systemName: "xmark")
                         .font(.system(size: 14, weight: .semibold))
                         .foregroundColor(Theme.textSecondary)
+                        .frame(width: 44, height: 44)
+                        .contentShape(Rectangle())
                 }
             }
 
@@ -336,6 +421,9 @@ private struct ExerciseCard: View {
                     },
                     onDelete: {
                         viewModel.removeSet(exerciseIndex: exerciseIndex, setIndex: setIdx)
+                    },
+                    onToggleWeightMode: {
+                        viewModel.toggleWeightMode(exerciseIndex: exerciseIndex, setIndex: setIdx)
                     }
                 )
             }
@@ -361,5 +449,54 @@ private struct ExerciseCard: View {
         .background(Theme.cardBackground)
         .cornerRadius(Theme.cornerRadius)
         }
+    }
+}
+
+// MARK: - Next Exercise Banner
+
+private struct NextExerciseBanner: View {
+    let completedName: String
+    let nextName: String?
+    let onDismiss: () -> Void
+
+    var body: some View {
+        HStack(spacing: Theme.paddingSmall) {
+            Image(systemName: "checkmark.circle.fill")
+                .font(.system(size: 20))
+                .foregroundStyle(Theme.accent)
+
+            VStack(alignment: .leading, spacing: 2) {
+                if let nextName {
+                    Text("\(completedName) complete")
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundStyle(Theme.textPrimary)
+                    Text("Up next: \(nextName)")
+                        .font(.system(size: 13, weight: .bold))
+                        .foregroundStyle(Theme.accent)
+                } else {
+                    Text("\(completedName) complete")
+                        .font(.system(size: 14, weight: .bold))
+                        .foregroundStyle(Theme.textPrimary)
+                }
+            }
+
+            Spacer()
+
+            Button(action: onDismiss) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 12, weight: .bold))
+                    .foregroundStyle(Theme.textSecondary)
+                    .frame(width: 44, height: 44)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(.horizontal, Theme.paddingMedium)
+        .padding(.vertical, Theme.paddingSmall)
+        .background(Theme.cardBackground)
+        .cornerRadius(Theme.cornerRadius)
+        .padding(.horizontal, Theme.paddingMedium)
+        .padding(.top, Theme.paddingSmall)
+        .shadow(color: .black.opacity(0.3), radius: 8, x: 0, y: 4)
     }
 }

--- a/Xomfit/Views/Workout/RestTimerView.swift
+++ b/Xomfit/Views/Workout/RestTimerView.swift
@@ -8,13 +8,28 @@ struct RestTimerView: View {
     let onSkip: () -> Void
     let onExtend: () -> Void
 
+    private var isOvertime: Bool {
+        restTimeRemaining <= 0
+    }
+
     private var progress: Double {
         guard restDuration > 0 else { return 0 }
+        if isOvertime { return 1.0 }
         return 1 - (restTimeRemaining / restDuration)
     }
 
+    private var ringColor: Color {
+        isOvertime ? Theme.destructive : Theme.accent
+    }
+
     private var timeString: String {
-        let total = max(0, Int(restTimeRemaining))
+        if isOvertime {
+            let total = Int(abs(restTimeRemaining))
+            let mins = total / 60
+            let secs = total % 60
+            return String(format: "-%d:%02d", mins, secs)
+        }
+        let total = Int(restTimeRemaining)
         let mins = total / 60
         let secs = total % 60
         return String(format: "%d:%02d", mins, secs)
@@ -33,7 +48,7 @@ struct RestTimerView: View {
                 Circle()
                     .trim(from: 0, to: progress)
                     .stroke(
-                        Theme.accent,
+                        ringColor,
                         style: StrokeStyle(lineWidth: 5, lineCap: .round)
                     )
                     .rotationEffect(.degrees(-90))
@@ -42,11 +57,11 @@ struct RestTimerView: View {
                 Text(timeString)
                     .font(.system(size: 16, weight: .bold, design: .monospaced))
                     .monospacedDigit()
-                    .foregroundStyle(Theme.accent)
+                    .foregroundStyle(isOvertime ? Theme.destructive : Theme.accent)
             }
             .frame(width: 64, height: 64)
             .accessibilityElement(children: .ignore)
-            .accessibilityLabel("Rest timer, \(timeString) remaining")
+            .accessibilityLabel(isOvertime ? "Rest timer, \(timeString) overtime" : "Rest timer, \(timeString) remaining")
 
             // Label + controls
             VStack(alignment: .leading, spacing: 8) {

--- a/Xomfit/Views/Workout/SetRowView.swift
+++ b/Xomfit/Views/Workout/SetRowView.swift
@@ -7,9 +7,12 @@ struct SetRowView: View {
     let onRepsChange: (Int) -> Void
     let onComplete: () -> Void
     let onDelete: () -> Void
+    let onToggleWeightMode: () -> Void
 
     @State private var weightText: String
     @State private var repsText: String
+    @FocusState private var isWeightFocused: Bool
+    @FocusState private var isRepsFocused: Bool
 
     private var isCompleted: Bool {
         workoutSet.completedAt != Date.distantPast
@@ -21,7 +24,8 @@ struct SetRowView: View {
         onWeightChange: @escaping (Double) -> Void,
         onRepsChange: @escaping (Int) -> Void,
         onComplete: @escaping () -> Void,
-        onDelete: @escaping () -> Void
+        onDelete: @escaping () -> Void,
+        onToggleWeightMode: @escaping () -> Void = {}
     ) {
         self.setNumber = setNumber
         self.workoutSet = workoutSet
@@ -29,6 +33,7 @@ struct SetRowView: View {
         self.onRepsChange = onRepsChange
         self.onComplete = onComplete
         self.onDelete = onDelete
+        self.onToggleWeightMode = onToggleWeightMode
 
         let w = workoutSet.weight
         let r = workoutSet.reps
@@ -54,15 +59,20 @@ struct SetRowView: View {
                 .cornerRadius(Theme.cornerRadiusSmall)
                 .foregroundColor(isCompleted ? Theme.accent : Theme.textPrimary)
                 .frame(maxWidth: .infinity)
+                .focused($isWeightFocused)
                 .onChange(of: weightText) { _, newValue in
                     if let w = Double(newValue) {
                         onWeightChange(w)
                     }
                 }
 
-            Text("lbs  ×")
-                .font(Theme.fontCaption)
-                .foregroundColor(Theme.textSecondary)
+            Button(action: onToggleWeightMode) {
+                Text(workoutSet.weightMode == .perSide ? "lbs ×2  ×" : "lbs  ×")
+                    .font(Theme.fontCaption)
+                    .foregroundStyle(workoutSet.weightMode == .perSide ? Theme.accent : Theme.textSecondary)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(workoutSet.weightMode == .perSide ? "Per side weight, tap to switch to total" : "Total weight, tap to switch to per side")
 
             // Reps field
             TextField("0", text: $repsText)
@@ -74,6 +84,7 @@ struct SetRowView: View {
                 .cornerRadius(Theme.cornerRadiusSmall)
                 .foregroundColor(isCompleted ? Theme.accent : Theme.textPrimary)
                 .frame(maxWidth: .infinity)
+                .focused($isRepsFocused)
                 .onChange(of: repsText) { _, newValue in
                     if let r = Int(newValue) {
                         onRepsChange(r)
@@ -83,15 +94,27 @@ struct SetRowView: View {
             // Complete checkmark button
             Button(action: onComplete) {
                 Image(systemName: isCompleted ? "checkmark.circle.fill" : "checkmark.circle")
-                    .font(.system(size: 24))
-                    .foregroundColor(isCompleted ? Theme.accent : Theme.textSecondary)
+                    .font(.system(size: 26))
+                    .foregroundStyle(isCompleted ? Theme.accent : Theme.textSecondary.opacity(0.6))
+                    .frame(width: 44, height: 44)
+                    .contentShape(Rectangle())
             }
-            .frame(width: 36)
+            .buttonStyle(.plain)
+            .accessibilityLabel(isCompleted ? "Mark set \(setNumber) incomplete" : "Complete set \(setNumber)")
         }
         .padding(.horizontal, Theme.paddingMedium)
         .padding(.vertical, 6)
-        .background(isCompleted ? Theme.accent.opacity(0.08) : Color.clear)
+        .background(isCompleted ? Theme.accent.opacity(0.12) : Color.clear)
         .cornerRadius(Theme.cornerRadiusSmall)
+        .toolbar {
+            ToolbarItemGroup(placement: .keyboard) {
+                Spacer()
+                Button("Done") {
+                    isWeightFocused = false
+                    isRepsFocused = false
+                }
+            }
+        }
         .swipeActions(edge: .trailing, allowsFullSwipe: true) {
             Button(role: .destructive, action: onDelete) {
                 Label("Delete", systemImage: "trash")

--- a/Xomfit/Views/Workout/TemplateDetailView.swift
+++ b/Xomfit/Views/Workout/TemplateDetailView.swift
@@ -1,0 +1,177 @@
+import SwiftUI
+
+struct TemplateDetailView: View {
+    let template: WorkoutTemplate
+    let onStart: () -> Void
+
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Theme.background.ignoresSafeArea()
+
+                VStack(spacing: 0) {
+                    ScrollView {
+                        VStack(alignment: .leading, spacing: Theme.paddingMedium) {
+                            headerSection
+                            exerciseList
+                        }
+                        .padding(Theme.paddingMedium)
+                        // Bottom padding for the start button
+                        .padding(.bottom, 80)
+                    }
+
+                    startButton
+                }
+            }
+            .navigationTitle(template.name)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbarColorScheme(.dark, for: .navigationBar)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Close") { dismiss() }
+                        .foregroundStyle(Theme.textSecondary)
+                }
+            }
+        }
+    }
+
+    // MARK: - Header
+
+    private var headerSection: some View {
+        VStack(alignment: .leading, spacing: Theme.paddingSmall) {
+            HStack(spacing: 10) {
+                Image(systemName: template.category.icon)
+                    .font(.system(size: 22))
+                    .foregroundStyle(Theme.accent)
+                    .frame(width: 40, height: 40)
+                    .background(Theme.accent.opacity(0.15))
+                    .clipShape(.rect(cornerRadius: 8))
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(template.category.displayName)
+                        .font(Theme.fontCaption)
+                        .foregroundStyle(Theme.accent)
+                    Text(template.description)
+                        .font(Theme.fontBody)
+                        .foregroundStyle(Theme.textSecondary)
+                }
+            }
+
+            HStack(spacing: Theme.paddingLarge) {
+                statPill(icon: "dumbbell.fill", label: "Exercises", value: "\(template.exercises.count)")
+                statPill(icon: "clock.fill", label: "Duration", value: "~\(template.estimatedDuration)m")
+                statPill(icon: "arrow.up.arrow.down", label: "Total Sets", value: "\(totalSets)")
+            }
+            .padding(.top, Theme.paddingSmall)
+        }
+        .padding(Theme.paddingMedium)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Theme.cardBackground)
+        .clipShape(.rect(cornerRadius: Theme.cornerRadius))
+    }
+
+    private var totalSets: Int {
+        template.exercises.reduce(0) { $0 + $1.targetSets }
+    }
+
+    private func statPill(icon: String, label: String, value: String) -> some View {
+        VStack(spacing: 4) {
+            Image(systemName: icon)
+                .font(.system(size: 14))
+                .foregroundStyle(Theme.accent)
+            Text(value)
+                .font(.system(size: 15, weight: .bold))
+                .foregroundStyle(Theme.textPrimary)
+            Text(label)
+                .font(Theme.fontSmall)
+                .foregroundStyle(Theme.textSecondary)
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    // MARK: - Exercise List
+
+    private var exerciseList: some View {
+        VStack(alignment: .leading, spacing: Theme.paddingSmall) {
+            Text("Exercises")
+                .font(.system(size: 16, weight: .bold))
+                .foregroundStyle(Theme.textPrimary)
+
+            ForEach(Array(template.exercises.enumerated()), id: \.element.id) { index, exercise in
+                exerciseRow(index: index + 1, exercise: exercise)
+            }
+        }
+    }
+
+    private func exerciseRow(index: Int, exercise: WorkoutTemplate.TemplateExercise) -> some View {
+        HStack(spacing: 12) {
+            Text("\(index)")
+                .font(.system(size: 13, weight: .bold, design: .monospaced))
+                .foregroundStyle(Theme.accent)
+                .frame(width: 24, height: 24)
+                .background(Theme.accent.opacity(0.15))
+                .clipShape(.rect(cornerRadius: 6))
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text(exercise.exercise.name)
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundStyle(Theme.textPrimary)
+
+                HStack(spacing: 6) {
+                    ForEach(exercise.exercise.muscleGroups.prefix(2), id: \.self) { mg in
+                        Text(mg.displayName)
+                            .font(Theme.fontSmall)
+                            .foregroundStyle(Theme.textSecondary)
+                    }
+                }
+
+                if let notes = exercise.notes, !notes.isEmpty {
+                    Text(notes)
+                        .font(Theme.fontCaption)
+                        .foregroundStyle(Theme.textSecondary.opacity(0.8))
+                        .italic()
+                }
+            }
+
+            Spacer()
+
+            Text("\(exercise.targetSets) x \(exercise.targetReps)")
+                .font(.system(size: 14, weight: .bold, design: .monospaced))
+                .foregroundStyle(Theme.accent)
+        }
+        .padding(Theme.paddingMedium)
+        .background(Theme.cardBackground)
+        .clipShape(.rect(cornerRadius: Theme.cornerRadius))
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(exercise.exercise.name), \(exercise.targetSets) sets of \(exercise.targetReps) reps")
+    }
+
+    // MARK: - Start Button
+
+    private var startButton: some View {
+        Button {
+            dismiss()
+            // Small delay so the sheet dismisses before the full-screen cover appears
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                onStart()
+            }
+        } label: {
+            HStack(spacing: 10) {
+                Image(systemName: "play.fill")
+                Text("Start Workout")
+                    .font(.system(size: 17, weight: .bold))
+            }
+            .foregroundStyle(.black)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 16)
+            .background(Theme.accent)
+            .clipShape(.rect(cornerRadius: Theme.cornerRadius))
+        }
+        .padding(.horizontal, Theme.paddingMedium)
+        .padding(.bottom, Theme.paddingMedium)
+        .background(Theme.background)
+        .accessibilityLabel("Start \(template.name) workout")
+    }
+}

--- a/Xomfit/Views/Workout/WorkoutFocusView.swift
+++ b/Xomfit/Views/Workout/WorkoutFocusView.swift
@@ -1,0 +1,295 @@
+import SwiftUI
+
+/// Full-screen "gym mode" view showing one exercise and set at a time with large, tappable controls.
+struct WorkoutFocusView: View {
+    let viewModel: WorkoutLoggerViewModel
+    @State private var isEditingWeight = false
+    @State private var isEditingReps = false
+    @State private var weightText = ""
+    @State private var repsText = ""
+    @FocusState private var weightFieldFocused: Bool
+    @FocusState private var repsFieldFocused: Bool
+
+    private var exercise: WorkoutExercise? { viewModel.focusExercise }
+    private var currentSet: WorkoutSet? { viewModel.focusSet }
+
+    var body: some View {
+        ZStack {
+            Theme.background.ignoresSafeArea()
+
+            if let exercise, let currentSet {
+                VStack(spacing: Theme.paddingLarge) {
+                    Spacer().frame(height: Theme.paddingSmall)
+
+                    exerciseHeader(exercise: exercise)
+
+                    setIndicator(exercise: exercise)
+
+                    weightDisplay(currentSet: currentSet)
+
+                    repsDisplay(currentSet: currentSet)
+
+                    doneButton(currentSet: currentSet)
+
+                    exerciseNavigation
+
+                    Spacer()
+                }
+                .padding(.horizontal, Theme.paddingLarge)
+
+                // Rest timer overlay
+                if viewModel.isRestTimerActive {
+                    restTimerOverlay
+                }
+            } else {
+                emptyFocusState
+            }
+        }
+    }
+
+    // MARK: - Exercise Header
+
+    private func exerciseHeader(exercise: WorkoutExercise) -> some View {
+        VStack(spacing: 4) {
+            Text(exercise.exercise.name)
+                .font(.system(size: 24, weight: .bold))
+                .foregroundStyle(Theme.textPrimary)
+                .multilineTextAlignment(.center)
+                .accessibilityAddTraits(.isHeader)
+
+            HStack(spacing: 4) {
+                ForEach(exercise.exercise.muscleGroups.prefix(2), id: \.self) { mg in
+                    Text(mg.displayName)
+                        .font(Theme.fontSmall)
+                        .foregroundStyle(Theme.accent)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(Theme.accent.opacity(0.15))
+                        .clipShape(.rect(cornerRadius: 4))
+                }
+            }
+        }
+    }
+
+    // MARK: - Set Indicator
+
+    private func setIndicator(exercise: WorkoutExercise) -> some View {
+        Text("Set \(viewModel.focusSetIndex + 1) of \(exercise.sets.count)")
+            .font(.system(size: 15, weight: .semibold))
+            .foregroundStyle(Theme.textSecondary)
+    }
+
+    // MARK: - Weight Display
+
+    private func weightDisplay(currentSet: WorkoutSet) -> some View {
+        VStack(spacing: 4) {
+            Text("WEIGHT")
+                .font(Theme.fontSmall)
+                .foregroundStyle(Theme.textSecondary)
+
+            if isEditingWeight {
+                TextField("0", text: $weightText)
+                    .font(.system(size: 48, weight: .bold, design: .monospaced))
+                    .foregroundStyle(Theme.textPrimary)
+                    .multilineTextAlignment(.center)
+                    .keyboardType(.decimalPad)
+                    .focused($weightFieldFocused)
+                    .onSubmit { commitWeight() }
+                    .onChange(of: weightFieldFocused) { _, focused in
+                        if !focused { commitWeight() }
+                    }
+                    .frame(maxWidth: 200)
+            } else {
+                Button {
+                    weightText = currentSet.weight > 0 ? currentSet.weight.formattedWeight : ""
+                    isEditingWeight = true
+                    weightFieldFocused = true
+                } label: {
+                    Text(currentSet.weight.formattedWeight)
+                        .font(.system(size: 48, weight: .bold, design: .monospaced))
+                        .foregroundStyle(Theme.textPrimary)
+                }
+                .accessibilityLabel("Weight: \(currentSet.weight.formattedWeight) pounds. Tap to edit.")
+            }
+
+            // Per-side indicator
+            if currentSet.weightMode == .perSide {
+                Text("lbs x2 (per side)")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(Theme.accent)
+            } else {
+                Text("lbs")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(Theme.textSecondary)
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, Theme.paddingMedium)
+        .background(Theme.cardBackground)
+        .clipShape(.rect(cornerRadius: Theme.cornerRadius))
+    }
+
+    // MARK: - Reps Display
+
+    private func repsDisplay(currentSet: WorkoutSet) -> some View {
+        VStack(spacing: 4) {
+            Text("REPS")
+                .font(Theme.fontSmall)
+                .foregroundStyle(Theme.textSecondary)
+
+            if isEditingReps {
+                TextField("0", text: $repsText)
+                    .font(.system(size: 48, weight: .bold, design: .monospaced))
+                    .foregroundStyle(Theme.textPrimary)
+                    .multilineTextAlignment(.center)
+                    .keyboardType(.numberPad)
+                    .focused($repsFieldFocused)
+                    .onSubmit { commitReps() }
+                    .onChange(of: repsFieldFocused) { _, focused in
+                        if !focused { commitReps() }
+                    }
+                    .frame(maxWidth: 200)
+            } else {
+                Button {
+                    repsText = currentSet.reps > 0 ? "\(currentSet.reps)" : ""
+                    isEditingReps = true
+                    repsFieldFocused = true
+                } label: {
+                    Text("\(currentSet.reps)")
+                        .font(.system(size: 48, weight: .bold, design: .monospaced))
+                        .foregroundStyle(Theme.textPrimary)
+                }
+                .accessibilityLabel("Reps: \(currentSet.reps). Tap to edit.")
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, Theme.paddingMedium)
+        .background(Theme.cardBackground)
+        .clipShape(.rect(cornerRadius: Theme.cornerRadius))
+    }
+
+    // MARK: - Done Button
+
+    private func doneButton(currentSet: WorkoutSet) -> some View {
+        let isCompleted = currentSet.completedAt != Date.distantPast
+        return Button {
+            dismissKeyboard()
+            if !isCompleted {
+                viewModel.completeFocusedSet()
+            }
+        } label: {
+            Text(isCompleted ? "COMPLETED" : "DONE")
+                .font(.system(size: 20, weight: .black))
+                .foregroundStyle(isCompleted ? Theme.textSecondary : .black)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 18)
+                .background(isCompleted ? Theme.cardBackground : Theme.accent)
+                .clipShape(.rect(cornerRadius: Theme.cornerRadius))
+        }
+        .disabled(isCompleted)
+        .accessibilityLabel(isCompleted ? "Set completed" : "Complete set")
+    }
+
+    // MARK: - Exercise Navigation
+
+    private var exerciseNavigation: some View {
+        HStack(spacing: Theme.paddingLarge) {
+            Button {
+                dismissKeyboard()
+                viewModel.focusPreviousExercise()
+            } label: {
+                Image(systemName: "chevron.left")
+                    .font(.system(size: 22, weight: .bold))
+                    .foregroundStyle(viewModel.focusExerciseIndex > 0 ? Theme.textPrimary : Theme.textSecondary.opacity(0.3))
+                    .frame(width: 56, height: 56)
+                    .background(Theme.cardBackground)
+                    .clipShape(Circle())
+            }
+            .disabled(viewModel.focusExerciseIndex <= 0)
+            .accessibilityLabel("Previous exercise")
+
+            Text("\(viewModel.focusExerciseIndex + 1) / \(viewModel.exercises.count)")
+                .font(.system(size: 15, weight: .semibold, design: .monospaced))
+                .foregroundStyle(Theme.textSecondary)
+
+            Button {
+                dismissKeyboard()
+                viewModel.focusNextExercise()
+            } label: {
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 22, weight: .bold))
+                    .foregroundStyle(viewModel.focusExerciseIndex < viewModel.exercises.count - 1 ? Theme.textPrimary : Theme.textSecondary.opacity(0.3))
+                    .frame(width: 56, height: 56)
+                    .background(Theme.cardBackground)
+                    .clipShape(Circle())
+            }
+            .disabled(viewModel.focusExerciseIndex >= viewModel.exercises.count - 1)
+            .accessibilityLabel("Next exercise")
+        }
+    }
+
+    // MARK: - Rest Timer Overlay
+
+    private var restTimerOverlay: some View {
+        VStack {
+            Spacer()
+            RestTimerView(
+                restTimeRemaining: viewModel.restTimeRemaining,
+                restDuration: viewModel.restDuration,
+                onSkip: { viewModel.skipRestTimer() },
+                onExtend: { viewModel.extendRestTimer() }
+            )
+            .padding(.horizontal, Theme.paddingMedium)
+            .padding(.bottom, Theme.paddingLarge)
+            .shadow(color: .black.opacity(0.5), radius: 12, x: 0, y: -4)
+        }
+        .transition(.move(edge: .bottom).combined(with: .opacity))
+    }
+
+    // MARK: - Empty State
+
+    private var emptyFocusState: some View {
+        VStack(spacing: Theme.paddingMedium) {
+            Image(systemName: "dumbbell")
+                .font(.system(size: 48))
+                .foregroundStyle(Theme.textSecondary)
+            Text("No exercises yet")
+                .font(Theme.fontHeadline)
+                .foregroundStyle(Theme.textPrimary)
+            Text("Add an exercise to use Focus Mode")
+                .font(Theme.fontBody)
+                .foregroundStyle(Theme.textSecondary)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func commitWeight() {
+        isEditingWeight = false
+        guard let value = Double(weightText) else { return }
+        viewModel.updateSet(
+            exerciseIndex: viewModel.focusExerciseIndex,
+            setIndex: viewModel.focusSetIndex,
+            weight: value,
+            reps: viewModel.focusSet?.reps ?? 0
+        )
+    }
+
+    private func commitReps() {
+        isEditingReps = false
+        guard let value = Int(repsText) else { return }
+        viewModel.updateSet(
+            exerciseIndex: viewModel.focusExerciseIndex,
+            setIndex: viewModel.focusSetIndex,
+            weight: viewModel.focusSet?.weight ?? 0,
+            reps: value
+        )
+    }
+
+    private func dismissKeyboard() {
+        if isEditingWeight { commitWeight() }
+        if isEditingReps { commitReps() }
+        weightFieldFocused = false
+        repsFieldFocused = false
+    }
+}

--- a/Xomfit/Views/Workout/WorkoutView.swift
+++ b/Xomfit/Views/Workout/WorkoutView.swift
@@ -10,6 +10,8 @@ struct WorkoutView: View {
     @State private var selectedTemplate: WorkoutTemplate?
     @State private var showTemplateList = false
     @State private var showBuilder = false
+    @State private var previewTemplate: WorkoutTemplate?
+    @State private var templateRefreshId = UUID()
 
     private var userId: String {
         authService.currentUser?.id.uuidString ?? ""
@@ -65,6 +67,11 @@ struct WorkoutView: View {
 
                     // Quick Start templates
                     templateSection
+
+                    // Recent workouts
+                    if !workouts.isEmpty {
+                        recentSection
+                    }
 
                     // Workout history
                     if workouts.isEmpty {
@@ -133,12 +140,23 @@ struct WorkoutView: View {
             )
             .environment(authService)
         }
-        .sheet(isPresented: $showBuilder) {
+        .sheet(isPresented: $showBuilder, onDismiss: {
+            templateRefreshId = UUID()
+        }) {
             WorkoutBuilderView()
+        }
+        .sheet(item: $previewTemplate) { template in
+            TemplateDetailView(template: template) {
+                selectedTemplate = template
+            }
         }
         .sheet(isPresented: $showTemplateList) {
             TemplateListView { template in
-                selectedTemplate = template
+                // Dismiss the list first, then show preview after a brief delay
+                showTemplateList = false
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                    previewTemplate = template
+                }
             }
         }
     }
@@ -166,7 +184,51 @@ struct WorkoutView: View {
                 HStack(spacing: Theme.paddingSmall) {
                     ForEach(TemplateService.shared.allTemplates().prefix(6)) { template in
                         TemplateCardView(template: template) {
-                            selectedTemplate = template
+                            previewTemplate = template
+                        }
+                    }
+                }
+                .padding(.horizontal, Theme.paddingMedium)
+                .id(templateRefreshId)
+            }
+        }
+        .padding(.vertical, Theme.paddingSmall)
+    }
+
+    // MARK: - Recent Workouts
+
+    private var recentSection: some View {
+        VStack(alignment: .leading, spacing: Theme.paddingSmall) {
+            Text("Recent")
+                .font(.system(size: 16, weight: .bold))
+                .foregroundStyle(Theme.textPrimary)
+                .padding(.horizontal, Theme.paddingMedium)
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: Theme.paddingSmall) {
+                    ForEach(workouts.prefix(5)) { workout in
+                        RecentWorkoutCard(workout: workout) {
+                            pendingWorkoutName = workout.name
+                            // Build a template from the workout's exercises
+                            let templateExercises = workout.exercises.map { ex in
+                                WorkoutTemplate.TemplateExercise(
+                                    id: UUID().uuidString,
+                                    exercise: ex.exercise,
+                                    targetSets: ex.sets.count,
+                                    targetReps: ex.bestSet.map { "\($0.reps)" } ?? "0",
+                                    notes: ex.notes
+                                )
+                            }
+                            let replayTemplate = WorkoutTemplate(
+                                id: UUID().uuidString,
+                                name: workout.name,
+                                description: "Repeat of \(workout.name)",
+                                exercises: templateExercises,
+                                estimatedDuration: Int(workout.duration / 60),
+                                category: .custom,
+                                isCustom: false
+                            )
+                            selectedTemplate = replayTemplate
                         }
                     }
                 }
@@ -244,5 +306,51 @@ private struct WorkoutHistoryCard: View {
                 .font(Theme.fontSmall)
                 .foregroundColor(Theme.textSecondary)
         }
+    }
+}
+
+// MARK: - Recent Workout Card
+
+private struct RecentWorkoutCard: View {
+    let workout: Workout
+    let onRepeat: () -> Void
+
+    var body: some View {
+        Button(action: onRepeat) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text(workout.name)
+                    .font(.system(size: 13, weight: .bold))
+                    .foregroundStyle(Theme.textPrimary)
+                    .lineLimit(1)
+
+                Text(workout.startTime.workoutDateString)
+                    .font(Theme.fontSmall)
+                    .foregroundStyle(Theme.textSecondary)
+
+                HStack(spacing: 6) {
+                    Text("\(workout.exercises.count) ex")
+                    Text(workout.durationString)
+                        .foregroundStyle(Theme.accent)
+                }
+                .font(Theme.fontSmall)
+                .foregroundStyle(Theme.textSecondary)
+
+                HStack(spacing: 4) {
+                    Image(systemName: "arrow.counterclockwise")
+                        .font(.system(size: 10, weight: .bold))
+                    Text("Repeat")
+                        .font(.system(size: 11, weight: .bold))
+                }
+                .foregroundStyle(Theme.accent)
+                .padding(.top, 2)
+            }
+            .padding(12)
+            .frame(width: 140, alignment: .leading)
+            .background(Theme.cardBackground)
+            .clipShape(.rect(cornerRadius: Theme.cornerRadius))
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Repeat \(workout.name) workout from \(workout.startTime.workoutDateString)")
+        .accessibilityAddTraits(.isButton)
     }
 }


### PR DESCRIPTION
## Summary
19 issues addressed in one batch across the entire app.

### Workout
- Template preview before starting (#138)
- Recent workouts as quick-start (#138)
- Exercise reorder with up/down buttons (#143)
- Per-arm/leg weight mode — lbs vs lbs x2 (#144)
- Focus mode — large gym-floor view (#145)
- Keyboard dismiss button (#146)
- Larger checkmark touch targets (#147)
- Rest timer overtime (red, counts negative) (#148)
- Default 3 sets per exercise (#149)
- "Up next" exercise prompt (#150)
- Fix set counting on finish (#156)

### Profile
- Edit profile button in toolbar (#139)
- Username editing in edit sheet (#153)
- Body muscle heatmap with intensity colors (#154)

### Social
- Custom loader on all loading states (#140)
- Self excluded from friend search (#141)
- Feed shows real user names from profiles join (#142)
- Delete workout cascades to feed (#155)
- User search from Feed tab (#157)

### Deferred
- #151 (Live Activity widget) — requires Widget Extension target
- #152 (Exercise icons) — needs design pass

Closes #138 #139 #140 #141 #142 #143 #144 #145 #146 #147 #148 #149 #150 #153 #154 #155 #156 #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)