### PR TITLE
CI: auto-increment marketing version

### DIFF
--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -4,18 +4,22 @@
 cd "$CI_PRIMARY_REPOSITORY_PATH"
 PBXPROJ="Xomfit.xcodeproj/project.pbxproj"
 
-# 1. Set build number using Xcode Cloud's auto-incrementing CI_BUILD_NUMBER
-# Uses sed instead of agvtool (agvtool requires VERSIONING_SYSTEM=apple-generic)
+# 1. Build number — Xcode Cloud auto-increments CI_BUILD_NUMBER
+# Use sed to sync across all targets (app + widget must match)
 if [ -n "$CI_BUILD_NUMBER" ]; then
     echo "Setting build number to $CI_BUILD_NUMBER for all targets"
     sed -i '' "s/CURRENT_PROJECT_VERSION = [^;]*/CURRENT_PROJECT_VERSION = $CI_BUILD_NUMBER/g" "$PBXPROJ"
 fi
 
-# 2. Sync marketing version across all targets (app + widget must match)
-if [ -n "$APP_VERSION" ]; then
-    echo "Setting marketing version to $APP_VERSION for all targets"
-    sed -i '' "s/MARKETING_VERSION = [^;]*/MARKETING_VERSION = $APP_VERSION/g" "$PBXPROJ"
-fi
+# 2. Marketing version — auto-increment patch version based on build number
+# Format: MAJOR.MINOR.BUILD (e.g., 1.0.7, 1.0.8, 1.0.9...)
+# Set MAJOR and MINOR via env vars, patch auto-increments
+MAJOR="${APP_VERSION_MAJOR:-1}"
+MINOR="${APP_VERSION_MINOR:-0}"
+PATCH="${CI_BUILD_NUMBER:-0}"
+MARKETING_VERSION="${MAJOR}.${MINOR}.${PATCH}"
+echo "Setting marketing version to $MARKETING_VERSION for all targets"
+sed -i '' "s/MARKETING_VERSION = [^;]*/MARKETING_VERSION = $MARKETING_VERSION/g" "$PBXPROJ"
 
 # 3. Generate Config.swift from environment variables
 CONFIG_PATH="$CI_PRIMARY_REPOSITORY_PATH/Xomfit/Config.swift"


### PR DESCRIPTION
Version format: MAJOR.MINOR.BUILD (e.g., 1.0.7). Patch auto-increments with each Xcode Cloud build.