### PR TITLE
Fix CI versioning + encryption compliance

### DIFF
--- a/Xomfit.xcodeproj/project.pbxproj
+++ b/Xomfit.xcodeproj/project.pbxproj
@@ -726,10 +726,11 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = A3HMLDS2AL;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -739,7 +740,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1;
+				MARKETING_VERSION = 1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.Xomware.Xomfit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -760,10 +761,11 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 2;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = A3HMLDS2AL;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -773,7 +775,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1;
+				MARKETING_VERSION = 1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.Xomware.Xomfit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -794,18 +796,19 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = A3HMLDS2AL;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = XomfitWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = XomfitWidget;
+				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.Xomware.Xomfit.XomfitWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -825,18 +828,19 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = A3HMLDS2AL;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = XomfitWidget/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = XomfitWidget;
+				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 1.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.Xomware.Xomfit.XomfitWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -1,18 +1,23 @@
 #!/bin/sh
 # Xcode Cloud post-clone script
 
-# Auto-increment build number and sync versions across all targets
+cd "$CI_PRIMARY_REPOSITORY_PATH"
+PBXPROJ="Xomfit.xcodeproj/project.pbxproj"
+
+# 1. Set build number using Xcode Cloud's auto-incrementing CI_BUILD_NUMBER
+# Uses sed instead of agvtool (agvtool requires VERSIONING_SYSTEM=apple-generic)
 if [ -n "$CI_BUILD_NUMBER" ]; then
-    echo "Setting build number to $CI_BUILD_NUMBER"
-    cd "$CI_PRIMARY_REPOSITORY_PATH"
-    agvtool new-version -all "$CI_BUILD_NUMBER"
-    # Sync marketing version across all targets to match main app
-    MARKETING_VERSION=$(agvtool what-marketing-version -terse1 | head -1)
-    echo "Syncing marketing version $MARKETING_VERSION to all targets"
-    agvtool new-marketing-version "$MARKETING_VERSION"
+    echo "Setting build number to $CI_BUILD_NUMBER for all targets"
+    sed -i '' "s/CURRENT_PROJECT_VERSION = [^;]*/CURRENT_PROJECT_VERSION = $CI_BUILD_NUMBER/g" "$PBXPROJ"
 fi
 
-# Generate Config.swift from environment variables
+# 2. Sync marketing version across all targets (app + widget must match)
+if [ -n "$APP_VERSION" ]; then
+    echo "Setting marketing version to $APP_VERSION for all targets"
+    sed -i '' "s/MARKETING_VERSION = [^;]*/MARKETING_VERSION = $APP_VERSION/g" "$PBXPROJ"
+fi
+
+# 3. Generate Config.swift from environment variables
 CONFIG_PATH="$CI_PRIMARY_REPOSITORY_PATH/Xomfit/Config.swift"
 echo "Generating Config.swift..."
 
@@ -42,4 +47,4 @@ enum Config {
 }
 EOF
 
-echo "Config.swift generated at $CONFIG_PATH"
+echo "Config.swift generated"


### PR DESCRIPTION
Fixes agvtool (doesn't work without apple-generic), syncs widget versions, adds encryption flag to all targets.