### PR TITLE
Fix missing icons — safe SF Symbols for exercises and templates

### DIFF
--- a/Xomfit/Models/Exercise.swift
+++ b/Xomfit/Models/Exercise.swift
@@ -21,12 +21,12 @@ enum MuscleGroup: String, Codable, CaseIterable {
     
     var icon: String {
         switch self {
-        case .chest: return "figure.strengthtraining.traditional"
-        case .back, .lats: return "figure.rowing"
-        case .shoulders, .traps: return "figure.boxing"
-        case .biceps, .triceps, .forearms: return "figure.curling"
-        case .quads, .hamstrings, .glutes, .calves: return "figure.lunges"
-        case .abs: return "figure.core.training"
+        case .chest: return "dumbbell.fill"
+        case .back, .lats: return "figure.strengthtraining.traditional"
+        case .shoulders, .traps: return "bolt.fill"
+        case .biceps, .triceps, .forearms: return "dumbbell.fill"
+        case .quads, .hamstrings, .glutes, .calves: return "figure.walk"
+        case .abs: return "flame.fill"
         }
     }
 }
@@ -37,6 +37,19 @@ enum Equipment: String, Codable, CaseIterable {
     
     var displayName: String {
         rawValue.capitalized
+    }
+
+    var icon: String {
+        switch self {
+        case .barbell: return "figure.strengthtraining.traditional"
+        case .dumbbell: return "dumbbell.fill"
+        case .machine: return "gearshape.fill"
+        case .cable: return "arrow.up.and.down"
+        case .bodyweight: return "figure.walk"
+        case .kettlebell: return "dumbbell.fill"
+        case .bands: return "circle.dashed"
+        case .other: return "star.fill"
+        }
     }
 }
 

--- a/Xomfit/Models/WorkoutTemplate.swift
+++ b/Xomfit/Models/WorkoutTemplate.swift
@@ -40,16 +40,16 @@ struct WorkoutTemplate: Codable, Identifiable {
 
         var icon: String {
             switch self {
-            case .push: return "figure.strengthtraining.traditional"
-            case .pull: return "figure.rowing"
-            case .legs: return "figure.lunges"
-            case .upperBody: return "figure.boxing"
+            case .push: return "dumbbell.fill"
+            case .pull: return "figure.strengthtraining.traditional"
+            case .legs: return "figure.walk"
+            case .upperBody: return "dumbbell.fill"
             case .lowerBody: return "figure.run"
-            case .fullBody: return "figure.mixed.cardio"
-            case .chest: return "figure.strengthtraining.traditional"
-            case .back: return "figure.rowing"
-            case .shoulders: return "figure.boxing"
-            case .arms: return "figure.curling"
+            case .fullBody: return "figure.strengthtraining.traditional"
+            case .chest: return "dumbbell.fill"
+            case .back: return "figure.strengthtraining.traditional"
+            case .shoulders: return "bolt.fill"
+            case .arms: return "dumbbell.fill"
             case .custom: return "star.fill"
             }
         }

--- a/Xomfit/Views/Workout/ExercisePickerView.swift
+++ b/Xomfit/Views/Workout/ExercisePickerView.swift
@@ -136,7 +136,7 @@ private struct ExerciseRow: View {
     var body: some View {
         Button(action: onTap) {
             HStack(spacing: Theme.paddingMedium) {
-                Image(systemName: exercise.muscleGroups.first?.icon ?? "dumbbell.fill")
+                Image(systemName: exercise.equipment.icon)
                     .font(.system(size: 20))
                     .foregroundColor(Theme.accent)
                     .frame(width: 36, height: 36)


### PR DESCRIPTION
## Summary
Replaced SF Symbols that don't render on iOS 26 (figure.curling, figure.lunges, figure.core.training, etc.) with universally available alternatives. Added Equipment.icon for equipment-specific icons in the exercise picker.

Closes #152