### PR TITLE
Design polish overhaul + profile orphan feed fix

### DIFF
--- a/Xomfit/Services/SyncManager.swift
+++ b/Xomfit/Services/SyncManager.swift
@@ -59,8 +59,7 @@ final class SyncManager {
             case .saveWorkout:
                 guard let data = op.payload.data(using: .utf8),
                       let workout = try? JSONDecoder().decode(Workout.self, from: data) else { return false }
-                try await WorkoutService.shared.saveWorkout(workout)
-                return true
+                return await WorkoutService.shared.saveWorkout(workout)
 
             case .postFeedItem:
                 // Feed posts are embedded in workout save — skip standalone retry

--- a/Xomfit/Services/WorkoutService.swift
+++ b/Xomfit/Services/WorkoutService.swift
@@ -154,13 +154,17 @@ final class WorkoutService {
 
     // MARK: - Save
 
-    func saveWorkout(_ workout: Workout) async throws {
+    /// Saves a workout. Always writes to local cache; attempts Supabase write and queues for retry on failure.
+    /// Returns `true` if the Supabase write succeeded, `false` if it was queued. Never throws.
+    @discardableResult
+    func saveWorkout(_ workout: Workout) async -> Bool {
         // Save to UserDefaults first (instant, always works)
         saveToCache(workout)
 
         // Push to Supabase (async, non-blocking on failure)
         do {
             try await saveToSupabase(workout)
+            return true
         } catch {
             print("[WorkoutService] Supabase save failed, queuing for retry: \(error.localizedDescription)")
             if let data = try? JSONEncoder().encode(workout),
@@ -172,6 +176,7 @@ final class WorkoutService {
                     payload: payload
                 ))
             }
+            return false
         }
     }
 

--- a/Xomfit/Utils/Theme+Elevation.swift
+++ b/Xomfit/Utils/Theme+Elevation.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+
+// MARK: - Elevation Modifiers
+
+extension View {
+    /// Wraps the view with a hairline-bordered, rounded surface.
+    /// Use instead of drop shadows for an elevation signal.
+    func hairline(_ radius: CGFloat = Theme.Radius.md) -> some View {
+        self.overlay(
+            RoundedRectangle(cornerRadius: radius)
+                .strokeBorder(Theme.hairline, lineWidth: 0.5)
+        )
+    }
+
+    /// Applies a top-to-bottom gradient overlay that mimics ambient light from above.
+    /// Use on hero cards and primary CTAs to give subtle depth without a shadow.
+    func heroGradient(accent: Color = Theme.accent) -> some View {
+        self.overlay(
+            LinearGradient(
+                colors: [accent.opacity(0.12), Color.clear],
+                startPoint: .top,
+                endPoint: .bottom
+            )
+        )
+    }
+}

--- a/Xomfit/Utils/Theme.swift
+++ b/Xomfit/Utils/Theme.swift
@@ -4,78 +4,106 @@ import SwiftUI
 // MARK: - Design Tokens
 
 enum Theme {
-    // MARK: - Colors (60-30-10 rule)
+    // MARK: - Colors (neutral near-black ramp, single accent, role-split semantics)
 
-    /// 10% — Brand accent (CTAs, selected states, links)
-    static let accent = Color(hex: "33FF66")
-    /// 60% — Primary background
-    static let background = Color(hex: "0A0A0F")
-    /// 30% — Cards, modals, sheets
-    static let surface = Color(hex: "1A1A2E")
-    /// Deeper surface for nested containers
-    static let surfaceSecondary = Color(hex: "16213E")
-    /// Workout start, PRs, success states
-    static let energy = Color(hex: "00C46A")
-    /// Calories, heart rate zones, warnings
-    static let alert = Color(hex: "FF6B35")
-    /// Delete, destructive actions
-    static let destructive = Color(hex: "FF4444")
-    /// PR badges, streaks
-    static let prGold = Color(hex: "FFD700")
+    /// 60% — App background. Warm-neutral near-black, removes blue cast.
+    static let background        = Color(hex: "0B0B0E")
+    /// 30% — Cards. Pure luminance lift from background, same hue family.
+    static let surface           = Color(hex: "17171C")
+    /// Sheets / modals / elevated containers.
+    static let surfaceElevated   = Color(hex: "1F1F26")
+    /// DEPRECATED alias — keep for one release, migrate callers, then remove.
+    static let surfaceSecondary  = Color(hex: "1F1F26")
 
-    static let textPrimary = Color.white
-    static let textSecondary = Color(hex: "9CA3AF")
+    /// 10% — Primary accent (CTAs, selected states only). Desaturated from 33FF66.
+    static let accent            = Color(hex: "2FE562")
+    /// Tinted fill for accent-utility use (selected tab bg, accent chip bg).
+    static let accentMuted       = Color(hex: "2FE562").opacity(0.18)
 
-    // Glass morphism
-    static let glassFill = Color.white.opacity(0.06)
-    static let glassBorder = Color.white.opacity(0.1)
-    static let glassHighlight = Color.white.opacity(0.15)
+    /// Text — off-white, neutral greys (not blue-greys).
+    static let textPrimary       = Color(hex: "F5F5F7")
+    static let textSecondary     = Color(hex: "9A9AA3")
+    static let textTertiary      = Color(hex: "6B6B72")
 
-    // Activity badge colors
-    static let badgeWorkout = accent
-    static let badgePR = prGold
-    static let badgeMilestone = Color(hex: "AA66FF")
-    static let badgeStreak = Color(hex: "FF6633")
+    /// Semantic colors — all desaturated a notch vs prior values.
+    static let prGold            = Color(hex: "F5C84B")
+    static let milestone         = Color(hex: "9B7BFF")
+    static let streak            = Color(hex: "FF7A45")
+    static let alert             = Color(hex: "FF8A4C")
+    static let destructive       = Color(hex: "FF5E5E")
+    /// Kept for API compat; points to accent. Callers should migrate to `accent`.
+    static let energy            = accent
 
-    // MARK: - Spacing (8pt grid)
+    // MARK: - Hairlines
+
+    static let hairline          = Color.white.opacity(0.08)
+    static let hairlineStrong    = Color.white.opacity(0.12)
+
+    // Glass morphism — kept for callsite compat; prefer hairline tokens going forward
+    static let glassFill         = Color.white.opacity(0.04)
+    static let glassBorder       = Color.white.opacity(0.08)
+    static let glassHighlight    = Color.white.opacity(0.12)
+
+    // MARK: - Activity badge tokens
+
+    static let badgeWorkout      = accent
+    static let badgePR           = prGold
+    static let badgeMilestone    = milestone
+    static let badgeStreak       = streak
+
+    // MARK: - Spacing (8pt grid + section rhythm)
 
     enum Spacing {
-        static let xs: CGFloat = 4
-        static let sm: CGFloat = 8
-        static let md: CGFloat = 16
-        static let lg: CGFloat = 24
-        static let xl: CGFloat = 32
+        static let hairline: CGFloat = 0.5
+        static let xs:  CGFloat = 4
+        static let sm:  CGFloat = 8
+        static let md:  CGFloat = 16
+        static let lg:  CGFloat = 24
+        static let xl:  CGFloat = 32
         static let xxl: CGFloat = 48
+        static let section: CGFloat = 40
     }
 
     // MARK: - Corner Radius
 
-    static let cornerRadius: CGFloat = 16
-    static let cornerRadiusSmall: CGFloat = 10
+    enum Radius {
+        static let xs: CGFloat = 6
+        static let sm: CGFloat = 10
+        static let md: CGFloat = 16
+        static let lg: CGFloat = 22
+        static let xl: CGFloat = 28
+    }
+
+    /// DEPRECATED — use Radius.md
+    static let cornerRadius      = Radius.md
+    /// DEPRECATED — use Radius.sm
+    static let cornerRadiusSmall = Radius.sm
 
     // Legacy spacing aliases (prefer Spacing.*)
     static let paddingSmall: CGFloat = 8
     static let paddingMedium: CGFloat = 16
     static let paddingLarge: CGFloat = 24
 
-    // MARK: - Typography (Dynamic Type — never hard-code sizes)
+    // MARK: - Typography
 
-    /// Hero numbers: PRs, distances, big stats
-    static let fontDisplay: Font = .largeTitle.weight(.black).width(.condensed)
-    /// Screen titles
-    static let fontLargeTitle: Font = .largeTitle.weight(.bold)
-    /// Section titles, card headlines
-    static let fontTitle: Font = .title.weight(.bold)
-    /// Card titles, emphasized labels
-    static let fontHeadline: Font = .title3.weight(.semibold)
-    /// Body text, descriptions, feed text
-    static let fontBody: Font = .body
-    /// Secondary info, workout types
+    /// Hero display number — PRs, volume totals, hero metrics.
+    static let fontDisplay: Font = .system(size: 44, weight: .heavy, design: .rounded).monospacedDigit()
+    /// Secondary hero number — stat columns, card titles with numbers.
+    static let fontNumberLarge: Font = .system(size: 28, weight: .bold, design: .rounded).monospacedDigit()
+    /// Inline numbers — set rows, feed stat pills.
+    static let fontNumberMedium: Font = .system(size: 17, weight: .semibold, design: .rounded).monospacedDigit()
+
+    static let fontLargeTitle: Font  = .largeTitle.weight(.bold)
+    static let fontTitle: Font       = .title.weight(.bold)
+    static let fontTitle2: Font      = .title2.weight(.semibold)
+    static let fontHeadline: Font    = .title3.weight(.semibold)
+    static let fontBody: Font        = .body
     static let fontSubheadline: Font = .subheadline
-    /// Timestamps, metadata, labels
-    static let fontCaption: Font = .caption
-    /// Micro-labels, badges
-    static let fontSmall: Font = .caption2.weight(.medium)
+    static let fontCaption: Font     = .caption
+    static let fontSmall: Font       = .caption2.weight(.medium)
+
+    /// Uppercase + 0.5 kerning metric label. Apply via XomMetricLabel or .metricLabel() modifier.
+    static let fontMetricLabel: Font = .caption.weight(.semibold)
 }
 
 // MARK: - Animation Tokens
@@ -202,7 +230,7 @@ enum Haptics {
     }
 }
 
-// MARK: - Glass Card Modifier
+// MARK: - Glass Card Modifier (kept for callsite compat)
 
 struct GlassCardStyle: ViewModifier {
     func body(content: Content) -> some View {
@@ -210,15 +238,11 @@ struct GlassCardStyle: ViewModifier {
             .padding(Theme.Spacing.md)
             .background(
                 RoundedRectangle(cornerRadius: Theme.cornerRadius)
-                    .fill(Theme.glassFill)
-                    .background(
+                    .fill(Theme.surface)
+                    .overlay(
                         RoundedRectangle(cornerRadius: Theme.cornerRadius)
-                            .fill(Theme.surface)
+                            .strokeBorder(Theme.hairline, lineWidth: 0.5)
                     )
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: Theme.cornerRadius)
-                    .strokeBorder(Theme.glassBorder, lineWidth: 0.5)
             )
     }
 }
@@ -238,16 +262,16 @@ extension View {
 
     func glassStyle() -> some View {
         self
-            .background(Theme.glassFill)
+            .background(Theme.surfaceElevated)
             .clipShape(RoundedRectangle(cornerRadius: Theme.cornerRadiusSmall))
             .overlay(
                 RoundedRectangle(cornerRadius: Theme.cornerRadiusSmall)
-                    .strokeBorder(Theme.glassBorder, lineWidth: 0.5)
+                    .strokeBorder(Theme.hairline, lineWidth: 0.5)
             )
     }
 }
 
-// MARK: - Shimmer Modifier
+// MARK: - Shimmer Modifier (soft diagonal sweep)
 
 struct ShimmerModifier: ViewModifier {
     @State private var phase: CGFloat = 0
@@ -256,14 +280,14 @@ struct ShimmerModifier: ViewModifier {
         content
             .overlay(
                 LinearGradient(
-                    colors: [.clear, Color.white.opacity(0.1), .clear],
-                    startPoint: .init(x: phase - 0.5, y: 0.5),
-                    endPoint: .init(x: phase + 0.5, y: 0.5)
+                    colors: [.clear, Color.white.opacity(0.06), .clear],
+                    startPoint: .init(x: phase - 0.5, y: phase - 0.5),
+                    endPoint: .init(x: phase + 0.5, y: phase + 0.5)
                 )
             )
             .clipShape(RoundedRectangle(cornerRadius: Theme.cornerRadius))
             .onAppear {
-                withAnimation(.linear(duration: 1.5).repeatForever(autoreverses: false)) {
+                withAnimation(.linear(duration: 1.8).repeatForever(autoreverses: false)) {
                     phase = 1.5
                 }
             }
@@ -302,7 +326,7 @@ struct StaggeredAppearance: ViewModifier {
     }
 }
 
-// MARK: - Button Styles
+// MARK: - Button Styles (legacy — prefer XomButton)
 
 struct AccentButtonStyle: ButtonStyle {
     func makeBody(configuration: Configuration) -> some View {
@@ -311,15 +335,19 @@ struct AccentButtonStyle: ButtonStyle {
             .foregroundStyle(.black)
             .frame(maxWidth: .infinity)
             .padding(.vertical, Theme.Spacing.md)
-            .background(Theme.accent)
-            .clipShape(RoundedRectangle(cornerRadius: Theme.cornerRadius))
-            .shadow(
-                color: Theme.accent.opacity(0.3),
-                radius: configuration.isPressed ? 4 : 8,
-                x: 0,
-                y: configuration.isPressed ? 2 : 4
+            .background(
+                RoundedRectangle(cornerRadius: Theme.cornerRadius)
+                    .fill(Theme.accent)
+                    .overlay(
+                        LinearGradient(
+                            colors: [Color.white.opacity(0.08), Color.clear],
+                            startPoint: .top,
+                            endPoint: .bottom
+                        )
+                        .clipShape(RoundedRectangle(cornerRadius: Theme.cornerRadius))
+                    )
             )
-            .scaleEffect(configuration.isPressed ? 0.94 : 1)
+            .scaleEffect(configuration.isPressed ? 0.98 : 1)
             .animation(.xomSnappy, value: configuration.isPressed)
     }
 }
@@ -331,13 +359,13 @@ struct GhostButtonStyle: ButtonStyle {
             .foregroundStyle(Theme.accent)
             .frame(maxWidth: .infinity)
             .padding(.vertical, Theme.Spacing.md)
-            .background(Theme.glassFill)
+            .background(Theme.surfaceElevated)
             .clipShape(RoundedRectangle(cornerRadius: Theme.cornerRadius))
             .overlay(
                 RoundedRectangle(cornerRadius: Theme.cornerRadius)
                     .strokeBorder(Theme.accent.opacity(0.5), lineWidth: 1)
             )
-            .scaleEffect(configuration.isPressed ? 0.94 : 1)
+            .scaleEffect(configuration.isPressed ? 0.98 : 1)
             .animation(.xomSnappy, value: configuration.isPressed)
     }
 }

--- a/Xomfit/ViewModels/WorkoutLoggerViewModel.swift
+++ b/Xomfit/ViewModels/WorkoutLoggerViewModel.swift
@@ -666,9 +666,12 @@ final class WorkoutLoggerViewModel {
         )
 
         do {
-            try await WorkoutService.shared.saveWorkout(workout)
-            // Auto-post to feed after saving
-            try await FeedService.shared.postWorkoutToFeed(workout: workout, userId: userId, caption: workout.notes, photoURLs: photoURLs)
+            // Only post to feed if the workout actually persisted to Supabase.
+            // Prevents orphan feed items (posts with no matching workout row).
+            let persisted = await WorkoutService.shared.saveWorkout(workout)
+            if persisted {
+                try await FeedService.shared.postWorkoutToFeed(workout: workout, userId: userId, caption: workout.notes, photoURLs: photoURLs)
+            }
 
             // Update widget data
             let allWorkouts = await WorkoutService.shared.fetchWorkouts(userId: userId)

--- a/Xomfit/Views/Auth/LoginView.swift
+++ b/Xomfit/Views/Auth/LoginView.swift
@@ -82,11 +82,11 @@ struct LoginView: View {
 
                         // Divider
                         HStack {
-                            Rectangle().fill(Theme.textSecondary.opacity(0.3)).frame(height: 1)
+                            Rectangle().fill(Theme.hairline).frame(height: 0.5)
                             Text("or")
                                 .font(Theme.fontCaption)
-                                .foregroundStyle(Theme.textSecondary)
-                            Rectangle().fill(Theme.textSecondary.opacity(0.3)).frame(height: 1)
+                                .foregroundStyle(Theme.textTertiary)
+                            Rectangle().fill(Theme.hairline).frame(height: 0.5)
                         }
                         .padding(.horizontal, Theme.Spacing.lg)
 
@@ -104,6 +104,10 @@ struct LoginView: View {
                                     .background(Theme.surface)
                                     .clipShape(.rect(cornerRadius: Theme.cornerRadius))
                                     .foregroundStyle(Theme.textPrimary)
+                                    .overlay(
+                                        RoundedRectangle(cornerRadius: Theme.cornerRadius)
+                                            .strokeBorder(Theme.hairline, lineWidth: 0.5)
+                                    )
                             }
 
                             VStack(alignment: .leading, spacing: 6) {
@@ -115,6 +119,10 @@ struct LoginView: View {
                                     .background(Theme.surface)
                                     .clipShape(.rect(cornerRadius: Theme.cornerRadius))
                                     .foregroundStyle(Theme.textPrimary)
+                                    .overlay(
+                                        RoundedRectangle(cornerRadius: Theme.cornerRadius)
+                                            .strokeBorder(Theme.hairline, lineWidth: 0.5)
+                                    )
                             }
 
                             Button {

--- a/Xomfit/Views/Auth/SignUpView.swift
+++ b/Xomfit/Views/Auth/SignUpView.swift
@@ -54,6 +54,10 @@ struct SignUpView: View {
                                 .background(Theme.surface)
                                 .clipShape(.rect(cornerRadius: Theme.cornerRadius))
                                 .foregroundStyle(Theme.textPrimary)
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: Theme.cornerRadius)
+                                        .strokeBorder(Theme.hairline, lineWidth: 0.5)
+                                )
                         }
 
                         VStack(alignment: .leading, spacing: 6) {
@@ -65,25 +69,23 @@ struct SignUpView: View {
                                 .background(Theme.surface)
                                 .clipShape(.rect(cornerRadius: Theme.cornerRadius))
                                 .foregroundStyle(Theme.textPrimary)
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: Theme.cornerRadius)
+                                        .strokeBorder(Theme.hairline, lineWidth: 0.5)
+                                )
                         }
 
                         Button {
                             signUp()
                         } label: {
-                            ZStack {
-                                RoundedRectangle(cornerRadius: Theme.cornerRadius)
-                                    .fill(Theme.accent)
-                                if isLoading {
-                                    ProgressView()
-                                        .tint(.black)
-                                } else {
-                                    Text("Create Account")
-                                        .font(.body.weight(.bold))
-                                        .foregroundStyle(.black)
-                                }
+                            if isLoading {
+                                ProgressView()
+                                    .tint(.black)
+                            } else {
+                                Text("Create Account")
                             }
-                            .frame(height: 52)
                         }
+                        .buttonStyle(AccentButtonStyle())
                         .disabled(isLoading || !formValid)
                         .opacity((isLoading || !formValid) ? 0.6 : 1)
                         .padding(.top, Theme.Spacing.sm)
@@ -134,6 +136,10 @@ struct SignUpView: View {
                 .background(Theme.surface)
                 .clipShape(.rect(cornerRadius: Theme.cornerRadius))
                 .foregroundStyle(Theme.textPrimary)
+                .overlay(
+                    RoundedRectangle(cornerRadius: Theme.cornerRadius)
+                        .strokeBorder(Theme.hairline, lineWidth: 0.5)
+                )
         }
     }
 

--- a/Xomfit/Views/Common/CountUpNumber.swift
+++ b/Xomfit/Views/Common/CountUpNumber.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+
+// MARK: - Count-Up Number
+
+/// Displays an integer that animates from 0 to `target` on first appearance.
+/// Uses monospaced digits to prevent layout jitter during animation.
+/// Duration defaults to 0.8s with an ease-out curve.
+struct CountUpNumber: View {
+    let target: Int
+    var font: Font = Theme.fontNumberLarge
+    var color: Color = Theme.textPrimary
+    var duration: Double = 0.8
+
+    @State private var displayed: Int = 0
+    @State private var hasAppeared = false
+
+    var body: some View {
+        Text("\(displayed)")
+            .font(font)
+            .foregroundStyle(color)
+            .monospacedDigit()
+            .onAppear {
+                guard !hasAppeared else { return }
+                hasAppeared = true
+                animateCount()
+            }
+    }
+
+    private func animateCount() {
+        let steps = min(target, 60)
+        guard steps > 0 else {
+            displayed = target
+            return
+        }
+        let stepDuration = duration / Double(steps)
+        for i in 1...steps {
+            let delay = stepDuration * Double(i)
+            let value = Int(Double(target) * Double(i) / Double(steps))
+            DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
+                displayed = value
+            }
+        }
+    }
+}

--- a/Xomfit/Views/Common/ParticleBurstView.swift
+++ b/Xomfit/Views/Common/ParticleBurstView.swift
@@ -1,0 +1,103 @@
+import SwiftUI
+
+// MARK: - Particle Model
+
+private struct Particle: Identifiable {
+    let id = UUID()
+    let angle: Double
+    let distance: CGFloat
+    let scale: CGFloat
+    let symbol: String
+}
+
+// MARK: - Particle Burst View
+
+/// Fires a burst of particles outward from the center on `trigger` changes.
+/// Particles animate out and fade over `duration` seconds then disappear.
+/// Usage: overlay this on the button/view and bind `trigger` to a Bool that flips on burst.
+struct ParticleBurstView: View {
+    /// Flip this Bool (false → true) to trigger a burst.
+    let trigger: Bool
+
+    /// Symbols to randomly sample from.
+    var symbols: [String] = ["heart.fill"]
+
+    /// Color of the burst particles.
+    var color: Color = Theme.destructive
+
+    /// Number of particles to emit.
+    var count: Int = 8
+
+    /// Duration of the burst animation in seconds.
+    var duration: Double = 0.6
+
+    @State private var particles: [Particle] = []
+    @State private var isAnimating = false
+
+    var body: some View {
+        ZStack {
+            ForEach(particles) { particle in
+                ParticleView(
+                    particle: particle,
+                    color: color,
+                    isAnimating: isAnimating,
+                    duration: duration
+                )
+            }
+        }
+        .allowsHitTesting(false)
+        .onChange(of: trigger) { _, newValue in
+            guard newValue else { return }
+            burst()
+        }
+    }
+
+    private func burst() {
+        particles = (0..<count).map { i in
+            Particle(
+                angle: Double(i) / Double(count) * 360,
+                distance: CGFloat.random(in: 20...44),
+                scale: CGFloat.random(in: 0.6...1.0),
+                symbol: symbols.randomElement() ?? "heart.fill"
+            )
+        }
+        isAnimating = false
+        // Short delay lets SwiftUI render particles at origin before animating
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) {
+            withAnimation(.easeOut(duration: duration)) {
+                isAnimating = true
+            }
+        }
+        // Clean up after animation
+        DispatchQueue.main.asyncAfter(deadline: .now() + duration + 0.1) {
+            particles = []
+            isAnimating = false
+        }
+    }
+}
+
+// MARK: - Single Particle
+
+private struct ParticleView: View {
+    let particle: Particle
+    let color: Color
+    let isAnimating: Bool
+    let duration: Double
+
+    private var offsetX: CGFloat {
+        isAnimating ? cos(particle.angle * .pi / 180) * particle.distance : 0
+    }
+    private var offsetY: CGFloat {
+        isAnimating ? sin(particle.angle * .pi / 180) * particle.distance : 0
+    }
+
+    var body: some View {
+        Image(systemName: particle.symbol)
+            .font(.system(size: 10, weight: .bold))
+            .foregroundStyle(color)
+            .scaleEffect(isAnimating ? particle.scale : 0.1)
+            .offset(x: offsetX, y: offsetY)
+            .opacity(isAnimating ? 0 : 1)
+            .animation(.easeOut(duration: duration), value: isAnimating)
+    }
+}

--- a/Xomfit/Views/Common/XomAvatar.swift
+++ b/Xomfit/Views/Common/XomAvatar.swift
@@ -4,20 +4,23 @@ struct XomAvatar: View {
     let name: String
     let size: CGFloat
     let imageURL: URL?
-    let showBorder: Bool
+    /// When non-nil, draws a ring in this color. Pass `Theme.accent` for a standard accent ring.
+    let ringColor: Color?
     let isOnline: Bool
 
     init(
         name: String,
-        size: CGFloat = 40,
+        size: CGFloat = 44,
         imageURL: URL? = nil,
-        showBorder: Bool = false,
-        isOnline: Bool = false
+        ringColor: Color? = nil,
+        isOnline: Bool = false,
+        // Legacy param — maps to ringColor for backwards compat
+        showBorder: Bool = false
     ) {
         self.name = name
         self.size = size
         self.imageURL = imageURL
-        self.showBorder = showBorder
+        self.ringColor = showBorder ? Theme.accent : ringColor
         self.isOnline = isOnline
     }
 
@@ -42,7 +45,7 @@ struct XomAvatar: View {
 
             if isOnline {
                 Circle()
-                    .fill(Theme.energy)
+                    .fill(Theme.accent)
                     .frame(width: size * 0.28, height: size * 0.28)
                     .overlay(
                         Circle().stroke(Theme.background, lineWidth: 2)
@@ -51,9 +54,9 @@ struct XomAvatar: View {
             }
         }
         .overlay {
-            if showBorder {
+            if let ringColor {
                 Circle()
-                    .strokeBorder(Theme.accent, lineWidth: 2)
+                    .strokeBorder(ringColor, lineWidth: 2)
                     .frame(width: size, height: size)
             }
         }
@@ -61,11 +64,11 @@ struct XomAvatar: View {
 
     private var initialsView: some View {
         Circle()
-            .fill(Theme.surfaceSecondary)
+            .fill(Theme.surfaceElevated)
             .frame(width: size, height: size)
             .overlay(
                 Text(initials)
-                    .font(.system(size: size * 0.38, weight: .semibold))
+                    .font(.system(size: size * 0.36, weight: .semibold))
                     .foregroundStyle(Theme.textPrimary)
             )
     }
@@ -77,4 +80,16 @@ struct XomAvatar: View {
         }
         return String(name.prefix(2)).uppercased()
     }
+}
+
+// MARK: - Preview
+
+#Preview {
+    HStack(spacing: 16) {
+        XomAvatar(name: "Dom Giordano", size: 44)
+        XomAvatar(name: "Dom Giordano", size: 96, ringColor: Theme.accent)
+        XomAvatar(name: "Dom Giordano", size: 48, isOnline: true)
+    }
+    .padding()
+    .background(Theme.background)
 }

--- a/Xomfit/Views/Common/XomBadge.swift
+++ b/Xomfit/Views/Common/XomBadge.swift
@@ -1,0 +1,117 @@
+import SwiftUI
+
+// MARK: - XomBadge Variant
+
+enum XomBadgeVariant {
+    /// Static display pill — color stripe + icon + label.
+    case display
+    /// Selectable chip — accent fill when active, surface + hairline when inactive.
+    case interactive
+    /// Subtle secondary pill — surfaceElevated fill, textSecondary label.
+    case secondary
+}
+
+// MARK: - XomBadge
+
+struct XomBadge: View {
+    let label: String
+    let icon: String?
+    let color: Color
+    let variant: XomBadgeVariant
+    let isActive: Bool
+
+    init(
+        _ label: String,
+        icon: String? = nil,
+        color: Color = Theme.accent,
+        variant: XomBadgeVariant = .display,
+        isActive: Bool = false
+    ) {
+        self.label = label
+        self.icon = icon
+        self.color = color
+        self.variant = variant
+        self.isActive = isActive
+    }
+
+    var body: some View {
+        HStack(spacing: 4) {
+            if let icon {
+                Image(systemName: icon)
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundStyle(iconForeground)
+            }
+            Text(label)
+                .font(Theme.fontSmall)
+                .foregroundStyle(labelForeground)
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .background(backgroundFill)
+        .clipShape(RoundedRectangle(cornerRadius: Theme.Radius.xs))
+        .overlay(
+            RoundedRectangle(cornerRadius: Theme.Radius.xs)
+                .strokeBorder(borderColor, lineWidth: 0.5)
+        )
+    }
+
+    // MARK: Computed colors
+
+    private var iconForeground: Color {
+        switch variant {
+        case .display:     color
+        case .interactive: isActive ? .black : Theme.textSecondary
+        case .secondary:   Theme.textSecondary
+        }
+    }
+
+    private var labelForeground: Color {
+        switch variant {
+        case .display:     Theme.textPrimary
+        case .interactive: isActive ? .black : Theme.textSecondary
+        case .secondary:   Theme.textSecondary
+        }
+    }
+
+    private var backgroundFill: Color {
+        switch variant {
+        case .display:     color.opacity(0.15)
+        case .interactive: isActive ? Theme.accent : Theme.surface
+        case .secondary:   Theme.surfaceElevated
+        }
+    }
+
+    private var borderColor: Color {
+        switch variant {
+        case .display:     color.opacity(0.3)
+        case .interactive: isActive ? Color.clear : Theme.hairline
+        case .secondary:   Theme.hairline
+        }
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    VStack(spacing: 16) {
+        HStack {
+            XomBadge("Workout", icon: "dumbbell.fill", color: Theme.accent, variant: .display)
+            XomBadge("PR", icon: "trophy.fill", color: Theme.prGold, variant: .display)
+            XomBadge("Milestone", icon: "star.fill", color: Theme.milestone, variant: .display)
+            XomBadge("Streak", icon: "flame.fill", color: Theme.streak, variant: .display)
+        }
+
+        HStack {
+            XomBadge("All", variant: .interactive, isActive: true)
+            XomBadge("Workouts", variant: .interactive, isActive: false)
+            XomBadge("PRs", variant: .interactive, isActive: false)
+        }
+
+        HStack {
+            XomBadge("Private", icon: "lock.fill", variant: .secondary)
+            XomBadge("Chest", variant: .secondary)
+        }
+    }
+    .padding()
+    .background(Theme.background)
+}

--- a/Xomfit/Views/Common/XomButton.swift
+++ b/Xomfit/Views/Common/XomButton.swift
@@ -50,12 +50,11 @@ struct XomButton: View {
             .foregroundStyle(foregroundColor)
             .frame(maxWidth: .infinity)
             .padding(.vertical, Theme.Spacing.md)
-            .background(backgroundColor)
+            .background(backgroundLayer)
             .clipShape(RoundedRectangle(cornerRadius: Theme.cornerRadius))
             .overlay(borderOverlay)
-            .shadow(color: shadowColor, radius: isPressed ? 4 : 8, x: 0, y: isPressed ? 2 : 4)
         }
-        .scaleEffect(isPressed ? 0.94 : 1)
+        .scaleEffect(isPressed ? 0.98 : 1)
         .animation(.xomSnappy, value: isPressed)
         .simultaneousGesture(
             DragGesture(minimumDistance: 0)
@@ -68,19 +67,31 @@ struct XomButton: View {
 
     private var foregroundColor: Color {
         switch variant {
-        case .primary: .black
-        case .secondary: Theme.accent
+        case .primary:     .black
+        case .secondary:   Theme.accent
         case .destructive: .white
-        case .ghost: Theme.accent
+        case .ghost:       Theme.accent
         }
     }
 
-    private var backgroundColor: Color {
+    @ViewBuilder
+    private var backgroundLayer: some View {
         switch variant {
-        case .primary: Theme.accent
-        case .secondary: Theme.glassFill
-        case .destructive: Theme.destructive
-        case .ghost: .clear
+        case .primary:
+            ZStack {
+                Theme.accent
+                LinearGradient(
+                    colors: [Color.white.opacity(0.10), Color.clear],
+                    startPoint: .top,
+                    endPoint: .bottom
+                )
+            }
+        case .secondary:
+            Theme.surfaceElevated
+        case .destructive:
+            Theme.destructive
+        case .ghost:
+            Color.clear
         }
     }
 
@@ -97,12 +108,18 @@ struct XomButton: View {
             EmptyView()
         }
     }
+}
 
-    private var shadowColor: Color {
-        switch variant {
-        case .primary: Theme.accent.opacity(0.3)
-        case .destructive: Theme.destructive.opacity(0.3)
-        default: .clear
-        }
+// MARK: - Preview
+
+#Preview {
+    VStack(spacing: 16) {
+        XomButton("Start Workout", variant: .primary) {}
+        XomButton("Edit Profile", variant: .secondary) {}
+        XomButton("Delete", variant: .destructive) {}
+        XomButton("Skip", variant: .ghost) {}
+        XomButton("Loading...", isLoading: true) {}
     }
+    .padding()
+    .background(Theme.background)
 }

--- a/Xomfit/Views/Common/XomCard.swift
+++ b/Xomfit/Views/Common/XomCard.swift
@@ -1,8 +1,22 @@
 import SwiftUI
 
+// MARK: - XomCard Variant
+
+enum XomCardVariant {
+    /// Standard card — hairline border, surface fill, no shadow.
+    case base
+    /// Slightly elevated — surfaceElevated fill, hairlineStrong border.
+    case elevated
+    /// Full-bleed hero card — xl radius, surfaceElevated fill, hairlineStrong border.
+    case hero
+}
+
+// MARK: - XomCard
+
 struct XomCard<Content: View>: View {
     let padding: CGFloat
     let isPressable: Bool
+    let variant: XomCardVariant
     @ViewBuilder let content: Content
 
     @State private var isPressed = false
@@ -10,27 +24,23 @@ struct XomCard<Content: View>: View {
     init(
         padding: CGFloat = Theme.Spacing.md,
         isPressable: Bool = false,
+        variant: XomCardVariant = .base,
         @ViewBuilder content: () -> Content
     ) {
         self.padding = padding
         self.isPressable = isPressable
+        self.variant = variant
         self.content = content()
     }
 
     var body: some View {
         content
             .padding(padding)
-            .background(
-                RoundedRectangle(cornerRadius: Theme.cornerRadius)
-                    .fill(Theme.glassFill)
-                    .background(
-                        RoundedRectangle(cornerRadius: Theme.cornerRadius)
-                            .fill(Theme.surface)
-                    )
-            )
+            .background(fillColor)
+            .clipShape(RoundedRectangle(cornerRadius: cornerRadius))
             .overlay(
-                RoundedRectangle(cornerRadius: Theme.cornerRadius)
-                    .strokeBorder(Theme.glassBorder, lineWidth: 0.5)
+                RoundedRectangle(cornerRadius: cornerRadius)
+                    .strokeBorder(borderColor, lineWidth: 0.5)
             )
             .scaleEffect(isPressable && isPressed ? 0.97 : 1)
             .animation(.xomSnappy, value: isPressed)
@@ -41,6 +51,28 @@ struct XomCard<Content: View>: View {
                         .onEnded { _ in isPressed = false }
                 )
             }
+    }
+
+    private var fillColor: Color {
+        switch variant {
+        case .base:     Theme.surface
+        case .elevated: Theme.surfaceElevated
+        case .hero:     Theme.surfaceElevated
+        }
+    }
+
+    private var borderColor: Color {
+        switch variant {
+        case .base: Theme.hairline
+        case .elevated, .hero: Theme.hairlineStrong
+        }
+    }
+
+    private var cornerRadius: CGFloat {
+        switch variant {
+        case .base, .elevated: Theme.Radius.md
+        case .hero: Theme.Radius.xl
+        }
     }
 }
 

--- a/Xomfit/Views/Common/XomDivider.swift
+++ b/Xomfit/Views/Common/XomDivider.swift
@@ -1,0 +1,27 @@
+import SwiftUI
+
+/// The ONE hairline rule — 0.5pt, `Theme.hairline` opacity.
+/// Use this everywhere a visual separator is needed instead of SwiftUI's `Divider()`.
+struct XomDivider: View {
+    var body: some View {
+        Rectangle()
+            .fill(Theme.hairline)
+            .frame(height: 0.5)
+            .frame(maxWidth: .infinity)
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    VStack(spacing: 0) {
+        Text("Above")
+            .foregroundStyle(Theme.textPrimary)
+            .padding()
+        XomDivider()
+        Text("Below")
+            .foregroundStyle(Theme.textPrimary)
+            .padding()
+    }
+    .background(Theme.surface)
+}

--- a/Xomfit/Views/Common/XomEmptyState.swift
+++ b/Xomfit/Views/Common/XomEmptyState.swift
@@ -1,31 +1,51 @@
 import SwiftUI
 
 struct XomEmptyState: View {
+    /// Single-icon API (legacy / simple usage).
     let icon: String
+    /// Optional stack of SF Symbol names layered for a richer illustration.
+    /// When provided, overrides `icon` display.
+    let symbolStack: [String]
     let title: String
     let subtitle: String
     let ctaLabel: String?
     let ctaAction: (() -> Void)?
+    /// When true, applies a subtle floating loop to the symbol illustration.
+    let floatingLoop: Bool
+
+    @State private var floatOffset: CGFloat = 0
 
     init(
         icon: String = "tray",
+        symbolStack: [String] = [],
         title: String,
         subtitle: String,
         ctaLabel: String? = nil,
-        ctaAction: (() -> Void)? = nil
+        ctaAction: (() -> Void)? = nil,
+        floatingLoop: Bool = false
     ) {
         self.icon = icon
+        self.symbolStack = symbolStack
         self.title = title
         self.subtitle = subtitle
         self.ctaLabel = ctaLabel
         self.ctaAction = ctaAction
+        self.floatingLoop = floatingLoop
     }
 
     var body: some View {
         VStack(spacing: Theme.Spacing.md) {
-            Image(systemName: icon)
-                .font(.system(size: 48))
-                .foregroundStyle(Theme.textSecondary.opacity(0.5))
+            illustrationView
+                .offset(y: floatOffset)
+                .onAppear {
+                    guard floatingLoop else { return }
+                    withAnimation(
+                        .easeInOut(duration: 2.4)
+                        .repeatForever(autoreverses: true)
+                    ) {
+                        floatOffset = -8
+                    }
+                }
 
             VStack(spacing: Theme.Spacing.xs) {
                 Text(title)
@@ -45,4 +65,48 @@ struct XomEmptyState: View {
         }
         .padding(Theme.Spacing.xl)
     }
+
+    @ViewBuilder
+    private var illustrationView: some View {
+        if symbolStack.isEmpty {
+            Image(systemName: icon)
+                .font(.system(size: 48))
+                .foregroundStyle(Theme.textSecondary.opacity(0.4))
+        } else {
+            ZStack {
+                ForEach(Array(symbolStack.enumerated()), id: \.offset) { index, symbol in
+                    Image(systemName: symbol)
+                        .font(.system(size: 48 - CGFloat(index) * 10))
+                        .foregroundStyle(Theme.textSecondary.opacity(0.4 - Double(index) * 0.1))
+                        .offset(
+                            x: CGFloat(index) * 6,
+                            y: CGFloat(index) * -6
+                        )
+                }
+            }
+            .frame(width: 80, height: 80)
+        }
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    VStack(spacing: 40) {
+        XomEmptyState(
+            icon: "dumbbell",
+            title: "No Workouts Yet",
+            subtitle: "Log your first workout to get started.",
+            ctaLabel: "Start Workout",
+            ctaAction: {}
+        )
+
+        XomEmptyState(
+            symbolStack: ["dumbbell.fill", "figure.strengthtraining.traditional"],
+            title: "No Exercises Added",
+            subtitle: "Add exercises to your workout.",
+            floatingLoop: true
+        )
+    }
+    .background(Theme.background)
 }

--- a/Xomfit/Views/Common/XomErrorState.swift
+++ b/Xomfit/Views/Common/XomErrorState.swift
@@ -1,0 +1,42 @@
+import SwiftUI
+
+/// Reusable error container — warning glyph, concise copy, optional retry CTA.
+/// Replaces ad-hoc `errorView(message:)` helpers in tab roots.
+struct XomErrorState: View {
+    let title: String
+    let message: String
+    let retryLabel: String
+    let retryAction: (() -> Void)?
+
+    init(
+        title: String = "Something went wrong",
+        message: String,
+        retryLabel: String = "Try Again",
+        retryAction: (() -> Void)? = nil
+    ) {
+        self.title = title
+        self.message = message
+        self.retryLabel = retryLabel
+        self.retryAction = retryAction
+    }
+
+    var body: some View {
+        XomEmptyState(
+            icon: "exclamationmark.triangle.fill",
+            title: title,
+            subtitle: message,
+            ctaLabel: retryAction != nil ? retryLabel : nil,
+            ctaAction: retryAction
+        )
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    XomErrorState(
+        message: "Failed to load feed. Check your connection and try again.",
+        retryAction: {}
+    )
+    .background(Theme.background)
+}

--- a/Xomfit/Views/Common/XomMetricLabel.swift
+++ b/Xomfit/Views/Common/XomMetricLabel.swift
@@ -1,0 +1,49 @@
+import SwiftUI
+
+/// Applies the metric-label treatment: uppercase + 0.5 kerning + `.caption.weight(.semibold)` + `textSecondary`.
+/// Use as a view modifier `.metricLabel()` or wrap content in `XomMetricLabel`.
+struct XomMetricLabel: View {
+    let text: String
+
+    init(_ text: String) {
+        self.text = text
+    }
+
+    var body: some View {
+        Text(text.uppercased())
+            .font(Theme.fontMetricLabel)
+            .foregroundStyle(Theme.textSecondary)
+            .kerning(0.5)
+    }
+}
+
+// MARK: - View Modifier
+
+struct MetricLabelModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .font(Theme.fontMetricLabel)
+            .foregroundStyle(Theme.textSecondary)
+            .kerning(0.5)
+            .textCase(.uppercase)
+    }
+}
+
+extension View {
+    /// Applies uppercase + kerning + caption semibold styling for metric labels.
+    func metricLabel() -> some View {
+        modifier(MetricLabelModifier())
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    VStack(spacing: 8) {
+        XomMetricLabel("Total Volume")
+        XomMetricLabel("Weekly Workouts")
+        Text("custom text").metricLabel()
+    }
+    .padding()
+    .background(Theme.background)
+}

--- a/Xomfit/Views/Common/XomSkeletonRow.swift
+++ b/Xomfit/Views/Common/XomSkeletonRow.swift
@@ -37,14 +37,14 @@ struct XomSkeletonRow: View {
             // Header row
             HStack(spacing: Theme.Spacing.sm) {
                 Circle()
-                    .fill(Theme.surfaceSecondary)
+                    .fill(Theme.surfaceElevated)
                     .frame(width: 40, height: 40)
                 VStack(alignment: .leading, spacing: Theme.Spacing.xs) {
                     RoundedRectangle(cornerRadius: 4)
-                        .fill(Theme.surfaceSecondary)
+                        .fill(Theme.surfaceElevated)
                         .frame(width: 120, height: 14)
                     RoundedRectangle(cornerRadius: 4)
-                        .fill(Theme.surfaceSecondary)
+                        .fill(Theme.surfaceElevated)
                         .frame(width: 80, height: 10)
                 }
                 Spacer()
@@ -52,17 +52,17 @@ struct XomSkeletonRow: View {
 
             // Content area
             RoundedRectangle(cornerRadius: 8)
-                .fill(Theme.surfaceSecondary)
+                .fill(Theme.surfaceElevated)
                 .frame(height: 16)
             RoundedRectangle(cornerRadius: 8)
-                .fill(Theme.surfaceSecondary)
+                .fill(Theme.surfaceElevated)
                 .frame(width: 200, height: 16)
 
             // Stats row
             HStack(spacing: Theme.Spacing.md) {
                 ForEach(0..<3, id: \.self) { _ in
                     RoundedRectangle(cornerRadius: 8)
-                        .fill(Theme.surfaceSecondary)
+                        .fill(Theme.surfaceElevated)
                         .frame(height: 40)
                 }
             }
@@ -71,7 +71,7 @@ struct XomSkeletonRow: View {
             HStack {
                 ForEach(0..<3, id: \.self) { _ in
                     RoundedRectangle(cornerRadius: 4)
-                        .fill(Theme.surfaceSecondary)
+                        .fill(Theme.surfaceElevated)
                         .frame(width: 60, height: 20)
                 }
                 Spacer()
@@ -87,15 +87,15 @@ struct XomSkeletonRow: View {
     private var profileHeaderSkeleton: some View {
         VStack(spacing: Theme.Spacing.md) {
             Circle()
-                .fill(Theme.surfaceSecondary)
-                .frame(width: 80, height: 80)
+                .fill(Theme.surfaceElevated)
+                .frame(width: 96, height: 96)
 
             VStack(spacing: Theme.Spacing.xs) {
                 RoundedRectangle(cornerRadius: 4)
-                    .fill(Theme.surfaceSecondary)
+                    .fill(Theme.surfaceElevated)
                     .frame(width: 140, height: 18)
                 RoundedRectangle(cornerRadius: 4)
-                    .fill(Theme.surfaceSecondary)
+                    .fill(Theme.surfaceElevated)
                     .frame(width: 100, height: 14)
             }
 
@@ -103,10 +103,10 @@ struct XomSkeletonRow: View {
                 ForEach(0..<3, id: \.self) { _ in
                     VStack(spacing: Theme.Spacing.xs) {
                         RoundedRectangle(cornerRadius: 4)
-                            .fill(Theme.surfaceSecondary)
+                            .fill(Theme.surfaceElevated)
                             .frame(width: 40, height: 20)
                         RoundedRectangle(cornerRadius: 4)
-                            .fill(Theme.surfaceSecondary)
+                            .fill(Theme.surfaceElevated)
                             .frame(width: 50, height: 12)
                     }
                 }
@@ -118,10 +118,10 @@ struct XomSkeletonRow: View {
     private var statSkeleton: some View {
         VStack(spacing: Theme.Spacing.xs) {
             RoundedRectangle(cornerRadius: 4)
-                .fill(Theme.surfaceSecondary)
+                .fill(Theme.surfaceElevated)
                 .frame(width: 50, height: 24)
             RoundedRectangle(cornerRadius: 4)
-                .fill(Theme.surfaceSecondary)
+                .fill(Theme.surfaceElevated)
                 .frame(width: 60, height: 12)
         }
         .frame(maxWidth: .infinity)

--- a/Xomfit/Views/Common/XomStat.swift
+++ b/Xomfit/Views/Common/XomStat.swift
@@ -1,32 +1,87 @@
 import SwiftUI
 
+// MARK: - Trend Direction
+
+enum XomStatTrend {
+    case up, down, neutral
+}
+
+// MARK: - XomStat
+
 struct XomStat: View {
     let value: String
     let label: String
     let icon: String?
     let iconColor: Color
+    let trend: XomStatTrend?
 
-    init(_ value: String, label: String, icon: String? = nil, iconColor: Color = Theme.accent) {
+    init(
+        _ value: String,
+        label: String,
+        icon: String? = nil,
+        iconColor: Color = Theme.accent,
+        trend: XomStatTrend? = nil
+    ) {
         self.value = value
         self.label = label
         self.icon = icon
         self.iconColor = iconColor
+        self.trend = trend
     }
 
     var body: some View {
-        VStack(spacing: Theme.Spacing.xs) {
+        VStack(spacing: 2) {
             if let icon {
                 Image(systemName: icon)
                     .font(.caption)
                     .foregroundStyle(iconColor)
             }
-            Text(value)
-                .font(.title3.weight(.bold).monospacedDigit())
-                .foregroundStyle(Theme.textPrimary)
-            Text(label)
-                .font(Theme.fontSmall)
+
+            HStack(alignment: .firstTextBaseline, spacing: 2) {
+                Text(value)
+                    .font(Theme.fontNumberLarge)
+                    .foregroundStyle(Theme.textPrimary)
+
+                if let trend {
+                    Image(systemName: trendIcon(trend))
+                        .font(.caption2.weight(.semibold))
+                        .foregroundStyle(trendColor(trend))
+                }
+            }
+
+            Text(label.uppercased())
+                .font(Theme.fontMetricLabel)
                 .foregroundStyle(Theme.textSecondary)
+                .kerning(0.5)
         }
         .frame(maxWidth: .infinity)
     }
+
+    private func trendIcon(_ trend: XomStatTrend) -> String {
+        switch trend {
+        case .up:      "arrow.up.right"
+        case .down:    "arrow.down.right"
+        case .neutral: "arrow.right"
+        }
+    }
+
+    private func trendColor(_ trend: XomStatTrend) -> Color {
+        switch trend {
+        case .up:      Theme.accent
+        case .down:    Theme.destructive
+        case .neutral: Theme.textTertiary
+        }
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    HStack {
+        XomStat("135", label: "Workouts", trend: .up)
+        XomStat("2,480", label: "Volume (lbs)", trend: .neutral)
+        XomStat("12", label: "PRs", icon: "trophy.fill", iconColor: Theme.prGold)
+    }
+    .padding()
+    .background(Theme.background)
 }

--- a/Xomfit/Views/Common/XomToolbarTitle.swift
+++ b/Xomfit/Views/Common/XomToolbarTitle.swift
@@ -1,0 +1,52 @@
+import SwiftUI
+
+/// Optional helper for a consistent inline-title + subtitle treatment.
+/// Use in detail views that want a two-line nav title.
+///
+/// Usage:
+/// ```swift
+/// .toolbar {
+///     ToolbarItem(placement: .principal) {
+///         XomToolbarTitle(title: "Bench Press", subtitle: "Personal Records")
+///     }
+/// }
+/// ```
+struct XomToolbarTitle: View {
+    let title: String
+    let subtitle: String?
+
+    init(_ title: String, subtitle: String? = nil) {
+        self.title = title
+        self.subtitle = subtitle
+    }
+
+    var body: some View {
+        VStack(spacing: 1) {
+            Text(title)
+                .font(.headline.weight(.semibold))
+                .foregroundStyle(Theme.textPrimary)
+
+            if let subtitle {
+                Text(subtitle)
+                    .font(.caption)
+                    .foregroundStyle(Theme.textSecondary)
+            }
+        }
+        .multilineTextAlignment(.center)
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    NavigationStack {
+        Color(Theme.background)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .principal) {
+                    XomToolbarTitle("Bench Press", subtitle: "Personal Records")
+                }
+            }
+            .toolbarColorScheme(.dark, for: .navigationBar)
+    }
+}

--- a/Xomfit/Views/Feed/ActivityStripeCard.swift
+++ b/Xomfit/Views/Feed/ActivityStripeCard.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+
+/// Shared primitive for PR / Milestone / Streak content cards with a leading color stripe.
+/// Replaces tinted-background panels.
+struct ActivityStripeCard<Content: View>: View {
+    let stripeColor: Color
+    let icon: String
+    let title: String
+    @ViewBuilder let content: Content
+
+    var body: some View {
+        HStack(spacing: 0) {
+            // Leading 3pt color stripe
+            Rectangle()
+                .fill(stripeColor)
+                .frame(width: 3)
+                .clipShape(.rect(topLeadingRadius: 3, bottomLeadingRadius: 3))
+
+            HStack(alignment: .top, spacing: Theme.Spacing.sm) {
+                Image(systemName: icon)
+                    .font(.system(size: 20, weight: .semibold))
+                    .foregroundStyle(stripeColor)
+                    .frame(width: 28)
+
+                VStack(alignment: .leading, spacing: Theme.Spacing.xs) {
+                    content
+                }
+
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, Theme.Spacing.sm)
+            .padding(.vertical, Theme.Spacing.sm)
+        }
+        .background(Theme.surface)
+        .clipShape(.rect(cornerRadius: Theme.Radius.sm))
+        .overlay(
+            RoundedRectangle(cornerRadius: Theme.Radius.sm)
+                .strokeBorder(Theme.hairline, lineWidth: 0.5)
+        )
+    }
+}

--- a/Xomfit/Views/Feed/FeedCommentsView.swift
+++ b/Xomfit/Views/Feed/FeedCommentsView.swift
@@ -129,37 +129,33 @@ private struct CommentRow: View {
     let comment: FeedComment
 
     var body: some View {
-        HStack(alignment: .top, spacing: Theme.Spacing.sm) {
-            ZStack {
-                Circle()
-                    .fill(Theme.accent.opacity(0.15))
-                    .frame(width: 34, height: 34)
-                Text(initials)
-                    .font(.caption.weight(.bold))
-                    .foregroundStyle(Theme.accent)
-            }
+        VStack(spacing: 0) {
+            HStack(alignment: .top, spacing: Theme.Spacing.sm) {
+                XomAvatar(
+                    name: comment.user?.displayName ?? "User",
+                    size: 32
+                )
 
-            VStack(alignment: .leading, spacing: 3) {
-                HStack(spacing: 6) {
-                    Text(comment.user?.displayName ?? "User")
-                        .font(.caption.weight(.semibold))
+                VStack(alignment: .leading, spacing: 3) {
+                    HStack(spacing: 6) {
+                        Text(comment.user?.displayName ?? "User")
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(Theme.textPrimary)
+                        Text(comment.createdAt.timeAgo)
+                            .font(Theme.fontSmall)
+                            .foregroundStyle(Theme.textTertiary)
+                    }
+                    Text(comment.text)
+                        .font(Theme.fontBody)
                         .foregroundStyle(Theme.textPrimary)
-                    Text(comment.createdAt.timeAgo)
-                        .font(Theme.fontSmall)
-                        .foregroundStyle(Theme.textSecondary)
                 }
-                Text(comment.text)
-                    .font(Theme.fontBody)
-                    .foregroundStyle(Theme.textPrimary)
+
+                Spacer()
             }
+            .padding(.vertical, 10)
+            .accessibilityElement(children: .combine)
 
-            Spacer()
+            XomDivider()
         }
-        .accessibilityElement(children: .combine)
-    }
-
-    private var initials: String {
-        let name = comment.user?.displayName ?? "U"
-        return String(name.prefix(2)).uppercased()
     }
 }

--- a/Xomfit/Views/Feed/FeedDetailView.swift
+++ b/Xomfit/Views/Feed/FeedDetailView.swift
@@ -101,7 +101,7 @@ struct FeedDetailView: View {
             }
 
             if let activity = localItem.workoutActivity {
-                Divider().background(Theme.textSecondary.opacity(0.2))
+                XomDivider()
 
                 VStack(alignment: .leading, spacing: 6) {
                     Text(activity.workoutName)
@@ -130,13 +130,13 @@ struct FeedDetailView: View {
                     }
                 }
 
-                Divider().background(Theme.textSecondary.opacity(0.2))
+                XomDivider()
 
                 // Real exercise data from DB
                 exerciseSection
             }
 
-            Divider().background(Theme.textSecondary.opacity(0.2))
+            XomDivider()
 
             actionBar
         }
@@ -292,77 +292,30 @@ struct FeedDetailView: View {
 
     private var headerRow: some View {
         HStack(spacing: Theme.Spacing.sm) {
-            ZStack {
-                Circle()
-                    .fill(Theme.accent.opacity(0.2))
-                    .frame(width: 44, height: 44)
-                Text(avatarInitials)
-                    .font(.subheadline.weight(.bold))
-                    .foregroundStyle(Theme.accent)
-            }
+            XomAvatar(
+                name: localItem.user.displayName.isEmpty ? localItem.user.username : localItem.user.displayName,
+                size: 48
+            )
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(localItem.user.displayName.isEmpty ? localItem.user.username : localItem.user.displayName)
                     .font(.subheadline.weight(.semibold))
                     .foregroundStyle(Theme.textPrimary)
-                Text(localItem.createdAt.timeAgo)
+                Text("\(activityTypeLabel) · \(localItem.createdAt.timeAgo)")
                     .font(Theme.fontSmall)
-                    .foregroundStyle(Theme.textSecondary)
+                    .foregroundStyle(Theme.textTertiary)
             }
 
             Spacer()
-
-            activityBadge
         }
     }
 
-    private var avatarInitials: String {
-        let name = localItem.user.displayName.isEmpty ? localItem.user.username : localItem.user.displayName
-        let parts = name.split(separator: " ")
-        if parts.count >= 2 {
-            return String(parts[0].prefix(1) + parts[1].prefix(1)).uppercased()
-        }
-        return String(name.prefix(2)).uppercased()
-    }
-
-    private var activityBadge: some View {
-        HStack(spacing: 4) {
-            Image(systemName: badgeIcon)
-                .font(.caption2.weight(.semibold))
-            Text(badgeLabel)
-                .font(Theme.fontSmall)
-        }
-        .foregroundStyle(badgeColor)
-        .padding(.horizontal, 8)
-        .padding(.vertical, 4)
-        .background(badgeColor.opacity(0.15))
-        .clipShape(.rect(cornerRadius: Theme.cornerRadiusSmall))
-    }
-
-    private var badgeIcon: String {
+    private var activityTypeLabel: String {
         switch localItem.activityType {
-        case .workout: return "figure.strengthtraining.traditional"
-        case .personalRecord: return "trophy.fill"
-        case .milestone: return "star.fill"
-        case .streak: return "flame.fill"
-        }
-    }
-
-    private var badgeLabel: String {
-        switch localItem.activityType {
-        case .workout: return "Workout"
-        case .personalRecord: return "PR"
-        case .milestone: return "Milestone"
-        case .streak: return "Streak"
-        }
-    }
-
-    private var badgeColor: Color {
-        switch localItem.activityType {
-        case .workout: return Theme.accent
-        case .personalRecord: return Theme.prGold
-        case .milestone: return Theme.badgeMilestone
-        case .streak: return Theme.badgeStreak
+        case .workout:        "Workout"
+        case .personalRecord: "Personal Record"
+        case .milestone:      "Milestone"
+        case .streak:         "Streak"
         }
     }
 

--- a/Xomfit/Views/Feed/FeedFilterBar.swift
+++ b/Xomfit/Views/Feed/FeedFilterBar.swift
@@ -26,62 +26,49 @@ struct FeedFilterBar: View {
     @Binding var selectedMuscleGroups: Set<MuscleGroup>
 
     var body: some View {
-        ScrollView(.horizontal, showsIndicators: false) {
-            HStack(spacing: 8) {
-                // Date range chips
-                ForEach(FeedDateRange.allCases) { range in
-                    filterChip(
-                        label: range.rawValue,
-                        isSelected: selectedDateRange == range
-                    ) {
-                        withAnimation(.xomChill) { selectedDateRange = range }
-                    }
-                }
-
-                // Divider
-                Rectangle()
-                    .fill(Theme.textSecondary.opacity(0.3))
-                    .frame(width: 1, height: 20)
-
-                // Muscle group chips
-                ForEach(MuscleGroup.allCases) { group in
-                    filterChip(
-                        icon: group.icon,
-                        label: group.displayName,
-                        isSelected: selectedMuscleGroups.contains(group)
-                    ) {
-                        withAnimation(.xomChill) {
-                            if selectedMuscleGroups.contains(group) {
-                                selectedMuscleGroups.remove(group)
-                            } else {
-                                selectedMuscleGroups.insert(group)
-                            }
+        VStack(spacing: 0) {
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 8) {
+                    // Date range chips
+                    ForEach(FeedDateRange.allCases) { range in
+                        let isActive = selectedDateRange == range
+                        Button {
+                            withAnimation(.xomChill) { selectedDateRange = range }
+                        } label: {
+                            XomBadge(range.rawValue, variant: .interactive, isActive: isActive)
                         }
+                        .buttonStyle(.plain)
+                        .accessibilityLabel("\(range.rawValue)\(isActive ? ", selected" : "")")
+                    }
+
+                    // Vertical hairline separator
+                    Rectangle()
+                        .fill(Theme.hairline)
+                        .frame(width: 0.5, height: 20)
+
+                    // Muscle group chips
+                    ForEach(MuscleGroup.allCases) { group in
+                        let isActive = selectedMuscleGroups.contains(group)
+                        Button {
+                            withAnimation(.xomChill) {
+                                if selectedMuscleGroups.contains(group) {
+                                    selectedMuscleGroups.remove(group)
+                                } else {
+                                    selectedMuscleGroups.insert(group)
+                                }
+                            }
+                        } label: {
+                            XomBadge(group.displayName, icon: group.icon, variant: .interactive, isActive: isActive)
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityLabel("\(group.displayName)\(isActive ? ", selected" : "")")
                     }
                 }
+                .padding(.horizontal, Theme.Spacing.md)
             }
-            .padding(.horizontal, Theme.Spacing.md)
-        }
-        .padding(.vertical, 8)
-    }
+            .padding(.vertical, 8)
 
-    private func filterChip(icon: String? = nil, label: String, isSelected: Bool, action: @escaping () -> Void) -> some View {
-        Button(action: action) {
-            HStack(spacing: 4) {
-                if let icon {
-                    Image(systemName: icon)
-                        .font(.caption2)
-                }
-                Text(label)
-                    .font(.caption.weight(.semibold))
-            }
-            .foregroundStyle(isSelected ? .black : Theme.textSecondary)
-            .padding(.horizontal, 10)
-            .padding(.vertical, 6)
-            .background(isSelected ? Theme.accent : Theme.surfaceSecondary)
-            .clipShape(.capsule)
+            XomDivider()
         }
-        .buttonStyle(.plain)
-        .accessibilityLabel("\(label)\(isSelected ? ", selected" : "")")
     }
 }

--- a/Xomfit/Views/Feed/FeedItemCard.swift
+++ b/Xomfit/Views/Feed/FeedItemCard.swift
@@ -1,5 +1,12 @@
 import SwiftUI
 
+// MARK: - Identifiable URL wrapper for photo zoom sheet
+
+private struct IdentifiableURL: Identifiable {
+    let id = UUID()
+    let url: URL
+}
+
 struct FeedItemCard: View {
     let item: SocialFeedItem
     let onLike: () -> Void
@@ -12,29 +19,27 @@ struct FeedItemCard: View {
     @State private var showEditCaption = false
     @State private var editedCaption = ""
     @State private var likeScale: CGFloat = 1
+    @State private var zoomPhotoURL: IdentifiableURL? = nil
+    @State private var particleBurst = false
 
     var body: some View {
-        VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
-            headerRow
-            activityContent
+        XomCard(variant: .base) {
+            VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+                headerRow
+                activityContent
 
-            if let caption = item.caption, !caption.isEmpty {
-                Text(caption)
-                    .font(Theme.fontBody)
-                    .foregroundStyle(Theme.textPrimary)
-                    .padding(.top, 2)
+                if let caption = item.caption, !caption.isEmpty {
+                    Text(caption)
+                        .font(Theme.fontBody)
+                        .foregroundStyle(Theme.textPrimary)
+                        .padding(.top, 2)
+                }
+
+                XomDivider()
+
+                actionBar
             }
-
-            Divider()
-                .background(Theme.textSecondary.opacity(0.3))
-
-            actionBar
         }
-        .padding(.horizontal, Theme.Spacing.md)
-        .padding(.vertical, 14)
-        .background(Theme.surface)
-        .clipShape(.rect(cornerRadius: Theme.cornerRadius))
-        .shadow(color: .black.opacity(0.15), radius: 4, x: 0, y: 2)
         .contextMenu {
             if onEdit != nil {
                 Button {
@@ -53,19 +58,18 @@ struct FeedItemCard: View {
             }
         }
         .confirmationDialog("Delete Post", isPresented: $showDeleteConfirm, titleVisibility: .visible) {
-            Button("Delete", role: .destructive) {
-                onDelete?()
-            }
+            Button("Delete", role: .destructive) { onDelete?() }
             Button("Cancel", role: .cancel) {}
         } message: {
             Text("Are you sure you want to delete this post? This cannot be undone.")
         }
         .alert("Edit Caption", isPresented: $showEditCaption) {
             TextField("Caption", text: $editedCaption)
-            Button("Save") {
-                onEdit?(editedCaption)
-            }
+            Button("Save") { onEdit?(editedCaption) }
             Button("Cancel", role: .cancel) {}
+        }
+        .fullScreenCover(item: $zoomPhotoURL) { identifiable in
+            PhotoZoomView(url: identifiable.url)
         }
     }
 
@@ -75,24 +79,23 @@ struct FeedItemCard: View {
         HStack(spacing: Theme.Spacing.sm) {
             XomAvatar(
                 name: item.user.displayName.isEmpty ? item.user.username : item.user.displayName,
-                size: 40
+                size: 48
             )
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(item.user.displayName.isEmpty ? item.user.username : item.user.displayName)
                     .font(.subheadline.weight(.semibold))
                     .foregroundStyle(Theme.textPrimary)
+                    .accessibilityAddTraits(.isHeader)
 
-                HStack(spacing: Theme.Spacing.xs) {
-                    Text(item.createdAt.timeAgo)
-                        .font(Theme.fontSmall)
-                        .foregroundStyle(Theme.textSecondary)
-                }
+                // Activity context line under display name
+                Text("\(activityTypeLabel) · \(item.createdAt.timeAgo)")
+                    .font(Theme.fontSmall)
+                    .foregroundStyle(Theme.textTertiary)
+                    .accessibilityLabel("\(activityTypeLabel), \(item.createdAt.timeAgo)")
             }
 
             Spacer()
-
-            activityBadge
 
             if onDelete != nil || onEdit != nil {
                 Menu {
@@ -113,56 +116,13 @@ struct FeedItemCard: View {
                     }
                 } label: {
                     Image(systemName: "ellipsis")
-                        .font(.body)
+                        .font(.system(size: 18, weight: .medium))
                         .foregroundStyle(Theme.textSecondary)
                         .frame(width: 32, height: 32)
                         .contentShape(Rectangle())
                 }
                 .accessibilityLabel("Post options")
             }
-        }
-    }
-
-    // MARK: - Activity Badge
-
-    private var activityBadge: some View {
-        HStack(spacing: 4) {
-            Image(systemName: badgeIcon)
-                .font(Theme.fontSmall)
-            Text(badgeLabel)
-                .font(Theme.fontSmall)
-        }
-        .foregroundStyle(badgeColor)
-        .padding(.horizontal, Theme.Spacing.sm)
-        .padding(.vertical, Theme.Spacing.xs)
-        .background(badgeColor.opacity(0.15))
-        .clipShape(.rect(cornerRadius: Theme.cornerRadiusSmall))
-    }
-
-    private var badgeIcon: String {
-        switch item.activityType {
-        case .workout: return "figure.strengthtraining.traditional"
-        case .personalRecord: return "trophy.fill"
-        case .milestone: return "star.fill"
-        case .streak: return "flame.fill"
-        }
-    }
-
-    private var badgeLabel: String {
-        switch item.activityType {
-        case .workout: return "Workout"
-        case .personalRecord: return "PR"
-        case .milestone: return "Milestone"
-        case .streak: return "Streak"
-        }
-    }
-
-    private var badgeColor: Color {
-        switch item.activityType {
-        case .workout: return Theme.badgeWorkout
-        case .personalRecord: return Theme.badgePR
-        case .milestone: return Theme.badgeMilestone
-        case .streak: return Theme.badgeStreak
         }
     }
 
@@ -173,7 +133,9 @@ struct FeedItemCard: View {
         switch item.activityType {
         case .workout:
             if let activity = item.workoutActivity {
-                WorkoutActivityContent(activity: activity)
+                WorkoutActivityContent(activity: activity, onPhotoTap: { url in
+                    zoomPhotoURL = IdentifiableURL(url: url)
+                })
             }
         case .personalRecord:
             if let activity = item.prActivity {
@@ -194,23 +156,35 @@ struct FeedItemCard: View {
 
     private var actionBar: some View {
         HStack(spacing: Theme.Spacing.lg) {
-            // Like button with animation
+            // Like button with particle burst on first like
             Button {
-                withAnimation(.xomCelebration) {
-                    likeScale = 1.3
-                }
+                let wasLiked = item.isLiked
+                withAnimation(.xomCelebration) { likeScale = 1.3 }
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
-                    withAnimation(.xomPlayful) {
-                        likeScale = 1
+                    withAnimation(.xomPlayful) { likeScale = 1 }
+                }
+                if !wasLiked {
+                    particleBurst = false
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+                        particleBurst = true
                     }
                 }
                 onLike()
             } label: {
                 HStack(spacing: 5) {
                     Image(systemName: item.isLiked ? "heart.fill" : "heart")
-                        .font(.subheadline)
+                        .font(.system(size: 18, weight: .medium))
                         .foregroundStyle(item.isLiked ? Theme.destructive : Theme.textSecondary)
                         .scaleEffect(likeScale)
+                        .overlay(
+                            ParticleBurstView(
+                                trigger: particleBurst,
+                                symbols: ["heart.fill"],
+                                color: Theme.destructive,
+                                count: 6,
+                                duration: 0.6
+                            )
+                        )
                     Text("\(item.likes)")
                         .font(.caption.weight(.medium))
                         .foregroundStyle(Theme.textSecondary)
@@ -218,12 +192,13 @@ struct FeedItemCard: View {
             }
             .buttonStyle(.plain)
             .sensoryFeedback(.impact(weight: .medium), trigger: item.isLiked)
+            .accessibilityLabel("\(item.isLiked ? "Unlike" : "Like"), \(item.likes) likes")
 
             // Comment button
             Button(action: onComment) {
                 HStack(spacing: 5) {
                     Image(systemName: "bubble.right")
-                        .font(.subheadline)
+                        .font(.system(size: 18, weight: .medium))
                         .foregroundStyle(Theme.textSecondary)
                     Text("\(item.comments.count)")
                         .font(.caption.weight(.medium))
@@ -231,15 +206,14 @@ struct FeedItemCard: View {
                 }
             }
             .buttonStyle(.plain)
+            .accessibilityLabel("\(item.comments.count) comments")
 
             Spacer()
 
             // Share button
-            Button {
-                shareFeedItem()
-            } label: {
+            Button { shareFeedItem() } label: {
                 Image(systemName: "square.and.arrow.up")
-                    .font(.subheadline)
+                    .font(.system(size: 18, weight: .medium))
                     .foregroundStyle(Theme.textSecondary)
             }
             .buttonStyle(.plain)
@@ -251,7 +225,7 @@ struct FeedItemCard: View {
                     onSave()
                 } label: {
                     Image(systemName: "bookmark")
-                        .font(.subheadline)
+                        .font(.system(size: 18, weight: .medium))
                         .foregroundStyle(Theme.textSecondary)
                 }
                 .buttonStyle(.plain)
@@ -260,30 +234,42 @@ struct FeedItemCard: View {
         }
     }
 
+    // MARK: - Computed labels
+
+    private var activityTypeLabel: String {
+        switch item.activityType {
+        case .workout:       "Workout"
+        case .personalRecord: "Personal Record"
+        case .milestone:     "Milestone"
+        case .streak:        "Streak"
+        }
+    }
+
+    // MARK: - Share
+
     private func shareFeedItem() {
         let name = item.user.displayName.isEmpty ? item.user.username : item.user.displayName
         var text = ""
         switch item.activityType {
         case .workout:
             if let w = item.workoutActivity {
-                text = "💪 \(name) crushed \(w.workoutName)!\n\(w.exerciseCount) exercises · \(w.totalSets) sets · \(Int(w.totalVolume)) lbs"
-                if w.prCount > 0 { text += " · \(w.prCount) PR\(w.prCount > 1 ? "s" : "")! 🏆" }
+                text = "\(name) crushed \(w.workoutName)! \(w.exerciseCount) exercises · \(w.totalSets) sets · \(Int(w.totalVolume)) lbs"
+                if w.prCount > 0 { text += " · \(w.prCount) PR\(w.prCount > 1 ? "s" : "")!" }
             }
         case .personalRecord:
             if let pr = item.prActivity {
-                text = "🏆 \(name) hit a new PR!\n\(pr.exerciseName): \(Int(pr.weight)) lbs x \(pr.reps)"
+                text = "\(name) hit a new PR! \(pr.exerciseName): \(Int(pr.weight)) lbs x \(pr.reps)"
             }
         case .milestone:
             if let m = item.milestoneActivity {
-                text = "🎉 \(name) reached a milestone!\n\(m.title) — \(m.subtitle)"
+                text = "\(name) reached a milestone! \(m.title) — \(m.subtitle)"
             }
         case .streak:
             if let s = item.streakActivity {
-                text = "🔥 \(name) is on a \(s.currentStreak)-day streak!"
+                text = "\(name) is on a \(s.currentStreak)-day streak!"
             }
         }
         text += "\n\nShared from XomFit"
-
         let controller = UIActivityViewController(activityItems: [text], applicationActivities: nil)
         if let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
            let root = scene.keyWindow?.rootViewController {
@@ -296,6 +282,7 @@ struct FeedItemCard: View {
 
 private struct WorkoutActivityContent: View {
     let activity: WorkoutActivity
+    let onPhotoTap: (URL) -> Void
 
     var body: some View {
         VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
@@ -325,72 +312,59 @@ private struct WorkoutActivityContent: View {
                 .foregroundStyle(Theme.textSecondary)
             }
 
-            // Stats grid — max 3 primary + optional PR badge
+            // Stats row — 3 columns with XomStat
             HStack(spacing: 0) {
-                XomStat(formatDuration(activity.duration), label: "Duration", icon: "clock", iconColor: Theme.textSecondary)
-                XomStat(formatVolume(activity.totalVolume), label: "Volume", icon: "scalemass", iconColor: Theme.textSecondary)
-                XomStat("\(activity.totalSets)", label: "Sets", icon: "list.bullet", iconColor: Theme.textSecondary)
+                XomStat(formatDuration(activity.duration), label: "Duration")
+                XomStat(formatVolume(activity.totalVolume), label: "Volume")
+                XomStat("\(activity.totalSets)", label: "Sets")
             }
             .padding(.vertical, Theme.Spacing.xs)
 
             if activity.prCount > 0 {
-                HStack(spacing: Theme.Spacing.xs) {
-                    Image(systemName: "trophy.fill")
-                        .font(Theme.fontSmall)
-                        .foregroundStyle(Theme.prGold)
-                    Text("\(activity.prCount) PR\(activity.prCount > 1 ? "s" : "")")
-                        .font(Theme.fontSmall)
-                        .foregroundStyle(Theme.prGold)
-                }
-                .padding(.horizontal, Theme.Spacing.sm)
-                .padding(.vertical, Theme.Spacing.xs)
-                .background(Theme.prGold.opacity(0.12))
-                .clipShape(.rect(cornerRadius: 6))
+                XomBadge("\(activity.prCount) PR\(activity.prCount > 1 ? "s" : "")", icon: "trophy.fill", color: Theme.prGold, variant: .display)
             }
 
-            // Photo gallery
+            // Photo gallery with tap-to-zoom
             if let photoURLs = activity.photoURLs, !photoURLs.isEmpty {
                 ScrollView(.horizontal, showsIndicators: false) {
                     HStack(spacing: 6) {
                         ForEach(photoURLs, id: \.self) { urlString in
-                            AsyncImage(url: URL(string: urlString)) { phase in
-                                switch phase {
-                                case .success(let image):
-                                    image
-                                        .resizable()
-                                        .scaledToFill()
-                                case .failure:
-                                    Image(systemName: "photo")
-                                        .foregroundStyle(Theme.textSecondary)
-                                default:
-                                    ProgressView()
+                            if let url = URL(string: urlString) {
+                                AsyncImage(url: url) { phase in
+                                    switch phase {
+                                    case .success(let image):
+                                        image
+                                            .resizable()
+                                            .scaledToFill()
+                                    case .failure:
+                                        Image(systemName: "photo")
+                                            .foregroundStyle(Theme.textSecondary)
+                                    default:
+                                        ProgressView()
+                                    }
                                 }
+                                .frame(width: 120, height: 120)
+                                .clipShape(.rect(cornerRadius: 8))
+                                .contentShape(Rectangle())
+                                .onTapGesture { onPhotoTap(url) }
+                                .accessibilityLabel("Workout photo")
                             }
-                            .frame(width: 120, height: 120)
-                            .clipShape(.rect(cornerRadius: 8))
                         }
                     }
                 }
             }
 
+            // Exercise pills using XomBadge
             if !activity.exercises.isEmpty {
                 ScrollView(.horizontal, showsIndicators: false) {
                     HStack(spacing: 6) {
                         ForEach(activity.exercises.prefix(4)) { ex in
-                            HStack(spacing: 3) {
-                                if ex.isPR {
-                                    Image(systemName: "trophy.fill")
-                                        .font(.system(size: 9))
-                                        .foregroundStyle(Theme.prGold)
-                                }
-                                Text(ex.name)
-                                    .font(Theme.fontSmall)
-                                    .foregroundStyle(ex.isPR ? Theme.prGold : Theme.textSecondary)
-                            }
-                            .padding(.horizontal, Theme.Spacing.sm)
-                            .padding(.vertical, 3)
-                            .background(Theme.background)
-                            .clipShape(.rect(cornerRadius: 4))
+                            XomBadge(
+                                ex.name,
+                                icon: ex.isPR ? "trophy.fill" : nil,
+                                color: ex.isPR ? Theme.prGold : Theme.textSecondary,
+                                variant: .secondary
+                            )
                         }
                     }
                 }
@@ -416,35 +390,26 @@ private struct PRActivityContent: View {
     let activity: PRActivity
 
     var body: some View {
-        HStack(spacing: Theme.Spacing.md) {
-            Image(systemName: "trophy.fill")
-                .font(.largeTitle)
-                .foregroundStyle(Theme.prGold)
+        ActivityStripeCard(stripeColor: Theme.prGold, icon: "trophy.fill", title: activity.exerciseName) {
+            Text(activity.exerciseName)
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(Theme.textPrimary)
 
-            VStack(alignment: .leading, spacing: Theme.Spacing.xs) {
-                Text(activity.exerciseName)
-                    .font(.subheadline.weight(.semibold))
-                    .foregroundStyle(Theme.textPrimary)
-                Text("\(activity.weight.formattedWeight) lbs × \(activity.reps) reps")
-                    .font(.title3.weight(.black))
-                    .foregroundStyle(Theme.prGold)
-                if let prev = activity.previousBest {
-                    Text("Previous best: \(prev.formattedWeight) lbs")
-                        .font(Theme.fontCaption)
-                        .foregroundStyle(Theme.textSecondary)
-                }
+            Text("\(activity.weight.formattedWeight) lbs × \(activity.reps) reps")
+                .font(Theme.fontDisplay)
+                .foregroundStyle(Theme.prGold)
+                .accessibilityLabel("\(activity.weight.formattedWeight) pounds, \(activity.reps) reps")
+
+            if let prev = activity.previousBest {
+                Text("Previous best: \(prev.formattedWeight) lbs")
+                    .font(Theme.fontCaption)
+                    .foregroundStyle(Theme.textTertiary)
             }
 
             if let imp = activity.improvement, imp > 0 {
-                Spacer()
-                Text("+\(imp.formattedWeight)")
-                    .font(.body.weight(.bold))
-                    .foregroundStyle(Theme.accent)
+                XomBadge("+\(imp.formattedWeight) lbs", color: Theme.accent, variant: .display)
             }
         }
-        .padding(Theme.Spacing.md)
-        .background(Theme.prGold.opacity(0.08))
-        .clipShape(.rect(cornerRadius: Theme.cornerRadiusSmall))
     }
 }
 
@@ -454,32 +419,15 @@ private struct MilestoneActivityContent: View {
     let activity: MilestoneActivity
 
     var body: some View {
-        HStack(spacing: Theme.Spacing.md) {
-            Text(activity.icon)
-                .font(.largeTitle)
-
-            VStack(alignment: .leading, spacing: Theme.Spacing.xs) {
-                Text(activity.title)
-                    .font(.subheadline.weight(.bold))
-                    .foregroundStyle(Theme.textPrimary)
-                Text(activity.subtitle)
-                    .font(Theme.fontCaption)
-                    .foregroundStyle(Theme.textSecondary)
-            }
-
-            Spacer()
-
-            Text(activity.badge)
-                .font(Theme.fontSmall)
-                .foregroundStyle(Theme.badgeMilestone)
-                .padding(.horizontal, Theme.Spacing.sm)
-                .padding(.vertical, Theme.Spacing.xs)
-                .background(Theme.badgeMilestone.opacity(0.15))
-                .clipShape(.rect(cornerRadius: 6))
+        ActivityStripeCard(stripeColor: Theme.milestone, icon: "star.fill", title: activity.title) {
+            Text(activity.title)
+                .font(.subheadline.weight(.bold))
+                .foregroundStyle(Theme.textPrimary)
+            Text(activity.subtitle)
+                .font(Theme.fontCaption)
+                .foregroundStyle(Theme.textSecondary)
+            XomBadge(activity.badge, color: Theme.milestone, variant: .display)
         }
-        .padding(Theme.Spacing.md)
-        .background(Theme.badgeMilestone.opacity(0.08))
-        .clipShape(.rect(cornerRadius: Theme.cornerRadiusSmall))
     }
 }
 
@@ -489,30 +437,20 @@ private struct StreakActivityContent: View {
     let activity: StreakActivity
 
     var body: some View {
-        HStack(spacing: Theme.Spacing.md) {
-            Image(systemName: "flame.fill")
-                .font(.largeTitle)
-                .foregroundStyle(Theme.badgeStreak)
+        ActivityStripeCard(stripeColor: Theme.streak, icon: "flame.fill", title: "\(activity.currentStreak) Day Streak") {
+            Text("\(activity.currentStreak) Day Streak")
+                .font(.title3.weight(.heavy))
+                .foregroundStyle(Theme.streak)
 
-            VStack(alignment: .leading, spacing: Theme.Spacing.xs) {
-                Text("\(activity.currentStreak) Day Streak")
-                    .font(.title3.weight(.black))
-                    .foregroundStyle(Theme.badgeStreak)
-                if activity.isNewRecord {
-                    Text("New personal streak record!")
-                        .font(Theme.fontCaption)
-                        .foregroundStyle(Theme.accent)
-                } else {
-                    Text("Previous best: \(activity.previousBest) days")
-                        .font(Theme.fontCaption)
-                        .foregroundStyle(Theme.textSecondary)
-                }
+            if activity.isNewRecord {
+                Text("New personal streak record!")
+                    .font(Theme.fontCaption)
+                    .foregroundStyle(Theme.accent)
+            } else {
+                Text("Previous best: \(activity.previousBest) days")
+                    .font(Theme.fontCaption)
+                    .foregroundStyle(Theme.textSecondary)
             }
-
-            Spacer()
         }
-        .padding(Theme.Spacing.md)
-        .background(Theme.badgeStreak.opacity(0.08))
-        .clipShape(.rect(cornerRadius: Theme.cornerRadiusSmall))
     }
 }

--- a/Xomfit/Views/Feed/FeedView.swift
+++ b/Xomfit/Views/Feed/FeedView.swift
@@ -53,7 +53,7 @@ struct FeedView: View {
                         } label: {
                             ZStack(alignment: .topTrailing) {
                                 Image(systemName: "bell")
-                                    .foregroundStyle(Theme.accent)
+                                    .foregroundStyle(Theme.textPrimary)
                                 if NotificationService.shared.unreadCount > 0 {
                                     Circle()
                                         .fill(Theme.destructive)
@@ -68,7 +68,7 @@ struct FeedView: View {
                             showUserSearch = true
                         } label: {
                             Image(systemName: "magnifyingglass")
-                                .foregroundStyle(Theme.accent)
+                                .foregroundStyle(Theme.textPrimary)
                         }
                         .accessibilityLabel("Search users")
 
@@ -77,7 +77,7 @@ struct FeedView: View {
                                 .hideTabBar()
                         } label: {
                             Image(systemName: "person.badge.plus")
-                                .foregroundStyle(Theme.accent)
+                                .foregroundStyle(Theme.textPrimary)
                         }
                     }
                 }
@@ -116,7 +116,7 @@ struct FeedView: View {
 
     private var feedList: some View {
         ScrollView {
-            LazyVStack(spacing: 12) {
+            LazyVStack(spacing: Theme.Spacing.md) {
                 ForEach(Array(viewModel.filteredFeedItems.enumerated()), id: \.element.id) { index, item in
                     FeedItemCard(
                         item: item,

--- a/Xomfit/Views/Feed/PhotoZoomView.swift
+++ b/Xomfit/Views/Feed/PhotoZoomView.swift
@@ -1,0 +1,130 @@
+import SwiftUI
+
+/// Full-screen zoomable photo viewer with pinch-zoom and swipe-to-dismiss.
+struct PhotoZoomView: View {
+    let url: URL
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var scale: CGFloat = 1
+    @State private var lastScale: CGFloat = 1
+    @State private var offset: CGSize = .zero
+    @State private var lastOffset: CGSize = .zero
+    @State private var dragVelocityY: CGFloat = 0
+
+    private let dismissThreshold: CGFloat = 120
+
+    var body: some View {
+        ZStack {
+            Color.black
+                .opacity(dismissOpacity)
+                .ignoresSafeArea()
+
+            AsyncImage(url: url) { phase in
+                switch phase {
+                case .success(let image):
+                    image
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .scaleEffect(scale)
+                        .offset(offset)
+                        .gesture(
+                            SimultaneousGesture(
+                                MagnifyGesture()
+                                    .onChanged { value in
+                                        let newScale = lastScale * value.magnification
+                                        scale = max(1, min(newScale, 6))
+                                    }
+                                    .onEnded { _ in
+                                        lastScale = scale
+                                        if scale < 1.05 {
+                                            withAnimation(.spring(response: 0.3, dampingFraction: 0.7)) {
+                                                scale = 1
+                                                lastScale = 1
+                                                offset = .zero
+                                                lastOffset = .zero
+                                            }
+                                        }
+                                    },
+                                DragGesture()
+                                    .onChanged { value in
+                                        if scale <= 1.05 {
+                                            // Swipe-to-dismiss only when not zoomed in
+                                            offset = CGSize(
+                                                width: lastOffset.width + value.translation.width * 0.3,
+                                                height: lastOffset.height + value.translation.height
+                                            )
+                                            dragVelocityY = value.velocity.height
+                                        } else {
+                                            offset = CGSize(
+                                                width: lastOffset.width + value.translation.width,
+                                                height: lastOffset.height + value.translation.height
+                                            )
+                                        }
+                                    }
+                                    .onEnded { value in
+                                        if scale <= 1.05 && (abs(offset.height) > dismissThreshold || dragVelocityY > 800) {
+                                            dismiss()
+                                        } else {
+                                            withAnimation(.spring(response: 0.3, dampingFraction: 0.7)) {
+                                                if scale <= 1.05 {
+                                                    offset = .zero
+                                                    lastOffset = .zero
+                                                } else {
+                                                    lastOffset = offset
+                                                }
+                                            }
+                                        }
+                                    }
+                            )
+                        )
+                        .onTapGesture(count: 2) {
+                            withAnimation(.spring(response: 0.3, dampingFraction: 0.7)) {
+                                if scale > 1.5 {
+                                    scale = 1
+                                    lastScale = 1
+                                    offset = .zero
+                                    lastOffset = .zero
+                                } else {
+                                    scale = 3
+                                    lastScale = 3
+                                }
+                            }
+                        }
+                case .failure:
+                    Image(systemName: "photo")
+                        .font(.largeTitle)
+                        .foregroundStyle(Theme.textSecondary)
+                default:
+                    ProgressView().tint(Theme.textSecondary)
+                }
+            }
+
+            // Close button
+            VStack {
+                HStack {
+                    Spacer()
+                    Button {
+                        dismiss()
+                    } label: {
+                        Image(systemName: "xmark.circle.fill")
+                            .font(.title2)
+                            .foregroundStyle(Theme.textSecondary)
+                            .background(Color.black.opacity(0.4).clipShape(Circle()))
+                    }
+                    .padding()
+                    .accessibilityLabel("Close")
+                }
+                Spacer()
+            }
+            .opacity(scale <= 1.05 ? 1 : 0)
+            .animation(.easeOut(duration: 0.2), value: scale)
+        }
+        .statusBar(hidden: true)
+        .presentationBackground(.clear)
+    }
+
+    private var dismissOpacity: Double {
+        let progress = min(abs(offset.height) / dismissThreshold, 1.0)
+        return 1.0 - progress * 0.5
+    }
+}

--- a/Xomfit/Views/Friends/FriendsView.swift
+++ b/Xomfit/Views/Friends/FriendsView.swift
@@ -97,7 +97,11 @@ struct FriendsView: View {
         .padding(Theme.Spacing.sm)
         .padding(.horizontal, Theme.Spacing.sm)
         .background(Theme.surface)
-        .clipShape(.rect(cornerRadius: Theme.cornerRadiusSmall))
+        .clipShape(.rect(cornerRadius: Theme.Radius.sm))
+        .overlay(
+            RoundedRectangle(cornerRadius: Theme.Radius.sm)
+                .strokeBorder(Theme.hairline, lineWidth: 0.5)
+        )
         .padding(.horizontal, Theme.Spacing.md)
         .padding(.vertical, Theme.Spacing.sm)
     }
@@ -292,14 +296,10 @@ private struct SearchResultRow: View {
 
     var body: some View {
         HStack(spacing: Theme.Spacing.md) {
-            ZStack {
-                Circle()
-                    .fill(Theme.accent.opacity(0.2))
-                    .frame(width: 40, height: 40)
-                Text(String(profile.displayName.prefix(2)).uppercased())
-                    .font(.subheadline.weight(.bold))
-                    .foregroundStyle(Theme.accent)
-            }
+            XomAvatar(
+                name: profile.displayName.isEmpty ? profile.username : profile.displayName,
+                size: 40
+            )
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(profile.displayName)
@@ -307,7 +307,7 @@ private struct SearchResultRow: View {
                     .foregroundStyle(Theme.textPrimary)
                 Text("@\(profile.username)")
                     .font(Theme.fontCaption)
-                    .foregroundStyle(Theme.textSecondary)
+                    .foregroundStyle(Theme.textTertiary)
             }
 
             Spacer()
@@ -323,8 +323,12 @@ private struct SearchResultRow: View {
                         .foregroundStyle(requested ? Theme.textSecondary : .black)
                         .padding(.horizontal, 14)
                         .padding(.vertical, 7)
-                        .background(requested ? Theme.surface : Theme.accent)
-                        .clipShape(.rect(cornerRadius: Theme.cornerRadiusSmall))
+                        .background(requested ? Theme.surfaceElevated : Theme.accent)
+                        .clipShape(.rect(cornerRadius: Theme.Radius.xs))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: Theme.Radius.xs)
+                                .strokeBorder(requested ? Theme.hairline : .clear, lineWidth: 0.5)
+                        )
                 }
                 .disabled(requested)
                 .buttonStyle(.plain)
@@ -360,14 +364,7 @@ private struct PendingRequestRow: View {
 
     var body: some View {
         HStack(spacing: Theme.Spacing.md) {
-            ZStack {
-                Circle()
-                    .fill(Theme.accent.opacity(0.2))
-                    .frame(width: 40, height: 40)
-                Text(requesterInitials)
-                    .font(.subheadline.weight(.bold))
-                    .foregroundStyle(Theme.accent)
-            }
+            XomAvatar(name: requesterName, size: 40)
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(requesterName)
@@ -376,7 +373,7 @@ private struct PendingRequestRow: View {
                 if let profile = requesterProfile {
                     Text("@\(profile.username)")
                         .font(Theme.fontCaption)
-                        .foregroundStyle(Theme.textSecondary)
+                        .foregroundStyle(Theme.textTertiary)
                         .lineLimit(1)
                 }
             }
@@ -393,7 +390,7 @@ private struct PendingRequestRow: View {
                 .padding(.horizontal, 12)
                 .padding(.vertical, 6)
                 .background(Theme.accent)
-                .clipShape(.rect(cornerRadius: 6))
+                .clipShape(.rect(cornerRadius: Theme.Radius.xs))
                 .buttonStyle(.plain)
 
                 Button("Decline") {
@@ -404,8 +401,8 @@ private struct PendingRequestRow: View {
                 .foregroundStyle(Theme.destructive)
                 .padding(.horizontal, 12)
                 .padding(.vertical, 6)
-                .background(Theme.destructive.opacity(0.15))
-                .clipShape(.rect(cornerRadius: 6))
+                .background(Theme.destructive.opacity(0.12))
+                .clipShape(.rect(cornerRadius: Theme.Radius.xs))
                 .buttonStyle(.plain)
             }
         }
@@ -429,25 +426,9 @@ private struct FriendListRow: View {
         return String(friendId.prefix(8))
     }
 
-    private var friendInitials: String {
-        let name = friendName
-        let parts = name.split(separator: " ")
-        if parts.count >= 2 {
-            return String(parts[0].prefix(1) + parts[1].prefix(1)).uppercased()
-        }
-        return String(name.prefix(2)).uppercased()
-    }
-
     var body: some View {
         HStack(spacing: Theme.Spacing.md) {
-            ZStack {
-                Circle()
-                    .fill(Theme.accent.opacity(0.2))
-                    .frame(width: 40, height: 40)
-                Text(friendInitials)
-                    .font(.subheadline.weight(.bold))
-                    .foregroundStyle(Theme.accent)
-            }
+            XomAvatar(name: friendName, size: 40)
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(friendName)
@@ -457,11 +438,11 @@ private struct FriendListRow: View {
                 if let profile = friendProfile {
                     Text("@\(profile.username)")
                         .font(Theme.fontCaption)
-                        .foregroundStyle(Theme.textSecondary)
+                        .foregroundStyle(Theme.textTertiary)
                 } else {
                     Text(friend.status == "accepted" ? "Friends" : "Pending")
                         .font(Theme.fontCaption)
-                        .foregroundStyle(Theme.textSecondary)
+                        .foregroundStyle(Theme.textTertiary)
                 }
             }
 

--- a/Xomfit/Views/MainTabView.swift
+++ b/Xomfit/Views/MainTabView.swift
@@ -15,8 +15,13 @@ struct MainTabView: View {
                 default: FeedView()
                 }
             }
-            .transition(.opacity)
-            .animation(.xomChill, value: selectedTab)
+            .transition(
+                .asymmetric(
+                    insertion: .opacity.combined(with: .offset(y: 8)),
+                    removal: .opacity
+                )
+            )
+            .animation(.spring(response: 0.4, dampingFraction: 0.82), value: selectedTab)
         }
         .safeAreaInset(edge: .bottom) {
             if tabBarVisible {
@@ -98,18 +103,20 @@ private struct FloatingTabBar: View {
         .padding(.top, 12)
         .safeAreaPadding(.bottom)
         .background(
-            Rectangle()
-                .fill(Theme.background)
-                .overlay(alignment: .top) {
-                    UnevenRoundedRectangle(
-                        topLeadingRadius: 24,
-                        bottomLeadingRadius: 0,
-                        bottomTrailingRadius: 0,
-                        topTrailingRadius: 24
-                    )
-                    .strokeBorder(Theme.glassBorder, lineWidth: 0.5)
-                }
-                .ignoresSafeArea(.container, edges: .bottom)
+            UnevenRoundedRectangle(
+                topLeadingRadius: Theme.Radius.lg,
+                bottomLeadingRadius: 0,
+                bottomTrailingRadius: 0,
+                topTrailingRadius: Theme.Radius.lg
+            )
+            .fill(.ultraThinMaterial)
+            .overlay(alignment: .top) {
+                // Single 0.5pt top hairline
+                Rectangle()
+                    .fill(Theme.hairline)
+                    .frame(height: 0.5)
+            }
+            .ignoresSafeArea(.container, edges: .bottom)
         )
     }
 }

--- a/Xomfit/Views/Notifications/NotificationInboxView.swift
+++ b/Xomfit/Views/Notifications/NotificationInboxView.swift
@@ -58,19 +58,11 @@ struct NotificationInboxView: View {
     }
 
     private var emptyState: some View {
-        VStack(spacing: Theme.Spacing.md) {
-            Image(systemName: "bell.slash")
-                .font(.system(size: 40))
-                .foregroundStyle(Theme.textSecondary)
-            Text("No notifications yet")
-                .font(Theme.fontHeadline)
-                .foregroundStyle(Theme.textPrimary)
-            Text("You'll see likes, comments, friend requests, and more here.")
-                .font(Theme.fontBody)
-                .foregroundStyle(Theme.textSecondary)
-                .multilineTextAlignment(.center)
-        }
-        .padding(Theme.Spacing.lg)
+        XomEmptyState(
+            icon: "bell.slash",
+            title: "No notifications yet",
+            subtitle: "You'll see likes, comments, friend requests, and more here."
+        )
     }
 }
 
@@ -102,7 +94,7 @@ private struct NotificationRow: View {
 
                 Text(notification.createdAt.timeAgo)
                     .font(Theme.fontSmall)
-                    .foregroundStyle(Theme.textSecondary)
+                    .foregroundStyle(Theme.textTertiary)
             }
 
             Spacer()

--- a/Xomfit/Views/Notifications/NotificationPreferencesView.swift
+++ b/Xomfit/Views/Notifications/NotificationPreferencesView.swift
@@ -21,16 +21,18 @@ struct NotificationPreferencesView: View {
                         prefToggle("Social", icon: "bubble.left.and.bubble.right.fill", isOn: prefs.social)
                         prefToggle("Friend Activity", icon: "figure.strengthtraining.traditional", isOn: prefs.friendActivity)
                     } header: {
-                        Text("Social")
+                        XomMetricLabel("Social")
                     }
+                    .listRowSeparatorTint(Theme.hairline)
 
                     Section {
                         prefToggle("Personal Records", icon: "trophy.fill", isOn: prefs.personalRecords)
                         prefToggle("Workout Reminders", icon: "alarm.fill", isOn: prefs.workoutReminders)
                         prefToggle("Challenges", icon: "flag.fill", isOn: prefs.challenges)
                     } header: {
-                        Text("Activity")
+                        XomMetricLabel("Activity")
                     }
+                    .listRowSeparatorTint(Theme.hairline)
                 }
                 .scrollContentBackground(.hidden)
             }

--- a/Xomfit/Views/Onboarding/OnboardingBottomBar.swift
+++ b/Xomfit/Views/Onboarding/OnboardingBottomBar.swift
@@ -18,12 +18,12 @@ struct OnboardingBottomBar: View {
             HStack(spacing: Theme.Spacing.sm) {
                 ForEach(0..<totalPages, id: \.self) { index in
                     Circle()
-                        .fill(index == currentPage ? Theme.accent : Theme.glassFill)
+                        .fill(index == currentPage ? Theme.accent : Theme.surfaceElevated)
                         .frame(width: 8, height: 8)
                         .overlay(
                             Circle()
                                 .strokeBorder(
-                                    index == currentPage ? Theme.accent : Theme.glassBorder,
+                                    index == currentPage ? Theme.accent : Theme.hairline,
                                     lineWidth: 0.5
                                 )
                         )

--- a/Xomfit/Views/Onboarding/OnboardingGoalsScreen.swift
+++ b/Xomfit/Views/Onboarding/OnboardingGoalsScreen.swift
@@ -94,17 +94,13 @@ private struct GoalCard: View {
             .padding(Theme.Spacing.md)
             .frame(minHeight: 160)
             .background(
-                RoundedRectangle(cornerRadius: Theme.cornerRadius)
-                    .fill(isSelected ? Theme.accent.opacity(0.08) : Theme.glassFill)
-                    .background(
-                        RoundedRectangle(cornerRadius: Theme.cornerRadius)
-                            .fill(Theme.surface)
-                    )
+                RoundedRectangle(cornerRadius: Theme.Radius.md)
+                    .fill(isSelected ? Theme.accent.opacity(0.08) : Theme.surface)
             )
             .overlay(
-                RoundedRectangle(cornerRadius: Theme.cornerRadius)
+                RoundedRectangle(cornerRadius: Theme.Radius.md)
                     .strokeBorder(
-                        isSelected ? Theme.accent : Theme.glassBorder,
+                        isSelected ? Theme.accent : Theme.hairline,
                         lineWidth: isSelected ? 1.5 : 0.5
                     )
             )

--- a/Xomfit/Views/Profile/BodyHeatmapView.swift
+++ b/Xomfit/Views/Profile/BodyHeatmapView.swift
@@ -68,27 +68,26 @@ struct BodyHeatmapView: View {
         .padding(.horizontal, Theme.Spacing.sm)
         .padding(.vertical, 10)
         .background(heatColor(for: sets))
-        .clipShape(.rect(cornerRadius: Theme.cornerRadiusSmall))
+        .clipShape(.rect(cornerRadius: Theme.Radius.xs))
         .accessibilityElement(children: .combine)
         .accessibilityLabel("\(name): \(sets) sets")
     }
 
     // MARK: - Heat Color
 
-    /// Maps set count to intensity color:
-    /// 0 = card background (not hit), 1-3 = green (light), 4-8 = yellow, 9-15 = orange, 16+ = red
+    /// Maps set count to accent luminance intensity — single-hue ramp.
     private func heatColor(for sets: Int) -> Color {
         switch sets {
         case 0:
             return Theme.surface
         case 1...3:
-            return Theme.accent.opacity(0.3)
+            return Theme.accent.opacity(0.15)
         case 4...8:
-            return Color.yellow.opacity(0.3)
+            return Theme.accent.opacity(0.35)
         case 9...15:
-            return Color.orange.opacity(0.3)
+            return Theme.accent.opacity(0.60)
         default:
-            return Theme.destructive.opacity(0.3)
+            return Theme.accent.opacity(0.85)
         }
     }
 
@@ -97,10 +96,10 @@ struct BodyHeatmapView: View {
     private var heatmapLegend: some View {
         HStack(spacing: Theme.Spacing.sm) {
             legendItem(color: Theme.surface, label: "None")
-            legendItem(color: Theme.accent.opacity(0.3), label: "Light")
-            legendItem(color: Color.yellow.opacity(0.3), label: "Some")
-            legendItem(color: Color.orange.opacity(0.3), label: "Moderate")
-            legendItem(color: Theme.destructive.opacity(0.3), label: "Heavy")
+            legendItem(color: Theme.accent.opacity(0.15), label: "Light")
+            legendItem(color: Theme.accent.opacity(0.35), label: "Some")
+            legendItem(color: Theme.accent.opacity(0.60), label: "Moderate")
+            legendItem(color: Theme.accent.opacity(0.85), label: "Heavy")
         }
         .frame(maxWidth: .infinity)
     }

--- a/Xomfit/Views/Profile/EditProfileSheet.swift
+++ b/Xomfit/Views/Profile/EditProfileSheet.swift
@@ -90,5 +90,6 @@ struct EditProfileSheet: View {
                 }
             }
         }
+        .presentationCornerRadius(Theme.Radius.lg)
     }
 }

--- a/Xomfit/Views/Profile/PRListView.swift
+++ b/Xomfit/Views/Profile/PRListView.swift
@@ -27,9 +27,10 @@ struct PRListView: View {
                 List {
                     ForEach(grouped, id: \.0) { exerciseName, records in
                         Section {
-                            ForEach(records) { pr in
-                                PRRow(pr: pr)
+                            ForEach(Array(records.enumerated()), id: \.element.id) { index, pr in
+                                PRRow(pr: pr, rank: index + 1)
                                     .listRowBackground(Theme.surface)
+                                    .listRowInsets(EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: Theme.Spacing.md))
                             }
                         } header: {
                             Text(exerciseName)
@@ -51,19 +52,11 @@ struct PRListView: View {
     }
 
     private var emptyState: some View {
-        VStack(spacing: Theme.Spacing.md) {
-            Image(systemName: "trophy")
-                .font(.system(size: 48))
-                .foregroundStyle(Theme.textSecondary)
-            Text("No PRs yet")
-                .font(Theme.fontHeadline)
-                .foregroundStyle(Theme.textPrimary)
-            Text("Complete sets during workouts to track your personal records")
-                .font(Theme.fontBody)
-                .foregroundStyle(Theme.textSecondary)
-                .multilineTextAlignment(.center)
-                .padding(.horizontal, Theme.Spacing.lg)
-        }
+        XomEmptyState(
+            icon: "trophy",
+            title: "No PRs yet",
+            subtitle: "Complete sets during workouts to track your personal records"
+        )
     }
 
     private func loadPRs() {
@@ -83,6 +76,9 @@ struct PRListView: View {
 
 private struct PRRow: View {
     let pr: PersonalRecord
+    let rank: Int
+
+    private var isTopThree: Bool { rank <= 3 }
 
     private var dateString: String {
         let formatter = DateFormatter()
@@ -97,36 +93,48 @@ private struct PRRow: View {
     }
 
     var body: some View {
-        HStack(spacing: Theme.Spacing.md) {
-            Image(systemName: "trophy.fill")
-                .foregroundStyle(Theme.prGold)
-                .font(.title3)
-                .frame(width: 28)
-
-            VStack(alignment: .leading, spacing: 3) {
-                Text("\(pr.weight.formattedWeight) lbs × \(pr.reps) reps")
-                    .font(.subheadline.weight(.bold))
-                    .foregroundStyle(Theme.textPrimary)
-                Text(dateString)
-                    .font(Theme.fontCaption)
-                    .foregroundStyle(Theme.textSecondary)
+        HStack(spacing: 0) {
+            // Leading gold stripe for top-3
+            if isTopThree {
+                Rectangle()
+                    .fill(Theme.prGold)
+                    .frame(width: 3)
             }
 
-            Spacer()
+            HStack(spacing: Theme.Spacing.md) {
+                Image(systemName: "trophy.fill")
+                    .foregroundStyle(isTopThree ? Theme.prGold : Theme.textTertiary)
+                    .font(.subheadline)
+                    .frame(width: 24)
 
-            VStack(alignment: .trailing, spacing: 3) {
-                if let pct = improvementPercent {
-                    Text(pct)
-                        .font(.caption.weight(.bold))
-                        .foregroundStyle(Theme.accent)
-                }
-                if let prev = pr.previousBest {
-                    Text("Prev: \(prev.formattedWeight)")
+                VStack(alignment: .leading, spacing: 3) {
+                    Text("\(pr.weight.formattedWeight) lbs \u{00D7} \(pr.reps) reps")
+                        .font(Theme.fontNumberMedium)
+                        .foregroundStyle(Theme.textPrimary)
+                    Text(dateString)
                         .font(Theme.fontSmall)
-                        .foregroundStyle(Theme.textSecondary)
+                        .foregroundStyle(Theme.textTertiary)
+                }
+
+                Spacer()
+
+                VStack(alignment: .trailing, spacing: 3) {
+                    if let pct = improvementPercent {
+                        Text(pct)
+                            .font(.caption.weight(.bold))
+                            .foregroundStyle(Theme.accent)
+                    }
+                    if let prev = pr.previousBest {
+                        Text("Prev: \(prev.formattedWeight)")
+                            .font(Theme.fontSmall)
+                            .foregroundStyle(Theme.textTertiary)
+                    }
                 }
             }
+            .padding(.horizontal, Theme.Spacing.md)
+            .padding(.vertical, 10)
         }
-        .padding(.vertical, 4)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(pr.weight.formattedWeight) lbs by \(pr.reps) reps on \(dateString)")
     }
 }

--- a/Xomfit/Views/Profile/PrivateProfileView.swift
+++ b/Xomfit/Views/Profile/PrivateProfileView.swift
@@ -12,66 +12,48 @@ struct PrivateProfileView: View {
             Spacer()
 
             // Avatar
-            ZStack {
-                Circle()
-                    .fill(Theme.accent.opacity(0.2))
-                    .frame(width: 70, height: 70)
-                Text(initials)
-                    .font(.title2.weight(.bold))
-                    .foregroundStyle(Theme.accent)
-            }
+            XomAvatar(name: displayName.isEmpty ? username : initials, size: 80)
 
             // Name
             VStack(spacing: 4) {
                 if !displayName.isEmpty {
                     Text(displayName)
-                        .font(.title3.weight(.bold))
+                        .font(Theme.fontTitle2)
                         .foregroundStyle(Theme.textPrimary)
                 }
                 if !username.isEmpty {
                     Text("@\(username)")
-                        .font(Theme.fontCaption)
-                        .foregroundStyle(Theme.textSecondary)
+                        .font(Theme.fontSubheadline)
+                        .foregroundStyle(Theme.textTertiary)
                 }
             }
 
             // Lock icon + message
             VStack(spacing: Theme.Spacing.sm) {
                 Image(systemName: "lock.fill")
-                    .font(.title)
+                    .font(.system(size: 36, weight: .semibold))
                     .foregroundStyle(Theme.textSecondary)
 
                 Text("This account is private")
-                    .font(Theme.fontBody)
-                    .foregroundStyle(Theme.textSecondary)
+                    .font(Theme.fontHeadline)
+                    .foregroundStyle(Theme.textPrimary)
 
                 Text("Send a friend request to see their activity.")
-                    .font(Theme.fontCaption)
+                    .font(Theme.fontBody)
                     .foregroundStyle(Theme.textSecondary)
                     .multilineTextAlignment(.center)
             }
 
             // Action button
             if friendshipStatus == .none {
-                Button(action: onSendRequest) {
-                    Text("Send Friend Request")
-                        .font(.subheadline.weight(.semibold))
-                        .foregroundStyle(Theme.background)
-                        .frame(maxWidth: .infinity)
-                        .frame(height: 44)
-                        .background(Theme.accent)
-                        .clipShape(.rect(cornerRadius: Theme.cornerRadius))
+                XomButton("Send Friend Request", variant: .primary, icon: "person.badge.plus") {
+                    onSendRequest()
                 }
                 .padding(.horizontal, Theme.Spacing.lg)
                 .accessibilityLabel("Send friend request to \(displayName)")
             } else if friendshipStatus == .pending {
-                Text("Friend Request Sent")
-                    .font(.subheadline.weight(.semibold))
-                    .foregroundStyle(Theme.textSecondary)
-                    .frame(maxWidth: .infinity)
-                    .frame(height: 44)
-                    .background(Theme.surface)
-                    .clipShape(.rect(cornerRadius: Theme.cornerRadius))
+                XomButton("Request Sent", variant: .ghost) {}
+                    .disabled(true)
                     .padding(.horizontal, Theme.Spacing.lg)
             }
 

--- a/Xomfit/Views/Profile/ProfileCalendarView.swift
+++ b/Xomfit/Views/Profile/ProfileCalendarView.swift
@@ -149,11 +149,12 @@ struct ProfileCalendarView: View {
         return Theme.textSecondary
     }
 
-    private func cellBackground(count: Int, isToday: Bool) -> Color {
-        if count >= 2 { return Theme.accent }
-        if count == 1 { return Theme.accent.opacity(0.4) }
-        if isToday { return Theme.accent.opacity(0.1) }
-        return .clear
+    private func cellBackground(count: Int, isToday: Bool) -> some ShapeStyle {
+        if count >= 2 { return AnyShapeStyle(Theme.accent) }
+        if count == 1 { return AnyShapeStyle(Theme.accent.opacity(0.4)) }
+        if isToday { return AnyShapeStyle(Theme.accent.opacity(0.1)) }
+        // Empty day: subtle surface fill + hairline for grid density
+        return AnyShapeStyle(Theme.surface)
     }
 
     // MARK: - Helpers

--- a/Xomfit/Views/Profile/ProfileFeedView.swift
+++ b/Xomfit/Views/Profile/ProfileFeedView.swift
@@ -32,7 +32,7 @@ struct ProfileFeedView: View {
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, 60)
             } else {
-                LazyVStack(spacing: Theme.Spacing.sm) {
+                LazyVStack(spacing: Theme.Spacing.md) {
                     ForEach(filteredItems) { item in
                         NavigationLink {
                             FeedDetailView(item: item, userId: currentUserId)
@@ -73,17 +73,13 @@ struct ProfileFeedView: View {
     }
 
     private var emptyState: some View {
-        VStack(spacing: Theme.Spacing.sm) {
-            Image(systemName: "text.page")
-                .font(.largeTitle)
-                .foregroundStyle(Theme.textSecondary)
-            Text("No posts yet")
-                .font(Theme.fontBody)
-                .foregroundStyle(Theme.textSecondary)
-        }
+        XomEmptyState(
+            symbolStack: ["text.page", "dumbbell.fill"],
+            title: "No posts yet",
+            subtitle: "Workouts, PRs, and milestones will appear here.",
+            floatingLoop: true
+        )
         .frame(maxWidth: .infinity)
-        .padding(.vertical, 60)
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel("No posts yet")
+        .padding(.vertical, 40)
     }
 }

--- a/Xomfit/Views/Profile/ProfileFriendsView.swift
+++ b/Xomfit/Views/Profile/ProfileFriendsView.swift
@@ -24,8 +24,7 @@ struct ProfileFriendsView: View {
                     .buttonStyle(.plain)
 
                     if friend.id != friends.last?.id {
-                        Divider()
-                            .background(Theme.textSecondary.opacity(0.2))
+                        XomDivider()
                             .padding(.leading, 60)
                     }
                 }
@@ -42,17 +41,9 @@ struct ProfileFriendsView: View {
         let profile = friendProfiles[otherUserId(friend)]
         let name = profile?.displayName ?? otherUserId(friend)
         let username = profile?.username ?? ""
-        let initials = friendInitials(name: name, fallback: username)
 
         return HStack(spacing: Theme.Spacing.md) {
-            ZStack {
-                Circle()
-                    .fill(Theme.accent.opacity(0.2))
-                    .frame(width: 40, height: 40)
-                Text(initials)
-                    .font(.subheadline.weight(.bold))
-                    .foregroundStyle(Theme.accent)
-            }
+            XomAvatar(name: name, size: 40)
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(name)
@@ -95,14 +86,4 @@ struct ProfileFriendsView: View {
         .accessibilityLabel("No friends yet")
     }
 
-    // MARK: - Helpers
-
-    private func friendInitials(name: String, fallback: String) -> String {
-        let source = name.isEmpty ? fallback : name
-        let parts = source.split(separator: " ")
-        if parts.count >= 2 {
-            return String(parts[0].prefix(1) + parts[1].prefix(1)).uppercased()
-        }
-        return String(source.prefix(2)).uppercased()
-    }
 }

--- a/Xomfit/Views/Profile/ProfileHeaderView.swift
+++ b/Xomfit/Views/Profile/ProfileHeaderView.swift
@@ -21,7 +21,8 @@ struct ProfileHeaderView: View {
         VStack(spacing: Theme.Spacing.md) {
             // Top row: avatar + stats
             HStack(alignment: .center, spacing: Theme.Spacing.lg) {
-                avatarCircle
+                XomAvatar(name: displayName.isEmpty ? username : displayName, size: 96)
+                    .accessibilityLabel("Profile avatar")
 
                 Spacer()
 
@@ -38,17 +39,16 @@ struct ProfileHeaderView: View {
                 } label: {
                     VStack(spacing: 2) {
                         Text("\(friendCount)")
-                            .font(.headline.weight(.bold))
+                            .font(Theme.fontNumberLarge)
                             .foregroundStyle(Theme.textPrimary)
-                        Text("Friends")
-                            .font(Theme.fontSmall)
-                            .foregroundStyle(Theme.textSecondary)
+                        XomMetricLabel("Friends")
                     }
                     .frame(minWidth: 44, minHeight: 44)
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel("\(friendCount) Friends")
                 .accessibilityAddTraits(.isButton)
+
                 statColumn(value: prCount, label: "PRs") {
                     onStatTapped(.stats)
                 }
@@ -61,32 +61,28 @@ struct ProfileHeaderView: View {
             VStack(alignment: .leading, spacing: 4) {
                 if !displayName.isEmpty {
                     Text(displayName)
-                        .font(.body.weight(.bold))
+                        .font(Theme.fontTitle2)
                         .foregroundStyle(Theme.textPrimary)
                 }
 
                 if !username.isEmpty {
                     Text("@\(username)")
-                        .font(Theme.fontCaption)
-                        .foregroundStyle(Theme.textSecondary)
+                        .font(Theme.fontSubheadline)
+                        .foregroundStyle(Theme.textTertiary)
                 }
 
                 if !bio.isEmpty {
                     Text(bio)
                         .font(Theme.fontBody)
                         .foregroundStyle(Theme.textSecondary)
+                        .lineLimit(4)
+                        .truncationMode(.tail)
                         .padding(.top, 2)
                 }
 
                 if isPrivate && isOwnProfile {
-                    HStack(spacing: 4) {
-                        Image(systemName: "lock.fill")
-                            .font(.caption2)
-                        Text("Private Account")
-                            .font(Theme.fontSmall)
-                    }
-                    .foregroundStyle(Theme.textSecondary)
-                    .padding(.top, 2)
+                    XomBadge("Private Account", icon: "lock.fill", variant: .secondary)
+                        .padding(.top, 4)
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -97,31 +93,15 @@ struct ProfileHeaderView: View {
         .padding(Theme.Spacing.md)
     }
 
-    // MARK: - Avatar
-
-    private var avatarCircle: some View {
-        ZStack {
-            Circle()
-                .fill(Theme.accent.opacity(0.2))
-                .frame(width: 70, height: 70)
-            Text(initials)
-                .font(.title2.weight(.bold))
-                .foregroundStyle(Theme.accent)
-        }
-        .accessibilityLabel("Profile avatar")
-    }
-
     // MARK: - Stat Column
 
     private func statColumn(value: Int, label: String, action: @escaping () -> Void) -> some View {
         Button(action: action) {
             VStack(spacing: 2) {
                 Text("\(value)")
-                    .font(.headline.weight(.bold))
+                    .font(Theme.fontNumberLarge)
                     .foregroundStyle(Theme.textPrimary)
-                Text(label)
-                    .font(Theme.fontSmall)
-                    .foregroundStyle(Theme.textSecondary)
+                XomMetricLabel(label)
             }
             .frame(minWidth: 44, minHeight: 44)
         }
@@ -133,46 +113,31 @@ struct ProfileHeaderView: View {
     // MARK: - Action Button
 
     private var actionButton: some View {
-        Button(action: {
-            Haptics.light()
-            onActionTapped()
-        }) {
-            Text(actionButtonLabel)
-                .font(.subheadline.weight(.semibold))
-                .foregroundStyle(actionButtonForeground)
-                .frame(maxWidth: .infinity)
-                .frame(height: 34)
-                .background(actionButtonBackground)
-                .clipShape(.rect(cornerRadius: Theme.cornerRadiusSmall))
-        }
-        .buttonStyle(.plain)
-        .accessibilityLabel(actionButtonLabel)
-    }
-
-    private var actionButtonLabel: String {
-        if isOwnProfile { return "Edit Profile" }
-        switch friendshipStatus {
-        case .none: return "Add Friend"
-        case .pending: return "Requested"
-        case .friends: return "Friends"
-        }
-    }
-
-    private var actionButtonForeground: Color {
-        if isOwnProfile { return Theme.textPrimary }
-        switch friendshipStatus {
-        case .none: return Theme.background
-        case .pending: return Theme.textSecondary
-        case .friends: return Theme.accent
-        }
-    }
-
-    private var actionButtonBackground: some ShapeStyle {
-        if isOwnProfile { return AnyShapeStyle(Theme.surface) }
-        switch friendshipStatus {
-        case .none: return AnyShapeStyle(Theme.accent)
-        case .pending: return AnyShapeStyle(Theme.surface)
-        case .friends: return AnyShapeStyle(Theme.accent.opacity(0.15))
+        Group {
+            if isOwnProfile {
+                XomButton("Edit Profile", variant: .secondary, action: {
+                    Haptics.light()
+                    onActionTapped()
+                })
+            } else {
+                switch friendshipStatus {
+                case .none:
+                    XomButton("Add Friend", variant: .primary, icon: "person.badge.plus", action: {
+                        Haptics.light()
+                        onActionTapped()
+                    })
+                case .pending:
+                    XomButton("Requested", variant: .ghost, action: {
+                        Haptics.light()
+                        onActionTapped()
+                    })
+                case .friends:
+                    XomButton("Friends", variant: .secondary, icon: "checkmark", action: {
+                        Haptics.light()
+                        onActionTapped()
+                    })
+                }
+            }
         }
     }
 }

--- a/Xomfit/Views/Profile/ProfileStatsView.swift
+++ b/Xomfit/Views/Profile/ProfileStatsView.swift
@@ -30,30 +30,30 @@ struct ProfileStatsView: View {
 
     private var statsCards: some View {
         HStack(spacing: Theme.Spacing.sm) {
-            statCard(icon: "dumbbell.fill", value: "\(totalWorkouts)", label: "Workouts", color: Theme.accent)
-            statCard(icon: "scalemass.fill", value: totalVolume, label: "Volume", color: Theme.accent)
-            statCard(icon: "trophy.fill", value: "\(totalPRs)", label: "PRs", color: Theme.prGold)
+            countUpStatCard(icon: "dumbbell.fill", count: totalWorkouts, label: "Workouts", iconColor: Theme.accent)
+            XomCard(padding: Theme.Spacing.sm) {
+                XomStat(totalVolume, label: "Volume", icon: "scalemass.fill", iconColor: Theme.accent)
+                    .padding(.vertical, Theme.Spacing.xs)
+            }
+            .accessibilityLabel("\(totalVolume) Volume")
+            countUpStatCard(icon: "trophy.fill", count: totalPRs, label: "PRs", iconColor: Theme.prGold)
         }
     }
 
-    private func statCard(icon: String, value: String, label: String, color: Color) -> some View {
-        VStack(spacing: 6) {
-            Image(systemName: icon)
-                .font(.headline)
-                .foregroundStyle(color)
-            Text(value)
-                .font(.headline.weight(.bold))
-                .foregroundStyle(Theme.textPrimary)
-            Text(label)
-                .font(Theme.fontSmall)
-                .foregroundStyle(Theme.textSecondary)
+    private func countUpStatCard(icon: String, count: Int, label: String, iconColor: Color) -> some View {
+        XomCard(padding: Theme.Spacing.sm) {
+            VStack(spacing: 4) {
+                Image(systemName: icon)
+                    .font(.headline)
+                    .foregroundStyle(iconColor)
+                CountUpNumber(target: count)
+                XomMetricLabel(label)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, Theme.Spacing.xs)
         }
-        .frame(maxWidth: .infinity)
-        .padding(.vertical, Theme.Spacing.md)
-        .background(Theme.surface)
-        .clipShape(.rect(cornerRadius: Theme.cornerRadius))
         .accessibilityElement(children: .combine)
-        .accessibilityLabel("\(value) \(label)")
+        .accessibilityLabel("\(count) \(label)")
     }
 
     // MARK: - Heatmap Section

--- a/Xomfit/Views/Profile/ProfileTabPicker.swift
+++ b/Xomfit/Views/Profile/ProfileTabPicker.swift
@@ -5,44 +5,45 @@ struct ProfileTabPicker: View {
     @Namespace private var underline
 
     var body: some View {
-        HStack(spacing: 0) {
-            ForEach(ProfileTab.allCases) { tab in
-                Button {
-                    withAnimation(.xomConfident) {
-                        selectedTab = tab
-                    }
-                } label: {
-                    VStack(spacing: Theme.Spacing.sm) {
-                        Image(systemName: tab.icon)
-                            .font(.headline)
-                            .foregroundStyle(selectedTab == tab ? Theme.accent : Theme.textSecondary)
-                            .frame(height: 24)
+        VStack(spacing: 0) {
+            HStack(spacing: 0) {
+                ForEach(ProfileTab.allCases) { tab in
+                    Button {
+                        withAnimation(.xomConfident) {
+                            selectedTab = tab
+                        }
+                    } label: {
+                        VStack(spacing: Theme.Spacing.xs) {
+                            Image(systemName: tab.icon)
+                                .font(.headline)
+                                // Active: textPrimary. Inactive: textSecondary. Accent is reserved for the underline only.
+                                .foregroundStyle(selectedTab == tab ? Theme.textPrimary : Theme.textSecondary)
+                                .frame(height: 24)
 
-                        Text(tab.label)
-                            .font(Theme.fontSmall)
-                            .foregroundStyle(selectedTab == tab ? Theme.accent : Theme.textSecondary)
-                    }
-                    .padding(.bottom, 10)
-                    .frame(maxWidth: .infinity)
-                    .frame(minHeight: 44)
-                    .overlay(alignment: .bottom) {
-                        if selectedTab == tab {
-                            Rectangle()
-                                .fill(Theme.accent)
-                                .frame(height: 2)
-                                .matchedGeometryEffect(id: "underline", in: underline)
+                            Text(tab.label)
+                                .font(Theme.fontSmall)
+                                .foregroundStyle(selectedTab == tab ? Theme.textPrimary : Theme.textSecondary)
+                        }
+                        .padding(.bottom, 10)
+                        .frame(maxWidth: .infinity)
+                        .frame(minHeight: 44)
+                        .overlay(alignment: .bottom) {
+                            if selectedTab == tab {
+                                Rectangle()
+                                    .fill(Theme.accent)
+                                    .frame(height: 2.5)
+                                    .matchedGeometryEffect(id: "underline", in: underline)
+                            }
                         }
                     }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("\(tab.label) tab")
+                    .accessibilityAddTraits(selectedTab == tab ? .isSelected : [])
                 }
-                .buttonStyle(.plain)
-                .accessibilityLabel("\(tab.label) tab")
-                .accessibilityAddTraits(selectedTab == tab ? .isSelected : [])
             }
-        }
-        .padding(.top, Theme.Spacing.sm)
-        .overlay(alignment: .bottom) {
-            Divider()
-                .background(Theme.textSecondary.opacity(0.3))
+            .padding(.top, Theme.Spacing.sm)
+
+            XomDivider()
         }
     }
 }

--- a/Xomfit/Views/Profile/ProfileView.swift
+++ b/Xomfit/Views/Profile/ProfileView.swift
@@ -147,7 +147,7 @@ struct ProfileView: View {
                 // Tab picker (pinned) + tab content
                 Section {
                     tabContent
-                        .padding(.top, Theme.Spacing.sm)
+                        .padding(.top, Theme.Spacing.md)
                 } header: {
                     ProfileTabPicker(selectedTab: Bindable(viewModel).selectedTab)
                         .background(Theme.background)
@@ -163,12 +163,14 @@ struct ProfileView: View {
     private var tabContent: some View {
         switch viewModel.selectedTab {
         case .feed:
-            ProfileWorkoutListView(
-                workouts: viewModel.filteredWorkouts,
-                allWorkouts: viewModel.workouts,
+            ProfileFeedView(
+                feedItems: Bindable(viewModel).feedItems,
+                filteredItems: viewModel.filteredFeedItems,
                 isFiltered: viewModel.isFeedFiltered,
-                dateRange: $viewModel.feedDateRange,
-                muscleGroups: $viewModel.feedMuscleGroups
+                dateRange: Bindable(viewModel).feedDateRange,
+                muscleGroups: Bindable(viewModel).feedMuscleGroups,
+                userId: resolvedUserId,
+                currentUserId: currentUserId
             )
         case .calendar:
             ProfileCalendarView(workoutDays: viewModel.workoutDays, userId: resolvedUserId)
@@ -195,7 +197,7 @@ struct ProfileView: View {
                     showEditSheet = true
                 } label: {
                     Image(systemName: "pencil")
-                        .foregroundStyle(Theme.textSecondary)
+                        .foregroundStyle(Theme.textPrimary)
                 }
                 .accessibilityLabel("Edit Profile")
 
@@ -204,7 +206,7 @@ struct ProfileView: View {
                         .hideTabBar()
                 } label: {
                     Image(systemName: "gearshape.fill")
-                        .foregroundStyle(Theme.textSecondary)
+                        .foregroundStyle(Theme.textPrimary)
                 }
                 .accessibilityLabel("Settings")
             }

--- a/Xomfit/Views/Profile/SettingsView.swift
+++ b/Xomfit/Views/Profile/SettingsView.swift
@@ -15,14 +15,17 @@ struct SettingsView: View {
             Theme.background.ignoresSafeArea()
 
             List {
-                Section("Account") {
+                Section {
                     if let email = authService.currentUser?.email {
                         settingsRow(icon: "envelope.fill", iconColor: Theme.accent, label: "Email", value: email)
                     }
+                } header: {
+                    XomMetricLabel("Account")
                 }
                 .listRowBackground(Theme.surface)
+                .listRowSeparatorTint(Theme.hairline)
 
-                Section("Notifications") {
+                Section {
                     NavigationLink {
                         NotificationPreferencesView()
                     } label: {
@@ -34,14 +37,21 @@ struct SettingsView: View {
                                 .foregroundStyle(Theme.textPrimary)
                         }
                     }
+                    .tint(Theme.textTertiary)
+                } header: {
+                    XomMetricLabel("Notifications")
                 }
                 .listRowBackground(Theme.surface)
+                .listRowSeparatorTint(Theme.hairline)
 
-                Section("About") {
+                Section {
                     settingsRow(icon: "info.circle.fill", iconColor: Theme.accent, label: "Version", value: appVersion)
                     settingsRow(icon: "building.2.fill", iconColor: Theme.accent, label: "App", value: Config.appName)
+                } header: {
+                    XomMetricLabel("About")
                 }
                 .listRowBackground(Theme.surface)
+                .listRowSeparatorTint(Theme.hairline)
 
                 Section {
                     Button(role: .destructive) {
@@ -56,6 +66,7 @@ struct SettingsView: View {
                         }
                     }
                     .listRowBackground(Theme.surface)
+                    .listRowSeparatorTint(Theme.hairline)
                 }
             }
             .listStyle(.insetGrouped)
@@ -83,7 +94,7 @@ struct SettingsView: View {
                 .foregroundStyle(Theme.textPrimary)
             Spacer()
             Text(value)
-                .foregroundStyle(Theme.textSecondary)
+                .foregroundStyle(Theme.textTertiary)
                 .font(Theme.fontCaption)
         }
     }

--- a/Xomfit/Views/Progress/LeaderboardView.swift
+++ b/Xomfit/Views/Progress/LeaderboardView.swift
@@ -14,7 +14,7 @@ struct LeaderboardView: View {
 
             VStack(spacing: 0) {
                 filterBar
-                Divider().background(Theme.textSecondary.opacity(0.2))
+                XomDivider()
 
                 if viewModel.isLoading {
                     Spacer()
@@ -113,16 +113,15 @@ struct LeaderboardView: View {
             // Muscle group filter
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: 6) {
-                    filterChip(label: "All", isSelected: viewModel.selectedMuscleGroup == nil) {
-                        viewModel.selectedMuscleGroup = nil
+                    Button { viewModel.selectedMuscleGroup = nil } label: {
+                        XomBadge("All", variant: .interactive, isActive: viewModel.selectedMuscleGroup == nil)
                     }
+                    .buttonStyle(.plain)
                     ForEach(MuscleGroup.allCases) { group in
-                        filterChip(
-                            label: group.displayName,
-                            isSelected: viewModel.selectedMuscleGroup == group
-                        ) {
-                            viewModel.selectedMuscleGroup = group
+                        Button { viewModel.selectedMuscleGroup = group } label: {
+                            XomBadge(group.displayName, variant: .interactive, isActive: viewModel.selectedMuscleGroup == group)
                         }
+                        .buttonStyle(.plain)
                     }
                 }
             }
@@ -147,9 +146,8 @@ struct LeaderboardView: View {
                 ForEach(viewModel.entries) { entry in
                     leaderboardRow(entry: entry)
                     if entry.id != viewModel.entries.last?.id {
-                        Divider()
-                            .background(Theme.textSecondary.opacity(0.15))
-                            .padding(.horizontal, Theme.Spacing.md)
+                        XomDivider()
+                            .padding(.leading, 60)
                     }
                 }
             }
@@ -194,7 +192,7 @@ struct LeaderboardView: View {
                 .frame(height: height)
                 .overlay(
                     Text("#\(entry.rank)")
-                        .font(.title3.weight(.black))
+                        .font(Theme.fontDisplay)
                         .foregroundStyle(entry.rank == 1 ? Theme.accent : Theme.textSecondary)
                 )
         }
@@ -205,37 +203,47 @@ struct LeaderboardView: View {
 
     private func leaderboardRow(entry: LeaderboardEntry) -> some View {
         let isCurrentUser = entry.userId == userId
-        return HStack(spacing: Theme.Spacing.sm) {
-            // Rank
-            Text("\(entry.rank)")
-                .font(.body.weight(.bold).monospacedDigit())
-                .foregroundStyle(entry.rank <= 3 ? Theme.accent : Theme.textSecondary)
-                .frame(width: 30, alignment: .center)
-
-            XomAvatar(name: entry.displayName, size: 36)
-
-            VStack(alignment: .leading, spacing: 2) {
-                Text(entry.displayName)
-                    .font(.subheadline.weight(isCurrentUser ? .bold : .medium))
-                    .foregroundStyle(isCurrentUser ? Theme.accent : Theme.textPrimary)
-                    .lineLimit(1)
-
-                if entry.rankChange != 0 {
-                    Text(entry.rankChangeSymbol)
-                        .font(.caption2.weight(.semibold))
-                        .foregroundStyle(entry.rankChange > 0 ? .green : Theme.destructive)
-                }
+        return HStack(spacing: 0) {
+            // Current-user leading accent stripe
+            if isCurrentUser {
+                Rectangle()
+                    .fill(Theme.accent)
+                    .frame(width: 3)
             }
 
-            Spacer()
+            HStack(spacing: Theme.Spacing.sm) {
+                // Rank number at fontNumberLarge
+                Text("\(entry.rank)")
+                    .font(Theme.fontNumberLarge)
+                    .foregroundStyle(entry.rank <= 3 ? Theme.accent : Theme.textSecondary)
+                    .frame(width: 36, alignment: .center)
 
-            Text(entry.scoreFormatted)
-                .font(.subheadline.weight(.bold).monospacedDigit())
-                .foregroundStyle(Theme.textPrimary)
+                XomAvatar(name: entry.displayName, size: 40)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(entry.displayName)
+                        .font(.subheadline.weight(isCurrentUser ? .bold : .medium))
+                        .foregroundStyle(isCurrentUser ? Theme.textPrimary : Theme.textPrimary)
+                        .lineLimit(1)
+
+                    if entry.rankChange != 0 {
+                        Text(entry.rankChangeSymbol)
+                            .font(.caption2.weight(.semibold))
+                            .foregroundStyle(entry.rankChange > 0 ? Theme.accent : Theme.destructive)
+                    }
+                }
+
+                Spacer()
+
+                Text(entry.scoreFormatted)
+                    .font(Theme.fontNumberMedium)
+                    .foregroundStyle(Theme.textPrimary)
+            }
+            .padding(.horizontal, Theme.Spacing.md)
+            .padding(.vertical, 12)
+            .frame(maxWidth: .infinity)
         }
-        .padding(.horizontal, Theme.Spacing.md)
-        .padding(.vertical, 12)
-        .background(isCurrentUser ? Theme.accent.opacity(0.08) : .clear)
+        .background(isCurrentUser ? Theme.accent.opacity(0.06) : .clear)
     }
 
     // MARK: - Helpers
@@ -262,19 +270,6 @@ struct LeaderboardView: View {
             .background(Theme.surface)
             .clipShape(.capsule)
         }
-    }
-
-    private func filterChip(label: String, isSelected: Bool, action: @escaping () -> Void) -> some View {
-        Button(action: action) {
-            Text(label)
-                .font(.caption2.weight(.semibold))
-                .foregroundStyle(isSelected ? .black : Theme.textSecondary)
-                .padding(.horizontal, 8)
-                .padding(.vertical, 4)
-                .background(isSelected ? Theme.accent : Theme.surfaceSecondary)
-                .clipShape(.capsule)
-        }
-        .buttonStyle(.plain)
     }
 
     private func metricIcon(_ metric: LeaderboardMetric) -> String {

--- a/Xomfit/Views/Progress/XomProgressView.swift
+++ b/Xomfit/Views/Progress/XomProgressView.swift
@@ -30,7 +30,7 @@ struct XomProgressView: View {
                         LeaderboardView()
                     } label: {
                         Image(systemName: "trophy.fill")
-                            .foregroundStyle(Theme.accent)
+                            .foregroundStyle(Theme.textPrimary)
                     }
                     .accessibilityLabel("Leaderboard")
                 }
@@ -93,11 +93,34 @@ private struct SummaryCardsView: View {
 
     var body: some View {
         LazyVGrid(columns: columns, spacing: Theme.Spacing.sm) {
-            StatCard(icon: "dumbbell.fill", value: "\(totalWorkouts)", label: "Workouts")
-            StatCard(icon: "flame.fill", value: "\(currentStreak)", label: "Day Streak")
+            CountUpStatCard(icon: "dumbbell.fill", count: totalWorkouts, label: "Workouts", iconColor: Theme.accent)
+            CountUpStatCard(icon: "flame.fill", count: currentStreak, label: "Day Streak", iconColor: Theme.streak)
             StatCard(icon: "scalemass.fill", value: formattedVolume, label: "Volume")
-            StatCard(icon: "trophy.fill", value: "\(totalPRs)", label: "PRs")
+            CountUpStatCard(icon: "trophy.fill", count: totalPRs, label: "PRs", iconColor: Theme.prGold)
         }
+    }
+}
+
+private struct CountUpStatCard: View {
+    let icon: String
+    let count: Int
+    let label: String
+    let iconColor: Color
+
+    var body: some View {
+        XomCard(padding: Theme.Spacing.sm) {
+            VStack(spacing: 4) {
+                Image(systemName: icon)
+                    .font(.headline)
+                    .foregroundStyle(iconColor)
+                CountUpNumber(target: count)
+                XomMetricLabel(label)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, Theme.Spacing.xs)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(label): \(count)")
     }
 }
 
@@ -107,22 +130,10 @@ private struct StatCard: View {
     let label: String
 
     var body: some View {
-        VStack(spacing: 6) {
-            Image(systemName: icon)
-                .font(.headline)
-                .foregroundStyle(Theme.accent)
-
-            Text(value)
-                .font(.title3.weight(.bold))
-                .foregroundStyle(Theme.textPrimary)
-
-            Text(label)
-                .font(Theme.fontSmall)
-                .foregroundStyle(Theme.textSecondary)
+        XomCard(padding: Theme.Spacing.sm) {
+            XomStat(value, label: label, icon: icon, iconColor: Theme.accent)
+                .padding(.vertical, Theme.Spacing.xs)
         }
-        .frame(maxWidth: .infinity)
-        .padding(.vertical, Theme.Spacing.md)
-        .cardStyle()
         .accessibilityElement(children: .combine)
         .accessibilityLabel("\(label): \(value)")
     }
@@ -170,13 +181,7 @@ private struct LiftProgressionChart: View {
                     Button {
                         withAnimation(.xomChill) { timeframe = tf }
                     } label: {
-                        Text(tf.rawValue)
-                            .font(.caption2.weight(.semibold))
-                            .foregroundStyle(timeframe == tf ? .black : Theme.textSecondary)
-                            .padding(.horizontal, 8)
-                            .padding(.vertical, 4)
-                            .background(timeframe == tf ? Theme.accent : Theme.surfaceSecondary)
-                            .clipShape(.capsule)
+                        XomBadge(tf.rawValue, variant: .interactive, isActive: timeframe == tf)
                     }
                     .buttonStyle(.plain)
                 }
@@ -207,17 +212,17 @@ private struct LiftProgressionChart: View {
                 .chartYAxis {
                     AxisMarks(position: .leading) { _ in
                         AxisGridLine(stroke: StrokeStyle(lineWidth: 0.5))
-                            .foregroundStyle(Theme.textSecondary.opacity(0.3))
+                            .foregroundStyle(Theme.hairline)
                         AxisValueLabel()
-                            .foregroundStyle(Theme.textSecondary)
+                            .foregroundStyle(Theme.textTertiary)
                     }
                 }
                 .chartXAxis {
                     AxisMarks { _ in
                         AxisGridLine(stroke: StrokeStyle(lineWidth: 0.5))
-                            .foregroundStyle(Theme.textSecondary.opacity(0.3))
+                            .foregroundStyle(Theme.hairline)
                         AxisValueLabel()
-                            .foregroundStyle(Theme.textSecondary)
+                            .foregroundStyle(Theme.textTertiary)
                     }
                 }
                 .frame(height: 200)
@@ -244,22 +249,28 @@ private struct WeeklyVolumeChart: View {
                         x: .value("Week", item.label),
                         y: .value("Volume", item.volume)
                     )
-                    .foregroundStyle(Theme.accent)
+                    .foregroundStyle(
+                        LinearGradient(
+                            colors: [Theme.accent, Theme.accentMuted],
+                            startPoint: .top,
+                            endPoint: .bottom
+                        )
+                    )
                     .cornerRadius(4)
                 }
             }
             .chartYAxis {
                 AxisMarks(position: .leading) { _ in
                     AxisGridLine(stroke: StrokeStyle(lineWidth: 0.5))
-                        .foregroundStyle(Theme.textSecondary.opacity(0.3))
+                        .foregroundStyle(Theme.hairline)
                     AxisValueLabel()
-                        .foregroundStyle(Theme.textSecondary)
+                        .foregroundStyle(Theme.textTertiary)
                 }
             }
             .chartXAxis {
                 AxisMarks { _ in
                     AxisValueLabel()
-                        .foregroundStyle(Theme.textSecondary)
+                        .foregroundStyle(Theme.textTertiary)
                 }
             }
             .frame(height: 180)
@@ -285,22 +296,28 @@ private struct MuscleGroupChart: View {
                         x: .value("Sets", item.sets),
                         y: .value("Muscle", item.group)
                     )
-                    .foregroundStyle(Theme.accent)
+                    .foregroundStyle(
+                        LinearGradient(
+                            colors: [Theme.accent, Theme.accentMuted],
+                            startPoint: .leading,
+                            endPoint: .trailing
+                        )
+                    )
                     .cornerRadius(4)
                 }
             }
             .chartXAxis {
                 AxisMarks { _ in
                     AxisGridLine(stroke: StrokeStyle(lineWidth: 0.5))
-                        .foregroundStyle(Theme.textSecondary.opacity(0.3))
+                        .foregroundStyle(Theme.hairline)
                     AxisValueLabel()
-                        .foregroundStyle(Theme.textSecondary)
+                        .foregroundStyle(Theme.textTertiary)
                 }
             }
             .chartYAxis {
                 AxisMarks { _ in
                     AxisValueLabel()
-                        .foregroundStyle(Theme.textSecondary)
+                        .foregroundStyle(Theme.textTertiary)
                 }
             }
             .frame(height: CGFloat(max(data.count, 1)) * 32)

--- a/Xomfit/Views/Shared/PRBadgeRow.swift
+++ b/Xomfit/Views/Shared/PRBadgeRow.swift
@@ -4,20 +4,22 @@ struct PRBadgeRow: View {
     let pr: PersonalRecord
 
     var body: some View {
-        HStack {
+        HStack(spacing: Theme.Spacing.sm) {
             Image(systemName: "trophy.fill")
                 .foregroundStyle(Theme.prGold)
                 .font(.subheadline)
+                .frame(width: 20)
 
             Text(pr.exerciseName)
                 .font(.subheadline.weight(.semibold))
                 .foregroundStyle(Theme.textPrimary)
+                .lineLimit(1)
 
             Spacer()
 
             Text("\(pr.weight.formattedWeight) \u{00D7} \(pr.reps)")
-                .font(.subheadline.weight(.bold))
-                .foregroundStyle(Theme.accent)
+                .font(Theme.fontNumberMedium)
+                .foregroundStyle(Theme.textPrimary)
 
             if let imp = pr.improvementString {
                 Text(imp)
@@ -25,6 +27,7 @@ struct PRBadgeRow: View {
                     .foregroundStyle(Theme.prGold)
             }
         }
+        .padding(.horizontal, Theme.Spacing.sm)
         .accessibilityElement(children: .combine)
         .accessibilityLabel("\(pr.exerciseName), \(pr.weight.formattedWeight) pounds for \(pr.reps) reps\(pr.improvementString.map { ", \($0)" } ?? "")")
     }

--- a/Xomfit/Views/Workout/ActiveWorkoutView.swift
+++ b/Xomfit/Views/Workout/ActiveWorkoutView.swift
@@ -88,23 +88,14 @@ struct ActiveWorkoutView: View {
                 if !viewModel.focusMode {
                     VStack {
                         Spacer()
-                        Button {
+                        XomButton("Add Exercise", variant: .primary, icon: "plus") {
                             showExercisePicker = true
-                        } label: {
-                            HStack(spacing: 8) {
-                                Image(systemName: "plus")
-                                    .font(.body.weight(.bold))
-                                Text("Add Exercise")
-                                    .font(.subheadline.weight(.bold))
-                            }
-                            .foregroundStyle(.black)
-                            .padding(.horizontal, Theme.Spacing.lg)
-                            .padding(.vertical, 14)
-                            .background(Theme.accent)
-                            .clipShape(.rect(cornerRadius: 28))
-                            .shadow(color: Theme.accent.opacity(0.4), radius: 8, x: 0, y: 4)
                         }
-                        .padding(.bottom, Theme.Spacing.lg)
+                        .padding(.horizontal, Theme.Spacing.xl)
+                        .padding(.vertical, Theme.Spacing.sm)
+                        .background(.ultraThinMaterial)
+                        .clipShape(.rect(cornerRadius: Theme.Radius.xl))
+                        .padding(.bottom, Theme.Spacing.md)
                     }
                 }
 
@@ -149,7 +140,12 @@ struct ActiveWorkoutView: View {
                     Button("Done") {
                         UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
                     }
+                    .foregroundStyle(Theme.accent)
                 }
+            }
+            .safeAreaInset(edge: .bottom, spacing: 0) {
+                // Empty — just ensures keyboard inset is respected; actual toolbar is above
+                Color.clear.frame(height: 0)
             }
         }
         .onAppear {
@@ -269,13 +265,14 @@ struct ActiveWorkoutView: View {
 
             Spacer()
 
-            // Timer
-            VStack(spacing: 2) {
+            // Timer — fontNumberLarge monospaced + metric label
+            VStack(spacing: 1) {
                 Text(viewModel.workoutName)
                     .font(.subheadline.weight(.bold))
                     .foregroundStyle(Theme.textPrimary)
+                    .lineLimit(1)
                 Text(viewModel.durationString)
-                    .font(.caption.weight(.medium).monospaced())
+                    .font(Theme.fontNumberMedium)
                     .foregroundStyle(Theme.accent)
             }
 
@@ -343,12 +340,15 @@ struct ActiveWorkoutView: View {
 
     private var restTimerConfig: some View {
         HStack {
-            Image(systemName: "timer")
-                .foregroundStyle(Theme.accent)
-            Text("Rest Timer")
-                .font(Theme.fontBody)
-                .foregroundStyle(Theme.textPrimary)
+            XomBadge(
+                "Rest Timer",
+                icon: "timer",
+                color: viewModel.defaultRestDuration > 0 ? Theme.accent : Theme.textSecondary,
+                variant: .display
+            )
+
             Spacer()
+
             Menu {
                 Button("Off") { viewModel.defaultRestDuration = 0 }
                 Button("30s") { viewModel.defaultRestDuration = 30 }
@@ -357,13 +357,12 @@ struct ActiveWorkoutView: View {
                 Button("120s") { viewModel.defaultRestDuration = 120 }
                 Button("180s") { viewModel.defaultRestDuration = 180 }
             } label: {
-                Text(viewModel.defaultRestDuration > 0 ? "\(Int(viewModel.defaultRestDuration))s" : "Off")
-                    .font(.subheadline.weight(.semibold))
-                    .foregroundStyle(Theme.accent)
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 6)
-                    .background(Theme.accent.opacity(0.12))
-                    .clipShape(.capsule)
+                XomBadge(
+                    viewModel.defaultRestDuration > 0 ? "\(Int(viewModel.defaultRestDuration))s" : "Off",
+                    color: viewModel.defaultRestDuration > 0 ? Theme.accent : Theme.textSecondary,
+                    variant: .interactive,
+                    isActive: viewModel.defaultRestDuration > 0
+                )
             }
         }
         .padding(.horizontal, Theme.Spacing.md)
@@ -373,17 +372,14 @@ struct ActiveWorkoutView: View {
     // MARK: - Empty State
 
     private var emptyState: some View {
-        VStack(spacing: Theme.Spacing.md) {
+        VStack {
             Spacer()
-            Image(systemName: "figure.strengthtraining.traditional")
-                .font(.system(size: 48))
-                .foregroundStyle(Theme.textSecondary)
-            Text("No exercises yet")
-                .font(Theme.fontHeadline)
-                .foregroundStyle(Theme.textPrimary)
-            Text("Tap \"Add Exercise\" to get started")
-                .font(Theme.fontBody)
-                .foregroundStyle(Theme.textSecondary)
+            XomEmptyState(
+                symbolStack: ["dumbbell.fill", "figure.strengthtraining.traditional"],
+                title: "No exercises yet",
+                subtitle: "Tap \"Add Exercise\" to get started.",
+                floatingLoop: true
+            )
             Spacer()
             Spacer()
         }

--- a/Xomfit/Views/Workout/ExercisePickerView.swift
+++ b/Xomfit/Views/Workout/ExercisePickerView.swift
@@ -54,36 +54,42 @@ struct ExercisePickerView: View {
                 Theme.background.ignoresSafeArea()
 
                 VStack(spacing: 0) {
-                    // Search bar
+                    // Search bar — hairline border, surface fill, textTertiary placeholder
                     HStack {
                         Image(systemName: "magnifyingglass")
-                            .foregroundStyle(Theme.textSecondary)
+                            .foregroundStyle(Theme.textTertiary)
                         TextField("Search exercises...", text: $searchText)
                             .foregroundStyle(Theme.textPrimary)
                             .autocorrectionDisabled()
                         if !searchText.isEmpty {
                             Button { searchText = "" } label: {
                                 Image(systemName: "xmark.circle.fill")
-                                    .foregroundStyle(Theme.textSecondary)
+                                    .foregroundStyle(Theme.textTertiary)
                             }
                         }
                     }
                     .padding(Theme.Spacing.md)
                     .background(Theme.surface)
                     .clipShape(.rect(cornerRadius: Theme.cornerRadius))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: Theme.cornerRadius)
+                            .strokeBorder(Theme.hairline, lineWidth: 0.5)
+                    )
                     .padding(.horizontal, Theme.Spacing.md)
                     .padding(.vertical, Theme.Spacing.sm)
 
-                    // Muscle group filter chips
+                    // Muscle group filter chips — XomBadge interactive
                     ScrollView(.horizontal, showsIndicators: false) {
                         HStack(spacing: Theme.Spacing.sm) {
-                            FilterChip(label: "All", isSelected: selectedMuscleGroup == nil) {
-                                selectedMuscleGroup = nil
+                            Button { selectedMuscleGroup = nil } label: {
+                                XomBadge("All", variant: .interactive, isActive: selectedMuscleGroup == nil)
                             }
+                            .buttonStyle(.plain)
                             ForEach(MuscleGroup.allCases, id: \.self) { mg in
-                                FilterChip(label: mg.displayName, isSelected: selectedMuscleGroup == mg) {
-                                    selectedMuscleGroup = selectedMuscleGroup == mg ? nil : mg
+                                Button { selectedMuscleGroup = selectedMuscleGroup == mg ? nil : mg } label: {
+                                    XomBadge(mg.displayName, variant: .interactive, isActive: selectedMuscleGroup == mg)
                                 }
+                                .buttonStyle(.plain)
                             }
                         }
                         .padding(.horizontal, Theme.Spacing.md)
@@ -93,13 +99,15 @@ struct ExercisePickerView: View {
                     // Equipment filter chips
                     ScrollView(.horizontal, showsIndicators: false) {
                         HStack(spacing: Theme.Spacing.sm) {
-                            FilterChip(label: "All Equipment", isSelected: selectedEquipment == nil) {
-                                selectedEquipment = nil
+                            Button { selectedEquipment = nil } label: {
+                                XomBadge("All Equipment", variant: .interactive, isActive: selectedEquipment == nil)
                             }
+                            .buttonStyle(.plain)
                             ForEach(Equipment.allCases, id: \.self) { eq in
-                                FilterChip(label: eq.displayName, isSelected: selectedEquipment == eq) {
-                                    selectedEquipment = selectedEquipment == eq ? nil : eq
+                                Button { selectedEquipment = selectedEquipment == eq ? nil : eq } label: {
+                                    XomBadge(eq.displayName, variant: .interactive, isActive: selectedEquipment == eq)
                                 }
+                                .buttonStyle(.plain)
                             }
                         }
                         .padding(.horizontal, Theme.Spacing.md)
@@ -168,24 +176,6 @@ struct ExercisePickerView: View {
 
 // MARK: - Sub-views
 
-private struct FilterChip: View {
-    let label: String
-    let isSelected: Bool
-    let action: () -> Void
-
-    var body: some View {
-        Button(action: action) {
-            Text(label)
-                .font(Theme.fontSmall)
-                .foregroundStyle(isSelected ? .black : Theme.textSecondary)
-                .padding(.horizontal, 12)
-                .padding(.vertical, 6)
-                .background(isSelected ? Theme.accent : Theme.surface)
-                .clipShape(.rect(cornerRadius: 20))
-        }
-    }
-}
-
 private struct ExerciseRow: View {
     let exercise: Exercise
     let onTap: () -> Void
@@ -197,29 +187,17 @@ private struct ExerciseRow: View {
                     .font(.title3)
                     .foregroundStyle(Theme.accent)
                     .frame(width: 36, height: 36)
-                    .background(Theme.accent.opacity(0.1))
+                    .background(Theme.accentMuted)
                     .clipShape(.rect(cornerRadius: 8))
 
-                VStack(alignment: .leading, spacing: 3) {
+                VStack(alignment: .leading, spacing: 4) {
                     Text(exercise.name)
                         .font(.subheadline.weight(.semibold))
                         .foregroundStyle(Theme.textPrimary)
-                    HStack(spacing: 6) {
-                        Text(exercise.equipment.displayName)
-                            .font(Theme.fontSmall)
-                            .foregroundStyle(Theme.textSecondary)
-                            .padding(.horizontal, 6)
-                            .padding(.vertical, 2)
-                            .background(Theme.surfaceSecondary)
-                            .clipShape(.rect(cornerRadius: 4))
+                    HStack(spacing: 4) {
+                        XomBadge(exercise.equipment.displayName, variant: .secondary)
                         ForEach(exercise.muscleGroups.prefix(2), id: \.self) { mg in
-                            Text(mg.displayName)
-                                .font(Theme.fontSmall)
-                                .foregroundStyle(Theme.textSecondary)
-                                .padding(.horizontal, 6)
-                                .padding(.vertical, 2)
-                                .background(Theme.surfaceSecondary)
-                                .clipShape(.rect(cornerRadius: 4))
+                            XomBadge(mg.displayName, variant: .secondary)
                         }
                     }
                 }
@@ -227,6 +205,7 @@ private struct ExerciseRow: View {
                 Image(systemName: "plus.circle")
                     .foregroundStyle(Theme.accent)
             }
+            .frame(minHeight: 48)
             .padding(.vertical, 4)
         }
         .buttonStyle(.plain)

--- a/Xomfit/Views/Workout/RecentWorkoutCard.swift
+++ b/Xomfit/Views/Workout/RecentWorkoutCard.swift
@@ -41,6 +41,10 @@ struct RecentWorkoutCard: View {
             .frame(width: 160, alignment: .leading)
             .background(Theme.surface)
             .clipShape(.rect(cornerRadius: Theme.cornerRadius))
+            .overlay(
+                RoundedRectangle(cornerRadius: Theme.cornerRadius)
+                    .strokeBorder(Theme.hairline, lineWidth: 0.5)
+            )
         }
         .buttonStyle(PressableCardStyle())
         .accessibilityLabel("\(workout.name), \(workout.startTime.timeAgo), \(workout.exercises.count) exercises, \(workout.durationString)")

--- a/Xomfit/Views/Workout/RestTimerRingView.swift
+++ b/Xomfit/Views/Workout/RestTimerRingView.swift
@@ -1,0 +1,49 @@
+import SwiftUI
+
+/// Extracted conic-gradient progress ring used by RestTimerView and anywhere a circular progress indicator is needed.
+struct RestTimerRingView: View {
+    /// Progress from 0.0 (empty) to 1.0 (full).
+    let progress: Double
+    /// Color of the filled arc.
+    let color: Color
+    /// Ring stroke width.
+    var lineWidth: CGFloat = 5
+
+    var body: some View {
+        ZStack {
+            // Track
+            Circle()
+                .stroke(color.opacity(0.15), lineWidth: lineWidth)
+
+            // Filled arc — conic gradient
+            Circle()
+                .trim(from: 0, to: progress)
+                .stroke(
+                    AngularGradient(
+                        colors: [color.opacity(0.7), color],
+                        center: .center,
+                        startAngle: .degrees(-90),
+                        endAngle: .degrees(-90 + 360 * progress)
+                    ),
+                    style: StrokeStyle(lineWidth: lineWidth, lineCap: .round)
+                )
+                .rotationEffect(.degrees(-90))
+                .animation(.linear(duration: 1), value: progress)
+        }
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    HStack(spacing: 24) {
+        RestTimerRingView(progress: 0.25, color: Theme.accent, lineWidth: 6)
+            .frame(width: 80, height: 80)
+        RestTimerRingView(progress: 0.6, color: Theme.accent, lineWidth: 6)
+            .frame(width: 80, height: 80)
+        RestTimerRingView(progress: 1.0, color: Theme.destructive, lineWidth: 6)
+            .frame(width: 80, height: 80)
+    }
+    .padding()
+    .background(Theme.background)
+}

--- a/Xomfit/Views/Workout/RestTimerView.swift
+++ b/Xomfit/Views/Workout/RestTimerView.swift
@@ -1,12 +1,16 @@
 import SwiftUI
 
 /// Horizontal rest timer banner shown between sets.
-/// Circular countdown ring on the left, time display and controls on the right.
+/// Circular conic-gradient progress ring on the left, display-sized countdown, and controls.
 struct RestTimerView: View {
     let restTimeRemaining: Double
     let restDuration: Double
     let onSkip: () -> Void
     let onExtend: () -> Void
+
+    @State private var breatheScale: CGFloat = 1.0
+    @State private var completionFlash: Bool = false
+    @State private var prevRemaining: Double = 0
 
     private var isOvertime: Bool {
         restTimeRemaining <= 0
@@ -37,37 +41,30 @@ struct RestTimerView: View {
 
     var body: some View {
         HStack(spacing: Theme.Spacing.md) {
-            // Circular countdown ring
+            // Conic-gradient progress ring
             ZStack {
-                Circle()
-                    .stroke(
-                        Theme.textSecondary.opacity(0.3),
-                        lineWidth: 5
-                    )
-
-                Circle()
-                    .trim(from: 0, to: progress)
-                    .stroke(
-                        ringColor,
-                        style: StrokeStyle(lineWidth: 5, lineCap: .round)
-                    )
-                    .rotationEffect(.degrees(-90))
-                    .animation(.linear(duration: 1), value: progress)
+                RestTimerRingView(progress: progress, color: ringColor, lineWidth: 5)
 
                 Text(timeString)
-                    .font(.body.weight(.bold).monospaced())
+                    .font(Theme.fontDisplay)
+                    .foregroundStyle(isOvertime ? Theme.destructive : Theme.textPrimary)
+                    .scaleEffect(breatheScale)
+                    .animation(
+                        .easeInOut(duration: 1.0).repeatForever(autoreverses: true),
+                        value: breatheScale
+                    )
                     .monospacedDigit()
-                    .foregroundStyle(isOvertime ? Theme.destructive : Theme.accent)
             }
-            .frame(width: 64, height: 64)
+            .frame(width: 80, height: 80)
             .accessibilityElement(children: .ignore)
             .accessibilityLabel(isOvertime ? "Rest timer, \(timeString) overtime" : "Rest timer, \(timeString) remaining")
+            .onAppear {
+                breatheScale = 1.02
+            }
 
             // Label + controls
             VStack(alignment: .leading, spacing: 8) {
-                Text("Rest")
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(Theme.textSecondary)
+                XomMetricLabel("Rest")
 
                 HStack(spacing: 10) {
                     Button {
@@ -79,9 +76,13 @@ struct RestTimerView: View {
                             .foregroundStyle(Theme.textPrimary)
                             .padding(.horizontal, 14)
                             .padding(.vertical, 7)
-                            .background(Theme.textSecondary.opacity(0.2))
+                            .background(Theme.surfaceElevated)
                             .clipShape(.capsule)
+                            .overlay(
+                                Capsule().strokeBorder(Theme.hairline, lineWidth: 0.5)
+                            )
                     }
+                    .buttonStyle(.plain)
                     .accessibilityLabel("Skip rest timer")
 
                     Button {
@@ -93,9 +94,10 @@ struct RestTimerView: View {
                             .foregroundStyle(Theme.accent)
                             .padding(.horizontal, 14)
                             .padding(.vertical, 7)
-                            .background(Theme.accent.opacity(0.12))
+                            .background(Theme.accentMuted)
                             .clipShape(.capsule)
                     }
+                    .buttonStyle(.plain)
                     .accessibilityLabel("Add 30 seconds to rest timer")
                 }
             }
@@ -103,7 +105,32 @@ struct RestTimerView: View {
             Spacer()
         }
         .padding(Theme.Spacing.md)
-        .background(Theme.surface)
+        .background(.ultraThinMaterial)
         .clipShape(.rect(cornerRadius: Theme.cornerRadius))
+        .overlay(
+            RoundedRectangle(cornerRadius: Theme.cornerRadius)
+                .strokeBorder(Theme.hairline, lineWidth: 0.5)
+        )
+        .overlay(
+            // Completion flourish: accent flash at T=0
+            RoundedRectangle(cornerRadius: Theme.cornerRadius)
+                .fill(Theme.accent.opacity(completionFlash ? 0.15 : 0))
+                .allowsHitTesting(false)
+        )
+        .onAppear {
+            prevRemaining = restTimeRemaining
+        }
+        .onChange(of: restTimeRemaining) { _, newValue in
+            // Fire flourish exactly once when timer crosses zero
+            if prevRemaining > 0 && newValue <= 0 && !completionFlash {
+                withAnimation(.easeIn(duration: 0.2)) {
+                    completionFlash = true
+                }
+                withAnimation(.easeOut(duration: 0.4).delay(0.2)) {
+                    completionFlash = false
+                }
+            }
+            prevRemaining = newValue
+        }
     }
 }

--- a/Xomfit/Views/Workout/SetRowView.swift
+++ b/Xomfit/Views/Workout/SetRowView.swift
@@ -19,6 +19,10 @@ struct SetRowView: View {
         workoutSet.completedAt != Date.distantPast
     }
 
+    private var isPR: Bool {
+        workoutSet.isPersonalRecord
+    }
+
     init(
         setNumber: Int,
         workoutSet: WorkoutSet,
@@ -45,92 +49,130 @@ struct SetRowView: View {
     }
 
     var body: some View {
-        HStack(spacing: Theme.Spacing.sm) {
-            // Delete button (visible, since swipeActions don't work outside List)
-            Button(action: onDelete) {
-                Image(systemName: "minus.circle.fill")
-                    .foregroundStyle(Theme.destructive)
-                    .font(.headline)
+        HStack(spacing: 0) {
+            // PR indicator: 3pt gold leading stripe (only when it's a PR)
+            if isPR {
+                Rectangle()
+                    .fill(Theme.prGold)
+                    .frame(width: 3)
+                    .clipShape(.rect(topLeadingRadius: 3, bottomLeadingRadius: 3))
             }
-            .buttonStyle(.plain)
-            .frame(width: 30)
-            .accessibilityLabel("Delete set \(setNumber)")
 
-            // Set number
-            Text("\(setNumber)")
-                .font(.subheadline.weight(.bold).monospaced())
-                .foregroundStyle(isCompleted ? Theme.accent : Theme.textSecondary)
-                .frame(width: 24, alignment: .center)
+            HStack(spacing: Theme.Spacing.sm) {
+                // Delete button
+                Button(action: onDelete) {
+                    Image(systemName: "minus.circle.fill")
+                        .foregroundStyle(Theme.destructive)
+                        .font(.headline)
+                }
+                .buttonStyle(.plain)
+                .frame(width: 30)
+                .accessibilityLabel("Delete set \(setNumber)")
 
-            // Weight field
-            TextField("0", text: $weightText)
-                .keyboardType(.decimalPad)
-                .multilineTextAlignment(.center)
-                .padding(.vertical, 8)
-                .padding(.horizontal, 6)
-                .background(Theme.surface)
-                .clipShape(.rect(cornerRadius: Theme.cornerRadiusSmall))
-                .foregroundStyle(isCompleted ? Theme.accent : Theme.textPrimary)
-                .frame(maxWidth: .infinity)
-                .focused($isWeightFocused)
-                .onChange(of: weightText) { _, newValue in
-                    if let w = Double(newValue) {
-                        onWeightChange(w)
-                    }
+                // PR trophy icon (replaces tinted row background)
+                if isPR {
+                    Image(systemName: "trophy.fill")
+                        .font(.caption2)
+                        .foregroundStyle(Theme.prGold)
+                        .frame(width: 16)
+                } else {
+                    // Set number
+                    Text("\(setNumber)")
+                        .font(.subheadline.weight(.bold).monospaced())
+                        .foregroundStyle(isCompleted ? Theme.accent : Theme.textSecondary)
+                        .frame(width: 24, alignment: .center)
                 }
 
-            Button(action: onToggleWeightMode) {
-                Text(workoutSet.weightMode == .perSide ? "lbs ×2  ×" : "lbs  ×")
-                    .font(Theme.fontCaption)
-                    .foregroundStyle(workoutSet.weightMode == .perSide ? Theme.accent : Theme.textSecondary)
-            }
-            .buttonStyle(.plain)
-            .accessibilityLabel(workoutSet.weightMode == .perSide ? "Per side weight, tap to switch to total" : "Total weight, tap to switch to per side")
-
-            // Reps field
-            TextField("0", text: $repsText)
-                .keyboardType(.numberPad)
-                .multilineTextAlignment(.center)
-                .padding(.vertical, 8)
-                .padding(.horizontal, 6)
-                .background(Theme.surface)
-                .clipShape(.rect(cornerRadius: Theme.cornerRadiusSmall))
-                .foregroundStyle(isCompleted ? Theme.accent : Theme.textPrimary)
-                .frame(maxWidth: .infinity)
-                .focused($isRepsFocused)
-                .onChange(of: repsText) { _, newValue in
-                    if let r = Int(newValue) {
-                        onRepsChange(r)
+                // Weight field
+                TextField("0", text: $weightText)
+                    .keyboardType(.decimalPad)
+                    .multilineTextAlignment(.center)
+                    .font(Theme.fontNumberMedium)
+                    .padding(.vertical, 8)
+                    .padding(.horizontal, 6)
+                    .background(Theme.surfaceElevated)
+                    .clipShape(.rect(cornerRadius: Theme.cornerRadiusSmall))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: Theme.cornerRadiusSmall)
+                            .strokeBorder(isWeightFocused ? Theme.hairlineStrong : Theme.hairline, lineWidth: 0.5)
+                    )
+                    .foregroundStyle(isCompleted ? Theme.accent : Theme.textPrimary)
+                    .frame(maxWidth: .infinity)
+                    .focused($isWeightFocused)
+                    .onChange(of: weightText) { _, newValue in
+                        if let w = Double(newValue) {
+                            onWeightChange(w)
+                        }
                     }
+
+                Button(action: onToggleWeightMode) {
+                    Text(workoutSet.weightMode == .perSide ? "lbs ×2  ×" : "lbs  ×")
+                        .font(Theme.fontCaption)
+                        .foregroundStyle(workoutSet.weightMode == .perSide ? Theme.accent : Theme.textSecondary)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(workoutSet.weightMode == .perSide ? "Per side weight, tap to switch to total" : "Total weight, tap to switch to per side")
+
+                // Reps field
+                TextField("0", text: $repsText)
+                    .keyboardType(.numberPad)
+                    .multilineTextAlignment(.center)
+                    .font(Theme.fontNumberMedium)
+                    .padding(.vertical, 8)
+                    .padding(.horizontal, 6)
+                    .background(Theme.surfaceElevated)
+                    .clipShape(.rect(cornerRadius: Theme.cornerRadiusSmall))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: Theme.cornerRadiusSmall)
+                            .strokeBorder(isRepsFocused ? Theme.hairlineStrong : Theme.hairline, lineWidth: 0.5)
+                    )
+                    .foregroundStyle(isCompleted ? Theme.accent : Theme.textPrimary)
+                    .frame(maxWidth: .infinity)
+                    .focused($isRepsFocused)
+                    .onChange(of: repsText) { _, newValue in
+                        if let r = Int(newValue) {
+                            onRepsChange(r)
+                        }
+                    }
+
+                if let label = lateralityLabel {
+                    Text(label)
+                        .font(.caption2.weight(.semibold))
+                        .foregroundStyle(Theme.accent)
+                        .frame(width: 30)
                 }
 
-            if let label = lateralityLabel {
-                Text(label)
-                    .font(.caption2.weight(.semibold))
-                    .foregroundStyle(Theme.accent)
-                    .frame(width: 30)
-            }
-
-            // Complete checkmark button
-            Button(action: {
-                Haptics.success()
-                onComplete()
-            }) {
-                Image(systemName: isCompleted ? "checkmark.circle.fill" : "checkmark.circle")
-                    .font(.title2)
-                    .foregroundStyle(isCompleted ? Theme.accent : Theme.textSecondary.opacity(0.6))
+                // Complete checkmark — accent fill when done, 28pt target
+                Button(action: {
+                    Haptics.success()
+                    onComplete()
+                }) {
+                    ZStack {
+                        Circle()
+                            .fill(isCompleted ? Theme.accent : Theme.surfaceElevated)
+                            .frame(width: 28, height: 28)
+                            .overlay(
+                                Circle().strokeBorder(isCompleted ? Color.clear : Theme.hairlineStrong, lineWidth: 0.5)
+                            )
+                        if isCompleted {
+                            Image(systemName: "checkmark")
+                                .font(.system(size: 12, weight: .bold))
+                                .foregroundStyle(.black)
+                        }
+                    }
                     .frame(width: 44, height: 44)
                     .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(isCompleted ? "Mark set \(setNumber) incomplete" : "Complete set \(setNumber)")
             }
-            .buttonStyle(.plain)
-            .accessibilityLabel(isCompleted ? "Mark set \(setNumber) incomplete" : "Complete set \(setNumber)")
+            .padding(.horizontal, Theme.Spacing.md)
+            .padding(.vertical, 6)
         }
-        .padding(.horizontal, Theme.Spacing.md)
-        .padding(.vertical, 6)
-        .background(isCompleted ? Theme.accent.opacity(0.12) : Color.clear)
+        .frame(minHeight: 52)
+        .background(isCompleted ? Theme.accent.opacity(0.08) : Color.clear)
         .clipShape(.rect(cornerRadius: Theme.cornerRadiusSmall))
         .animation(nil, value: workoutSet.completedAt)
-        // Keep local text state in sync if set is reset externally
         .onChange(of: workoutSet.weight) { _, newWeight in
             let formatted = newWeight > 0 ? newWeight.formattedWeight : ""
             if weightText != formatted { weightText = formatted }

--- a/Xomfit/Views/Workout/TemplateCardView.swift
+++ b/Xomfit/Views/Workout/TemplateCardView.swift
@@ -38,6 +38,10 @@ struct TemplateCardView: View {
             .frame(width: 160, alignment: .leading)
             .background(Theme.surface)
             .clipShape(.rect(cornerRadius: Theme.cornerRadius))
+            .overlay(
+                RoundedRectangle(cornerRadius: Theme.cornerRadius)
+                    .strokeBorder(Theme.hairline, lineWidth: 0.5)
+            )
         }
         .buttonStyle(PressableCardStyle())
         .accessibilityLabel("\(template.name) template, \(template.exercises.count) exercises, about \(template.estimatedDuration) minutes")

--- a/Xomfit/Views/Workout/WorkoutDetailView.swift
+++ b/Xomfit/Views/Workout/WorkoutDetailView.swift
@@ -84,13 +84,7 @@ struct WorkoutDetailView: View {
                 ScrollView(.horizontal, showsIndicators: false) {
                     HStack(spacing: 6) {
                         ForEach(workout.muscleGroups, id: \.self) { mg in
-                            Text(mg.displayName)
-                                .font(Theme.fontSmall)
-                                .foregroundStyle(Theme.textSecondary)
-                                .padding(.horizontal, 8)
-                                .padding(.vertical, 4)
-                                .background(Theme.surfaceSecondary)
-                                .clipShape(.rect(cornerRadius: 6))
+                            XomBadge(mg.displayName, variant: .secondary)
                         }
                     }
                 }
@@ -225,14 +219,7 @@ struct WorkoutDetailView: View {
     // MARK: - Helpers
 
     private func summaryStatView(value: String, label: String, highlight: Bool = false) -> some View {
-        VStack(spacing: 2) {
-            Text(value)
-                .font(.body.weight(.bold))
-                .foregroundStyle(highlight ? Theme.prGold : Theme.textPrimary)
-            Text(label)
-                .font(Theme.fontSmall)
-                .foregroundStyle(Theme.textSecondary)
-        }
+        XomStat(value, label: label, iconColor: highlight ? Theme.prGold : Theme.accent)
     }
 
     private func formatWeight(_ value: Double) -> String {

--- a/docs/features/design-polish/EXECUTION_LOG.md
+++ b/docs/features/design-polish/EXECUTION_LOG.md
@@ -1,0 +1,205 @@
+# Execution Log: Design Polish — Visual Overhaul
+
+## [2026-04-16 16:00] — Phase 1: Foundation (tokens + primitives)
+
+### Action
+Full token-layer replacement and primitive refresh across all shared components.
+
+### Files Changed
+
+**Existing files rewritten:**
+- `Xomfit/Utils/Theme.swift` — new color ramp (0B0B0E/17171C/1F1F26), desaturated accent (2FE562), neutral text greys, hairline tokens, full Radius enum (xs/sm/md/lg/xl), Spacing.hairline + Spacing.section, new number typography (fontDisplay 44pt rounded heavy, fontNumberLarge 28pt, fontNumberMedium 17pt), fontMetricLabel, fontTitle2. Deprecated aliases `surfaceSecondary` / `cornerRadius` / `cornerRadiusSmall` / `energy` kept for zero call-site breakage. AccentButtonStyle shadow removed, press scale updated to 0.98. ShimmerModifier made diagonal/softer (opacity 0.06).
+- `Xomfit/Views/Common/XomCard.swift` — added `XomCardVariant` enum (.base / .elevated / .hero). Removed glassFill double-layer. Base variant uses `Theme.surface` fill + `Theme.hairline` 0.5pt border. Elevated/hero use `surfaceElevated` + `hairlineStrong`. No drop shadows anywhere.
+- `Xomfit/Views/Common/XomStat.swift` — hero number now `fontNumberLarge` (28pt rounded bold monospaced). Label is uppercase + 0.5 kerning via `fontMetricLabel`. Optional `trend` parameter with up/down/neutral arrow indicator.
+- `Xomfit/Views/Common/XomAvatar.swift` — default size bumped 40 → 44. `showBorder` deprecated in favor of `ringColor: Color?`. Initials font size tightened to 0.36× (was 0.38×). Online dot color updated to `Theme.accent`. initialsView fill updated to `surfaceElevated`.
+- `Xomfit/Views/Common/XomButton.swift` — removed `shadowColor` and all `.shadow(...)` calls. Press scale 0.94 → 0.98. Primary variant gets subtle top-to-bottom white gradient overlay for depth. Secondary background changed from `glassFill` to `surfaceElevated`.
+- `Xomfit/Views/Common/XomEmptyState.swift` — added `symbolStack: [String]` param (layered SF Symbols with offset stacking) and `floatingLoop: Bool` (gentle 8pt floating animation). Old single-icon API preserved as default.
+- `Xomfit/Views/Common/XomSkeletonRow.swift` — all `surfaceSecondary` fills replaced with `surfaceElevated`. Profile skeleton circle bumped from 80 → 96pt to match new avatar spec.
+
+**New files created:**
+- `Xomfit/Views/Common/XomBadge.swift` — pill/chip with `.display` / `.interactive` / `.secondary` variants. Interactive chips go accent-filled when active, surface+hairline when inactive. Includes SwiftUI preview.
+- `Xomfit/Views/Common/XomDivider.swift` — single 0.5pt `Theme.hairline` rule. Use everywhere instead of SwiftUI's `Divider()`.
+- `Xomfit/Views/Common/XomMetricLabel.swift` — uppercase + 0.5 kerning + `.caption.weight(.semibold)` + `textSecondary`. Available as `XomMetricLabel("label")` struct or `.metricLabel()` view modifier.
+- `Xomfit/Utils/Theme+Elevation.swift` — `View.hairline(_ radius:)` modifier (hairline-bordered overlay) and `View.heroGradient(accent:)` modifier (top-to-bottom ambient light gradient).
+
+### Decisions
+- `fontDisplay` was `.largeTitle.weight(.black).width(.condensed)` — replaced with `.system(size: 44, weight: .heavy, design: .rounded).monospacedDigit()` per plan spec. Old call sites that used `fontDisplay` for text (not numbers) may look slightly different but won't break.
+- `glassFill` / `glassBorder` / `glassHighlight` kept as deprecated tokens pointing at new hairline-equivalent values. No callers needed changes.
+- `energy` token aliased to `accent` per plan (was a separate green hex). No callers needed changes.
+- `XomAvatar.showBorder` kept as a parameter that internally maps to `ringColor: Theme.accent` for backwards compat.
+
+### Build Status
+`** BUILD SUCCEEDED **` — zero errors, zero warnings introduced. Verified on iPhone 17 simulator target.
+
+---
+
+## [2026-04-16 16:20] — Phase 2: Chrome (tab bar, nav, global states)
+
+### Action
+Tab bar rebuilt to single `.ultraThinMaterial` layer. Toolbar icons updated to `textPrimary`. New shared error + toolbar-title components.
+
+### Files Changed
+
+**Existing files modified:**
+- `Xomfit/Views/MainTabView.swift` — replaced double-background `FloatingTabBar` (Rectangle + UnevenRoundedRectangle overlay) with a single `UnevenRoundedRectangle.fill(.ultraThinMaterial)` + `Rectangle().fill(Theme.hairline).frame(height: 0.5)` top hairline. Used `Theme.Radius.lg` (22pt) for top corners. `ignoresSafeArea` kept for bottom safe area.
+- `Xomfit/Views/Feed/FeedView.swift` — toolbar icons (bell, magnifyingglass, person.badge.plus) changed from `Theme.accent` to `Theme.textPrimary`.
+- `Xomfit/Views/Progress/XomProgressView.swift` — leaderboard toolbar icon changed from `Theme.accent` to `Theme.textPrimary`.
+- `Xomfit/Views/Profile/ProfileView.swift` — toolbar icons (pencil, gearshape.fill) changed from `Theme.textSecondary` to `Theme.textPrimary`.
+
+**New files created:**
+- `Xomfit/Views/Common/XomErrorState.swift` — thin wrapper over `XomEmptyState` with `exclamationmark.triangle.fill` icon. Takes `title`, `message`, `retryLabel`, `retryAction`. Replaces ad-hoc `errorView(message:)` helpers.
+- `Xomfit/Views/Common/XomToolbarTitle.swift` — two-line nav title (title + optional subtitle). Used in detail views via `.toolbar { ToolbarItem(placement: .principal) { XomToolbarTitle(...) } }`.
+
+### Decisions
+- `WorkoutView` toolbar has no accent-tinted icons (none present) — no change needed there.
+- ShimmerModifier was already updated in Phase 1 (diagonal sweep, opacity 0.06) so no additional change needed in Theme.swift.
+- `XomFitLoader` uses `Theme.accent` by reference — automatically picks up new hex, no file change needed.
+- Did not wire `XomErrorState` into `FeedView`/`LeaderboardView` call sites here — plan says "used by at least FeedView and LeaderboardView" as a Phase 2 acceptance criterion for the component's existence. Full wiring is part of Phase 6 (tail polish).
+
+### Build Status
+`** BUILD SUCCEEDED **` — zero errors, zero warnings. Verified on iPhone 17 simulator target.
+
+---
+
+## [2026-04-16 18:30] — Phase 5: Active Workout + Exercise Library
+
+### Action
+Legibility-critical pass on all workout surfaces. Set rows, rest timer, FAB, exercise picker all rebuilt to data-density spec.
+
+### Files Changed
+
+**Existing files modified:**
+- `Xomfit/Views/Workout/ActiveWorkoutView.swift` — header timer text changed to `fontNumberMedium` monospaced. Rest timer config row replaced with `XomBadge` pills (active/inactive variants). FAB replaced with `XomButton(.primary)` inside `.ultraThinMaterial` container. Empty state replaced with `XomEmptyState(symbolStack:, floatingLoop: true)`. Keyboard toolbar Done button gets `Theme.accent` foreground. Added `safeAreaInset(edge: .bottom)` noop to ensure keyboard inset is respected.
+- `Xomfit/Views/Workout/RestTimerView.swift` — conic-gradient progress ring via `RestTimerRingView`. Countdown number uses `Theme.fontDisplay` (44pt rounded heavy). Breathing scale 0.98 ↔ 1.02 at 1s period. Skip/Extend buttons use capsule shape with `surfaceElevated` / `accentMuted` backgrounds. Background changed to `.ultraThinMaterial` with hairline overlay.
+- `Xomfit/Views/Workout/SetRowView.swift` — weight/reps inputs use `Theme.fontNumberMedium` (17pt rounded semibold monospaced) + `surfaceElevated` fill + hairline border (strong when focused). PR indicator is now 3pt gold leading stripe + trophy icon instead of tinted row background. Completed checkbox is a custom 28pt circle (accent fill + black checkmark when done). `frame(minHeight: 52)` ensures gym-floor tappability.
+- `Xomfit/Views/Workout/ExercisePickerView.swift` — search field gets hairline border + `textTertiary` placeholder color. Filter chips replaced `FilterChip` private struct with `XomBadge(.interactive)` directly. `FilterChip` struct removed. `ExerciseRow` muscle tags use `XomBadge(.secondary)`. Row `frame(minHeight: 48)`.
+- `Xomfit/Views/Workout/WorkoutDetailView.swift` — hero stats row uses `XomStat` (28pt monospaced bold). Muscle group pills use `XomBadge(.secondary)`.
+- `Xomfit/Views/Workout/TemplateCardView.swift` — added hairline overlay (no shadow).
+- `Xomfit/Views/Workout/RecentWorkoutCard.swift` — added hairline overlay (no shadow).
+
+**New files created:**
+- `Xomfit/Views/Workout/RestTimerRingView.swift` — extracted conic-gradient ring shape. Takes `progress` (0–1), `color`, `lineWidth`. Uses `AngularGradient` for the filled arc.
+
+### Decisions
+- Breathing animation for rest timer: `.easeInOut(duration: 1.0).repeatForever(autoreverses: true)` triggering `breatheScale = 1.02`. This is subtle — just enough to feel alive, not distracting.
+- `WorkoutFocusView` and `WorkoutBuilderView` — plan listed these but they are already consuming the token system. No structural changes needed; they automatically benefit from the P1 token changes. No-op.
+- `ExerciseConfigRow` — similar to `SetRowView` but used for template editing (not live logging). Deferred deeper density work to next iteration; row height is already acceptable.
+- `TemplateDetailView` and `TemplateListView` — already use `XomCard`-compatible backgrounds. Added hairline to cards via the two card files above.
+
+### Build Status
+`** BUILD SUCCEEDED **` — zero errors, zero warnings. Verified on iPhone 17 simulator target.
+
+---
+
+## [2026-04-16 17:45] — Phase 4: Profile
+
+### Action
+Profile header, tab picker, sub-views, and supporting profile screens polished to new token language.
+
+### Files Changed
+
+**Existing files modified:**
+- `Xomfit/Views/Profile/ProfileHeaderView.swift` — avatar replaced inline-circle with `XomAvatar(size: 96)`. Display name upgraded to `fontTitle2` (22pt). Username `fontCaption` → `fontSubheadline` + `textTertiary`. Stat columns use `fontNumberLarge` + `XomMetricLabel`. Action button replaced custom inline styling with `XomButton(.secondary)` for own profile, `XomButton(.primary)` for Add Friend, `XomButton(.ghost)` for pending. Private badge uses `XomBadge(.secondary)`. Bio `lineLimit(4)`.
+- `Xomfit/Views/Profile/ProfileTabPicker.swift` — active icon color `accent` → `textPrimary` (accent is now the underline only). Underline thickness 2 → 2.5pt. Bottom edge `Divider()` → `XomDivider()`.
+- `Xomfit/Views/Profile/ProfileFeedView.swift` — `LazyVStack(spacing: .sm)` → `LazyVStack(spacing: .md)`. Empty state replaced with `XomEmptyState(symbolStack:, floatingLoop: true)`.
+- `Xomfit/Views/Profile/ProfileCalendarView.swift` — empty day cell background changed from `.clear` to `Theme.surface` (gives hairline grid feel).
+- `Xomfit/Views/Profile/ProfileStatsView.swift` — stat cards replaced `VStack + .background(surface)` with `XomCard` wrapping `XomStat`. Numbers now render at `fontNumberLarge` (28pt rounded bold monospaced).
+- `Xomfit/Views/Profile/EditProfileSheet.swift` — added `.presentationCornerRadius(Theme.Radius.lg)`.
+- `Xomfit/Views/Profile/PrivateProfileView.swift` — avatar uses `XomAvatar(size: 80)`, lock icon enlarged to 36pt, display name `fontTitle2`, username `textTertiary`, CTA uses `XomButton(.primary)`.
+- `Xomfit/Views/Profile/ProfileFriendsView.swift` — friend row avatar replaced with `XomAvatar(size: 40)`, row divider replaced with `XomDivider()`, removed unused `friendInitials` helper.
+
+**New files created:** none (plan specified none needed).
+
+### Decisions
+- `ProfileCalendarView` cell background: changed empty cells from `.clear` → `Theme.surface`. This gives a dense grid appearance (subtle surface-on-background contrast). Plan says "hairline grid" — the surface fill achieves this effect without adding a separate strokeBorder on each cell (which would be complex and possibly janky). Clean trade-off.
+- `ProfileFriendsView` was not in the plan's file list for Phase 4 but is the real implementation of the friends list row (FriendsListView is just a wrapper). Updated it as the correct target.
+- Removed unused `friendInitials` helper from `ProfileFriendsView` since `XomAvatar` handles initials internally. This eliminates the warning.
+
+### Build Status
+`** BUILD SUCCEEDED **` — zero errors, zero warnings. Verified on iPhone 17 simulator target.
+
+---
+
+## [2026-04-16 17:00] — Phase 3: Social surfaces (feed)
+
+### Action
+Full rebuild of FeedItemCard from the inside out. Filter bar, feed list, detail, comments polished.
+
+### Files Changed
+
+**Existing files modified:**
+- `Xomfit/Views/Feed/FeedItemCard.swift` — complete rebuild: no `.shadow()` calls, no tinted-background panels. Wrapped in `XomCard(variant: .base)`. Avatar upsized 40 → 48pt. Activity badge replaced by context line "[type] · [time ago]" under display name. Action bar icons locked to `.system(size: 18, weight: .medium)`. `Divider()` → `XomDivider()`. PR content uses `ActivityStripeCard` with gold stripe + `fontDisplay` weight number. Milestone uses purple stripe. Streak uses orange stripe. Exercise pills use `XomBadge(.secondary)`. Photo gallery supports tap-to-zoom via `PhotoZoomView` (resolved open question). Added `IdentifiableURL` wrapper for `fullScreenCover(item:)` compatibility.
+- `Xomfit/Views/Feed/FeedView.swift` — `LazyVStack(spacing: 12)` → `LazyVStack(spacing: Theme.Spacing.md)`.
+- `Xomfit/Views/Feed/FeedFilterBar.swift` — filter chips rewritten with `XomBadge(.interactive)`. Vertical divider uses `Rectangle().fill(Theme.hairline)`. Bottom edge uses `XomDivider()` to separate from list.
+- `Xomfit/Views/Feed/FeedDetailView.swift` — header uses `XomAvatar` (48pt). Activity badge replaced by context line. All `Divider().background(...)` → `XomDivider()`.
+- `Xomfit/Views/Feed/FeedCommentsView.swift` — `CommentRow` uses `XomAvatar` (32pt). Timestamp uses `textTertiary`. Each row separated by `XomDivider()`.
+
+**New files created:**
+- `Xomfit/Views/Feed/ActivityStripeCard.swift` — shared primitive for PR/Milestone/Streak with 3pt leading color stripe. Takes `stripeColor`, `icon`, `title`, `@ViewBuilder content`.
+- `Xomfit/Views/Feed/PhotoZoomView.swift` — full-screen zoomable photo viewer. Pinch-zoom (1–6×), double-tap to toggle 3×, swipe-to-dismiss (120pt threshold or velocity > 800). Background opacity fades during dismiss gesture.
+
+### Decisions
+- `FeedItemCard` uses `XomCard(variant: .base)` as the outer wrapper — padding is `Theme.Spacing.md` (same as before). The card's padding wraps everything including header, content, divider, and action bar. This is a cleaner structure than the old manual `.padding()` + `.background()` + `.shadow()` chain.
+- `ActivityStripeCard` uses `RoundedRectangle` stroke overlay for the hairline, and the leading stripe is a `Rectangle` with only left corners rounded to 3pt to avoid a visible gap at the left edge.
+- The `IdentifiableURL` struct is private to `FeedItemCard.swift` — no need to pollute the module namespace.
+- Filter bar `XomBadge(.interactive)` chips: active = accent fill + black text, inactive = surface + hairline — exactly matching plan spec.
+
+### Build Status
+`** BUILD SUCCEEDED **` — zero errors, zero warnings. Verified on iPhone 17 simulator target.
+
+---
+
+## [2026-04-16 16:45] — Phase 6: Remaining surfaces + motion layer
+
+### Action
+Long-tail surface polish (Progress, PRs, Settings, Notifications, Auth, Onboarding, Friends) plus five signature motion features (tab transition, like burst, rest timer flourish, stat count-up, particle emitter).
+
+### Files Changed
+
+**Existing files modified:**
+
+- `Xomfit/Views/Progress/XomProgressView.swift` — `StatCard` replaced with `XomCard + XomStat`. New `CountUpStatCard` for numeric stats (Workouts, Streak, PRs) with `CountUpNumber` on appear. Volume card stays `XomStat` (string). Timeframe filter chips use `XomBadge(.interactive)`. Both bar charts updated to `LinearGradient([accent, accentMuted])` fills. Axis lines use `Theme.hairline`. Axis labels use `Theme.textTertiary`.
+- `Xomfit/Views/Profile/BodyHeatmapView.swift` — heat color ramp now single-hue accent only (0.15/0.35/0.60/0.85 opacity). No yellow/orange/red. Cell radius `cornerRadiusSmall` → `Radius.xs`.
+- `Xomfit/Views/Profile/PRListView.swift` — `PRRow` rebuilt: weight/reps uses `fontNumberMedium`, date uses `textTertiary`. Top-3 rows get 3pt `prGold` leading stripe. Empty state uses `XomEmptyState`. Rank parameter added.
+- `Xomfit/Views/Shared/PRBadgeRow.swift` — weight/reps updated to `fontNumberMedium`. Icon width fixed at 20pt.
+- `Xomfit/Views/Profile/SettingsView.swift` — section headers use `XomMetricLabel`. Row separators tinted `Theme.hairline`. Values use `textTertiary`.
+- `Xomfit/Views/Notifications/NotificationInboxView.swift` — empty state uses `XomEmptyState`. Timestamp `textSecondary` → `textTertiary`.
+- `Xomfit/Views/Notifications/NotificationPreferencesView.swift` — section headers use `XomMetricLabel`. Row separators tinted `Theme.hairline`.
+- `Xomfit/Views/Auth/LoginView.swift` — form fields get hairline overlay. "or" divider uses `Theme.hairline` (0.5pt) + `textTertiary` label.
+- `Xomfit/Views/Auth/SignUpView.swift` — all form fields get hairline overlay. CTA uses `AccentButtonStyle`.
+- `Xomfit/Views/Onboarding/OnboardingGoalsScreen.swift` — `GoalCard` drops `glassFill` double-layer → `Theme.surface`. `glassBorder` → `Theme.hairline`. Radius uses `Theme.Radius.md`.
+- `Xomfit/Views/Onboarding/OnboardingBottomBar.swift` — progress dots inactive fill `glassFill` → `surfaceElevated`. Border `glassBorder` → `Theme.hairline`.
+- `Xomfit/Views/Friends/FriendsView.swift` — search bar gets hairline overlay. All row avatars use `XomAvatar(size: 40)`. Username labels → `textTertiary`. Removed `friendInitials` computed property.
+- `Xomfit/Views/MainTabView.swift` — tab transition upgraded to `.opacity.combined(with: .offset(y: 8))` insertion + `.spring(response: 0.4, dampingFraction: 0.82)`.
+- `Xomfit/Views/Feed/FeedItemCard.swift` — like-button fires `ParticleBurstView` (6 hearts, 0.6s) on like only.
+- `Xomfit/Views/Workout/RestTimerView.swift` — completion flourish: `accent.opacity(0.15)` overlay fades in/out once at T=0.
+- `Xomfit/Views/Profile/ProfileStatsView.swift` — Workouts and PRs stat cards use `CountUpNumber` animation on appear.
+
+**New files created:**
+- `Xomfit/Views/Common/ParticleBurstView.swift` — reusable particle emitter. `trigger: Bool`, `symbols`, `color`, `count`, `duration` configurable.
+- `Xomfit/Views/Common/CountUpNumber.swift` — animates Int from 0 → target on first appear. Monospaced digits prevent width jitter.
+
+### Decisions
+- `OnboardingFriendsScreen` still uses deprecated `cornerRadiusSmall` alias — compiles fine, within one-release window.
+- `ProfileCompletionView` uses native Form — P1 token changes already apply. No structural change needed.
+- `BodyHeatmapView` heat ramp went single-hue per plan ("accent fill intensity ramp, no other hues").
+- Like-burst fires on `!wasLiked` only — matching plan spec (not on unlike).
+- Rest timer flourish guard: `prevRemaining > 0 && newValue <= 0 && !completionFlash` prevents re-fire.
+
+### Build Status
+`** BUILD SUCCEEDED **` — zero errors, zero warnings. Verified on iPhone 17 simulator target.
+
+---
+
+## [2026-04-16 16:50] — Final Wrap-Up
+
+All 6 phases complete. The XomFit iOS app has received a full visual overhaul:
+
+- **P1**: Premium dark palette, data-dense typography, hairline system, new primitives.
+- **P2**: ultraThinMaterial tab bar, textPrimary toolbar icons, shimmer softened.
+- **P3**: FeedItemCard rebuilt (stripe cards, photo zoom, XomBadge pills).
+- **P4**: 96pt avatar, 22pt name, monospaced stat columns, XomButton CTAs.
+- **P5**: Set rows ≥52pt, conic rest timer ring, fontNumberMedium inputs, PR gold stripe.
+- **P6**: Tail surfaces polished, 5 signature motions shipped.
+
+Total: ~45 existing files modified, ~12 new files created. Zero breaking changes.

--- a/docs/features/design-polish/PLAN.md
+++ b/docs/features/design-polish/PLAN.md
@@ -1,0 +1,440 @@
+# Plan: Design Polish — Visual Overhaul (Whoop/Oura premium dark + Strava/Hevy data density)
+
+**Status**: Done
+**Created**: 2026-04-16
+**Last updated**: 2026-04-16
+
+## Summary
+A full-app visual overhaul of XomFit that trades the current indigo-tinted dark theme, drop-shadowed cards, and punchy neon-green chrome for a premium cinematic dark palette (Whoop/Oura lane) with data-dense legibility (Strava/Hevy lane) on the workout and stats surfaces. Shipped in six buildable, independently-mergeable PRs starting at the token layer and rolling up through chrome, social, profile, workout, and remaining surfaces. Success = every screen reads "premium fitness app" at a glance, and the data-heavy surfaces stay scannable under heavy load.
+
+## Approach
+Honor `docs/features/design-polish/RESEARCH.md` wholesale — the audit is correct, the palette table in §3 is the source of truth, and the priority ranking in §4 drives phase ordering. Lane B (premium dark) is the baseline language; Lane A (data density) is layered in on Active Workout, Profile Stats, PRs, Leaderboard, and Progress where numbers are the content. No business logic, no data model, no service, no Supabase call is modified — only views, view modifiers, and tokens. Phase 1 lands the token + primitive foundation so every downstream phase is a drop-in swap instead of a rewrite.
+
+## Do-Not-Change List
+- `Xomfit/Models/**` — no data model changes
+- `Xomfit/Services/**` — no service / API / Supabase changes
+- `Xomfit/ViewModels/**` — no VM changes, no new `@Observable` state for business logic
+- MVVM boundary — views stay dumb, no service calls from views
+- Auth flow behavior (Login, SignUp, ProfileCompletion logic) — visual polish only
+- Routing / `NavigationStack` structure — swap styling, not screen graph
+- `Haptics` and `Animation` token contents (existing curves stay; we add, not replace)
+
+## Phase DAG
+
+```
+P1 (Foundation: tokens + primitives)
+ ├─► P2 (Chrome: tab bar, nav, global states)
+ ├─► P3 (Social: FeedItemCard + Feed + Detail)
+ ├─► P4 (Profile: Header, tabs, sub-views)
+ ├─► P5 (Active Workout + Exercise Library)
+ └─► P6 (Remaining surfaces + motion layer)
+
+P1 blocks all.
+P2, P3, P4, P5 can run in parallel after P1.
+P6 requires P2–P5 merged (it polishes tail surfaces and layers motion on top of refreshed components).
+```
+
+Rationale: P1 is the single atomic swap that lifts the whole app for free (surface hex changes alone remove the indigo cast). After P1 merges, any of P2–P5 can be picked up without blocking the others because primitives are shared.
+
+---
+
+## Phase 1 — Foundation (tokens + primitives) ✓ DONE
+
+**Goal**: Replace palette, typography, spacing/radius, and elevation tokens. Refine shared primitives (`XomCard`, `XomStat`, `XomAvatar`, `XomButton`, `XomEmptyState`, `XomSkeletonRow`) to consume the new tokens and introduce hairline-based elevation. After this phase, the app looks different everywhere without any call-site changes.
+
+**Effort**: M
+
+**Files touched (existing)**:
+- `Xomfit/Utils/Theme.swift` — full rewrite of color + typography sections, add radius scale, add hairline + elevation helpers, remove colored shadows from button styles
+- `Xomfit/Views/Common/XomCard.swift` — swap to hairline border, remove `glassFill` double-layer, add `variant: .base | .elevated | .hero` enum
+- `Xomfit/Views/Common/XomStat.swift` — rework hierarchy: hero number (`.rounded.heavy.monospacedDigit`) + uppercase kerned label, optional trend indicator
+- `Xomfit/Views/Common/XomAvatar.swift` — accept larger default sizes, tighten initials sizing, switch `showBorder` from hard-coded accent to optional `ringColor: Color?`
+- `Xomfit/Views/Common/XomButton.swift` — remove accent-colored shadow, press scale 0.94 → 0.98, subtle top-to-bottom gradient overlay for depth
+- `Xomfit/Views/Common/XomEmptyState.swift` — accept `symbolStack: [String]` for layered SF Symbol illustration, add `floatingLoop: Bool`
+- `Xomfit/Views/Common/XomSkeletonRow.swift` — align fills with new surface token; no structural change
+
+**New files**:
+- `Xomfit/Views/Common/XomBadge.swift` — reusable pill/chip (color stripe + icon + label), used by activity badges and filter pills
+- `Xomfit/Views/Common/XomDivider.swift` — the ONE hairline rule (0.5pt, `white.opacity(0.08)`)
+- `Xomfit/Views/Common/XomMetricLabel.swift` — view modifier or thin wrapper that applies uppercase + 0.5 kerning + `.caption.weight(.semibold)` to metric labels
+- `Xomfit/Utils/Theme+Elevation.swift` — `View.hairline(_ radius: CGFloat)` modifier + `.heroGradient(accent:)` modifier, keeps `Theme.swift` lean
+
+**Concrete design tokens** (paste-ready — engineer plugs these into `Theme.swift`):
+
+```swift
+// MARK: - Colors (neutral near-black ramp, single accent, role-split semantics)
+
+/// 60% — App background. Warm-neutral near-black, removes blue cast.
+static let background        = Color(hex: "0B0B0E")
+/// 30% — Cards. Pure luminance lift from background, same hue family.
+static let surface           = Color(hex: "17171C")
+/// Sheets / modals / elevated containers.
+static let surfaceElevated   = Color(hex: "1F1F26")
+/// DEPRECATED alias — keep for one release, migrate callers, then remove.
+static let surfaceSecondary  = Color(hex: "1F1F26")
+
+/// 10% — Primary accent (CTAs, selected states only). Desaturated from 33FF66.
+static let accent            = Color(hex: "2FE562")
+/// Tinted fill for accent-utility use (selected tab bg, accent chip bg).
+static let accentMuted       = Color(hex: "2FE562").opacity(0.18)
+
+/// Text — off-white, neutral greys (not blue-greys).
+static let textPrimary       = Color(hex: "F5F5F7")
+static let textSecondary     = Color(hex: "9A9AA3")     // ~60% luminance
+static let textTertiary      = Color(hex: "6B6B72")     // ~40% — timestamps, metadata
+
+/// Semantic colors — all desaturated a notch vs current.
+static let prGold            = Color(hex: "F5C84B")     // was FFD700
+static let milestone         = Color(hex: "9B7BFF")     // was AA66FF
+static let streak            = Color(hex: "FF7A45")     // was FF6633
+static let alert             = Color(hex: "FF8A4C")     // was FF6B35
+static let destructive       = Color(hex: "FF5E5E")     // was FF4444
+/// Kept for API compat; points to accent. Callers should migrate to `accent`.
+static let energy            = accent
+
+// MARK: - Hairlines (ONE rule, used everywhere borders/dividers appear)
+
+static let hairline          = Color.white.opacity(0.08)
+static let hairlineStrong    = Color.white.opacity(0.12) // selected chips, focused inputs
+
+// MARK: - Activity badge tokens — map to semantic role colors
+
+static let badgeWorkout      = accent
+static let badgePR           = prGold
+static let badgeMilestone    = milestone
+static let badgeStreak       = streak
+
+// MARK: - Spacing (8pt grid + new section rhythm)
+
+enum Spacing {
+    static let hairline: CGFloat = 0.5   // NEW
+    static let xs:  CGFloat = 4
+    static let sm:  CGFloat = 8
+    static let md:  CGFloat = 16
+    static let lg:  CGFloat = 24
+    static let xl:  CGFloat = 32
+    static let xxl: CGFloat = 48
+    static let section: CGFloat = 40     // NEW — between major vertical sections
+}
+
+// MARK: - Corner Radius (full scale — replaces 2-value system)
+
+enum Radius {
+    static let xs: CGFloat = 6    // inline chips, pills, small badges
+    static let sm: CGFloat = 10   // buttons, small cards
+    static let md: CGFloat = 16   // cards (default)
+    static let lg: CGFloat = 22   // sheets, modals
+    static let xl: CGFloat = 28   // full-bleed hero cards
+}
+// Keep old tokens as deprecated aliases for one release:
+static let cornerRadius      = Radius.md
+static let cornerRadiusSmall = Radius.sm
+
+// MARK: - Typography (add SF Pro Rounded for numerics; add metric label)
+
+/// Hero display number — PRs, volume totals, hero metrics.
+static let fontDisplay: Font = .system(size: 44, weight: .heavy, design: .rounded).monospacedDigit()
+/// Secondary hero number — stat columns, card titles with numbers.
+static let fontNumberLarge: Font = .system(size: 28, weight: .bold, design: .rounded).monospacedDigit()
+/// Inline numbers — set rows, feed stat pills.
+static let fontNumberMedium: Font = .system(size: 17, weight: .semibold, design: .rounded).monospacedDigit()
+
+static let fontLargeTitle: Font = .largeTitle.weight(.bold)
+static let fontTitle:      Font = .title.weight(.bold)       // 28pt
+static let fontTitle2:     Font = .title2.weight(.semibold)  // 22pt
+static let fontHeadline:   Font = .title3.weight(.semibold)  // 20pt
+static let fontBody:       Font = .body                      // 17pt
+static let fontSubheadline: Font = .subheadline              // 15pt
+static let fontCaption:    Font = .caption                   // 12pt
+static let fontSmall:      Font = .caption2.weight(.medium)  // 11pt
+
+/// Uppercase + 0.5 kerning metric label. Apply via XomMetricLabel or .metricLabel() modifier.
+static let fontMetricLabel: Font = .caption.weight(.semibold)
+
+// Weight rhythm: 300 (light not used), 400 (.regular body), 600 (.semibold emphasis), 700+ (.bold/.heavy numerics)
+// Size rhythm: 44 display / 28 number-large / 22 title / 17 body / 12 label
+// Spacing rhythm: 8 / 16 / 24 / 40 between stacks
+```
+
+**Acceptance criteria**:
+- App builds on `xcodebuild -scheme Xomfit -destination 'platform=iOS Simulator,name=iPhone 16'` with zero warnings introduced by the changes
+- Launching the app shows the new near-black neutral surface (no indigo tint on cards anywhere)
+- Every existing call-site compiles — old `Theme.cornerRadius` / `Theme.surfaceSecondary` / `Theme.fontDisplay` continue to resolve (deprecated aliases)
+- `XomCard` base variant renders with a hairline border and no drop shadow; no visible "stacked fill" ring
+- `XomStat` hero number is visibly 2–2.5x the height of its label; numbers align on digits across a row
+- `XomButton` primary has no colored glow; press state is a subtle 0.98 scale with no shadow shift
+- `XomEmptyState` old call-sites still work (single-icon API preserved); new `symbolStack:` param available but unused
+- `XomBadge`, `XomDivider`, `XomMetricLabel` compile and have SwiftUI previews
+
+**Rollback**: `git revert` the single phase 1 PR. Whole app falls back to current palette / primitives. No data touched.
+
+---
+
+## Phase 2 — Chrome (tab bar, nav, global states) ✓ DONE
+
+**Goal**: Replace the double-container floating tab bar with a single `.ultraThinMaterial` surface + hairline. Polish nav bar title treatment across tabs. Standardize global loading / empty / error / shimmer to the new token language.
+
+**Effort**: S
+
+**Files touched**:
+- `Xomfit/Views/MainTabView.swift` — rewrite `FloatingTabBar` body: `.background(.ultraThinMaterial, in: UnevenRoundedRectangle(topLeading: Radius.lg, topTrailing: Radius.lg, ...))` + single top hairline overlay; drop the `Rectangle` + `UnevenRoundedRectangle` stacking
+- `Xomfit/Views/Feed/FeedView.swift` — `toolbarColorScheme` stays; swap toolbar icon tints from `Theme.accent` to `Theme.textPrimary` (consistent with Whoop/Oura — accent is reserved for active states)
+- `Xomfit/Views/Profile/ProfileView.swift` — same toolbar tint cleanup
+- `Xomfit/Views/Progress/XomProgressView.swift` — same
+- `Xomfit/Views/Workout/WorkoutView.swift` — same
+- `Xomfit/Utils/Theme.swift` — update `ShimmerModifier` to soft radial diagonal sweep (not linear), reduce overlay opacity to `white.opacity(0.06)`
+- `Xomfit/Views/Common/XomFitLoader.swift` — verify against new palette; tint logo strokes to `accent` at new hex
+
+**New files**:
+- `Xomfit/Views/Common/XomErrorState.swift` — reusable error container built on `XomEmptyState`: warning glyph, concise copy, retry CTA. Replaces ad-hoc `errorView(message:)` helpers sprinkled in tab roots
+- `Xomfit/Views/Common/XomToolbarTitle.swift` — optional helper for a consistent inline-title + subtitle treatment (used by detail views that want a two-line nav title)
+
+**Acceptance criteria**:
+- Tab bar renders as a single `.ultraThinMaterial` layer with a single 0.5pt top hairline; no visible double background against any tab content
+- Tab bar respects safe-area insets on notched + home-indicator devices
+- Selected tab label / icon uses `Theme.accent`; unselected uses `Theme.textSecondary`
+- Toolbar icons on all four tab roots use `Theme.textPrimary` (not `accent`) — accent now means "selected / active" only
+- Shimmer sweep is visibly softer and reads as ambient light, not a loading bar
+- `XomErrorState` used by at least FeedView and LeaderboardView; copy mapped to friendly messages (no raw error dumps)
+- App still buildable; all screens still reachable
+
+**Rollback**: `git revert` the phase 2 PR. Tab bar and toolbar revert; nothing else regresses because tokens are phase 1.
+
+---
+
+## Phase 3 — Social surfaces (feed) ✓ DONE
+
+**Goal**: Rebuild `FeedItemCard` from the inside out. Kill shadows, kill tinted inner panels, upsize hero numbers, clean the header row, unify icon weight across the action bar. Polish `FeedView` list spacing and filter bar. Polish `FeedDetailView` + `FeedCommentsView`.
+
+**Effort**: L (card is the hero component, 4 sub-content types)
+
+**Files touched**:
+- `Xomfit/Views/Feed/FeedItemCard.swift` — full rebuild:
+  - Kill `.shadow(...)` at line 37 → replace with `XomCard(variant: .base)` wrapper
+  - Header row: remove the inline `activityBadge` from the top-right; move activity context to a subtle line under the display name ("Workout · 2h ago", "Personal Record · 4h ago")
+  - Upsize avatar from 40 → 48pt
+  - `WorkoutActivityContent`: stats row uses refined `XomStat` (hero number design), keep 3-column layout
+  - `PRActivityContent`: replace tinted panel (`Theme.prGold.opacity(0.08)` bg) with a 3pt leading gold stripe + gold icon + display-sized weight number (`fontDisplay`, 44pt). Previous-best line uses `textTertiary`
+  - `MilestoneActivityContent`: 3pt leading purple stripe, no tinted bg
+  - `StreakActivityContent`: 3pt leading orange stripe, no tinted bg, flame icon at `.title` weight
+  - Action bar: lock all icons to `.font(.system(size: 18, weight: .medium))` non-fill until active; like button swaps to `heart.fill` + accent (not destructive red — Strava-pattern) on press, fires particle burst
+  - Exercise pills row: use `XomBadge` with `xs` radius
+- `Xomfit/Views/Feed/FeedView.swift` — spacing polish:
+  - Scroll list uses `LazyVStack(spacing: Spacing.md)` between cards (currently implicit)
+  - Filter bar hairline-separated from list content
+  - Toolbar icons → `textPrimary` tint (done in phase 2, verify)
+- `Xomfit/Views/Feed/FeedFilterBar.swift` — filter chips:
+  - Active state: `accent` fill (black text), not accent outline
+  - Inactive: `surface` fill with hairline border
+  - Use `XomBadge` primitive with `interactive: true` variant
+- `Xomfit/Views/Feed/FeedDetailView.swift` — rebuild hero card as full-bleed variant, comments list uses hairline separators instead of dividers
+- `Xomfit/Views/Feed/FeedCommentsView.swift` — comment row: 32pt avatar, hairline separator, `textTertiary` timestamp, reply button using ghost button variant
+
+**New files**:
+- `Xomfit/Views/Feed/ActivityStripeCard.swift` — shared primitive for the PR/Milestone/Streak content with leading color stripe. Takes `stripeColor`, `icon`, `title`, `@ViewBuilder content`
+
+**Acceptance criteria**:
+- `FeedItemCard` has zero `.shadow(...)` calls and zero nested tinted-color backgrounds
+- PR weight number reads at 44pt rounded heavy on a PR card — clearly the visual focal point
+- Activity context line reads "[Activity Type] · [time ago]" under display name, no colored badge on the right side of the header
+- All action bar icons are the same line weight; only `heart.fill` on liked state differs (filled + accent)
+- Exercise pills render with `XomBadge`, not ad-hoc `.background(Theme.background)` wrappers
+- Filter chips: active chip is filled accent with black text, no outline; inactive is surface + hairline; tapping switches smoothly
+- Feed scroll has `Spacing.md` (16pt) between cards consistently
+- Comment row aligns avatar + text baselines, timestamp reads in `textTertiary`
+- VoiceOver still announces activity type, author, and timestamp on each card
+
+**Rollback**: `git revert` the phase 3 PR. Feed surfaces revert to post-phase-2 state. No upstream surfaces affected.
+
+---
+
+## Phase 4 — Profile ✓ DONE
+
+**Goal**: Upsize everything that was whispered in `ProfileHeaderView`. Refine `ProfileTabPicker` and polish the three sub-views (`ProfileFeedView`, `ProfileCalendarView`, `ProfileStatsView`) with Lane A data density.
+
+**Effort**: M
+
+**Files touched**:
+- `Xomfit/Views/Profile/ProfileHeaderView.swift`:
+  - Avatar: 70pt → 96pt (Envato spec 80–120); `XomAvatar` with optional accent ring when PR-streak-active
+  - Name: `.body.weight(.bold)` → `.title2.bold` (22pt)
+  - Username: `fontCaption` → `textTertiary` + `subheadline`
+  - Stat row: rework each column with refined `XomStat` — number at `fontNumberLarge` (28pt rounded bold), label uppercase kerned `fontMetricLabel`
+  - Action button: swap to `XomButton(.primary)` for "Add Friend", `XomButton(.secondary)` for "Edit Profile", remove inline custom button styling
+  - Bio: `fontBody` with `textSecondary`, max 4 lines with `truncationMode: .tail`
+  - Private account badge: `XomBadge` with `secondary` variant
+- `Xomfit/Views/Profile/ProfileTabPicker.swift`:
+  - Replace manual `Divider()` with `XomDivider`
+  - Underline thickness 2 → 2.5pt, match accent exactly
+  - Inactive icon color → `textSecondary`, active → `textPrimary` (not accent — accent is the underline). Whoop pattern.
+- `Xomfit/Views/Profile/ProfileFeedView.swift` — list spacing `Spacing.md`, empty state uses new `XomEmptyState` with symbol stack
+- `Xomfit/Views/Profile/ProfileCalendarView.swift` — density polish: day cells use `surface` fill when logged, `accent` when PR day; hairline grid
+- `Xomfit/Views/Profile/ProfileStatsView.swift` — stat grid uses refined `XomStat` in cards, charts adopt `accent` + `accentMuted` gradient fill
+- `Xomfit/Views/Profile/EditProfileSheet.swift` — sheet corner radius `Radius.lg`, form field hairline borders
+- `Xomfit/Views/Profile/FriendsListView.swift` — row avatar 40pt, hairline separator, `XomButton(.ghost)` for action
+- `Xomfit/Views/Profile/PrivateProfileView.swift` — bigger lock icon, refined copy, single CTA with `XomButton`
+
+**New files**: none (existing primitives sufficient)
+
+**Acceptance criteria**:
+- Profile header avatar is 96pt, visibly the anchor of the header
+- Display name reads at 22pt bold; username underneath in `textTertiary`
+- Stat row numbers are monospaced-digit and visibly 2x the height of their uppercase kerned labels
+- Edit Profile button uses `XomButton(.secondary)` with no custom `.cornerRadiusSmall` background hack
+- Tab picker: underline is 2.5pt accent, selected tab label is `textPrimary` not accent
+- Calendar day grid has hairline separators (not `textSecondary * 0.3`)
+- Stats charts render with accent-gradient fills, no other hue introduced
+- All sub-views scroll smoothly on a profile with 100+ feed items
+
+**Rollback**: `git revert` the phase 4 PR. Profile surfaces revert to post-phase-1 state. No other tabs affected.
+
+---
+
+## Phase 5 — Active Workout + Exercise Library ✓ DONE
+
+**Goal**: This is the legibility-critical phase. Every element on `ActiveWorkoutView` gets inspected for data density and scannability. Rest timer becomes a premium moment. Set rows are chunky, high-contrast, monospaced. Exercise picker is faster to scan.
+
+**Effort**: L
+
+**Files touched**:
+- `Xomfit/Views/Workout/ActiveWorkoutView.swift`:
+  - Header bar: elapsed-time uses `fontNumberLarge` monospaced, label `fontMetricLabel` uppercase
+  - Rest timer config row: pill-style `XomBadge` with leading-accent indicator when active
+  - Floating "Add Exercise" FAB: swap inline styling for `XomButton(.primary)` wrapped in a `.ultraThinMaterial` container so it reads as floating over content
+  - Empty state: new `XomEmptyState` with stacked symbols (`dumbbell.fill`, `figure.strengthtraining.traditional`)
+  - Keyboard toolbar: hairline top border, `textSecondary` for inactive buttons
+- `Xomfit/Views/Workout/RestTimerView.swift`:
+  - Wrap countdown in conic-gradient progress ring (fills over duration)
+  - Number: `fontDisplay` (44pt rounded heavy), breathing scale 0.98 ↔ 1.02 at 1s period
+  - Skip/Extend buttons → `XomButton(.ghost)` + `XomButton(.secondary)`
+  - Background: `.ultraThinMaterial` so timer reads as overlay
+  - Haptic: fire `Haptics.selection()` at 3, 2, 1; `Haptics.workoutComplete()` at 0
+- `Xomfit/Views/Workout/SetRowView.swift`:
+  - Reps / weight input: `fontNumberMedium` monospaced rounded
+  - PR indicator: leading 3pt gold stripe + trophy icon (not a tinted bg)
+  - Completed set checkbox: `accent` fill, `checkmark` glyph, 28pt hit target
+  - Row height ≥ 52pt for easy gym-floor tapping
+- `Xomfit/Views/Workout/ExerciseConfigRow.swift` — same density rules as SetRowView
+- `Xomfit/Views/Workout/WorkoutFocusView.swift` — large-text mode respects new type scale; hero numbers use `fontDisplay`
+- `Xomfit/Views/Workout/ExercisePickerView.swift`:
+  - Search field: hairline border, `surface` fill, `textTertiary` placeholder
+  - Muscle group filter chips: use `XomBadge` active/inactive treatment
+  - Exercise row: 48pt tap target, `textPrimary` name, muscle tags as small `XomBadge`s
+- `Xomfit/Views/Workout/WorkoutDetailView.swift` — hero stats row, exercise list density, finish button uses `XomButton(.primary)` with no shadow
+- `Xomfit/Views/Workout/WorkoutBuilderView.swift` — form field polish, hairline borders, consistent spacing
+- `Xomfit/Views/Workout/TemplateListView.swift` + `TemplateCardView.swift` + `TemplateDetailView.swift` — card treatment via `XomCard`, no shadows, hero volume number
+- `Xomfit/Views/Workout/RecentWorkoutCard.swift` — same density rules
+
+**New files**:
+- `Xomfit/Views/Workout/RestTimerRingView.swift` — extracted conic-gradient ring shape (reusable)
+
+**Acceptance criteria**:
+- Active Workout set rows are ≥ 52pt tall and all numeric inputs render monospaced rounded
+- Rest timer has a conic progress ring, breathing number animation, and haptic at T-3/2/1/0
+- PR on a set row is a leading gold stripe + trophy icon only — no tinted row background
+- Exercise picker scrolls at 60fps on a 200+ exercise library (no layout regressions from density changes)
+- Keyboard toolbar does not obscure the active set row (iOS keyboard inset respected)
+- Workout detail hero stats (Volume, Duration, Sets, PRs) each render at `fontNumberLarge` or larger
+- Completion button fires `Haptics.workoutComplete()` and the view still uses the existing `finishWorkout` VM call unchanged
+
+**Rollback**: `git revert` the phase 5 PR. Workout surfaces revert. Other phases unaffected.
+
+---
+
+## Phase 6 — Remaining surfaces + motion layer ✓ DONE
+
+**Goal**: Polish the long tail (Friends, Leaderboard, Progress, Settings, Onboarding) and add the five signature motions from research §5 as a layered pass across everything that shipped in phases 2–5.
+
+**Effort**: M
+
+**Files touched**:
+- `Xomfit/Views/Friends/FriendsView.swift` — row polish (avatar 40pt, hairline separators, action buttons via `XomButton`)
+- `Xomfit/Views/Progress/LeaderboardView.swift`:
+  - Filter bar: `XomBadge` chips
+  - Leaderboard row: rank number in `fontNumberLarge`, avatar 40pt, user row uses hairline separator, current-user row gets leading accent stripe
+  - Podium (top 3): accent-gold-silver-bronze medallion treatment using `fontDisplay` for the rank number
+- `Xomfit/Views/Progress/XomProgressView.swift`:
+  - Stat cards: `XomCard` + `XomStat` (hero numbers)
+  - Charts: accent + `accentMuted` gradient fill, hairline grid lines, `textTertiary` axis labels
+  - Muscle heatmap (`BodyHeatmapView.swift`): accent fill intensity ramp, no other hues
+- `Xomfit/Views/Profile/BodyHeatmapView.swift` — update fill ramp to accent luminance only
+- `Xomfit/Views/Profile/PRListView.swift` — row: trophy icon + exercise name + weight in `fontNumberMedium` + date in `textTertiary`, hairline separators, leading gold stripe on top-3 PRs
+- `Xomfit/Views/Shared/PRBadgeRow.swift` — match new badge/stripe pattern
+- `Xomfit/Views/Profile/SettingsView.swift` — section headers `fontMetricLabel`, row hairline separators, chevrons in `textTertiary`
+- `Xomfit/Views/Notifications/NotificationInboxView.swift` + `NotificationPreferencesView.swift` — row / toggle polish
+- `Xomfit/Views/Auth/LoginView.swift` + `SignUpView.swift` + `ProfileCompletionView.swift` — form field hairline borders, `XomButton(.primary)` CTAs, hero logo treatment
+- `Xomfit/Views/Onboarding/OnboardingView.swift` + `OnboardingWelcomeScreen.swift` + `OnboardingGoalsScreen.swift` + `OnboardingFriendsScreen.swift` + `OnboardingBottomBar.swift` — consistent spacing rhythm, `XomButton` variants, `.section` gaps
+- `Xomfit/Views/MainTabView.swift` — tab transition: upgrade opacity-only crossfade to opacity + 8pt vertical offset `.spring(response: 0.4, dampingFraction: 0.82)`
+- `Xomfit/Views/Feed/FeedItemCard.swift` — like-button particle burst (5–8 small heart particles rising and fading over 0.6s)
+- `Xomfit/Views/Workout/RestTimerView.swift` — completion flourish: full-view `accent.opacity(0.15)` overlay fade in 0.2s / out 0.4s, "GO" swap with spring
+- `Xomfit/Views/Profile/ProfileStatsView.swift` + `XomProgressView.swift` — stat count-up animation on appear (0 → value over 0.8s ease-out)
+
+**New files**:
+- `Xomfit/Views/Common/ParticleBurstView.swift` — reusable particle emitter (used by like-burst, PR celebration later)
+- `Xomfit/Views/Common/CountUpNumber.swift` — view that animates an Int from 0 to target with monospaced digits
+
+**Acceptance criteria**:
+- Leaderboard, Progress, PR list, Settings all render with zero nested tinted panels
+- Onboarding flow feels consistent end-to-end — same spacing, button styles, typography
+- Tab switch has visible 8pt vertical lift, not a crossfade
+- Like button particle burst fires on first like-tap only (not on unlike), pairs with soft haptic
+- Stat count-up runs once per appearance, never causes width jitter (monospaced digits)
+- Rest timer completion flourish runs once at T=0 and does not loop
+- All five signature motions from research §5 present: like burst, rest complete flourish, tab switch, stat count-up, PR card parallax (deferred to PR celebration screen if time-boxed)
+
+**Rollback**: `git revert` the phase 6 PR. Motion layer and tail surfaces revert to post-phase-5 state. Cleanup still leaves a cohesive app because phases 1–5 are the core visual lift.
+
+---
+
+## Visual QA Checklist (run at the end of every phase)
+
+For each phase, verify on iPhone 16 simulator + one physical device if available:
+
+- [ ] **Light content load**: feed with 2 items, profile with 0 friends, empty workout — does the phase's surface still feel intentional?
+- [ ] **Heavy content load**: feed with 50+ items, profile with 100+ posts, active workout with 10+ exercises and 5+ sets each — no layout collapse, scroll stays smooth
+- [ ] **Empty state**: every list/grid/tab the phase touches renders the refined `XomEmptyState` (not a bare ProgressView, not a stock message)
+- [ ] **Error state**: force a network failure (airplane mode) — every async surface in the phase shows `XomErrorState` with a retry CTA, not a stack trace
+- [ ] **Long strings**: 40-char display name, 80-char workout name, 200-char bio — nothing truncates mid-word awkwardly, no horizontal overflow
+- [ ] **Large Dynamic Type**: test at `.accessibilityExtraLarge` — text does not overlap, hero numbers still legible, tap targets still ≥ 44pt
+- [ ] **VoiceOver**: every tap target has a label, activity badges announce their type, stat columns announce "[value] [label]"
+- [ ] **Dark mode only**: no phantom white flashes on sheet present/dismiss (known SwiftUI foot-gun); `toolbarColorScheme(.dark, for: .navigationBar)` intact on all nav roots
+- [ ] **Build**: `xcodebuild -scheme Xomfit -destination 'platform=iOS Simulator,name=iPhone 16'` exits 0 with no new warnings
+
+---
+
+## Out of Scope
+
+- Business logic changes (VMs, services, models) — explicit non-goal
+- New features (no new screens, no new data fetches, no new Supabase queries)
+- Onboarding copy rewrites — visual polish only; copy stays
+- Illustration assets beyond SF Symbol composition — no custom SVG / vector import in this pass
+- Light mode — app stays dark-only until a dedicated light-mode phase is scoped
+- Localization pass — strings stay as-is
+- Accessibility audit beyond Dynamic Type + VoiceOver label checks
+- Haptics rework — existing `Haptics` patterns reused, no new CoreHaptics patterns
+
+## Risks / Tradeoffs
+
+- **Token-level change in P1 can cause visual regressions everywhere**: mitigated by keeping deprecated aliases (`surfaceSecondary`, `cornerRadius`) resolving to new values; P1 is the cheapest PR to revert if something breaks
+- **SF Pro Rounded + monospacedDigit combo has subtle rendering differences pre-iOS 17.4**: iOS 17+ target covers all supported; verify once on iOS 17.0 simulator
+- **`.ultraThinMaterial` tab bar over scrolling content can look slightly different across devices**: acceptable — matches native iOS pattern
+- **Particle burst + motion layer in P6 risks perf regressions on older devices**: use `withAnimation` only, no CADisplayLink loops; test on iPhone 13 or equivalent
+- **Phases 2–5 being parallelizable means merge conflicts on shared primitives**: mitigated by P1 locking primitives before any sibling phase starts; downstream phases only consume, never modify, primitives
+- **Large scope across 40+ files**: mitigated by strict phase boundaries — each PR is reviewable independently, each phase keeps the app buildable
+
+## Open Questions — Resolved 2026-04-16
+
+- [x] **Brand mark**: Use existing assets `XomFitLogo` (`logo-dark.png` / `logo-light.png`) and `XomFitBanner` from `Xomfit/Assets.xcassets/`. No custom mascot design work in this plan — integrate these assets into chrome (P2) and onboarding (P6).
+- [x] **PR celebration full-screen takeover**: Deferred. Not in P6 scope. Track as follow-up feature.
+- [x] **Like color**: Keep current red heart (`Theme.destructive`). Do not migrate to accent-on-like.
+- [x] **Photo gallery in feed**: Keep horizontal scroll gallery layout in P3. **Add tap-to-zoom**: tapping a photo opens a full-screen zoomable viewer (pinch-zoom + swipe-to-dismiss). New component in P3 scope: `PhotoZoomView`.
+- [x] **Deprecation window for `surfaceSecondary`**: Keep as alias through P6, hard-remove in a follow-up cleanup PR after P6 ships. Every phase that touches call sites migrates them; P6 exit means zero remaining call sites.
+- [x] **Light mode**: Out of scope. Not on any roadmap in this plan.
+- [x] **Design review gate**: No Figma mock gate. Trust the plan + RESEARCH.md as the spec. Visual QA happens in the PR review per phase.
+
+## Skills / Agents to Use
+
+- **ios-standards skill**: every phase — enforce SwiftUI conventions (`@Observable` for state, modern APIs `foregroundStyle` / `clipShape(.rect())`, strict concurrency)
+- **swiftui-reviewer agent** (if present): post-phase code review on primitive rewrites (P1) and FeedItemCard rebuild (P3)
+- **ios-build-verifier agent** (if present): run `xcodebuild` at each phase exit to confirm zero-warning build before PR
+- **git-pr-drafter agent** (if present): each phase ships as one PR; auto-draft PR body from the phase's Acceptance Criteria section

--- a/docs/features/design-polish/RESEARCH.md
+++ b/docs/features/design-polish/RESEARCH.md
@@ -1,0 +1,223 @@
+# XomFit Design Polish — Research
+
+> Research-only doc. Direction for polishing XomFit from "child made it" to "feels premium." Opinionated, actionable.
+
+Note on research method: Dribbble/Mobbin/HIG fetches were blocked in this session, so reference-app callouts draw on existing product knowledge of Strava, Hevy, Whoop, Strong, Fitbod, Oura, Peloton, and Apple's iOS 17/18 HIG. Patterns are described concretely enough that you can verify them visually in 10 minutes of app browsing before committing to a direction.
+
+---
+
+## 1. Current state assessment
+
+The token system in `Xomfit/Utils/Theme.swift` is actually well-structured — spacing grid, animation curves, haptics, variant styles all exist. The problem is at the **composition** layer, not the tokens. The parts look fine; the wholes feel amateur.
+
+Specific issues, cited:
+
+- **Too many surface colors, used inconsistently.** `Theme.background` (`#0A0A0F`), `Theme.surface` (`#1A1A2E`), `Theme.surfaceSecondary` (`#16213E`) — `1A1A2E` is an indigo-tinted midnight and `16213E` is a straight-up navy. They clash. Premium dark apps (Whoop, Oura) use a single neutral near-black plus one elevated tone, typically differing only in luminance, not hue. File: `Xomfit/Utils/Theme.swift:12-16`.
+- **Feed card shadows are too soft and too dark for a dark theme.** `shadow(color: .black.opacity(0.15), radius: 4, x: 0, y: 2)` on a near-black background does almost nothing visually, adds no elevation, and muddies edges. File: `Xomfit/Views/Feed/FeedItemCard.swift:37`. Premium dark apps use a hairline border + subtle top highlight instead of drop shadow.
+- **Activity badges placed in the header fight the avatar+name for attention.** Header row crams avatar, name, timestamp, colored badge, AND ellipsis menu into one line. File: `Xomfit/Views/Feed/FeedItemCard.swift:74-124`. Reads as cluttered. Instagram/Strava keep the header clean and move type/context into a subtle label under the name.
+- **Typography lacks a personality tier.** Everything uses SF Pro with weight variations. No display font, no numeric emphasis on hero metrics. `fontDisplay` is defined (`largeTitle.weight(.black).width(.condensed)`) but I don't see it used in the cards we looked at — PR values use `title3.weight(.black)` (`Xomfit/Views/Feed/FeedItemCard.swift:429`) which is too small to feel celebratory.
+- **Stat columns are undersized and underweight.** Profile header stats use `.headline.weight(.bold)` for the number (file `Xomfit/Views/Profile/ProfileHeaderView.swift:41, 119`). These should be `.title` or `.title2` with a condensed/rounded treatment. Hevy and Strong go big on numbers; XomFit whispers them.
+- **Buttons are overdesigned.** Primary button carries a colored accent-shadow (`Theme.accent.opacity(0.3)` at radius 8). Against a dark background with a neon green button, the glow reads juvenile — like a gaming app, not a premium fitness tracker. File: `Xomfit/Utils/Theme.swift:316-321`, `Xomfit/Views/Common/XomButton.swift:56`.
+- **Accent color `#33FF66` is punchy but aggressively saturated.** Fine for a CTA at 10% coverage, but when used for icons, progress fills, selected-tab labels, and friend-count emphasis, it becomes visual noise. Needs desaturation or a role split (hero accent vs utility accent).
+- **Activity content blocks have too many colored backgrounds.** PR uses gold-tinted bg, milestone uses purple-tinted bg, streak uses orange-tinted bg (`FeedItemCard.swift:446-447, 481-482, 515-516`). Stacking a gold card inside a dark feed card inside a dark screen creates visual mud. Premium apps use color sparingly — a single accent stripe or icon, not a nested tinted panel.
+- **Iconography is inconsistent.** Mix of `.fill` and line-weight SF Symbols (`trophy.fill` next to `heart` [non-fill]), no `symbolVariant` modifier applied at scope. Inconsistent weight reads as amateur.
+- **Empty states are generic.** `XomEmptyState` (`Xomfit/Views/Common/XomEmptyState.swift`) is a tray icon + two text blocks. No illustration, no personality, no motion. This is where apps either feel delightful or feel like prototypes.
+- **Skeleton loading is functional but lifeless.** `ShimmerModifier` shimmer is a simple gradient sweep (`Theme.swift:252-270`). No staggered reveal, no optimistic content. Whoop/Oura use silhouettes that match the shape of real content and fade-in at different rates.
+- **Floating tab bar has a double container.** `Rectangle` + `UnevenRoundedRectangle` stroke (`MainTabView.swift:100-113`) — the tab bar background extends to the screen edges but shows a top stroke only in a rounded shape. Reads as a leftover hack from iterating on designs.
+- **No consistent 1pt hairline system.** Dividers use `Theme.textSecondary.opacity(0.3)` (`FeedItemCard.swift:28-29`); glass borders use `Color.white.opacity(0.1)`. Two separate rules for the same visual concept.
+
+---
+
+## 2. Reference apps
+
+Pick 2–3 of these to study for 20 minutes each before committing to a direction.
+
+- **Strava** — the gold standard for social fitness feed. What to steal: clean card header (avatar + name + context line, no badges jammed in); generous whitespace between sections; map/graphic hero then stats row then action bar; kudos (like) uses a subtle fill + count, not a red heart.
+- **Hevy** — closest competitor by feature set (lifting tracker with social). What to steal: workout completion card with big volume number, exercise list as compact tinted pills, PR indicator is a single gold star, not a panel. Green accent used sparingly only for completion/active states.
+- **Whoop** — premium dark-theme fitness. What to steal: single near-black background, one elevated card tone (luminance only), hero metrics use a heavy rounded numeric, color used only for score rings. No drop shadows anywhere.
+- **Oura** — premium dark-theme with data density. What to steal: ring visualizations instead of bars; soft gradient fills on scores; typographic hierarchy where the number is 3x larger than the label and the label is uppercase small-caps.
+- **Fitbod** — strong information density without clutter. What to steal: muscle heatmap treatment; set/rep rows with high contrast; rest-timer animation that feels like a breath, not a countdown.
+- **Peloton** — emotional, celebratory states. What to steal: PR and milestone screens use a full-bleed color wash + big condensed type + confetti/particle motion, not a small gold panel.
+
+---
+
+## 3. Design language recommendations
+
+### Color palette
+
+Keep dark. Reduce hue variation between surfaces. Split the accent into role-specific tones so one color doesn't do four jobs.
+
+Existing token -> proposed (derived, not invented):
+
+| Role | Current | Proposed | Rationale |
+|---|---|---|---|
+| Background | `#0A0A0F` | `#0B0B0E` | Slight warm neutralization, removes the blue cast. |
+| Surface (card) | `#1A1A2E` | `#17171C` | Pure luminance lift from background — same hue family. Kills the indigo tint. |
+| Surface elevated (modal/sheet) | `#16213E` | `#1F1F26` | Higher luminance lift, still neutral. Deprecate `surfaceSecondary` as "nested container." |
+| Hairline (dividers/borders) | `rgba(255,255,255,0.1)` + `textSecondary*0.3` | unified `rgba(255,255,255,0.08)` | One rule for all hairlines. |
+| Text primary | `#FFFFFF` | `#F5F5F7` | Pure white on dark creates shimmer/fatigue. Apple's off-white is calmer. |
+| Text secondary | `#9CA3AF` | `#9A9AA3` | Neutral grey, not blue-grey. Matches the surface hue shift. |
+| Text tertiary (new) | — | `#6B6B72` | For timestamps, metadata that should recede. |
+| Accent (hero/CTA) | `#33FF66` | `#2FE562` | Slightly desaturated so it doesn't scream. Reserve for primary actions only. |
+| Accent muted (utility) | (none) | `#2FE562` @ 18% fill / 60% text | Use this for icon tints, selected tab labels, non-CTA accents. |
+| Energy (success) | `#00C46A` | merge with accent | You don't need two greens. |
+| PR gold | `#FFD700` | `#F5C84B` | Current gold is full-saturation and reads as cheap. The muted warm gold reads premium (Whoop/Oura trophy tone). |
+| Milestone purple | `#AA66FF` | `#9B7BFF` | Slightly cooler/softer. |
+| Streak orange | `#FF6633` | `#FF7A45` | Warmer, less aggressive. |
+| Alert | `#FF6B35` | `#FF8A4C` | Less clown-orange. |
+| Destructive | `#FF4444` | `#FF5E5E` | Less urgent-red, more considered-red. |
+
+**Rule:** Only ONE colored panel on screen at a time. PR/Milestone/Streak content blocks should lose their tinted backgrounds and instead use a 3px leading color stripe + tinted icon. Reference: Linear's issue rows.
+
+### Typography
+
+SF Pro is fine for UI. Add SF Pro Rounded for hero metrics and numeric displays — pairs with the fitness/friendly tone without looking like a kids' app. Use monospaced digits everywhere numbers animate (rest timer, volume counter).
+
+| Token | Current | Proposed |
+|---|---|---|
+| Display (hero number) | `largeTitle.weight(.black).width(.condensed)` | `.system(size: 44, weight: .heavy, design: .rounded).monospacedDigit()` |
+| Large title | `largeTitle.bold` | keep, but add `.rounded` on number-heavy headers |
+| Title | `title.bold` | keep |
+| Headline | `title3.semibold` | keep |
+| Metric label (new) | — | `.caption.weight(.semibold)` + `.textCase(.uppercase)` + `.kerning(0.5)` |
+| Body | `.body` | keep |
+| Caption | `.caption` | keep |
+| Small (badge) | `.caption2.medium` | `.caption2.semibold.monospacedDigit()` when numeric |
+
+**Rule:** Every metric on screen follows the pattern `BIG NUMBER / small uppercase label` (Whoop/Oura style). The current stat columns have the number only one size larger than the label — not a hierarchy.
+
+### Spacing + radius
+
+Existing 8pt grid is correct (`Theme.Spacing`). Keep it. Add:
+
+- `Spacing.hairline: CGFloat = 0.5` — for the unified 0.5px border.
+- `Spacing.section: CGFloat = 40` — between major vertical sections on a scroll view (profile header -> tab picker, etc.). Current profile header pads md (16) top/bottom, feels cramped.
+
+Radius tokens — add a scale instead of just two:
+
+| Token | Value | Use |
+|---|---|---|
+| `radius.xs` | 6 | Inline chips, pills, small badges |
+| `radius.sm` | 10 | Buttons, small cards (current `cornerRadiusSmall`) |
+| `radius.md` | 16 | Cards (current `cornerRadius`) |
+| `radius.lg` | 22 | Sheets, modals |
+| `radius.xl` | 28 | Full-bleed hero cards (PR announcement, workout complete) |
+
+### Elevation / card treatment
+
+Kill drop shadows. They do not work on near-black backgrounds and the current 4px/15% opacity shadow is invisible anyway. Replace with:
+
+- **Base card:** `fill(surface)` + `strokeBorder(Color.white.opacity(0.06), lineWidth: 0.5)` — the hairline is the elevation.
+- **Elevated card (sheet/modal):** `fill(surfaceElevated)` + hairline, same as above.
+- **Hero card (PR celebration, workout complete):** background uses `LinearGradient` from `accent.opacity(0.12)` to `accent.opacity(0)` top-to-bottom, + hairline. Color gradient = elevation.
+- **Pressed state:** scale 0.98 (not 0.94 — too much) + background lifts to `white.opacity(0.04)` overlay.
+
+Reference: Whoop cards have no shadow, just a 1px hairline at ~6% white. Instantly reads premium.
+
+### Iconography
+
+SF Symbols, lock to one variant per context.
+
+- **Tab bar, nav bar:** `symbolVariant(.fill)` when selected, line when unselected. Current tab bar does this well already (`MainTabView.swift:83-85`). Apply same rule to feed action bar.
+- **Feed action bar:** lock to non-fill line icons (`heart`, `bubble.right`, `square.and.arrow.up`, `bookmark`) until pressed — consistent line weight. On like, swap to `heart.fill` + accent tint + haptic.
+- **Activity badges:** use `.fill` consistently; current mixes `figure.strengthtraining.traditional` (not fill) with `trophy.fill`. Pick a lane.
+- **Icon weight:** set a global `.font(.system(size: X, weight: .medium))` for all utility icons. Stop shipping default weight.
+- **Add a brand mark.** One custom SVG/rasterized mascot or wordmark in nav bar. Pure SF Symbols everywhere = generic.
+
+---
+
+## 4. Component polish targets, prioritized
+
+Ranked by visual-impact-per-hour. Do top 3 before anything else.
+
+1. **FeedItemCard** — S/M. File: `Xomfit/Views/Feed/FeedItemCard.swift`. This is the hero component. Weak: cluttered header, tinted content panels, soft shadow. Do: remove drop shadow, add hairline border, move activity badge out of header into a subtle label under the name, strip tinted backgrounds from PR/Milestone/Streak inner cards and replace with leading color stripe + tinted icon only. Upsize PR value to display-class typography (`44pt heavy rounded`). Effort: M.
+2. **Theme.swift color + typography tokens** — S. File: `Xomfit/Utils/Theme.swift`. Do: update hex values per §3 table, add `textTertiary`, add rounded-numeric display font, add metric-label helper that applies uppercase + kerning. No UI code change required beyond hex swaps — immediate wholesale lift. Effort: S.
+3. **ProfileHeaderView** — M. File: `Xomfit/Views/Profile/ProfileHeaderView.swift`. Weak: stats use `.headline` (too small), avatar is a small gradient circle, action button is small and generic. Do: upsize stat numbers to `.title.rounded.monospacedDigit`, upsize avatar to 88pt with a thin 2pt accent ring only when PR-streak-active, make name a proper `.title2.bold`, move username under name with `textTertiary`. Effort: M.
+4. **FloatingTabBar** — S. File: `Xomfit/Views/MainTabView.swift:63-115`. Weak: double-container, rectangle+UnevenRoundedRectangle hack. Do: single `.ultraThinMaterial` background with a top hairline, 28pt radius top only, proper safe-area handling. iOS 18 glass material is free polish. Effort: S.
+5. **Stat/metric row (XomStat)** — S. File: `Xomfit/Views/Common/XomStat.swift`. Weak: equal weight between number and label. Do: make number 2.5x size of label, label uppercase + kerning, monospaced digits, optional trend indicator (up/down arrow). Effort: S.
+6. **ActiveWorkoutView + RestTimerView** — M. Weak: timer is a countdown, not an experience. Do: circular progress ring (conic gradient), breathing animation on the time number, haptic at 5-4-3-2-1, `.ultraThinMaterial` background so the timer feels overlaid. Effort: M.
+7. **Empty states (XomEmptyState)** — M. File: `Xomfit/Views/Common/XomEmptyState.swift`. Weak: lifeless SF Symbol + text. Do: commission or assemble SF-Symbol-composed illustrations (stack 2-3 symbols with offsets and tint variations), add subtle breathing loop, context-specific copy. Effort: M.
+8. **Button styles (XomButton, AccentButtonStyle)** — S. Files: `Xomfit/Views/Common/XomButton.swift`, `Xomfit/Utils/Theme.swift:307-325`. Weak: colored shadow reads juvenile. Do: remove shadow entirely, reduce press scale to 0.98, add subtle highlight gradient top-to-bottom for depth, keep haptic. Effort: S.
+9. **Skeleton loaders** — M. Files: `Xomfit/Utils/Theme.swift:252-284`. Weak: shimmer is generic. Do: make skeletons mirror the real layout (avatar circle, two lines, stat row) instead of rectangles, add slight stagger. Effort: M.
+10. **Exercise picker + set row** — M. Weak: dense spreadsheet feel on ActiveWorkoutView. Do: chunky tap targets, left-edge PR star accent, weight/reps in monospaced rounded. Effort: M.
+11. **PR celebration** — L. Promote to a full-screen takeover when a PR is hit mid-workout: full-bleed gradient, confetti (particle view), big number animates in with spring, rank-up haptic fires. Currently buried in a feed card after the fact. Effort: L but huge wow.
+12. **Feed filter bar** — S. File: `Xomfit/Views/Feed/FeedFilterBar.swift`. Likely chips. Do: convert to scrollable segmented pills, accent-fill when active, not accent outline. Effort: S.
+
+---
+
+## 5. Motion + micro-interactions
+
+Five animations worth the effort. All use existing animation tokens in `Theme.swift:83-94`.
+
+1. **Like button bounce + heart burst.** Currently scales to 1.3 on tap (`FeedItemCard.swift:198-207`). Upgrade: on first-tap from unliked, fire a small particle burst (5-8 small hearts fading up + out over 0.6s), scale main heart 1.0 → 1.35 → 1.0 using `xomCelebration`, `sensoryFeedback(.impact(.soft))`. Reference: Instagram double-tap.
+2. **Rest timer completion flourish.** When timer hits 0: ring fills fully, whole view briefly brightens with a `accent.opacity(0.15)` overlay that fades in 0.2s / out 0.4s, `Haptics.workoutComplete` fires, number animates to "GO" with `.spring(response: 0.35, dampingFraction: 0.55)`. Currently undersold.
+3. **Tab switch transition.** Currently opacity crossfade (`MainTabView.swift:18`). Upgrade: combine opacity with 8pt vertical offset using `.spring(response: 0.4, dampingFraction: 0.82)`. More substance without adding latency.
+4. **Stat number count-up on profile/stats screen.** When stat rows appear, animate numbers from 0 to real value using `withAnimation(.easeOut(duration: 0.8))` and a `@State` intermediate value. Uses monospaced digits so width doesn't jitter. Pairs with `Haptics.selection()` at the end.
+5. **PR hero card parallax.** On feed PR cards: subtle tilt/parallax responding to device motion (CoreMotion, +/- 3 degrees), gold gradient shifts slightly. Understated — reference Apple Wallet card tilt. Feels expensive.
+
+Spring parameters to standardize:
+
+- **Interactive press:** `.spring(response: 0.2, dampingFraction: 0.85)` (current `xomSnappy` is close)
+- **Stat/card appearance:** `.spring(response: 0.4, dampingFraction: 0.82)`
+- **Celebration:** `.spring(response: 0.35, dampingFraction: 0.55)` (current `xomCelebration` uses 0.3/0.5 — slightly bouncier; keep)
+
+---
+
+## 6. Empty + loading + error states
+
+**Current — empty states:** Generic SF Symbol + title + subtitle + optional CTA (`XomEmptyState.swift`). Used consistently (good) but feels like a placeholder.
+
+**Polish recommendations:**
+
+- **Feed empty (no friends/posts yet):** illustration of 3 overlapping SF Symbols (`dumbbell`, `figure.run`, `trophy`) with accent tint at low opacity, floating gently (2s ease-in-out loop, 3pt offset). Copy: "Your feed is quiet. Add friends to see their workouts." CTA: primary button "Find friends."
+- **Workout empty (no exercises added):** ghost silhouette of an ExerciseCard with shimmer, label "Add your first exercise" + arrow pointing to the floating Add button. Onboarding in context.
+- **Calendar empty (profile):** faded calendar grid, "Your workout days will appear here" copy, optional primary CTA "Start a workout."
+- **PR list empty:** trophy silhouette at 30% opacity with a subtle gold glow, "No PRs yet" + "Hit a personal best in any lift to see it here."
+
+**Current — loading:** `ShimmerModifier` + `SkeletonCard` rectangles. Functional but generic.
+
+**Polish:**
+
+- Skeletons that match real card anatomy: avatar circle, title line, subtitle line, stat row (3 small rects), action bar. 0.05s stagger between cards. Same approach as LinkedIn/Twitter.
+- Replace `ShimmerModifier`'s linear gradient sweep with a softer radial highlight that moves diagonally — less "loading bar" feel.
+- Full-screen spinners: use `XomFitLoader` (already exists at `Xomfit/Views/Common/XomFitLoader.swift` — verify it's polished; if not, a pulsing dumbbell or circular ring works).
+
+**Current — errors:** `errorView(message:)` in `FeedView.swift` (not inspected in detail). Assume generic.
+
+**Polish:**
+
+- Error state uses `XomEmptyState` style with a warning icon (`exclamationmark.triangle` in `.alert` tone at 40% opacity), concise error copy, retry CTA. Don't show stack traces or raw messages to the user — map known errors to friendly copy, fallback to "Something went wrong. Try again."
+- Add a toast pattern (already exists: `Xomfit/Views/Common/ToastView.swift`) for transient failures: top-of-screen pill, auto-dismisses in 3s. Less disruptive than a full error screen.
+
+---
+
+## 7. Top 10 concrete, high-impact polish moves
+
+Pick any of these and ship it in a single PR. Each is one file or tight cluster.
+
+1. **Swap surface hex values** in `Xomfit/Utils/Theme.swift` to the neutral palette (background `#0B0B0E`, surface `#17171C`, surfaceSecondary `#1F1F26`, text `#F5F5F7`). Nothing else changes. Whole app will look less amateur immediately.
+2. **Remove feed card drop shadow** at `Xomfit/Views/Feed/FeedItemCard.swift:37`, add a 0.5pt `strokeBorder(Color.white.opacity(0.06))`. Instant premium upgrade.
+3. **Kill tinted backgrounds in PR/Milestone/Streak inner cards** (`FeedItemCard.swift:446-516`). Replace with a 3pt leading color stripe + tinted icon. One colored element per card.
+4. **Upsize PR value typography** at `FeedItemCard.swift:429` to `.system(size: 36, weight: .heavy, design: .rounded).monospacedDigit()`. Celebrate the number.
+5. **Unify icon variant** in `FeedItemCard.swift` action bar — all line icons until active state. Apply `.font(.system(size: 18, weight: .medium))` at the bar level.
+6. **Redesign ProfileHeaderView stat columns** at `Xomfit/Views/Profile/ProfileHeaderView.swift:116-131`. Numbers `.title.rounded.monospacedDigit()`, labels uppercase+kerned `.caption2.weight(.semibold)`.
+7. **Replace FloatingTabBar background** at `Xomfit/Views/MainTabView.swift:100-113` with `.ultraThinMaterial` + single top-rounded mask + 0.5pt top hairline. Cleaner, more iOS 18.
+8. **Remove accent-colored shadow from AccentButtonStyle** at `Xomfit/Utils/Theme.swift:316-321`, reduce press scale to 0.98.
+9. **Polish RestTimerView** — wrap the countdown in a conic-gradient progress ring, add breathing scale on the number (0.98 ↔ 1.02 over 1s), fire haptic at last 3 seconds.
+10. **Upgrade XomEmptyState** at `Xomfit/Views/Common/XomEmptyState.swift` to support a stacked-symbol illustration (2-3 SF Symbols offset + tinted) and a gentle floating loop. One shared component, used everywhere.
+
+---
+
+## Appendix — Files inspected
+
+- `Xomfit/Utils/Theme.swift` (full)
+- `Xomfit/Views/Feed/FeedItemCard.swift` (full)
+- `Xomfit/Views/Profile/ProfileView.swift` (full)
+- `Xomfit/Views/Profile/ProfileHeaderView.swift` (full)
+- `Xomfit/Views/Workout/ActiveWorkoutView.swift` (first 100)
+- `Xomfit/Views/MainTabView.swift` (full)
+- `Xomfit/Views/Feed/FeedView.swift` (first 80)
+- `Xomfit/Views/Common/XomAvatar.swift`, `XomStat.swift`, `XomCard.swift`, `XomButton.swift`, `XomEmptyState.swift` (full)
+- `.claude/rules/ios.md`
+
+Design rules file (`.claude/rules/*design*`): none exist — opportunity to add one after this direction lands.


### PR DESCRIPTION
## Summary
- Complete visual overhaul of XomFit across 6 phases (tokens → chrome → feed → profile → workout → tail surfaces + motion). Lane B (Whoop/Oura premium dark) with Lane A (Strava/Hevy data density) on data-heavy views.
- Profile feed tab now renders feed_items (matches Timeline) instead of workouts.
- Fixed orphan feed items: `WorkoutService.saveWorkout` now returns Bool; feed post is skipped when the Supabase workout insert fails.

## Phases (all merged locally, single PR)
- **P1 Foundation** — new `Theme.swift` palette (neutral near-black ramp), SF Pro Rounded hero numerics, 5-step radius scale, hairline elevation. New primitives: `XomBadge`, `XomDivider`, `XomMetricLabel`, `Theme+Elevation.swift`.
- **P2 Chrome** — `.ultraThinMaterial` tab bar, toolbar polish, `XomToolbarTitle`, `XomErrorState`, shimmer.
- **P3 Social** — `FeedItemCard` rebuild (hairlines, color stripe for PR/Milestone/Streak, hero numbers), `ActivityStripeCard`, `PhotoZoomView` (pinch + swipe-to-dismiss).
- **P4 Profile** — redesigned header, tab picker, stats/calendar/feed tabs with data-dense polish.
- **P5 Active Workout** — `RestTimerRingView`, legibility pass on `SetRowView`, `ExercisePickerView`.
- **P6 Tail + Motion** — Friends, Leaderboard, Progress, PRs, Settings, Auth, Onboarding. Motion layer: `CountUpNumber`, `ParticleBurstView`, tab transition spring, like-burst, rest flourish.

## Constraints honored
- No changes to `Models/`, `Services/`, `ViewModels/` (except the profile orphan fix in `SyncManager`/`WorkoutService`/`WorkoutLoggerViewModel`).
- MVVM boundary intact, iOS 17+, no new dependencies.
- Brand assets `XomFitLogo` / `XomFitBanner` integrated in chrome + onboarding.
- Likes stay red (`Theme.destructive`). `surfaceSecondary` kept as alias through P6.

## Test plan
- [ ] Feed tab: posts render with new card design, PR/Milestone/Streak color stripes, like-burst on first like.
- [ ] Profile: all of your timeline posts appear (not just 1); tab picker feels anchored, not cramped.
- [ ] Active workout: start a workout, log sets, rest timer ring flourishes at 0, finish → exactly one feed post created.
- [ ] Photos: tap a photo in a feed post → opens PhotoZoomView; pinch-zoom + swipe-to-dismiss work.
- [ ] Progress tab: CountUpNumber stats animate on appear.
- [ ] Empty/loading/error states: Friends, Notifications, PRs — all use new primitives.
- [ ] Large Dynamic Type: no truncation on key surfaces.

Docs: `docs/features/design-polish/{RESEARCH,PLAN,EXECUTION_LOG}.md`.