### PR TITLE
Exercise transition flow — do another set, move to next, or choose different

### DIFF
--- a/Xomfit/ViewModels/WorkoutLoggerViewModel.swift
+++ b/Xomfit/ViewModels/WorkoutLoggerViewModel.swift
@@ -1,5 +1,11 @@
 import SwiftUI
 
+struct RemainingExercise: Identifiable {
+    let index: Int
+    let name: String
+    var id: Int { index }
+}
+
 @MainActor
 @Observable
 final class WorkoutLoggerViewModel {
@@ -19,10 +25,23 @@ final class WorkoutLoggerViewModel {
     var newPR: PersonalRecord? = nil
     var showPRCelebration: Bool = false
 
-    // Next exercise prompt — shown when all sets of an exercise are complete
-    var nextExerciseSuggestion: String? = nil
-    var completedExerciseName: String? = nil
-    var showNextExercisePrompt: Bool = false
+    // Exercise transition — shown when all sets of an exercise are complete
+    var showExerciseTransition: Bool = false
+    var completedExerciseIndex: Int = 0
+    var nextExerciseIndex: Int? = nil
+    var remainingExercises: [RemainingExercise] = []
+
+    /// Name of the exercise that was just completed (for the transition card header).
+    var completedExerciseName: String {
+        guard exercises.indices.contains(completedExerciseIndex) else { return "" }
+        return exercises[completedExerciseIndex].exercise.name
+    }
+
+    /// The next exercise to suggest, if one exists.
+    var nextExercise: WorkoutExercise? {
+        guard let idx = nextExerciseIndex, exercises.indices.contains(idx) else { return nil }
+        return exercises[idx]
+    }
 
     // Focus mode — large gym-floor view
     var focusMode: Bool = false
@@ -69,9 +88,10 @@ final class WorkoutLoggerViewModel {
         activeUserId = userId
         newPR = nil
         showPRCelebration = false
-        nextExerciseSuggestion = nil
-        completedExerciseName = nil
-        showNextExercisePrompt = false
+        showExerciseTransition = false
+        completedExerciseIndex = 0
+        nextExerciseIndex = nil
+        remainingExercises = []
         focusMode = false
         focusExerciseIndex = 0
         focusSetIndex = 0
@@ -86,9 +106,10 @@ final class WorkoutLoggerViewModel {
         errorMessage = nil
         newPR = nil
         showPRCelebration = false
-        nextExerciseSuggestion = nil
-        completedExerciseName = nil
-        showNextExercisePrompt = false
+        showExerciseTransition = false
+        completedExerciseIndex = 0
+        nextExerciseIndex = nil
+        remainingExercises = []
         focusMode = false
         focusExerciseIndex = 0
         focusSetIndex = 0
@@ -255,16 +276,25 @@ final class WorkoutLoggerViewModel {
             // Check if all sets in this exercise are now complete
             let allDone = exercises[exerciseIndex].sets.allSatisfy { $0.completedAt != Date.distantPast }
             if allDone {
-                completedExerciseName = exercises[exerciseIndex].exercise.name
-                let nextIndex = exercises.indices.first { idx in
+                completedExerciseIndex = exerciseIndex
+
+                // Find the next incomplete exercise (prefer one after current, then wrap around)
+                let afterCurrent = exercises.indices.first { idx in
                     idx > exerciseIndex && exercises[idx].sets.contains { $0.completedAt == Date.distantPast }
                 }
-                if let nextIdx = nextIndex {
-                    nextExerciseSuggestion = exercises[nextIdx].exercise.name
-                } else {
-                    nextExerciseSuggestion = nil
+                let beforeCurrent = exercises.indices.first { idx in
+                    idx < exerciseIndex && exercises[idx].sets.contains { $0.completedAt == Date.distantPast }
                 }
-                showNextExercisePrompt = true
+                nextExerciseIndex = afterCurrent ?? beforeCurrent
+
+                // Build remaining exercises list (all incomplete, excluding current)
+                remainingExercises = exercises.enumerated().compactMap { idx, ex in
+                    guard idx != exerciseIndex,
+                          ex.sets.contains(where: { $0.completedAt == Date.distantPast }) else { return nil }
+                    return RemainingExercise(index: idx, name: ex.exercise.name)
+                }
+
+                showExerciseTransition = true
             }
         }
     }
@@ -330,6 +360,25 @@ final class WorkoutLoggerViewModel {
     func completeFocusedSet() {
         completeSet(exerciseIndex: focusExerciseIndex, setIndex: focusSetIndex)
         focusAdvance()
+    }
+
+    // MARK: - Exercise Transition Actions
+
+    func addAnotherSet() {
+        addSet(to: completedExerciseIndex)
+        showExerciseTransition = false
+    }
+
+    func moveToExercise(index: Int) {
+        if focusMode {
+            focusExerciseIndex = index
+            focusSetIndex = 0
+        }
+        showExerciseTransition = false
+    }
+
+    func dismissTransition() {
+        showExerciseTransition = false
     }
 
     // MARK: - Rest Timer

--- a/Xomfit/Views/Workout/ActiveWorkoutView.swift
+++ b/Xomfit/Views/Workout/ActiveWorkoutView.swift
@@ -64,7 +64,7 @@ struct ActiveWorkoutView: View {
                     }
                 }
                 .animation(.easeInOut(duration: 0.3), value: viewModel.isRestTimerActive)
-                .animation(.easeInOut(duration: 0.3), value: viewModel.showNextExercisePrompt)
+                .animation(.easeInOut(duration: 0.3), value: viewModel.showExerciseTransition)
                 .animation(.easeInOut(duration: 0.3), value: viewModel.focusMode)
 
                 // Floating Add Exercise button (hidden in focus mode)
@@ -102,24 +102,19 @@ struct ActiveWorkoutView: View {
                     }
                 }
 
-                // Next Exercise Toast
-                if viewModel.showNextExercisePrompt {
+                // Exercise Transition Overlay
+                if viewModel.showExerciseTransition {
+                    Color.black.opacity(0.4)
+                        .ignoresSafeArea()
+                        .onTapGesture { withAnimation { viewModel.dismissTransition() } }
+
                     VStack {
-                        NextExerciseBanner(
-                            completedName: viewModel.completedExerciseName ?? "",
-                            nextName: viewModel.nextExerciseSuggestion
-                        ) {
-                            withAnimation { viewModel.showNextExercisePrompt = false }
-                        }
-                        .transition(.move(edge: .top).combined(with: .opacity))
-                        .onAppear {
-                            Task {
-                                try? await Task.sleep(for: .seconds(3))
-                                withAnimation { viewModel.showNextExercisePrompt = false }
-                            }
-                        }
                         Spacer()
+                        ExerciseTransitionCard(viewModel: viewModel)
+                            .padding(Theme.paddingMedium)
+                            .transition(.move(edge: .bottom).combined(with: .opacity))
                     }
+                    .animation(.easeOut(duration: 0.3), value: viewModel.showExerciseTransition)
                 }
             }
             .toolbar(.hidden, for: .navigationBar)
@@ -535,51 +530,165 @@ private struct ExerciseConfigRow: View {
     }
 }
 
-// MARK: - Next Exercise Banner
+// MARK: - Exercise Transition Card
 
-private struct NextExerciseBanner: View {
-    let completedName: String
-    let nextName: String?
-    let onDismiss: () -> Void
+private struct ExerciseTransitionCard: View {
+    let viewModel: WorkoutLoggerViewModel
+    @State private var showRemainingList = false
 
     var body: some View {
-        HStack(spacing: Theme.paddingSmall) {
-            Image(systemName: "checkmark.circle.fill")
-                .font(.system(size: 20))
-                .foregroundStyle(Theme.accent)
-
-            VStack(alignment: .leading, spacing: 2) {
-                if let nextName {
-                    Text("\(completedName) complete")
-                        .font(.system(size: 13, weight: .semibold))
-                        .foregroundStyle(Theme.textPrimary)
-                    Text("Up next: \(nextName)")
+        VStack(spacing: Theme.paddingMedium) {
+            // Header: completed exercise name
+            HStack(spacing: Theme.paddingSmall) {
+                Image(systemName: "checkmark.circle.fill")
+                    .font(.system(size: 24))
+                    .foregroundStyle(Theme.accent)
+                Text("\(viewModel.completedExerciseName) Complete")
+                    .font(.system(size: 18, weight: .bold))
+                    .foregroundStyle(Theme.textPrimary)
+                Spacer()
+                Button {
+                    withAnimation { viewModel.dismissTransition() }
+                } label: {
+                    Image(systemName: "xmark")
                         .font(.system(size: 13, weight: .bold))
-                        .foregroundStyle(Theme.accent)
-                } else {
-                    Text("\(completedName) complete")
-                        .font(.system(size: 14, weight: .bold))
-                        .foregroundStyle(Theme.textPrimary)
+                        .foregroundStyle(Theme.textSecondary)
+                        .frame(width: 44, height: 44)
+                        .contentShape(Rectangle())
                 }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Dismiss")
             }
 
-            Spacer()
-
-            Button(action: onDismiss) {
-                Image(systemName: "xmark")
-                    .font(.system(size: 12, weight: .bold))
-                    .foregroundStyle(Theme.textSecondary)
-                    .frame(width: 44, height: 44)
-                    .contentShape(Rectangle())
+            // Option 1: Do Another Set
+            Button {
+                withAnimation { viewModel.addAnotherSet() }
+            } label: {
+                HStack(spacing: 8) {
+                    Image(systemName: "plus")
+                        .font(.system(size: 15, weight: .bold))
+                    Text("Do Another Set")
+                        .font(.system(size: 15, weight: .bold))
+                }
+                .foregroundStyle(Theme.accent)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 14)
+                .background(
+                    RoundedRectangle(cornerRadius: Theme.cornerRadiusSmall)
+                        .stroke(Theme.accent, lineWidth: 1.5)
+                )
             }
             .buttonStyle(.plain)
+            .accessibilityLabel("Add another set to \(viewModel.completedExerciseName)")
+
+            // Option 2: Move to Next Exercise
+            if let nextIdx = viewModel.nextExerciseIndex, let nextEx = viewModel.nextExercise {
+                Button {
+                    withAnimation { viewModel.moveToExercise(index: nextIdx) }
+                } label: {
+                    VStack(spacing: 4) {
+                        HStack(spacing: 8) {
+                            Image(systemName: "arrow.right")
+                                .font(.system(size: 15, weight: .bold))
+                            Text("Move to \(nextEx.exercise.name)")
+                                .font(.system(size: 15, weight: .bold))
+                        }
+                        .foregroundStyle(.black)
+
+                        // Show config hints (grips, attachments, positions)
+                        configHints(for: nextEx.exercise)
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 14)
+                    .background(Theme.accent)
+                    .clipShape(RoundedRectangle(cornerRadius: Theme.cornerRadiusSmall))
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Move to \(nextEx.exercise.name)")
+            }
+
+            // Option 3: Choose Different
+            if !viewModel.remainingExercises.isEmpty {
+                VStack(spacing: 0) {
+                    Button {
+                        withAnimation(.easeInOut(duration: 0.2)) {
+                            showRemainingList.toggle()
+                        }
+                    } label: {
+                        HStack(spacing: 8) {
+                            Image(systemName: "list.bullet")
+                                .font(.system(size: 15, weight: .bold))
+                            Text("Choose Different")
+                                .font(.system(size: 15, weight: .bold))
+                            Spacer()
+                            Image(systemName: showRemainingList ? "chevron.up" : "chevron.down")
+                                .font(.system(size: 12, weight: .semibold))
+                        }
+                        .foregroundStyle(Theme.textSecondary)
+                        .padding(.vertical, 12)
+                        .padding(.horizontal, Theme.paddingMedium)
+                        .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Choose a different exercise")
+
+                    if showRemainingList {
+                        VStack(spacing: 0) {
+                            ForEach(viewModel.remainingExercises) { item in
+                                Button {
+                                    withAnimation { viewModel.moveToExercise(index: item.index) }
+                                } label: {
+                                    HStack(spacing: Theme.paddingSmall) {
+                                        Circle()
+                                            .fill(Theme.accent.opacity(0.3))
+                                            .frame(width: 6, height: 6)
+                                        Text(item.name)
+                                            .font(.system(size: 14, weight: .medium))
+                                            .foregroundStyle(Theme.textPrimary)
+                                        Spacer()
+                                    }
+                                    .padding(.vertical, 10)
+                                    .padding(.horizontal, Theme.paddingMedium)
+                                    .contentShape(Rectangle())
+                                }
+                                .buttonStyle(.plain)
+                                .accessibilityLabel("Switch to \(item.name)")
+                            }
+                        }
+                        .transition(.opacity.combined(with: .move(edge: .top)))
+                    }
+                }
+                .background(Theme.secondaryBackground)
+                .clipShape(RoundedRectangle(cornerRadius: Theme.cornerRadiusSmall))
+            }
         }
-        .padding(.horizontal, Theme.paddingMedium)
-        .padding(.vertical, Theme.paddingSmall)
+        .padding(Theme.paddingMedium)
         .background(Theme.cardBackground)
-        .cornerRadius(Theme.cornerRadius)
-        .padding(.horizontal, Theme.paddingMedium)
-        .padding(.top, Theme.paddingSmall)
-        .shadow(color: .black.opacity(0.3), radius: 8, x: 0, y: 4)
+        .clipShape(RoundedRectangle(cornerRadius: Theme.cornerRadius))
+        .shadow(color: .black.opacity(0.5), radius: 16, x: 0, y: -4)
+    }
+
+    @ViewBuilder
+    private func configHints(for exercise: Exercise) -> some View {
+        let hints = buildConfigHints(for: exercise)
+        if !hints.isEmpty {
+            Text(hints.joined(separator: " \u{2022} "))
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(.black.opacity(0.6))
+        }
+    }
+
+    private func buildConfigHints(for exercise: Exercise) -> [String] {
+        var hints: [String] = []
+        if let attachments = exercise.supportedAttachments {
+            hints.append(contentsOf: attachments.prefix(2).map(\.displayName))
+        }
+        if let grips = exercise.supportedGrips {
+            hints.append(contentsOf: grips.prefix(2).map(\.displayName))
+        }
+        if let positions = exercise.supportedPositions {
+            hints.append(contentsOf: positions.prefix(2).map(\.displayName))
+        }
+        return hints
     }
 }


### PR DESCRIPTION
## Summary
When all sets of an exercise are completed, show a full transition card with 3 options:
- **Do Another Set** — adds a set pre-filled from last set's weight/reps
- **Move to [Next Exercise]** — shows name + config hints (grip/attachment/position)
- **Choose Different** — expandable list of remaining incomplete exercises

Replaces the old "Up next" banner with an interactive overlay.

## Test plan
- [ ] Complete all sets of an exercise — transition card appears
- [ ] "Do Another Set" adds a set and dismisses
- [ ] "Move to" advances to next exercise (works in focus mode too)
- [ ] "Choose Different" shows remaining exercises, tapping one navigates to it
- [ ] Tapping overlay background dismisses
- [ ] Card shows config hints for exercises with grips/attachments

🤖 Generated with [Claude Code](https://claude.com/claude-code)