### PR TITLE
fix 3 bugs: calendar, feed detail, tab bar

### DIFF
--- a/Xomfit/Models/SocialFeedItem.swift
+++ b/Xomfit/Models/SocialFeedItem.swift
@@ -64,6 +64,15 @@ struct WorkoutActivity: Codable {
         let bestWeight: Double
         let bestReps: Int
         let isPR: Bool
+        let setCount: Int?
+        let sets: [SetDetail]?
+
+        struct SetDetail: Codable, Identifiable {
+            var id: String { "\(setNumber)" }
+            let setNumber: Int
+            let weight: Double
+            let reps: Int
+        }
     }
 }
 
@@ -137,8 +146,17 @@ extension SocialFeedItem {
             exerciseCount: 5,
             prCount: 1,
             exercises: [
-                .init(id: "es-1", name: "Squat", bestWeight: 315, bestReps: 5, isPR: true),
-                .init(id: "es-2", name: "Leg Press", bestWeight: 450, bestReps: 10, isPR: false)
+                .init(id: "es-1", name: "Squat", bestWeight: 315, bestReps: 5, isPR: true, setCount: 4, sets: [
+                    .init(setNumber: 1, weight: 275, reps: 5),
+                    .init(setNumber: 2, weight: 295, reps: 5),
+                    .init(setNumber: 3, weight: 315, reps: 5),
+                    .init(setNumber: 4, weight: 315, reps: 3)
+                ]),
+                .init(id: "es-2", name: "Leg Press", bestWeight: 450, bestReps: 10, isPR: false, setCount: 3, sets: [
+                    .init(setNumber: 1, weight: 400, reps: 10),
+                    .init(setNumber: 2, weight: 450, reps: 10),
+                    .init(setNumber: 3, weight: 450, reps: 8)
+                ])
             ]
         ),
         caption: "Great leg session today!",

--- a/Xomfit/Services/FeedService.swift
+++ b/Xomfit/Services/FeedService.swift
@@ -156,7 +156,15 @@ final class FeedService {
                 name: ex.exercise.name,
                 bestWeight: ex.bestSet?.weight ?? 0,
                 bestReps: ex.bestSet?.reps ?? 0,
-                isPR: ex.sets.contains { $0.isPersonalRecord }
+                isPR: ex.sets.contains { $0.isPersonalRecord },
+                setCount: ex.sets.count,
+                sets: ex.sets.enumerated().map { index, set in
+                    WorkoutActivity.ExerciseSummary.SetDetail(
+                        setNumber: index + 1,
+                        weight: set.weight,
+                        reps: set.reps
+                    )
+                }
             )
         }
 

--- a/Xomfit/Views/Feed/FeedDetailView.swift
+++ b/Xomfit/Views/Feed/FeedDetailView.swift
@@ -6,6 +6,13 @@ struct FeedDetailView: View {
 
     @State private var viewModel = FeedViewModel()
     @State private var localItem: SocialFeedItem
+    @State private var expandedExercises: Set<String> = []
+    @State private var showDeleteConfirm = false
+    @State private var showEditCaption = false
+    @State private var editedCaption = ""
+    @Environment(\.dismiss) private var dismiss
+
+    private var isOwnPost: Bool { item.userId == userId }
 
     init(item: SocialFeedItem, userId: String) {
         self.item = item
@@ -19,32 +26,7 @@ struct FeedDetailView: View {
 
             ScrollView {
                 VStack(spacing: Theme.Spacing.md) {
-                    // Unified card: header + workout stats + exercises
                     unifiedCard
-
-                    // Comments navigation button
-                    NavigationLink {
-                        FeedCommentsView(feedItemId: item.id, userId: userId)
-                    } label: {
-                        HStack(spacing: 8) {
-                            Image(systemName: "bubble.right")
-                                .font(.body)
-                            Text("Comments")
-                                .font(.subheadline.weight(.semibold))
-                            Spacer()
-                            Text("\(localItem.comments.count)")
-                                .font(.subheadline.weight(.medium))
-                                .foregroundStyle(Theme.textSecondary)
-                            Image(systemName: "chevron.right")
-                                .font(.caption.weight(.semibold))
-                                .foregroundStyle(Theme.textSecondary)
-                        }
-                        .foregroundStyle(Theme.textPrimary)
-                        .padding(Theme.Spacing.md)
-                        .background(Theme.surface)
-                        .clipShape(.rect(cornerRadius: Theme.cornerRadius))
-                    }
-                    .buttonStyle(.plain)
                 }
                 .padding(Theme.Spacing.md)
                 .padding(.bottom, 20)
@@ -53,27 +35,66 @@ struct FeedDetailView: View {
         .navigationTitle("Post")
         .navigationBarTitleDisplayMode(.inline)
         .toolbarColorScheme(.dark, for: .navigationBar)
+        .toolbar {
+            if isOwnPost {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Menu {
+                        Button {
+                            editedCaption = localItem.caption ?? ""
+                            showEditCaption = true
+                        } label: {
+                            Label("Edit Caption", systemImage: "pencil")
+                        }
+                        Button(role: .destructive) {
+                            showDeleteConfirm = true
+                        } label: {
+                            Label("Delete Post", systemImage: "trash")
+                        }
+                    } label: {
+                        Image(systemName: "ellipsis")
+                            .foregroundStyle(Theme.textSecondary)
+                    }
+                }
+            }
+        }
+        .confirmationDialog("Delete Post", isPresented: $showDeleteConfirm, titleVisibility: .visible) {
+            Button("Delete", role: .destructive) {
+                Task {
+                    await viewModel.deleteFeedItem(id: item.id)
+                    dismiss()
+                }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("Are you sure you want to delete this post? This cannot be undone.")
+        }
+        .alert("Edit Caption", isPresented: $showEditCaption) {
+            TextField("Caption", text: $editedCaption)
+            Button("Save") {
+                Task {
+                    await viewModel.updateCaption(feedItemId: item.id, caption: editedCaption)
+                    localItem.caption = editedCaption
+                }
+            }
+            Button("Cancel", role: .cancel) {}
+        }
     }
 
     // MARK: - Unified Card
 
     private var unifiedCard: some View {
         VStack(alignment: .leading, spacing: Theme.Spacing.md) {
-            // User info header
             headerRow
 
-            // Caption
             if let caption = localItem.caption, !caption.isEmpty {
                 Text(caption)
                     .font(Theme.fontBody)
                     .foregroundStyle(Theme.textPrimary)
             }
 
-            // Workout breakdown (if workout type)
             if let activity = localItem.workoutActivity {
                 Divider().background(Theme.textSecondary.opacity(0.2))
 
-                // Workout name + date
                 VStack(alignment: .leading, spacing: 6) {
                     Text(activity.workoutName)
                         .font(.title3.weight(.bold))
@@ -92,7 +113,6 @@ struct FeedDetailView: View {
                     .foregroundStyle(Theme.textSecondary)
                 }
 
-                // Stats row
                 HStack(spacing: 0) {
                     workoutStat(value: "\(activity.exerciseCount)", label: "Exercises", icon: "dumbbell.fill")
                     workoutStat(value: "\(activity.totalSets)", label: "Sets", icon: "list.bullet")
@@ -102,7 +122,6 @@ struct FeedDetailView: View {
                     }
                 }
 
-                // Exercise list with sets/weights
                 Divider().background(Theme.textSecondary.opacity(0.2))
 
                 VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
@@ -118,7 +137,6 @@ struct FeedDetailView: View {
 
             Divider().background(Theme.textSecondary.opacity(0.2))
 
-            // Action bar (like)
             actionBar
         }
         .padding(Theme.Spacing.md)
@@ -223,6 +241,20 @@ struct FeedDetailView: View {
             }
             .buttonStyle(.plain)
 
+            NavigationLink {
+                FeedCommentsView(feedItemId: item.id, userId: userId)
+            } label: {
+                HStack(spacing: 5) {
+                    Image(systemName: "bubble.right")
+                        .font(.body)
+                        .foregroundStyle(Theme.textSecondary)
+                    Text("\(localItem.comments.count)")
+                        .font(.subheadline.weight(.medium))
+                        .foregroundStyle(Theme.textSecondary)
+                }
+            }
+            .buttonStyle(.plain)
+
             Spacer()
         }
     }
@@ -247,47 +279,98 @@ struct FeedDetailView: View {
     }
 
     private func exerciseRow(exercise: WorkoutActivity.ExerciseSummary) -> some View {
-        HStack(spacing: 12) {
-            Image(systemName: "dumbbell.fill")
-                .font(.subheadline)
-                .foregroundStyle(exercise.isPR ? Theme.prGold : Theme.accent)
-                .frame(width: 32, height: 32)
-                .background((exercise.isPR ? Theme.prGold : Theme.accent).opacity(0.15))
-                .clipShape(.rect(cornerRadius: 8))
+        let isExpanded = expandedExercises.contains(exercise.id)
+        let displaySets = exercise.setCount ?? 1
 
-            VStack(alignment: .leading, spacing: 3) {
-                HStack(spacing: 6) {
-                    Text(exercise.name)
-                        .font(.subheadline.weight(.semibold))
-                        .foregroundStyle(Theme.textPrimary)
-
-                    if exercise.isPR {
-                        HStack(spacing: 3) {
-                            Image(systemName: "trophy.fill")
-                                .font(.caption2)
-                            Text("PR")
-                                .font(.caption2.weight(.bold))
-                        }
-                        .foregroundStyle(Theme.prGold)
-                        .padding(.horizontal, 6)
-                        .padding(.vertical, 2)
-                        .background(Theme.prGold.opacity(0.15))
-                        .clipShape(.rect(cornerRadius: 4))
+        return VStack(spacing: 0) {
+            Button {
+                Haptics.selection()
+                withAnimation(.xomConfident) {
+                    if isExpanded {
+                        expandedExercises.remove(exercise.id)
+                    } else {
+                        expandedExercises.insert(exercise.id)
                     }
                 }
+            } label: {
+                HStack(spacing: 12) {
+                    Image(systemName: "dumbbell.fill")
+                        .font(.subheadline)
+                        .foregroundStyle(exercise.isPR ? Theme.prGold : Theme.accent)
+                        .frame(width: 32, height: 32)
+                        .background((exercise.isPR ? Theme.prGold : Theme.accent).opacity(0.15))
+                        .clipShape(.rect(cornerRadius: 8))
 
-                Text("\(exercise.bestWeight.formattedWeight) lbs x \(exercise.bestReps) reps")
-                    .font(.caption.weight(.medium))
-                    .foregroundStyle(Theme.textSecondary)
+                    VStack(alignment: .leading, spacing: 3) {
+                        HStack(spacing: 6) {
+                            Text(exercise.name)
+                                .font(.subheadline.weight(.semibold))
+                                .foregroundStyle(Theme.textPrimary)
+
+                            if exercise.isPR {
+                                HStack(spacing: 3) {
+                                    Image(systemName: "trophy.fill")
+                                        .font(.caption2)
+                                    Text("PR")
+                                        .font(.caption2.weight(.bold))
+                                }
+                                .foregroundStyle(Theme.prGold)
+                                .padding(.horizontal, 6)
+                                .padding(.vertical, 2)
+                                .background(Theme.prGold.opacity(0.15))
+                                .clipShape(.rect(cornerRadius: 4))
+                            }
+                        }
+
+                        Text("\(displaySets) set\(displaySets == 1 ? "" : "s") · Best: \(exercise.bestWeight.formattedWeight) lbs x \(exercise.bestReps) reps")
+                            .font(.caption.weight(.medium))
+                            .foregroundStyle(Theme.textSecondary)
+                    }
+
+                    Spacer()
+
+                    if let sets = exercise.sets, !sets.isEmpty {
+                        Image(systemName: "chevron.right")
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(Theme.textSecondary)
+                            .rotationEffect(.degrees(isExpanded ? 90 : 0))
+                    }
+                }
             }
+            .buttonStyle(.plain)
+            .padding(10)
 
-            Spacer()
+            if isExpanded, let sets = exercise.sets, !sets.isEmpty {
+                VStack(spacing: 0) {
+                    ForEach(sets) { set in
+                        HStack {
+                            Text("Set \(set.setNumber)")
+                                .font(.caption.weight(.semibold))
+                                .foregroundStyle(Theme.textSecondary)
+                                .frame(width: 44, alignment: .leading)
+                            Text("\(set.weight.formattedWeight) lbs")
+                                .font(.caption.weight(.medium))
+                                .foregroundStyle(Theme.textPrimary)
+                            Text("x")
+                                .font(.caption)
+                                .foregroundStyle(Theme.textSecondary)
+                            Text("\(set.reps) reps")
+                                .font(.caption.weight(.medium))
+                                .foregroundStyle(Theme.textPrimary)
+                            Spacer()
+                        }
+                        .padding(.horizontal, 54)
+                        .padding(.vertical, 6)
+                    }
+                }
+                .padding(.bottom, 8)
+                .transition(.opacity.combined(with: .move(edge: .top)))
+            }
         }
-        .padding(10)
         .background(Theme.background)
         .clipShape(.rect(cornerRadius: Theme.cornerRadiusSmall))
         .accessibilityElement(children: .combine)
-        .accessibilityLabel("\(exercise.name), \(exercise.bestWeight.formattedWeight) pounds by \(exercise.bestReps) reps\(exercise.isPR ? ", personal record" : "")")
+        .accessibilityLabel("\(exercise.name), \(displaySets) sets, best \(exercise.bestWeight.formattedWeight) pounds by \(exercise.bestReps) reps\(exercise.isPR ? ", personal record" : "")")
     }
 
     private func formatDuration(_ seconds: TimeInterval) -> String {

--- a/Xomfit/Views/MainTabView.swift
+++ b/Xomfit/Views/MainTabView.swift
@@ -68,7 +68,16 @@ private struct FloatingTabBar: View {
                 bottomTrailingRadius: 0,
                 topTrailingRadius: 24
             )
-            .fill(.ultraThinMaterial)
+            .fill(Theme.background.opacity(0.85))
+            .background(
+                UnevenRoundedRectangle(
+                    topLeadingRadius: 24,
+                    bottomLeadingRadius: 0,
+                    bottomTrailingRadius: 0,
+                    topTrailingRadius: 24
+                )
+                .fill(.ultraThinMaterial)
+            )
             .overlay(
                 UnevenRoundedRectangle(
                     topLeadingRadius: 24,

--- a/Xomfit/Views/Profile/ProfileCalendarView.swift
+++ b/Xomfit/Views/Profile/ProfileCalendarView.swift
@@ -4,6 +4,7 @@ struct ProfileCalendarView: View {
     let workoutDays: [Date: Int]
     var onDaySelected: ((Date, [Workout]) -> Void)? = nil
 
+    @Environment(AuthService.self) private var authService
     @State private var displayedMonth: Date = Date()
     @State private var selectedDate: Date? = nil
     @State private var selectedDateWorkouts: [Workout] = []
@@ -40,6 +41,7 @@ struct ProfileCalendarView: View {
                     date: selectedDate,
                     workoutCount: normalizedWorkoutDays[selectedDate] ?? 0
                 )
+                .environment(authService)
             }
         }
     }


### PR DESCRIPTION
## Summary
- **Calendar blank sheet**: pass `AuthService` environment to `CalendarDayDetailSheet` so it can load workouts
- **FeedDetailView UX**: inline comments with likes, expandable exercise rows with set details, edit/delete for own posts
- **Tab bar bleed-through**: add opaque background layer behind `ultraThinMaterial` on floating tab bar

## Test plan
- [ ] Tap calendar day with workouts → sheet shows workout list (not blank)
- [ ] FeedDetailView: like + comment counts on same row, tap exercise chevron to expand sets
- [ ] Own post: ellipsis menu shows Edit Caption + Delete Post
- [ ] Feed content no longer visible below floating tab bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)