### PR TITLE
Add Live Activity — workout on Lock Screen and Dynamic Island

### DIFF
--- a/Xomfit.xcodeproj/project.pbxproj
+++ b/Xomfit.xcodeproj/project.pbxproj
@@ -13,7 +13,34 @@
 		F29F21472F5F620700683551 /* Realtime in Frameworks */ = {isa = PBXBuildFile; productRef = F29F21462F5F620700683551 /* Realtime */; };
 		F29F21492F5F620700683551 /* Storage in Frameworks */ = {isa = PBXBuildFile; productRef = F29F21482F5F620700683551 /* Storage */; };
 		F29F214B2F5F620700683551 /* Supabase in Frameworks */ = {isa = PBXBuildFile; productRef = F29F214A2F5F620700683551 /* Supabase */; };
+		F2FA6B0C2F7C0635009E1AB8 /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F2FA6B0B2F7C0635009E1AB8 /* WidgetKit.framework */; };
+		F2FA6B0E2F7C0635009E1AB8 /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F2FA6B0D2F7C0635009E1AB8 /* SwiftUI.framework */; };
+		F2FA6B1F2F7C0636009E1AB8 /* XomfitWidgetExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = F2FA6B092F7C0635009E1AB8 /* XomfitWidgetExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		F2FA6B1D2F7C0636009E1AB8 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = F29F21292F5F61DC00683551 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = F2FA6B082F7C0635009E1AB8;
+			remoteInfo = XomfitWidgetExtension;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		F2FA6B242F7C0636009E1AB8 /* Embed Foundation Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				F2FA6B1F2F7C0636009E1AB8 /* XomfitWidgetExtension.appex in Embed Foundation Extensions */,
+			);
+			name = "Embed Foundation Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		F29F21312F5F61DC00683551 /* Xomfit.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Xomfit.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -94,12 +121,33 @@
 		F29F235E2F5F635F00683551 /* WorkoutControlView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkoutControlView.swift; sourceTree = "<group>"; };
 		F29F235F2F5F635F00683551 /* XomFitComplication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XomFitComplication.swift; sourceTree = "<group>"; };
 		F29F23602F5F635F00683551 /* XomFitWatchApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XomFitWatchApp.swift; sourceTree = "<group>"; };
+		F2FA6B092F7C0635009E1AB8 /* XomfitWidgetExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = XomfitWidgetExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		F2FA6B0B2F7C0635009E1AB8 /* WidgetKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WidgetKit.framework; path = System/Library/Frameworks/WidgetKit.framework; sourceTree = SDKROOT; };
+		F2FA6B0D2F7C0635009E1AB8 /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = System/Library/Frameworks/SwiftUI.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		F2FA6B202F7C0636009E1AB8 /* Exceptions for "XomfitWidget" folder in "XomfitWidgetExtension" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = F2FA6B082F7C0635009E1AB8 /* XomfitWidgetExtension */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		F29F21332F5F61DC00683551 /* Xomfit */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			path = Xomfit;
+			sourceTree = "<group>";
+		};
+		F2FA6B0F2F7C0635009E1AB8 /* XomfitWidget */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				F2FA6B202F7C0636009E1AB8 /* Exceptions for "XomfitWidget" folder in "XomfitWidgetExtension" target */,
+			);
+			path = XomfitWidget;
 			sourceTree = "<group>";
 		};
 /* End PBXFileSystemSynchronizedRootGroup section */
@@ -115,6 +163,15 @@
 				F29F21492F5F620700683551 /* Storage in Frameworks */,
 				F29F21472F5F620700683551 /* Realtime in Frameworks */,
 				F29F214B2F5F620700683551 /* Supabase in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F2FA6B062F7C0635009E1AB8 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F2FA6B0E2F7C0635009E1AB8 /* SwiftUI.framework in Frameworks */,
+				F2FA6B0C2F7C0635009E1AB8 /* WidgetKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -135,6 +192,8 @@
 				F29F23592F5F635F00683551 /* XomFitUITests */,
 				F29F23612F5F635F00683551 /* XomFitWatch */,
 				F29F21332F5F61DC00683551 /* Xomfit */,
+				F2FA6B0F2F7C0635009E1AB8 /* XomfitWidget */,
+				F2FA6B0A2F7C0635009E1AB8 /* Frameworks */,
 				F29F21322F5F61DC00683551 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -143,6 +202,7 @@
 			isa = PBXGroup;
 			children = (
 				F29F21312F5F61DC00683551 /* Xomfit.app */,
+				F2FA6B092F7C0635009E1AB8 /* XomfitWidgetExtension.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -390,6 +450,15 @@
 			path = XomFitWatch;
 			sourceTree = "<group>";
 		};
+		F2FA6B0A2F7C0635009E1AB8 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				F2FA6B0B2F7C0635009E1AB8 /* WidgetKit.framework */,
+				F2FA6B0D2F7C0635009E1AB8 /* SwiftUI.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -400,10 +469,12 @@
 				F29F212D2F5F61DC00683551 /* Sources */,
 				F29F212E2F5F61DC00683551 /* Frameworks */,
 				F29F212F2F5F61DC00683551 /* Resources */,
+				F2FA6B242F7C0636009E1AB8 /* Embed Foundation Extensions */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				F2FA6B1E2F7C0636009E1AB8 /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
 				F29F21332F5F61DC00683551 /* Xomfit */,
@@ -421,6 +492,28 @@
 			productReference = F29F21312F5F61DC00683551 /* Xomfit.app */;
 			productType = "com.apple.product-type.application";
 		};
+		F2FA6B082F7C0635009E1AB8 /* XomfitWidgetExtension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F2FA6B212F7C0636009E1AB8 /* Build configuration list for PBXNativeTarget "XomfitWidgetExtension" */;
+			buildPhases = (
+				F2FA6B052F7C0635009E1AB8 /* Sources */,
+				F2FA6B062F7C0635009E1AB8 /* Frameworks */,
+				F2FA6B072F7C0635009E1AB8 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				F2FA6B0F2F7C0635009E1AB8 /* XomfitWidget */,
+			);
+			name = XomfitWidgetExtension;
+			packageProductDependencies = (
+			);
+			productName = XomfitWidgetExtension;
+			productReference = F2FA6B092F7C0635009E1AB8 /* XomfitWidgetExtension.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -432,6 +525,9 @@
 				LastUpgradeCheck = 2620;
 				TargetAttributes = {
 					F29F21302F5F61DC00683551 = {
+						CreatedOnToolsVersion = 26.2;
+					};
+					F2FA6B082F7C0635009E1AB8 = {
 						CreatedOnToolsVersion = 26.2;
 					};
 				};
@@ -454,12 +550,20 @@
 			projectRoot = "";
 			targets = (
 				F29F21302F5F61DC00683551 /* Xomfit */,
+				F2FA6B082F7C0635009E1AB8 /* XomfitWidgetExtension */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
 		F29F212F2F5F61DC00683551 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F2FA6B072F7C0635009E1AB8 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -476,7 +580,22 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		F2FA6B052F7C0635009E1AB8 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		F2FA6B1E2F7C0636009E1AB8 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = F2FA6B082F7C0635009E1AB8 /* XomfitWidgetExtension */;
+			targetProxy = F2FA6B1D2F7C0636009E1AB8 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		F29F213A2F5F61DD00683551 /* Debug */ = {
@@ -605,8 +724,9 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = A3HMLDS2AL;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -619,9 +739,10 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.Xomware.Xomfit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_APPROACHABLE_CONCURRENCY = YES;
 				SWIFT_DEFAULT_ACTOR_ISOLATION = nonisolated;
@@ -637,8 +758,9 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_TEAM = A3HMLDS2AL;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -651,14 +773,77 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.Xomware.Xomfit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_APPROACHABLE_CONCURRENCY = YES;
 				SWIFT_DEFAULT_ACTOR_ISOLATION = nonisolated;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		F2FA6B222F7C0636009E1AB8 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = A3HMLDS2AL;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = XomfitWidget/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = XomfitWidget;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.Xomware.Xomfit.XomfitWidget;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		F2FA6B232F7C0636009E1AB8 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = A3HMLDS2AL;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = XomfitWidget/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = XomfitWidget;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.Xomware.Xomfit.XomfitWidget;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -681,6 +866,15 @@
 			buildConfigurations = (
 				F29F213D2F5F61DD00683551 /* Debug */,
 				F29F213E2F5F61DD00683551 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		F2FA6B212F7C0636009E1AB8 /* Build configuration list for PBXNativeTarget "XomfitWidgetExtension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F2FA6B222F7C0636009E1AB8 /* Debug */,
+				F2FA6B232F7C0636009E1AB8 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Xomfit/Models/XomfitWidgetAttributes.swift
+++ b/Xomfit/Models/XomfitWidgetAttributes.swift
@@ -1,0 +1,22 @@
+//
+//  XomfitWidgetAttributes.swift
+//  Xomfit
+//
+//  Shared between main app and widget extension.
+//  Add this file to BOTH the Xomfit and XomfitWidgetExtension targets.
+//
+
+import ActivityKit
+
+struct XomfitWidgetAttributes: ActivityAttributes {
+    public struct ContentState: Codable, Hashable {
+        var elapsedSeconds: Int
+        var completedSets: Int
+        var totalSets: Int
+        var currentExercise: String
+        var totalExercises: Int
+    }
+
+    var workoutName: String
+    var startTime: Date
+}

--- a/Xomfit/ViewModels/WorkoutLoggerViewModel.swift
+++ b/Xomfit/ViewModels/WorkoutLoggerViewModel.swift
@@ -1,3 +1,4 @@
+import ActivityKit
 import SwiftUI
 
 struct RemainingExercise: Identifiable {
@@ -48,6 +49,10 @@ final class WorkoutLoggerViewModel {
     var focusExerciseIndex: Int = 0
     var focusSetIndex: Int = 0
 
+    // Live Activity
+    private var liveActivity: Activity<XomfitWidgetAttributes>?
+    private var liveActivityUpdateCounter = 0
+
     // Stored so completeSet can fire PR checks without needing the caller to pass it
     private(set) var activeUserId: String = ""
 
@@ -96,9 +101,11 @@ final class WorkoutLoggerViewModel {
         focusExerciseIndex = 0
         focusSetIndex = 0
         skipRestTimer()
+        startLiveActivity()
     }
 
     func discardWorkout() {
+        endLiveActivity()
         workoutName = ""
         exercises = []
         isActive = false
@@ -146,6 +153,7 @@ final class WorkoutLoggerViewModel {
             ))
         }
         exercises = builtExercises
+        updateLiveActivity()
     }
 
     // MARK: - Exercise Management
@@ -177,6 +185,7 @@ final class WorkoutLoggerViewModel {
             notes: nil
         )
         exercises.append(workoutExercise)
+        updateLiveActivity()
     }
 
     /// Find the most recent set for an exercise from workout history.
@@ -195,6 +204,7 @@ final class WorkoutLoggerViewModel {
     func removeExercise(at index: Int) {
         guard exercises.indices.contains(index) else { return }
         exercises.remove(at: index)
+        updateLiveActivity()
     }
 
     func moveExercise(from source: Int, direction: Int) {
@@ -297,6 +307,7 @@ final class WorkoutLoggerViewModel {
                 showExerciseTransition = true
             }
         }
+        updateLiveActivity()
     }
 
     func removeSet(exerciseIndex: Int, setIndex: Int) {
@@ -440,9 +451,80 @@ final class WorkoutLoggerViewModel {
         showPRCelebration = true
     }
 
+    // MARK: - Live Activity
+
+    private func startLiveActivity() {
+        guard ActivityAuthorizationInfo().areActivitiesEnabled else { return }
+
+        let attributes = XomfitWidgetAttributes(
+            workoutName: workoutName,
+            startTime: startTime
+        )
+        let state = XomfitWidgetAttributes.ContentState(
+            elapsedSeconds: 0,
+            completedSets: completedSets,
+            totalSets: totalSets,
+            currentExercise: exercises.first?.exercise.name ?? "Warming up",
+            totalExercises: exercises.count
+        )
+
+        do {
+            liveActivity = try Activity.request(
+                attributes: attributes,
+                content: .init(state: state, staleDate: nil),
+                pushType: nil
+            )
+        } catch {
+            print("[LiveActivity] Failed to start: \(error)")
+        }
+    }
+
+    private func updateLiveActivity() {
+        guard let activity = liveActivity else { return }
+
+        let currentExName = exercises.first(where: { ex in
+            ex.sets.contains(where: { $0.completedAt == Date.distantPast })
+        })?.exercise.name ?? "Finishing up"
+
+        let state = XomfitWidgetAttributes.ContentState(
+            elapsedSeconds: Int(Date().timeIntervalSince(startTime)),
+            completedSets: completedSets,
+            totalSets: totalSets,
+            currentExercise: currentExName,
+            totalExercises: exercises.count
+        )
+
+        Task {
+            await activity.update(.init(state: state, staleDate: nil))
+        }
+    }
+
+    private func endLiveActivity() {
+        guard let activity = liveActivity else { return }
+        let finalState = XomfitWidgetAttributes.ContentState(
+            elapsedSeconds: Int(duration),
+            completedSets: completedSets,
+            totalSets: totalSets,
+            currentExercise: "Workout Complete",
+            totalExercises: exercises.count
+        )
+        Task {
+            await activity.end(.init(state: finalState, staleDate: nil), dismissalPolicy: .after(.now + 5))
+        }
+        liveActivity = nil
+    }
+
+    func tickLiveActivity() {
+        liveActivityUpdateCounter += 1
+        if liveActivityUpdateCounter % 30 == 0 {
+            updateLiveActivity()
+        }
+    }
+
     // MARK: - Finish Workout
 
     func finishWorkout(userId: String) async {
+        endLiveActivity()
         isSaving = true
         errorMessage = nil
 

--- a/Xomfit/Views/Workout/ActiveWorkoutView.swift
+++ b/Xomfit/Views/Workout/ActiveWorkoutView.swift
@@ -129,6 +129,7 @@ struct ActiveWorkoutView: View {
         }
         .onReceive(timer) { _ in
             viewModel.tickRestTimer()
+            viewModel.tickLiveActivity()
             // Haptic fires once when rest timer crosses zero
             if viewModel.isRestTimerActive && viewModel.restTimeRemaining <= 0 && !restTimerHapticFired {
                 restTimerHapticFired = true

--- a/XomfitWidget/AppIntent.swift
+++ b/XomfitWidget/AppIntent.swift
@@ -1,0 +1,18 @@
+//
+//  AppIntent.swift
+//  XomfitWidget
+//
+//  Created by Dominick Giordano on 3/31/26.
+//
+
+import WidgetKit
+import AppIntents
+
+struct ConfigurationAppIntent: WidgetConfigurationIntent {
+    static var title: LocalizedStringResource { "Configuration" }
+    static var description: IntentDescription { "This is an example widget." }
+
+    // An example configurable parameter.
+    @Parameter(title: "Favorite Emoji", default: "😃")
+    var favoriteEmoji: String
+}

--- a/XomfitWidget/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/XomfitWidget/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/XomfitWidget/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/XomfitWidget/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,35 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "tinted"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/XomfitWidget/Assets.xcassets/Contents.json
+++ b/XomfitWidget/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/XomfitWidget/Assets.xcassets/WidgetBackground.colorset/Contents.json
+++ b/XomfitWidget/Assets.xcassets/WidgetBackground.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/XomfitWidget/Info.plist
+++ b/XomfitWidget/Info.plist
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.widgetkit-extension</string>
+	</dict>
+</dict>
+</plist>

--- a/XomfitWidget/XomfitWidget.swift
+++ b/XomfitWidget/XomfitWidget.swift
@@ -1,0 +1,88 @@
+//
+//  XomfitWidget.swift
+//  XomfitWidget
+//
+//  Created by Dominick Giordano on 3/31/26.
+//
+
+import WidgetKit
+import SwiftUI
+
+struct Provider: AppIntentTimelineProvider {
+    func placeholder(in context: Context) -> SimpleEntry {
+        SimpleEntry(date: Date(), configuration: ConfigurationAppIntent())
+    }
+
+    func snapshot(for configuration: ConfigurationAppIntent, in context: Context) async -> SimpleEntry {
+        SimpleEntry(date: Date(), configuration: configuration)
+    }
+    
+    func timeline(for configuration: ConfigurationAppIntent, in context: Context) async -> Timeline<SimpleEntry> {
+        var entries: [SimpleEntry] = []
+
+        // Generate a timeline consisting of five entries an hour apart, starting from the current date.
+        let currentDate = Date()
+        for hourOffset in 0 ..< 5 {
+            let entryDate = Calendar.current.date(byAdding: .hour, value: hourOffset, to: currentDate)!
+            let entry = SimpleEntry(date: entryDate, configuration: configuration)
+            entries.append(entry)
+        }
+
+        return Timeline(entries: entries, policy: .atEnd)
+    }
+
+//    func relevances() async -> WidgetRelevances<ConfigurationAppIntent> {
+//        // Generate a list containing the contexts this widget is relevant in.
+//    }
+}
+
+struct SimpleEntry: TimelineEntry {
+    let date: Date
+    let configuration: ConfigurationAppIntent
+}
+
+struct XomfitWidgetEntryView : View {
+    var entry: Provider.Entry
+
+    var body: some View {
+        VStack {
+            Text("Time:")
+            Text(entry.date, style: .time)
+
+            Text("Favorite Emoji:")
+            Text(entry.configuration.favoriteEmoji)
+        }
+    }
+}
+
+struct XomfitWidget: Widget {
+    let kind: String = "XomfitWidget"
+
+    var body: some WidgetConfiguration {
+        AppIntentConfiguration(kind: kind, intent: ConfigurationAppIntent.self, provider: Provider()) { entry in
+            XomfitWidgetEntryView(entry: entry)
+                .containerBackground(.fill.tertiary, for: .widget)
+        }
+    }
+}
+
+extension ConfigurationAppIntent {
+    fileprivate static var smiley: ConfigurationAppIntent {
+        let intent = ConfigurationAppIntent()
+        intent.favoriteEmoji = "😀"
+        return intent
+    }
+    
+    fileprivate static var starEyes: ConfigurationAppIntent {
+        let intent = ConfigurationAppIntent()
+        intent.favoriteEmoji = "🤩"
+        return intent
+    }
+}
+
+#Preview(as: .systemSmall) {
+    XomfitWidget()
+} timeline: {
+    SimpleEntry(date: .now, configuration: .smiley)
+    SimpleEntry(date: .now, configuration: .starEyes)
+}

--- a/XomfitWidget/XomfitWidgetAttributes.swift
+++ b/XomfitWidget/XomfitWidgetAttributes.swift
@@ -1,0 +1,23 @@
+//
+//  XomfitWidgetAttributes.swift
+//  XomfitWidget
+//
+//  Shared ActivityAttributes for the workout Live Activity.
+//  This file is duplicated in Xomfit/Models/ for the main app target.
+//  Keep both copies in sync.
+//
+
+import ActivityKit
+
+struct XomfitWidgetAttributes: ActivityAttributes {
+    public struct ContentState: Codable, Hashable {
+        var elapsedSeconds: Int
+        var completedSets: Int
+        var totalSets: Int
+        var currentExercise: String
+        var totalExercises: Int
+    }
+
+    var workoutName: String
+    var startTime: Date
+}

--- a/XomfitWidget/XomfitWidgetBundle.swift
+++ b/XomfitWidget/XomfitWidgetBundle.swift
@@ -1,0 +1,18 @@
+//
+//  XomfitWidgetBundle.swift
+//  XomfitWidget
+//
+//  Created by Dominick Giordano on 3/31/26.
+//
+
+import WidgetKit
+import SwiftUI
+
+@main
+struct XomfitWidgetBundle: WidgetBundle {
+    var body: some Widget {
+        XomfitWidget()
+        XomfitWidgetControl()
+        XomfitWidgetLiveActivity()
+    }
+}

--- a/XomfitWidget/XomfitWidgetControl.swift
+++ b/XomfitWidget/XomfitWidgetControl.swift
@@ -1,0 +1,77 @@
+//
+//  XomfitWidgetControl.swift
+//  XomfitWidget
+//
+//  Created by Dominick Giordano on 3/31/26.
+//
+
+import AppIntents
+import SwiftUI
+import WidgetKit
+
+struct XomfitWidgetControl: ControlWidget {
+    static let kind: String = "com.Xomware.Xomfit.XomfitWidget"
+
+    var body: some ControlWidgetConfiguration {
+        AppIntentControlConfiguration(
+            kind: Self.kind,
+            provider: Provider()
+        ) { value in
+            ControlWidgetToggle(
+                "Start Timer",
+                isOn: value.isRunning,
+                action: StartTimerIntent(value.name)
+            ) { isRunning in
+                Label(isRunning ? "On" : "Off", systemImage: "timer")
+            }
+        }
+        .displayName("Timer")
+        .description("A an example control that runs a timer.")
+    }
+}
+
+extension XomfitWidgetControl {
+    struct Value {
+        var isRunning: Bool
+        var name: String
+    }
+
+    struct Provider: AppIntentControlValueProvider {
+        func previewValue(configuration: TimerConfiguration) -> Value {
+            XomfitWidgetControl.Value(isRunning: false, name: configuration.timerName)
+        }
+
+        func currentValue(configuration: TimerConfiguration) async throws -> Value {
+            let isRunning = true // Check if the timer is running
+            return XomfitWidgetControl.Value(isRunning: isRunning, name: configuration.timerName)
+        }
+    }
+}
+
+struct TimerConfiguration: ControlConfigurationIntent {
+    static let title: LocalizedStringResource = "Timer Name Configuration"
+
+    @Parameter(title: "Timer Name", default: "Timer")
+    var timerName: String
+}
+
+struct StartTimerIntent: SetValueIntent {
+    static let title: LocalizedStringResource = "Start a timer"
+
+    @Parameter(title: "Timer Name")
+    var name: String
+
+    @Parameter(title: "Timer is running")
+    var value: Bool
+
+    init() {}
+
+    init(_ name: String) {
+        self.name = name
+    }
+
+    func perform() async throws -> some IntentResult {
+        // Start the timer…
+        return .result()
+    }
+}

--- a/XomfitWidget/XomfitWidgetLiveActivity.swift
+++ b/XomfitWidget/XomfitWidgetLiveActivity.swift
@@ -1,0 +1,221 @@
+//
+//  XomfitWidgetLiveActivity.swift
+//  XomfitWidget
+//
+//  Created by Dominick Giordano on 3/31/26.
+//
+
+import ActivityKit
+import WidgetKit
+import SwiftUI
+
+// MARK: - Live Activity Widget
+//
+// NOTE: XomfitWidgetAttributes is defined in XomfitWidgetAttributes.swift
+// which lives in BOTH the XomfitWidget/ folder and Xomfit/Models/ folder
+// so each target compiles its own copy. Keep them in sync.
+
+struct XomfitWidgetLiveActivity: Widget {
+    private static let accentGreen = Color(red: 0.2, green: 1.0, blue: 0.4)     // #33FF66
+    private static let darkBackground = Color(red: 0.039, green: 0.039, blue: 0.059) // #0A0A0F
+
+    var body: some WidgetConfiguration {
+        ActivityConfiguration(for: XomfitWidgetAttributes.self) { context in
+            // Lock screen / banner UI
+            lockScreenView(context: context)
+                .activityBackgroundTint(Self.darkBackground)
+                .activitySystemActionForegroundColor(.white)
+        } dynamicIsland: { context in
+            DynamicIsland {
+                DynamicIslandExpandedRegion(.leading) {
+                    Text(context.attributes.workoutName)
+                        .font(.system(size: 14, weight: .bold))
+                        .foregroundStyle(.white)
+                        .lineLimit(1)
+                }
+                DynamicIslandExpandedRegion(.trailing) {
+                    Text(formatTime(context.state.elapsedSeconds))
+                        .font(.system(size: 14, weight: .semibold, design: .monospaced))
+                        .foregroundStyle(Self.accentGreen)
+                }
+                DynamicIslandExpandedRegion(.center) {
+                    Image(systemName: "dumbbell.fill")
+                        .font(.system(size: 16))
+                        .foregroundStyle(Self.accentGreen)
+                }
+                DynamicIslandExpandedRegion(.bottom) {
+                    expandedBottomView(state: context.state)
+                }
+            } compactLeading: {
+                Image(systemName: "dumbbell.fill")
+                    .font(.system(size: 12))
+                    .foregroundStyle(Self.accentGreen)
+            } compactTrailing: {
+                Text(formatTime(context.state.elapsedSeconds))
+                    .font(.system(size: 12, weight: .semibold, design: .monospaced))
+                    .foregroundStyle(Self.accentGreen)
+            } minimal: {
+                Image(systemName: "dumbbell.fill")
+                    .font(.system(size: 12))
+                    .foregroundStyle(Self.accentGreen)
+            }
+            .widgetURL(URL(string: "xomfit://workout"))
+            .keylineTint(Self.accentGreen)
+        }
+    }
+
+    // MARK: - Lock Screen View
+
+    @ViewBuilder
+    private func lockScreenView(context: ActivityViewContext<XomfitWidgetAttributes>) -> some View {
+        let state = context.state
+        let setProgress: Double = state.totalSets > 0
+            ? Double(state.completedSets) / Double(state.totalSets)
+            : 0
+
+        VStack(alignment: .leading, spacing: 8) {
+            // Top row: workout name + elapsed time
+            HStack {
+                HStack(spacing: 6) {
+                    Text("\u{1F3CB}\u{FE0F}")
+                        .font(.system(size: 14))
+                    Text(context.attributes.workoutName)
+                        .font(.system(size: 15, weight: .bold))
+                        .foregroundStyle(.white)
+                        .lineLimit(1)
+                }
+
+                Spacer()
+
+                Text(formatTime(state.elapsedSeconds))
+                    .font(.system(size: 15, weight: .semibold, design: .monospaced))
+                    .foregroundStyle(Self.accentGreen)
+            }
+
+            // Middle row: current exercise + set/exercise progress
+            HStack(spacing: 0) {
+                Text(state.currentExercise)
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(.white.opacity(0.8))
+                    .lineLimit(1)
+
+                Text("  \u{2022}  ")
+                    .foregroundStyle(.white.opacity(0.4))
+
+                Text("Set \(state.completedSets)/\(state.totalSets)")
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(.white.opacity(0.7))
+
+                Text("  \u{2022}  ")
+                    .foregroundStyle(.white.opacity(0.4))
+
+                let currentExNum = min(state.totalExercises, max(1, exerciseNumber(state: state)))
+                Text("\(currentExNum)/\(state.totalExercises) ex")
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(.white.opacity(0.7))
+            }
+
+            // Progress bar
+            GeometryReader { geo in
+                ZStack(alignment: .leading) {
+                    RoundedRectangle(cornerRadius: 3)
+                        .fill(.white.opacity(0.15))
+                        .frame(height: 6)
+
+                    RoundedRectangle(cornerRadius: 3)
+                        .fill(Self.accentGreen)
+                        .frame(width: max(0, geo.size.width * setProgress), height: 6)
+                }
+            }
+            .frame(height: 6)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 14)
+    }
+
+    // MARK: - Dynamic Island Expanded Bottom
+
+    @ViewBuilder
+    private func expandedBottomView(state: XomfitWidgetAttributes.ContentState) -> some View {
+        let setProgress: Double = state.totalSets > 0
+            ? Double(state.completedSets) / Double(state.totalSets)
+            : 0
+
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 0) {
+                Text(state.currentExercise)
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(.white.opacity(0.8))
+                    .lineLimit(1)
+
+                Spacer()
+
+                Text("Set \(state.completedSets)/\(state.totalSets)")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(.white.opacity(0.7))
+            }
+
+            // Progress bar
+            ProgressView(value: setProgress)
+                .tint(Self.accentGreen)
+                .scaleEffect(y: 1.5, anchor: .center)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func formatTime(_ totalSeconds: Int) -> String {
+        let hours = totalSeconds / 3600
+        let minutes = (totalSeconds % 3600) / 60
+        let seconds = totalSeconds % 60
+        if hours > 0 {
+            return String(format: "%d:%02d:%02d", hours, minutes, seconds)
+        }
+        return String(format: "%d:%02d", minutes, seconds)
+    }
+
+    /// Rough estimate of which exercise number we're on based on completed sets distribution.
+    private func exerciseNumber(state: XomfitWidgetAttributes.ContentState) -> Int {
+        guard state.totalExercises > 0, state.totalSets > 0 else { return 1 }
+        let avgSetsPerExercise = Double(state.totalSets) / Double(state.totalExercises)
+        guard avgSetsPerExercise > 0 else { return 1 }
+        return Int(Double(state.completedSets) / avgSetsPerExercise) + 1
+    }
+}
+
+// MARK: - Preview Data
+
+extension XomfitWidgetAttributes {
+    fileprivate static var preview: XomfitWidgetAttributes {
+        XomfitWidgetAttributes(workoutName: "Push Day", startTime: .now.addingTimeInterval(-754))
+    }
+}
+
+extension XomfitWidgetAttributes.ContentState {
+    fileprivate static var midWorkout: XomfitWidgetAttributes.ContentState {
+        XomfitWidgetAttributes.ContentState(
+            elapsedSeconds: 754,
+            completedSets: 7,
+            totalSets: 18,
+            currentExercise: "Bench Press",
+            totalExercises: 6
+        )
+    }
+
+    fileprivate static var nearEnd: XomfitWidgetAttributes.ContentState {
+        XomfitWidgetAttributes.ContentState(
+            elapsedSeconds: 3421,
+            completedSets: 16,
+            totalSets: 18,
+            currentExercise: "Lateral Raises",
+            totalExercises: 6
+        )
+    }
+}
+
+#Preview("Notification", as: .content, using: XomfitWidgetAttributes.preview) {
+    XomfitWidgetLiveActivity()
+} contentStates: {
+    XomfitWidgetAttributes.ContentState.midWorkout
+    XomfitWidgetAttributes.ContentState.nearEnd
+}


### PR DESCRIPTION
## Summary
Workout Live Activity shows on Lock Screen and Dynamic Island while a workout is in progress.

- **Lock Screen**: workout name, elapsed time, current exercise, set/exercise count, green progress bar
- **Dynamic Island compact**: dumbbell icon + elapsed timer
- **Dynamic Island expanded**: exercise name, progress bar, set count
- **Minimal**: dumbbell icon
- Starts on workout start, updates on set completion + every 30s, ends on finish/discard

Closes #151

## Test plan
- [ ] Start a workout — Live Activity appears on Lock Screen
- [ ] Complete sets — activity updates with new exercise/set count
- [ ] Lock phone — see workout status on Lock Screen
- [ ] Dynamic Island shows timer (iPhone 14 Pro+)
- [ ] Finish workout — activity dismisses after 5 seconds
- [ ] Discard workout — activity dismisses immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)