### PR TITLE
Fix main app widget attributes — add Foundation import

### DIFF
--- a/Xomfit/Models/XomfitWidgetAttributes.swift
+++ b/Xomfit/Models/XomfitWidgetAttributes.swift
@@ -7,6 +7,7 @@
 //
 
 import ActivityKit
+import Foundation
 
 struct XomfitWidgetAttributes: ActivityAttributes {
     public struct ContentState: Codable, Hashable {


### PR DESCRIPTION
Mirror the Foundation import fix to the main app copy of XomfitWidgetAttributes.