### PR TITLE
Board sweep: filters, leaderboard, metadata, flow fixes

### DIFF
--- a/Xomfit.xcodeproj/project.pbxproj
+++ b/Xomfit.xcodeproj/project.pbxproj
@@ -731,6 +731,7 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
+				INFOPLIST_KEY_NSSupportsLiveActivities = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -766,6 +767,7 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
+				INFOPLIST_KEY_NSSupportsLiveActivities = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;

--- a/Xomfit/Models/Exercise.swift
+++ b/Xomfit/Models/Exercise.swift
@@ -17,7 +17,8 @@ struct Exercise: Codable, Identifiable, Hashable {
     var defaultLaterality: Laterality = .bilateral
 }
 
-enum MuscleGroup: String, Codable, CaseIterable {
+enum MuscleGroup: String, Codable, CaseIterable, Identifiable {
+    var id: String { rawValue }
     case chest, back, shoulders, biceps, triceps
     case quads, hamstrings, glutes, calves
     case abs, forearms, traps, lats

--- a/Xomfit/Models/SocialFeedItem.swift
+++ b/Xomfit/Models/SocialFeedItem.swift
@@ -57,6 +57,8 @@ struct WorkoutActivity: Codable {
     let exerciseCount: Int
     let prCount: Int
     let exercises: [ExerciseSummary]
+    var location: String?
+    var rating: Int?
 
     struct ExerciseSummary: Codable, Identifiable {
         let id: String

--- a/Xomfit/Models/Workout.swift
+++ b/Xomfit/Models/Workout.swift
@@ -8,6 +8,8 @@ struct Workout: Codable, Identifiable {
     var startTime: Date
     var endTime: Date?
     var notes: String?
+    var location: String?
+    var rating: Int?
     
     var startDate: Date { startTime }
 

--- a/Xomfit/Services/FeedService.swift
+++ b/Xomfit/Services/FeedService.swift
@@ -176,7 +176,9 @@ final class FeedService {
             totalSets: workout.totalSets,
             exerciseCount: workout.exercises.count,
             prCount: workout.totalPRs,
-            exercises: exercises
+            exercises: exercises,
+            location: workout.location,
+            rating: workout.rating
         )
 
         let payloadData = try jsonEncoder.encode(activity)

--- a/Xomfit/Services/LeaderboardService.swift
+++ b/Xomfit/Services/LeaderboardService.swift
@@ -1,0 +1,132 @@
+import Foundation
+
+final class LeaderboardService {
+    static let shared = LeaderboardService()
+    private init() {}
+
+    /// Fetches leaderboard entries by aggregating workout feed items from Supabase.
+    func fetchLeaderboard(
+        metric: LeaderboardMetric,
+        timeframe: LeaderboardTimeframe,
+        scope: LeaderboardScope,
+        userId: String,
+        muscleGroupFilter: MuscleGroup? = nil
+    ) async throws -> [LeaderboardEntry] {
+        // Build date filter
+        let startDate: Date? = {
+            let cal = Calendar.current
+            let now = Date()
+            switch timeframe {
+            case .weekly: return cal.dateInterval(of: .weekOfYear, for: now)?.start
+            case .monthly: return cal.dateInterval(of: .month, for: now)?.start
+            case .allTime: return nil
+            }
+        }()
+
+        // Get friend IDs for friends scope
+        let friendIds: Set<String>?
+        if scope == .friends {
+            let friends = try await FriendsService.shared.fetchFriends(userId: userId)
+            let ids = friends.map { $0.requesterId == userId ? $0.addresseeId : $0.requesterId }
+            friendIds = Set(ids + [userId])
+        } else {
+            friendIds = nil
+        }
+
+        // Fetch workout feed items
+        var query = supabase
+            .from("feed_items")
+            .select()
+            .eq("activity_type", value: "workout")
+
+        if let startDate {
+            let iso = ISO8601DateFormatter()
+            iso.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+            query = query.gte("created_at", value: iso.string(from: startDate))
+        }
+
+        let response: [LeaderboardFeedRow] = try await query
+            .order("created_at", ascending: false)
+            .limit(500)
+            .execute()
+            .value
+
+        // Aggregate by user
+        var userScores: [String: (displayName: String, score: Int)] = [:]
+
+        for row in response {
+            // Scope filter
+            if let friendIds, !friendIds.contains(row.user_id) { continue }
+
+            guard let payloadData = row.payload.data(using: .utf8),
+                  let activity = try? JSONDecoder().decode(WorkoutActivity.self, from: payloadData) else { continue }
+
+            // Muscle group filter
+            if let filter = muscleGroupFilter {
+                let exerciseGroups = activity.exercises.flatMap { ex in
+                    ExerciseDatabase.all.first(where: { $0.name == ex.name })?.muscleGroups ?? []
+                }
+                guard exerciseGroups.contains(filter) else { continue }
+            }
+
+            let score: Int = {
+                switch metric {
+                case .weeklyVolume: return Int(activity.totalVolume)
+                case .personalRecords: return activity.prCount
+                case .totalWorkouts: return 1
+                case .workoutStreak: return 1 // approximation — streaks need separate tracking
+                }
+            }()
+
+            let existing = userScores[row.user_id]
+            userScores[row.user_id] = (
+                displayName: existing?.displayName ?? row.user_id,
+                score: (existing?.score ?? 0) + score
+            )
+        }
+
+        // Resolve display names
+        let userIds = Array(userScores.keys)
+        if !userIds.isEmpty {
+            let profiles: [LeaderboardProfile] = try await supabase
+                .from("profiles")
+                .select("id, display_name, username")
+                .in("id", values: userIds)
+                .execute()
+                .value
+
+            for profile in profiles {
+                if var entry = userScores[profile.id] {
+                    entry.displayName = profile.display_name.isEmpty ? profile.username : profile.display_name
+                    userScores[profile.id] = entry
+                }
+            }
+        }
+
+        // Sort and rank
+        let sorted = userScores.sorted { $0.value.score > $1.value.score }
+        return sorted.enumerated().map { rank, pair in
+            LeaderboardEntry(
+                userId: pair.key,
+                displayName: pair.value.displayName,
+                rank: rank + 1,
+                score: pair.value.score,
+                metric: metric
+            )
+        }
+    }
+}
+
+// MARK: - Supabase DTOs
+
+private struct LeaderboardFeedRow: Decodable {
+    let user_id: String
+    let payload: String
+    let created_at: String
+}
+
+private struct LeaderboardProfile: Decodable {
+    let id: String
+    let display_name: String
+    let username: String
+}

--- a/Xomfit/ViewModels/FeedViewModel.swift
+++ b/Xomfit/ViewModels/FeedViewModel.swift
@@ -8,6 +8,30 @@ final class FeedViewModel {
     var isRefreshing: Bool = false
     var errorMessage: String? = nil
 
+    // Filters
+    var dateRange: FeedDateRange = .all
+    var selectedMuscleGroups: Set<MuscleGroup> = []
+
+    var filteredFeedItems: [SocialFeedItem] {
+        feedItems.filter { item in
+            // Date filter
+            if let start = dateRange.startDate, item.createdAt < start {
+                return false
+            }
+            // Muscle group filter (only applies to workout posts)
+            if !selectedMuscleGroups.isEmpty {
+                guard let exercises = item.workoutActivity?.exercises else { return false }
+                let itemGroups = exercises.flatMap { ex in
+                    ExerciseDatabase.all.first(where: { $0.name == ex.name })?.muscleGroups ?? []
+                }
+                if selectedMuscleGroups.isDisjoint(with: itemGroups) { return false }
+            }
+            return true
+        }
+    }
+
+    var isFiltered: Bool { dateRange != .all || !selectedMuscleGroups.isEmpty }
+
     // Pagination state
     private let pageSize = 20
     private var offset = 0

--- a/Xomfit/ViewModels/LeaderboardViewModel.swift
+++ b/Xomfit/ViewModels/LeaderboardViewModel.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+@MainActor
+@Observable
+final class LeaderboardViewModel {
+    var entries: [LeaderboardEntry] = []
+    var isLoading = false
+    var errorMessage: String?
+
+    var selectedMetric: LeaderboardMetric = .weeklyVolume
+    var selectedTimeframe: LeaderboardTimeframe = .weekly
+    var selectedScope: LeaderboardScope = .friends
+    var selectedMuscleGroup: MuscleGroup?
+
+    func loadLeaderboard(userId: String) async {
+        isLoading = true
+        errorMessage = nil
+
+        do {
+            entries = try await LeaderboardService.shared.fetchLeaderboard(
+                metric: selectedMetric,
+                timeframe: selectedTimeframe,
+                scope: selectedScope,
+                userId: userId,
+                muscleGroupFilter: selectedMuscleGroup
+            )
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+
+        isLoading = false
+    }
+
+    /// The current user's entry, if they're on the leaderboard.
+    func currentUserEntry(userId: String) -> LeaderboardEntry? {
+        entries.first(where: { $0.userId == userId })
+    }
+}

--- a/Xomfit/ViewModels/ProfileViewModel.swift
+++ b/Xomfit/ViewModels/ProfileViewModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Supabase
 
 // MARK: - Profile Tab
 
@@ -52,6 +53,11 @@ final class ProfileViewModel {
     var editBio: String = ""
     var editIsPrivate: Bool = false
 
+    // MARK: - Username validation
+    var usernameError: String?
+    var isCheckingUsername: Bool = false
+    private var usernameCheckTask: Task<Void, Never>?
+
     // MARK: - Stats
     var totalWorkouts: Int = 0
     var totalVolume: Double = 0
@@ -67,6 +73,26 @@ final class ProfileViewModel {
 
     // MARK: - Feed
     var feedItems: [SocialFeedItem] = []
+    var feedDateRange: FeedDateRange = .all
+    var feedMuscleGroups: Set<MuscleGroup> = []
+
+    var filteredFeedItems: [SocialFeedItem] {
+        feedItems.filter { item in
+            if let start = feedDateRange.startDate, item.createdAt < start {
+                return false
+            }
+            if !feedMuscleGroups.isEmpty {
+                guard let exercises = item.workoutActivity?.exercises else { return false }
+                let itemGroups = exercises.flatMap { ex in
+                    ExerciseDatabase.all.first(where: { $0.name == ex.name })?.muscleGroups ?? []
+                }
+                if feedMuscleGroups.isDisjoint(with: itemGroups) { return false }
+            }
+            return true
+        }
+    }
+
+    var isFeedFiltered: Bool { feedDateRange != .all || !feedMuscleGroups.isEmpty }
 
     // MARK: - Calendar
     var workoutDays: [Date: Int] = [:]
@@ -191,10 +217,16 @@ final class ProfileViewModel {
     // MARK: - Update
 
     func updateProfile(userId: String) async {
+        guard canSaveProfile else {
+            errorMessage = usernameError ?? "Invalid username."
+            return
+        }
+
         isSaving = true
         errorMessage = nil
         do {
-            let savedUsername = editUsername.isEmpty ? (username.isEmpty ? userId : username) : editUsername
+            let savedUsername = editUsername.trimmingCharacters(in: .whitespaces).lowercased()
+                .isEmpty ? (username.isEmpty ? userId : username) : editUsername.trimmingCharacters(in: .whitespaces).lowercased()
             try await ProfileService.shared.upsertProfile(
                 userId: userId,
                 username: savedUsername,
@@ -220,6 +252,60 @@ final class ProfileViewModel {
         editDisplayName = displayName
         editBio = bio
         editIsPrivate = isPrivate
+        usernameError = nil
+        isCheckingUsername = false
+    }
+
+    /// Debounced username uniqueness check against Supabase.
+    func checkUsernameAvailability(userId: String) {
+        usernameCheckTask?.cancel()
+        usernameError = nil
+
+        let trimmed = editUsername.trimmingCharacters(in: .whitespaces).lowercased()
+        guard !trimmed.isEmpty else { return }
+
+        // Validate format first
+        guard trimmed.count >= 3 else {
+            usernameError = "Username must be at least 3 characters."
+            return
+        }
+        guard trimmed.allSatisfy({ $0.isLetter || $0.isNumber || $0 == "_" }) else {
+            usernameError = "Letters, numbers, and underscores only."
+            return
+        }
+
+        // Skip server check if username hasn't changed
+        if trimmed == username { return }
+
+        isCheckingUsername = true
+        usernameCheckTask = Task {
+            try? await Task.sleep(for: .milliseconds(300))
+            guard !Task.isCancelled else { return }
+
+            do {
+                let existing: [ProfileRow] = try await supabase
+                    .from("profiles")
+                    .select("id")
+                    .eq("username", value: trimmed)
+                    .neq("id", value: userId)
+                    .limit(1)
+                    .execute()
+                    .value
+
+                guard !Task.isCancelled else { return }
+                if !existing.isEmpty {
+                    usernameError = "Username already taken."
+                }
+            } catch {
+                guard !Task.isCancelled else { return }
+            }
+            isCheckingUsername = false
+        }
+    }
+
+    /// Whether the save button should be disabled.
+    var canSaveProfile: Bool {
+        usernameError == nil && !isCheckingUsername && !editUsername.trimmingCharacters(in: .whitespaces).isEmpty
     }
 
     // MARK: - Friend Request

--- a/Xomfit/ViewModels/WorkoutLoggerViewModel.swift
+++ b/Xomfit/ViewModels/WorkoutLoggerViewModel.swift
@@ -16,6 +16,8 @@ final class WorkoutLoggerViewModel {
     var isActive = false
     var isSaving = false
     var errorMessage: String?
+    var location: String = ""
+    var rating: Int = 0
 
     // Rest timer
     var restTimeRemaining: Double = 0
@@ -130,6 +132,8 @@ final class WorkoutLoggerViewModel {
         focusMode = false
         focusExerciseIndex = 0
         focusSetIndex = 0
+        location = ""
+        rating = 0
         skipRestTimer()
     }
 
@@ -322,9 +326,7 @@ final class WorkoutLoggerViewModel {
                     return RemainingExercise(index: idx, name: ex.exercise.name)
                 }
 
-                if focusMode {
-                    showExerciseTransition = true
-                }
+                showExerciseTransition = true
             }
         }
         updateLiveActivity()
@@ -387,6 +389,23 @@ final class WorkoutLoggerViewModel {
         focusSetIndex = 0
     }
 
+    /// Sync focus indices to the first incomplete exercise/set. Called when entering focus mode from list mode.
+    func syncFocusToCurrentExercise() {
+        // Find first exercise with an incomplete set
+        for (exIdx, ex) in exercises.enumerated() {
+            if let setIdx = ex.sets.firstIndex(where: { $0.completedAt == Date.distantPast }) {
+                focusExerciseIndex = exIdx
+                focusSetIndex = setIdx
+                return
+            }
+        }
+        // All done — point to last exercise, last set
+        if let last = exercises.indices.last {
+            focusExerciseIndex = last
+            focusSetIndex = max(exercises[last].sets.count - 1, 0)
+        }
+    }
+
     /// Complete the focused set and auto-advance.
     func completeFocusedSet() {
         completeSet(exerciseIndex: focusExerciseIndex, setIndex: focusSetIndex)
@@ -419,11 +438,22 @@ final class WorkoutLoggerViewModel {
 
     // MARK: - Rest Timer
 
+    /// Timestamp when the rest timer was started — used to survive background suspension.
+    private var restTimerStartDate: Date?
+
     func startRestTimer(for category: ExerciseCategory) {
         guard defaultRestDuration > 0 else { return }
         restDuration = defaultRestDuration
         restTimeRemaining = defaultRestDuration
         isRestTimerActive = true
+        restTimerStartDate = Date()
+    }
+
+    /// Called when the app returns to foreground. Recalculates rest timer based on wall-clock time elapsed.
+    func recalculateRestTimer() {
+        guard isRestTimerActive, let startDate = restTimerStartDate else { return }
+        let elapsed = Date().timeIntervalSince(startDate)
+        restTimeRemaining = restDuration - elapsed
     }
 
     func tickRestTimer() {
@@ -567,6 +597,7 @@ final class WorkoutLoggerViewModel {
         }
 
         let trimmedNotes = notes?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedLocation = location.trimmingCharacters(in: .whitespacesAndNewlines)
         let workout = Workout(
             id: UUID().uuidString,
             userId: userId,
@@ -574,7 +605,9 @@ final class WorkoutLoggerViewModel {
             exercises: completedExercises,
             startTime: startTime,
             endTime: Date(),
-            notes: trimmedNotes?.isEmpty == false ? trimmedNotes : nil
+            notes: trimmedNotes?.isEmpty == false ? trimmedNotes : nil,
+            location: trimmedLocation.isEmpty ? nil : trimmedLocation,
+            rating: rating > 0 ? rating : nil
         )
 
         do {

--- a/Xomfit/Views/Feed/FeedDetailView.swift
+++ b/Xomfit/Views/Feed/FeedDetailView.swift
@@ -387,6 +387,7 @@ struct FeedDetailView: View {
 
             NavigationLink {
                 FeedCommentsView(feedItemId: item.id, userId: userId)
+                    .hideTabBar()
             } label: {
                 HStack(spacing: 5) {
                     Image(systemName: "bubble.right")

--- a/Xomfit/Views/Feed/FeedFilterBar.swift
+++ b/Xomfit/Views/Feed/FeedFilterBar.swift
@@ -1,0 +1,87 @@
+import SwiftUI
+
+enum FeedDateRange: String, CaseIterable, Identifiable {
+    case all = "All Time"
+    case today = "Today"
+    case thisWeek = "This Week"
+    case thisMonth = "This Month"
+
+    var id: String { rawValue }
+
+    /// Returns the start date for this range, or nil for "all time".
+    var startDate: Date? {
+        let cal = Calendar.current
+        let now = Date()
+        switch self {
+        case .all: return nil
+        case .today: return cal.startOfDay(for: now)
+        case .thisWeek: return cal.dateInterval(of: .weekOfYear, for: now)?.start
+        case .thisMonth: return cal.dateInterval(of: .month, for: now)?.start
+        }
+    }
+}
+
+struct FeedFilterBar: View {
+    @Binding var selectedDateRange: FeedDateRange
+    @Binding var selectedMuscleGroups: Set<MuscleGroup>
+
+    var body: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+                // Date range chips
+                ForEach(FeedDateRange.allCases) { range in
+                    filterChip(
+                        label: range.rawValue,
+                        isSelected: selectedDateRange == range
+                    ) {
+                        withAnimation(.xomChill) { selectedDateRange = range }
+                    }
+                }
+
+                // Divider
+                Rectangle()
+                    .fill(Theme.textSecondary.opacity(0.3))
+                    .frame(width: 1, height: 20)
+
+                // Muscle group chips
+                ForEach(MuscleGroup.allCases) { group in
+                    filterChip(
+                        icon: group.icon,
+                        label: group.displayName,
+                        isSelected: selectedMuscleGroups.contains(group)
+                    ) {
+                        withAnimation(.xomChill) {
+                            if selectedMuscleGroups.contains(group) {
+                                selectedMuscleGroups.remove(group)
+                            } else {
+                                selectedMuscleGroups.insert(group)
+                            }
+                        }
+                    }
+                }
+            }
+            .padding(.horizontal, Theme.Spacing.md)
+        }
+        .padding(.vertical, 8)
+    }
+
+    private func filterChip(icon: String? = nil, label: String, isSelected: Bool, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            HStack(spacing: 4) {
+                if let icon {
+                    Image(systemName: icon)
+                        .font(.caption2)
+                }
+                Text(label)
+                    .font(.caption.weight(.semibold))
+            }
+            .foregroundStyle(isSelected ? .black : Theme.textSecondary)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .background(isSelected ? Theme.accent : Theme.surfaceSecondary)
+            .clipShape(.capsule)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("\(label)\(isSelected ? ", selected" : "")")
+    }
+}

--- a/Xomfit/Views/Feed/FeedItemCard.swift
+++ b/Xomfit/Views/Feed/FeedItemCard.swift
@@ -257,9 +257,31 @@ private struct WorkoutActivityContent: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
-            Text(activity.workoutName)
-                .font(.body.weight(.bold))
-                .foregroundStyle(Theme.textPrimary)
+            HStack(spacing: Theme.Spacing.sm) {
+                Text(activity.workoutName)
+                    .font(.body.weight(.bold))
+                    .foregroundStyle(Theme.textPrimary)
+
+                if let rating = activity.rating, rating > 0 {
+                    HStack(spacing: 2) {
+                        ForEach(1...5, id: \.self) { star in
+                            Image(systemName: star <= rating ? "star.fill" : "star")
+                                .font(.system(size: 10))
+                                .foregroundStyle(star <= rating ? Theme.accent : Theme.textSecondary.opacity(0.3))
+                        }
+                    }
+                }
+            }
+
+            if let location = activity.location, !location.isEmpty {
+                HStack(spacing: 4) {
+                    Image(systemName: "location.fill")
+                        .font(.system(size: 10))
+                    Text(location)
+                        .font(Theme.fontSmall)
+                }
+                .foregroundStyle(Theme.textSecondary)
+            }
 
             // Stats grid — max 3 primary + optional PR badge
             HStack(spacing: 0) {

--- a/Xomfit/Views/Feed/FeedView.swift
+++ b/Xomfit/Views/Feed/FeedView.swift
@@ -22,7 +22,24 @@ struct FeedView: View {
                 } else if viewModel.feedItems.isEmpty {
                     emptyState
                 } else {
-                    feedList
+                    VStack(spacing: 0) {
+                        FeedFilterBar(
+                            selectedDateRange: $viewModel.dateRange,
+                            selectedMuscleGroups: $viewModel.selectedMuscleGroups
+                        )
+
+                        if viewModel.isFiltered && viewModel.filteredFeedItems.isEmpty {
+                            Spacer()
+                            XomEmptyState(
+                                icon: "line.3.horizontal.decrease",
+                                title: "No matching posts",
+                                subtitle: "Try adjusting your filters"
+                            )
+                            Spacer()
+                        } else {
+                            feedList
+                        }
+                    }
                 }
             }
             .navigationTitle("Feed")
@@ -40,6 +57,7 @@ struct FeedView: View {
 
                         NavigationLink {
                             FriendsView()
+                                .hideTabBar()
                         } label: {
                             Image(systemName: "person.badge.plus")
                                 .foregroundStyle(Theme.accent)
@@ -49,6 +67,7 @@ struct FeedView: View {
             }
             .navigationDestination(item: $selectedFeedItem) { item in
                 FeedDetailView(item: item, userId: userId)
+                    .hideTabBar()
             }
             .sheet(isPresented: $showUserSearch) {
                 UserSearchView()
@@ -78,7 +97,7 @@ struct FeedView: View {
     private var feedList: some View {
         ScrollView {
             LazyVStack(spacing: 12) {
-                ForEach(Array(viewModel.feedItems.enumerated()), id: \.element.id) { index, item in
+                ForEach(Array(viewModel.filteredFeedItems.enumerated()), id: \.element.id) { index, item in
                     FeedItemCard(
                         item: item,
                         onLike: {
@@ -103,7 +122,7 @@ struct FeedView: View {
                     }
                 }
 
-                if !viewModel.hasMore && !viewModel.feedItems.isEmpty {
+                if !viewModel.hasMore && !viewModel.filteredFeedItems.isEmpty {
                     Text("You're all caught up!")
                         .font(Theme.fontCaption)
                         .foregroundStyle(Theme.textSecondary)

--- a/Xomfit/Views/MainTabView.swift
+++ b/Xomfit/Views/MainTabView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct MainTabView: View {
     @State private var selectedTab = 0
+    @State private var tabBarVisible = true
 
     var body: some View {
         ZStack {
@@ -18,8 +19,42 @@ struct MainTabView: View {
             .animation(.xomChill, value: selectedTab)
         }
         .safeAreaInset(edge: .bottom) {
-            FloatingTabBar(selectedTab: $selectedTab)
+            if tabBarVisible {
+                FloatingTabBar(selectedTab: $selectedTab)
+                    .transition(.move(edge: .bottom).combined(with: .opacity))
+            }
         }
+        .environment(\.tabBarVisible, $tabBarVisible)
+    }
+}
+
+// MARK: - Tab Bar Visibility Environment Key
+
+private struct TabBarVisibleKey: EnvironmentKey {
+    static let defaultValue: Binding<Bool> = .constant(true)
+}
+
+extension EnvironmentValues {
+    var tabBarVisible: Binding<Bool> {
+        get { self[TabBarVisibleKey.self] }
+        set { self[TabBarVisibleKey.self] = newValue }
+    }
+}
+
+/// Apply to any view pushed inside a NavigationStack to hide the floating tab bar.
+struct HideTabBar: ViewModifier {
+    @Environment(\.tabBarVisible) private var tabBarVisible
+
+    func body(content: Content) -> some View {
+        content
+            .onAppear { withAnimation(.xomChill) { tabBarVisible.wrappedValue = false } }
+            .onDisappear { withAnimation(.xomChill) { tabBarVisible.wrappedValue = true } }
+    }
+}
+
+extension View {
+    func hideTabBar() -> some View {
+        modifier(HideTabBar())
     }
 }
 

--- a/Xomfit/Views/Profile/EditProfileSheet.swift
+++ b/Xomfit/Views/Profile/EditProfileSheet.swift
@@ -17,6 +17,24 @@ struct EditProfileSheet: View {
                             .autocorrectionDisabled()
                             .listRowBackground(Theme.surface)
                             .foregroundStyle(Theme.textPrimary)
+                            .onChange(of: viewModel.editUsername) { _, _ in
+                                viewModel.checkUsernameAvailability(userId: userId)
+                            }
+
+                        if viewModel.isCheckingUsername {
+                            HStack(spacing: 6) {
+                                ProgressView().controlSize(.mini)
+                                Text("Checking availability...")
+                                    .font(Theme.fontSmall)
+                                    .foregroundStyle(Theme.textSecondary)
+                            }
+                            .listRowBackground(Theme.surface)
+                        } else if let error = viewModel.usernameError {
+                            Text(error)
+                                .font(Theme.fontSmall)
+                                .foregroundStyle(Theme.destructive)
+                                .listRowBackground(Theme.surface)
+                        }
                     }
 
                     Section("Display Name") {
@@ -66,7 +84,8 @@ struct EditProfileSheet: View {
                             }
                         }
                         .font(.subheadline.weight(.semibold))
-                        .foregroundStyle(Theme.accent)
+                        .foregroundStyle(viewModel.canSaveProfile ? Theme.accent : Theme.textSecondary)
+                        .disabled(!viewModel.canSaveProfile)
                     }
                 }
             }

--- a/Xomfit/Views/Profile/ProfileCalendarView.swift
+++ b/Xomfit/Views/Profile/ProfileCalendarView.swift
@@ -252,6 +252,7 @@ private struct CalendarDayDetailSheet: View {
                         ForEach(workouts) { workout in
                             NavigationLink {
                                 WorkoutDetailView(workout: workout)
+                                    .hideTabBar()
                             } label: {
                                 HStack(spacing: 12) {
                                     Image(systemName: "dumbbell.fill")

--- a/Xomfit/Views/Profile/ProfileFeedView.swift
+++ b/Xomfit/Views/Profile/ProfileFeedView.swift
@@ -2,30 +2,55 @@ import SwiftUI
 
 struct ProfileFeedView: View {
     @Binding var feedItems: [SocialFeedItem]
+    var filteredItems: [SocialFeedItem]
+    var isFiltered: Bool
+    @Binding var dateRange: FeedDateRange
+    @Binding var muscleGroups: Set<MuscleGroup>
     var userId: String = ""
     var currentUserId: String = ""
 
     var body: some View {
-        if feedItems.isEmpty {
-            emptyState
-        } else {
-            LazyVStack(spacing: Theme.Spacing.sm) {
-                ForEach(feedItems) { item in
-                    NavigationLink {
-                        FeedDetailView(item: item, userId: currentUserId)
-                    } label: {
-                        FeedItemCard(
-                            item: item,
-                            onLike: { /* Like handled at feed level */ },
-                            onComment: { /* Comment handled at feed level */ },
-                            onDelete: deleteAction(for: item),
-                            onEdit: editAction(for: item)
-                        )
-                    }
-                    .buttonStyle(.plain)
-                }
+        VStack(spacing: 0) {
+            if !feedItems.isEmpty {
+                FeedFilterBar(
+                    selectedDateRange: $dateRange,
+                    selectedMuscleGroups: $muscleGroups
+                )
             }
-            .padding(.horizontal, Theme.Spacing.md)
+
+            if feedItems.isEmpty {
+                emptyState
+            } else if isFiltered && filteredItems.isEmpty {
+                VStack(spacing: Theme.Spacing.sm) {
+                    Image(systemName: "line.3.horizontal.decrease")
+                        .font(.largeTitle)
+                        .foregroundStyle(Theme.textSecondary)
+                    Text("No matching posts")
+                        .font(Theme.fontBody)
+                        .foregroundStyle(Theme.textSecondary)
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 60)
+            } else {
+                LazyVStack(spacing: Theme.Spacing.sm) {
+                    ForEach(filteredItems) { item in
+                        NavigationLink {
+                            FeedDetailView(item: item, userId: currentUserId)
+                                .hideTabBar()
+                        } label: {
+                            FeedItemCard(
+                                item: item,
+                                onLike: { /* Like handled at feed level */ },
+                                onComment: { /* Comment handled at feed level */ },
+                                onDelete: deleteAction(for: item),
+                                onEdit: editAction(for: item)
+                            )
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+                .padding(.horizontal, Theme.Spacing.md)
+            }
         }
     }
 

--- a/Xomfit/Views/Profile/ProfileFriendsView.swift
+++ b/Xomfit/Views/Profile/ProfileFriendsView.swift
@@ -17,6 +17,7 @@ struct ProfileFriendsView: View {
                 ForEach(friends) { friend in
                     NavigationLink {
                         ProfileView(userId: otherUserId(friend))
+                            .hideTabBar()
                     } label: {
                         friendRow(friend: friend)
                     }

--- a/Xomfit/Views/Profile/ProfileHeaderView.swift
+++ b/Xomfit/Views/Profile/ProfileHeaderView.swift
@@ -34,6 +34,7 @@ struct ProfileHeaderView: View {
                         friendProfiles: friendProfiles,
                         currentUserId: currentUserId
                     )
+                    .hideTabBar()
                 } label: {
                     VStack(spacing: 2) {
                         Text("\(friendCount)")

--- a/Xomfit/Views/Profile/ProfileView.swift
+++ b/Xomfit/Views/Profile/ProfileView.swift
@@ -162,7 +162,15 @@ struct ProfileView: View {
     private var tabContent: some View {
         switch viewModel.selectedTab {
         case .feed:
-            ProfileFeedView(feedItems: $viewModel.feedItems, userId: resolvedUserId, currentUserId: currentUserId)
+            ProfileFeedView(
+                feedItems: $viewModel.feedItems,
+                filteredItems: viewModel.filteredFeedItems,
+                isFiltered: viewModel.isFeedFiltered,
+                dateRange: $viewModel.feedDateRange,
+                muscleGroups: $viewModel.feedMuscleGroups,
+                userId: resolvedUserId,
+                currentUserId: currentUserId
+            )
         case .calendar:
             ProfileCalendarView(workoutDays: viewModel.workoutDays, userId: resolvedUserId)
         case .stats:
@@ -194,6 +202,7 @@ struct ProfileView: View {
 
                 NavigationLink {
                     SettingsView()
+                        .hideTabBar()
                 } label: {
                     Image(systemName: "gearshape.fill")
                         .foregroundStyle(Theme.textSecondary)

--- a/Xomfit/Views/Progress/LeaderboardView.swift
+++ b/Xomfit/Views/Progress/LeaderboardView.swift
@@ -1,0 +1,288 @@
+import SwiftUI
+
+struct LeaderboardView: View {
+    @Environment(AuthService.self) private var authService
+    @State private var viewModel = LeaderboardViewModel()
+
+    private var userId: String {
+        authService.currentUser?.id.uuidString.lowercased() ?? ""
+    }
+
+    var body: some View {
+        ZStack {
+            Theme.background.ignoresSafeArea()
+
+            VStack(spacing: 0) {
+                filterBar
+                Divider().background(Theme.textSecondary.opacity(0.2))
+
+                if viewModel.isLoading {
+                    Spacer()
+                    ProgressView().tint(Theme.accent)
+                    Spacer()
+                } else if let error = viewModel.errorMessage {
+                    Spacer()
+                    XomEmptyState(
+                        icon: "exclamationmark.triangle",
+                        title: "Failed to load",
+                        subtitle: error,
+                        ctaLabel: "Retry",
+                        ctaAction: { Task { await viewModel.loadLeaderboard(userId: userId) } }
+                    )
+                    Spacer()
+                } else if viewModel.entries.isEmpty {
+                    Spacer()
+                    XomEmptyState(
+                        icon: "trophy",
+                        title: "No data yet",
+                        subtitle: "Complete workouts to appear on the leaderboard"
+                    )
+                    Spacer()
+                } else {
+                    leaderboardList
+                }
+            }
+        }
+        .navigationTitle("Leaderboard")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbarColorScheme(.dark, for: .navigationBar)
+        .hideTabBar()
+        .task {
+            await viewModel.loadLeaderboard(userId: userId)
+        }
+        .onChange(of: viewModel.selectedMetric) { _, _ in
+            Task { await viewModel.loadLeaderboard(userId: userId) }
+        }
+        .onChange(of: viewModel.selectedTimeframe) { _, _ in
+            Task { await viewModel.loadLeaderboard(userId: userId) }
+        }
+        .onChange(of: viewModel.selectedScope) { _, _ in
+            Task { await viewModel.loadLeaderboard(userId: userId) }
+        }
+        .onChange(of: viewModel.selectedMuscleGroup) { _, _ in
+            Task { await viewModel.loadLeaderboard(userId: userId) }
+        }
+    }
+
+    // MARK: - Filter Bar
+
+    private var filterBar: some View {
+        VStack(spacing: 8) {
+            // Metric + Timeframe row
+            HStack(spacing: 8) {
+                filterMenu(
+                    label: viewModel.selectedMetric.rawValue,
+                    icon: "chart.bar.fill"
+                ) {
+                    ForEach(LeaderboardMetric.allCases, id: \.self) { metric in
+                        Button {
+                            viewModel.selectedMetric = metric
+                        } label: {
+                            Label(metric.rawValue, systemImage: metricIcon(metric))
+                        }
+                    }
+                }
+
+                filterMenu(
+                    label: viewModel.selectedTimeframe.rawValue,
+                    icon: "calendar"
+                ) {
+                    ForEach(LeaderboardTimeframe.allCases, id: \.self) { tf in
+                        Button {
+                            viewModel.selectedTimeframe = tf
+                        } label: {
+                            Text(tf.rawValue)
+                        }
+                    }
+                }
+
+                filterMenu(
+                    label: viewModel.selectedScope.rawValue,
+                    icon: "person.2.fill"
+                ) {
+                    ForEach(LeaderboardScope.allCases, id: \.self) { scope in
+                        Button {
+                            viewModel.selectedScope = scope
+                        } label: {
+                            Text(scope.rawValue)
+                        }
+                    }
+                }
+            }
+
+            // Muscle group filter
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 6) {
+                    filterChip(label: "All", isSelected: viewModel.selectedMuscleGroup == nil) {
+                        viewModel.selectedMuscleGroup = nil
+                    }
+                    ForEach(MuscleGroup.allCases) { group in
+                        filterChip(
+                            label: group.displayName,
+                            isSelected: viewModel.selectedMuscleGroup == group
+                        ) {
+                            viewModel.selectedMuscleGroup = group
+                        }
+                    }
+                }
+            }
+        }
+        .padding(.horizontal, Theme.Spacing.md)
+        .padding(.vertical, Theme.Spacing.sm)
+        .background(Theme.surface.opacity(0.5))
+    }
+
+    // MARK: - Leaderboard List
+
+    private var leaderboardList: some View {
+        ScrollView {
+            LazyVStack(spacing: 0) {
+                // Podium for top 3
+                if viewModel.entries.count >= 3 {
+                    podiumView
+                        .padding(.vertical, Theme.Spacing.md)
+                }
+
+                // Full list
+                ForEach(viewModel.entries) { entry in
+                    leaderboardRow(entry: entry)
+                    if entry.id != viewModel.entries.last?.id {
+                        Divider()
+                            .background(Theme.textSecondary.opacity(0.15))
+                            .padding(.horizontal, Theme.Spacing.md)
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Podium
+
+    private var podiumView: some View {
+        HStack(alignment: .bottom, spacing: Theme.Spacing.md) {
+            if viewModel.entries.count >= 2 {
+                podiumColumn(entry: viewModel.entries[1], height: 80)
+            }
+            if !viewModel.entries.isEmpty {
+                podiumColumn(entry: viewModel.entries[0], height: 110)
+            }
+            if viewModel.entries.count >= 3 {
+                podiumColumn(entry: viewModel.entries[2], height: 60)
+            }
+        }
+        .padding(.horizontal, Theme.Spacing.lg)
+    }
+
+    private func podiumColumn(entry: LeaderboardEntry, height: CGFloat) -> some View {
+        VStack(spacing: Theme.Spacing.xs) {
+            Text(entry.badge ?? "")
+                .font(.title)
+
+            XomAvatar(name: entry.displayName, size: entry.rank == 1 ? 56 : 44)
+
+            Text(entry.displayName)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(Theme.textPrimary)
+                .lineLimit(1)
+
+            Text(entry.scoreFormatted)
+                .font(.caption2.weight(.bold))
+                .foregroundStyle(Theme.accent)
+
+            RoundedRectangle(cornerRadius: 8)
+                .fill(entry.rank == 1 ? Theme.accent.opacity(0.3) : Theme.surface)
+                .frame(height: height)
+                .overlay(
+                    Text("#\(entry.rank)")
+                        .font(.title3.weight(.black))
+                        .foregroundStyle(entry.rank == 1 ? Theme.accent : Theme.textSecondary)
+                )
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    // MARK: - Row
+
+    private func leaderboardRow(entry: LeaderboardEntry) -> some View {
+        let isCurrentUser = entry.userId == userId
+        return HStack(spacing: Theme.Spacing.sm) {
+            // Rank
+            Text("\(entry.rank)")
+                .font(.body.weight(.bold).monospacedDigit())
+                .foregroundStyle(entry.rank <= 3 ? Theme.accent : Theme.textSecondary)
+                .frame(width: 30, alignment: .center)
+
+            XomAvatar(name: entry.displayName, size: 36)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(entry.displayName)
+                    .font(.subheadline.weight(isCurrentUser ? .bold : .medium))
+                    .foregroundStyle(isCurrentUser ? Theme.accent : Theme.textPrimary)
+                    .lineLimit(1)
+
+                if entry.rankChange != 0 {
+                    Text(entry.rankChangeSymbol)
+                        .font(.caption2.weight(.semibold))
+                        .foregroundStyle(entry.rankChange > 0 ? .green : Theme.destructive)
+                }
+            }
+
+            Spacer()
+
+            Text(entry.scoreFormatted)
+                .font(.subheadline.weight(.bold).monospacedDigit())
+                .foregroundStyle(Theme.textPrimary)
+        }
+        .padding(.horizontal, Theme.Spacing.md)
+        .padding(.vertical, 12)
+        .background(isCurrentUser ? Theme.accent.opacity(0.08) : .clear)
+    }
+
+    // MARK: - Helpers
+
+    private func filterMenu<Content: View>(
+        label: String,
+        icon: String,
+        @ViewBuilder content: @escaping () -> Content
+    ) -> some View {
+        Menu {
+            content()
+        } label: {
+            HStack(spacing: 4) {
+                Image(systemName: icon)
+                    .font(.caption2)
+                Text(label)
+                    .font(.caption.weight(.semibold))
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 8, weight: .bold))
+            }
+            .foregroundStyle(Theme.textPrimary)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .background(Theme.surface)
+            .clipShape(.capsule)
+        }
+    }
+
+    private func filterChip(label: String, isSelected: Bool, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Text(label)
+                .font(.caption2.weight(.semibold))
+                .foregroundStyle(isSelected ? .black : Theme.textSecondary)
+                .padding(.horizontal, 8)
+                .padding(.vertical, 4)
+                .background(isSelected ? Theme.accent : Theme.surfaceSecondary)
+                .clipShape(.capsule)
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func metricIcon(_ metric: LeaderboardMetric) -> String {
+        switch metric {
+        case .weeklyVolume: return "scalemass"
+        case .personalRecords: return "trophy.fill"
+        case .workoutStreak: return "flame.fill"
+        case .totalWorkouts: return "figure.strengthtraining.traditional"
+        }
+    }
+}

--- a/Xomfit/Views/Progress/XomProgressView.swift
+++ b/Xomfit/Views/Progress/XomProgressView.swift
@@ -24,6 +24,17 @@ struct XomProgressView: View {
             }
             .navigationTitle("Progress")
             .toolbarColorScheme(.dark, for: .navigationBar)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    NavigationLink {
+                        LeaderboardView()
+                    } label: {
+                        Image(systemName: "trophy.fill")
+                            .foregroundStyle(Theme.accent)
+                    }
+                    .accessibilityLabel("Leaderboard")
+                }
+            }
         }
         .task {
             await viewModel.loadData(userId: userId)

--- a/Xomfit/Views/Workout/ActiveWorkoutView.swift
+++ b/Xomfit/Views/Workout/ActiveWorkoutView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct ActiveWorkoutView: View {
     @Environment(AuthService.self) private var authService
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.scenePhase) private var scenePhase
 
     @State private var viewModel = WorkoutLoggerViewModel()
     @State private var showExercisePicker = false
@@ -153,6 +154,11 @@ struct ActiveWorkoutView: View {
                 restTimerHapticFired = false
             }
         }
+        .onChange(of: scenePhase) { _, newPhase in
+            if newPhase == .active {
+                viewModel.recalculateRestTimer()
+            }
+        }
         .sheet(isPresented: $showExercisePicker) {
             ExercisePickerView { exercise in
                 viewModel.addExercise(exercise)
@@ -170,10 +176,12 @@ struct ActiveWorkoutView: View {
         .sheet(isPresented: $showFinishSheet) {
             FinishWorkoutSheet(
                 description: $workoutDescription,
+                location: $viewModel.location,
+                rating: $viewModel.rating,
                 isSaving: viewModel.isSaving,
                 onFinish: { finishWorkout() }
             )
-            .presentationDetents([.medium])
+            .presentationDetents([.large])
             .presentationDragIndicator(.visible)
         }
     }
@@ -208,7 +216,12 @@ struct ActiveWorkoutView: View {
 
             // Focus mode toggle
             Button {
-                withAnimation { viewModel.focusMode.toggle() }
+                withAnimation {
+                    viewModel.focusMode.toggle()
+                    if viewModel.focusMode {
+                        viewModel.syncFocusToCurrentExercise()
+                    }
+                }
             } label: {
                 Image(systemName: viewModel.focusMode ? "list.bullet" : "eye")
                     .font(.subheadline.weight(.semibold))
@@ -703,6 +716,8 @@ private struct ExerciseTransitionCard: View {
 
 private struct FinishWorkoutSheet: View {
     @Binding var description: String
+    @Binding var location: String
+    @Binding var rating: Int
     let isSaving: Bool
     let onFinish: () -> Void
 
@@ -711,54 +726,101 @@ private struct FinishWorkoutSheet: View {
             ZStack {
                 Theme.background.ignoresSafeArea()
 
-                VStack(spacing: Theme.Spacing.md) {
-                    VStack(alignment: .leading, spacing: 8) {
-                        Text("Add a description")
-                            .font(.subheadline.weight(.semibold))
-                            .foregroundStyle(Theme.textPrimary)
-                        Text("Optional -- this will appear as a caption on your feed post.")
-                            .font(Theme.fontCaption)
-                            .foregroundStyle(Theme.textSecondary)
-                    }
-                    .frame(maxWidth: .infinity, alignment: .leading)
-
-                    TextEditor(text: $description)
-                        .font(Theme.fontBody)
-                        .foregroundStyle(Theme.textPrimary)
-                        .scrollContentBackground(.hidden)
-                        .padding(Theme.Spacing.sm)
-                        .frame(minHeight: 100, maxHeight: 150)
-                        .background(Theme.surface)
-                        .clipShape(.rect(cornerRadius: Theme.cornerRadiusSmall))
-                        .overlay(
-                            RoundedRectangle(cornerRadius: Theme.cornerRadiusSmall)
-                                .stroke(Theme.textSecondary.opacity(0.2), lineWidth: 1)
-                        )
-
-                    Button {
-                        Haptics.success()
-                        onFinish()
-                    } label: {
-                        if isSaving {
-                            ProgressView()
-                                .tint(.black)
-                                .frame(maxWidth: .infinity)
-                                .padding(.vertical, 14)
-                        } else {
-                            Text("Finish Workout")
-                                .font(.body.weight(.bold))
-                                .foregroundStyle(.black)
-                                .frame(maxWidth: .infinity)
-                                .padding(.vertical, 14)
+                ScrollView {
+                    VStack(spacing: Theme.Spacing.lg) {
+                        // Star Rating
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text("How was your workout?")
+                                .font(.subheadline.weight(.semibold))
+                                .foregroundStyle(Theme.textPrimary)
+                            HStack(spacing: 8) {
+                                ForEach(1...5, id: \.self) { star in
+                                    Button {
+                                        withAnimation(.xomChill) {
+                                            rating = rating == star ? 0 : star
+                                        }
+                                    } label: {
+                                        Image(systemName: star <= rating ? "star.fill" : "star")
+                                            .font(.title2)
+                                            .foregroundStyle(star <= rating ? Theme.accent : Theme.textSecondary.opacity(0.4))
+                                    }
+                                    .buttonStyle(.plain)
+                                    .accessibilityLabel("\(star) star\(star > 1 ? "s" : "")")
+                                }
+                                Spacer()
+                            }
                         }
-                    }
-                    .background(Theme.accent)
-                    .clipShape(.rect(cornerRadius: Theme.cornerRadius))
-                    .disabled(isSaving)
 
-                    Spacer()
+                        // Location
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text("Location")
+                                .font(.subheadline.weight(.semibold))
+                                .foregroundStyle(Theme.textPrimary)
+                            HStack(spacing: 8) {
+                                Image(systemName: "location.fill")
+                                    .font(.caption)
+                                    .foregroundStyle(Theme.textSecondary)
+                                TextField("Gym name", text: $location)
+                                    .font(Theme.fontBody)
+                                    .foregroundStyle(Theme.textPrimary)
+                            }
+                            .padding(Theme.Spacing.sm)
+                            .background(Theme.surface)
+                            .clipShape(.rect(cornerRadius: Theme.cornerRadiusSmall))
+                            .overlay(
+                                RoundedRectangle(cornerRadius: Theme.cornerRadiusSmall)
+                                    .stroke(Theme.textSecondary.opacity(0.2), lineWidth: 1)
+                            )
+                        }
+
+                        // Description
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text("Caption")
+                                .font(.subheadline.weight(.semibold))
+                                .foregroundStyle(Theme.textPrimary)
+                            Text("Optional — appears on your feed post.")
+                                .font(Theme.fontCaption)
+                                .foregroundStyle(Theme.textSecondary)
+                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
+
+                        TextEditor(text: $description)
+                            .font(Theme.fontBody)
+                            .foregroundStyle(Theme.textPrimary)
+                            .scrollContentBackground(.hidden)
+                            .padding(Theme.Spacing.sm)
+                            .frame(minHeight: 80, maxHeight: 120)
+                            .background(Theme.surface)
+                            .clipShape(.rect(cornerRadius: Theme.cornerRadiusSmall))
+                            .overlay(
+                                RoundedRectangle(cornerRadius: Theme.cornerRadiusSmall)
+                                    .stroke(Theme.textSecondary.opacity(0.2), lineWidth: 1)
+                            )
+
+                        // Finish button
+                        Button {
+                            Haptics.success()
+                            onFinish()
+                        } label: {
+                            if isSaving {
+                                ProgressView()
+                                    .tint(.black)
+                                    .frame(maxWidth: .infinity)
+                                    .padding(.vertical, 14)
+                            } else {
+                                Text("Finish Workout")
+                                    .font(.body.weight(.bold))
+                                    .foregroundStyle(.black)
+                                    .frame(maxWidth: .infinity)
+                                    .padding(.vertical, 14)
+                            }
+                        }
+                        .background(Theme.accent)
+                        .clipShape(.rect(cornerRadius: Theme.cornerRadius))
+                        .disabled(isSaving)
+                    }
+                    .padding(Theme.Spacing.md)
                 }
-                .padding(Theme.Spacing.md)
             }
             .navigationTitle("Finish Workout")
             .navigationBarTitleDisplayMode(.inline)

--- a/Xomfit/Views/Workout/WorkoutFocusView.swift
+++ b/Xomfit/Views/Workout/WorkoutFocusView.swift
@@ -343,22 +343,47 @@ struct WorkoutFocusView: View {
     private var restTimerOverlay: some View {
         Group {
             if isRestTimerMinimized {
-                // Minimized: bottom banner
+                // Minimized: bottom banner with Lift button and tap-to-expand
                 VStack {
                     Spacer()
-                    RestTimerView(
-                        restTimeRemaining: viewModel.restTimeRemaining,
-                        restDuration: viewModel.restDuration,
-                        onSkip: {
+                    HStack(spacing: Theme.Spacing.sm) {
+                        // Tap the timer area to expand back to full screen
+                        Button {
+                            withAnimation(.xomChill) { isRestTimerMinimized = false }
+                        } label: {
+                            RestTimerView(
+                                restTimeRemaining: viewModel.restTimeRemaining,
+                                restDuration: viewModel.restDuration,
+                                onSkip: { viewModel.skipRestTimer() },
+                                onExtend: { viewModel.extendRestTimer() }
+                            )
+                        }
+                        .buttonStyle(.plain)
+
+                        // Lift button to skip timer entirely
+                        Button {
+                            Haptics.success()
                             viewModel.skipRestTimer()
                             isRestTimerMinimized = false
-                        },
-                        onExtend: { viewModel.extendRestTimer() }
-                    )
-                    .padding(.horizontal, Theme.Spacing.md)
-                    .padding(.bottom, Theme.Spacing.lg)
-                    .shadow(color: .black.opacity(0.5), radius: 12, x: 0, y: -4)
+                        } label: {
+                            Text("LIFT")
+                                .font(.caption.weight(.black))
+                                .foregroundStyle(.black)
+                                .padding(.horizontal, 16)
+                                .padding(.vertical, 10)
+                                .background(Theme.accent)
+                                .clipShape(.capsule)
+                        }
+                    }
+                    if let nextEx = viewModel.nextExercise {
+                        Text("Next: \(nextEx.exercise.name)")
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(Theme.accent)
+                    }
                 }
+                .padding(.horizontal, Theme.Spacing.md)
+                .padding(.bottom, Theme.Spacing.lg)
+                .shadow(color: .black.opacity(0.5), radius: 12, x: 0, y: -4)
                 .transition(.move(edge: .bottom).combined(with: .opacity))
             } else {
                 // Full-screen rest timer
@@ -432,6 +457,18 @@ struct WorkoutFocusView: View {
                     }
                 }
                 .frame(width: 240, height: 240)
+
+                // Next exercise hint
+                if let nextEx = viewModel.nextExercise {
+                    VStack(spacing: 4) {
+                        Text("NEXT UP")
+                            .font(.caption2.weight(.bold))
+                            .foregroundStyle(Theme.accent)
+                        Text(nextEx.exercise.name)
+                            .font(.subheadline.weight(.semibold))
+                            .foregroundStyle(Theme.textPrimary)
+                    }
+                }
 
                 // +30s button
                 Button {


### PR DESCRIPTION
## Summary
- **#195** Workout flow bugs: background rest timer persistence, "Next Up" exercise hint, scenePhase sync, focus mode improvements
- **#196** Feed/profile date range + muscle group filters (client-side)
- **#197** Leaderboard page with metric/timeframe/scope/muscle group filtering, podium UI
- **#198** Username uniqueness validation with debounced Supabase check
- **#199** Workout metadata: location field + star rating on finish sheet, displayed on feed cards
- **#200** Detail views rendering behind tab bar fixed via `hideTabBar()` environment modifier

Closes #195, Closes #196, Closes #197, Closes #198, Closes #199, Closes #200

## Backend Required
Supabase migration needed for #199 (location + rating columns on workouts table).

## Test plan
- [ ] Verify rest timer persists when backgrounding/foregrounding app
- [ ] Test feed filter chips (date range + muscle group) on both Feed and Profile tabs
- [ ] Test leaderboard loads from Progress tab trophy icon
- [ ] Test username validation on Edit Profile shows errors for taken names
- [ ] Test finish workout sheet shows rating stars and location field
- [ ] Test feed cards display location and rating when present
- [ ] Verify detail views don't render behind tab bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)