### PR TITLE
Fix post-polish bugs: profile counts, exercise display, rest timer

### DIFF
--- a/Xomfit/ViewModels/ProfileViewModel.swift
+++ b/Xomfit/ViewModels/ProfileViewModel.swift
@@ -188,7 +188,6 @@ final class ProfileViewModel {
         workouts = fetchedWorkouts
         totalWorkouts = fetchedWorkouts.count
         totalVolume = fetchedWorkouts.reduce(0) { $0 + $1.totalVolume }
-        feedItemCount = fetchedWorkouts.count
         loadCalendarData(workouts: fetchedWorkouts)
         computeMuscleGroupSets(workouts: fetchedWorkouts)
 

--- a/Xomfit/Views/Feed/FeedDetailView.swift
+++ b/Xomfit/Views/Feed/FeedDetailView.swift
@@ -161,12 +161,23 @@ struct FeedDetailView: View {
                     Spacer()
                 }
                 .padding(.vertical, Theme.Spacing.md)
-            } else if let workout = fetchedWorkout {
+            } else if let workout = fetchedWorkout, !workout.exercises.isEmpty {
                 ForEach(Array(workout.exercises.enumerated()), id: \.element.id) { index, exercise in
                     realExerciseCard(exercise: exercise, index: index + 1)
                 }
+
+                // If DB has fewer exercises than the feed snapshot, show the missing
+                // ones as summary rows (handles partial-save data).
+                if let activity = localItem.workoutActivity,
+                   activity.exercises.count > workout.exercises.count {
+                    let dbNames = Set(workout.exercises.map { $0.exercise.name.lowercased() })
+                    let missing = activity.exercises.filter { !dbNames.contains($0.name.lowercased()) }
+                    ForEach(missing) { exercise in
+                        fallbackExerciseRow(exercise: exercise)
+                    }
+                }
             } else if let activity = localItem.workoutActivity {
-                // Fallback to summary data if fetch failed
+                // Fallback to summary data if fetch failed or workout has no exercises
                 ForEach(activity.exercises) { exercise in
                     fallbackExerciseRow(exercise: exercise)
                 }
@@ -175,46 +186,33 @@ struct FeedDetailView: View {
     }
 
     private func realExerciseCard(exercise: WorkoutExercise, index: Int) -> some View {
-        VStack(alignment: .leading, spacing: 0) {
+        let totalVolume = exercise.sets.reduce(0.0) { $0 + ($1.weight * Double($1.reps)) }
+
+        return VStack(alignment: .leading, spacing: 0) {
             DisclosureGroup {
-                VStack(alignment: .leading, spacing: 0) {
-                    HStack(spacing: 0) {
-                        Text("SET")
-                            .frame(width: 36, alignment: .leading)
-                        Text("WEIGHT")
-                            .frame(maxWidth: .infinity, alignment: .trailing)
-                        Text("REPS")
-                            .frame(width: 50, alignment: .trailing)
-                    }
-                    .font(.caption2.weight(.semibold))
-                    .foregroundStyle(Theme.textSecondary)
-                    .padding(.top, Theme.Spacing.sm)
-
+                VStack(alignment: .leading, spacing: 6) {
                     ForEach(Array(exercise.sets.enumerated()), id: \.element.id) { setIndex, workoutSet in
-                        HStack(spacing: 0) {
+                        HStack(spacing: Theme.Spacing.sm) {
                             Text("\(setIndex + 1)")
-                                .frame(width: 36, alignment: .leading)
+                                .font(.caption.weight(.semibold).monospaced())
                                 .foregroundStyle(Theme.textSecondary)
+                                .frame(width: 20, alignment: .leading)
 
-                            Text("\(workoutSet.weight.formattedWeight) lbs")
-                                .frame(maxWidth: .infinity, alignment: .trailing)
-                                .foregroundStyle(Theme.textPrimary)
-
-                            Text("\(workoutSet.reps)")
-                                .frame(width: 50, alignment: .trailing)
+                            Text("\(workoutSet.reps) × \(workoutSet.weight.formattedWeight)lb")
+                                .font(.subheadline.weight(.semibold).monospaced())
                                 .foregroundStyle(Theme.textPrimary)
 
                             if workoutSet.isPersonalRecord {
                                 Image(systemName: "trophy.fill")
                                     .font(.caption2)
                                     .foregroundStyle(Theme.prGold)
-                                    .padding(.leading, 6)
                             }
+
+                            Spacer()
                         }
-                        .font(.subheadline.weight(.medium).monospaced())
-                        .padding(.vertical, 4)
                     }
                 }
+                .padding(.top, Theme.Spacing.sm)
             } label: {
                 HStack(spacing: Theme.Spacing.sm) {
                     Text("\(index)")
@@ -224,15 +222,18 @@ struct FeedDetailView: View {
                         .background(Theme.accent.opacity(0.12))
                         .clipShape(.rect(cornerRadius: 6))
 
-                    Text(exercise.exercise.name)
-                        .font(.subheadline.weight(.bold))
-                        .foregroundStyle(Theme.textPrimary)
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(exercise.exercise.name)
+                            .font(.subheadline.weight(.bold))
+                            .foregroundStyle(Theme.textPrimary)
+                            .lineLimit(1)
+
+                        Text("\(exercise.sets.count) set\(exercise.sets.count == 1 ? "" : "s") · \(formatVolume(totalVolume))")
+                            .font(Theme.fontCaption)
+                            .foregroundStyle(Theme.textSecondary)
+                    }
 
                     Spacer()
-
-                    Text("\(exercise.sets.count) sets")
-                        .font(Theme.fontCaption)
-                        .foregroundStyle(Theme.textSecondary)
 
                     if exercise.sets.contains(where: { $0.isPersonalRecord }) {
                         HStack(spacing: 3) {

--- a/Xomfit/Views/Profile/ProfileHeaderView.swift
+++ b/Xomfit/Views/Profile/ProfileHeaderView.swift
@@ -20,42 +20,44 @@ struct ProfileHeaderView: View {
     var body: some View {
         VStack(spacing: Theme.Spacing.md) {
             // Top row: avatar + stats
-            HStack(alignment: .center, spacing: Theme.Spacing.lg) {
-                XomAvatar(name: displayName.isEmpty ? username : displayName, size: 96)
+            HStack(alignment: .center, spacing: Theme.Spacing.md) {
+                XomAvatar(name: displayName.isEmpty ? username : displayName, size: 72)
                     .accessibilityLabel("Profile avatar")
 
-                Spacer()
-
-                statColumn(value: feedItemCount, label: "Posts") {
-                    onStatTapped(.feed)
-                }
-                NavigationLink {
-                    FriendsListView(
-                        friends: friends,
-                        friendProfiles: friendProfiles,
-                        currentUserId: currentUserId
-                    )
-                    .hideTabBar()
-                } label: {
-                    VStack(spacing: 2) {
-                        Text("\(friendCount)")
-                            .font(Theme.fontNumberLarge)
-                            .foregroundStyle(Theme.textPrimary)
-                        XomMetricLabel("Friends")
+                HStack(spacing: Theme.Spacing.sm) {
+                    statColumn(value: feedItemCount, label: "Posts") {
+                        onStatTapped(.feed)
                     }
-                    .frame(minWidth: 44, minHeight: 44)
-                }
-                .buttonStyle(.plain)
-                .accessibilityLabel("\(friendCount) Friends")
-                .accessibilityAddTraits(.isButton)
+                    NavigationLink {
+                        FriendsListView(
+                            friends: friends,
+                            friendProfiles: friendProfiles,
+                            currentUserId: currentUserId
+                        )
+                        .hideTabBar()
+                    } label: {
+                        VStack(spacing: 2) {
+                            Text("\(friendCount)")
+                                .font(Theme.fontNumberLarge)
+                                .foregroundStyle(Theme.textPrimary)
+                                .lineLimit(1)
+                                .minimumScaleFactor(0.6)
+                            XomMetricLabel("Friends")
+                                .lineLimit(1)
+                                .minimumScaleFactor(0.7)
+                        }
+                        .frame(maxWidth: .infinity, minHeight: 44)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("\(friendCount) Friends")
+                    .accessibilityAddTraits(.isButton)
 
-                statColumn(value: prCount, label: "PRs") {
-                    onStatTapped(.stats)
+                    statColumn(value: prCount, label: "PRs") {
+                        onStatTapped(.stats)
+                    }
                 }
-
-                Spacer()
+                .frame(maxWidth: .infinity)
             }
-            .padding(.horizontal, Theme.Spacing.sm)
 
             // Name + username + bio
             VStack(alignment: .leading, spacing: 4) {
@@ -101,9 +103,13 @@ struct ProfileHeaderView: View {
                 Text("\(value)")
                     .font(Theme.fontNumberLarge)
                     .foregroundStyle(Theme.textPrimary)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.6)
                 XomMetricLabel(label)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.7)
             }
-            .frame(minWidth: 44, minHeight: 44)
+            .frame(maxWidth: .infinity, minHeight: 44)
         }
         .buttonStyle(.plain)
         .accessibilityLabel("\(value) \(label)")

--- a/Xomfit/Views/Workout/ActiveWorkoutView.swift
+++ b/Xomfit/Views/Workout/ActiveWorkoutView.swift
@@ -31,8 +31,10 @@ struct ActiveWorkoutView: View {
                     // Header bar
                     headerBar
 
-                    // Rest timer config
-                    restTimerConfig
+                    // Rest timer config — hidden when rest timer is running (redundant with the active card)
+                    if !viewModel.isRestTimerActive && !viewModel.focusMode {
+                        restTimerConfig
+                    }
 
                     if viewModel.focusMode {
                         // Focus mode — large gym-floor view
@@ -265,16 +267,43 @@ struct ActiveWorkoutView: View {
 
             Spacer()
 
-            // Timer — fontNumberLarge monospaced + metric label
-            VStack(spacing: 1) {
-                Text(viewModel.workoutName)
-                    .font(.subheadline.weight(.bold))
-                    .foregroundStyle(Theme.textPrimary)
-                    .lineLimit(1)
-                Text(viewModel.durationString)
-                    .font(Theme.fontNumberMedium)
+            // Timer cluster — total time prominent + rest timer chip so both stay visible
+            // around the Dynamic Island. Name is secondary (can be hidden by island).
+            VStack(spacing: 2) {
+                HStack(spacing: 6) {
+                    HStack(spacing: 3) {
+                        Image(systemName: "clock.fill")
+                            .font(.caption2)
+                        Text(viewModel.durationString)
+                            .font(Theme.fontNumberMedium)
+                    }
                     .foregroundStyle(Theme.accent)
+
+                    if viewModel.isRestTimerActive {
+                        let isOvertime = viewModel.restTimeRemaining <= 0
+                        HStack(spacing: 3) {
+                            Image(systemName: "timer")
+                                .font(.caption2)
+                            Text(headerRestString)
+                                .font(Theme.fontNumberMedium)
+                        }
+                        .foregroundStyle(isOvertime ? Theme.destructive : Theme.textPrimary)
+                        .padding(.horizontal, 7)
+                        .padding(.vertical, 2)
+                        .background(
+                            Capsule()
+                                .fill((isOvertime ? Theme.destructive : Theme.accent).opacity(0.15))
+                        )
+                        .transition(.scale.combined(with: .opacity))
+                    }
+                }
+
+                Text(viewModel.workoutName)
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(Theme.textTertiary)
+                    .lineLimit(1)
             }
+            .animation(.xomChill, value: viewModel.isRestTimerActive)
 
             Spacer()
 
@@ -332,8 +361,19 @@ struct ActiveWorkoutView: View {
             .disabled(viewModel.isSaving)
         }
         .padding(.horizontal, Theme.Spacing.md)
-        .padding(.vertical, Theme.Spacing.md)
+        .padding(.top, Theme.Spacing.sm)
+        .padding(.bottom, Theme.Spacing.md)
         .background(Theme.surface)
+    }
+
+    /// Compact rest countdown string for the header chip (matches RestTimerView format).
+    private var headerRestString: String {
+        let remaining = viewModel.restTimeRemaining
+        let total = Int(abs(remaining))
+        let mins = total / 60
+        let secs = total % 60
+        let prefix = remaining < 0 ? "-" : ""
+        return prefix + String(format: "%d:%02d", mins, secs)
     }
 
     // MARK: - Rest Timer Config

--- a/Xomfit/Views/Workout/RestTimerView.swift
+++ b/Xomfit/Views/Workout/RestTimerView.swift
@@ -46,14 +46,18 @@ struct RestTimerView: View {
                 RestTimerRingView(progress: progress, color: ringColor, lineWidth: 5)
 
                 Text(timeString)
-                    .font(Theme.fontDisplay)
+                    .font(.system(size: 22, weight: .heavy, design: .rounded))
+                    .monospacedDigit()
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.5)
+                    .allowsTightening(true)
                     .foregroundStyle(isOvertime ? Theme.destructive : Theme.textPrimary)
                     .scaleEffect(breatheScale)
                     .animation(
                         .easeInOut(duration: 1.0).repeatForever(autoreverses: true),
                         value: breatheScale
                     )
-                    .monospacedDigit()
+                    .padding(.horizontal, 6)
             }
             .frame(width: 80, height: 80)
             .accessibilityElement(children: .ignore)


### PR DESCRIPTION
## Summary
- Profile header "Posts" count now matches the feed tab (removed stale workouts-count overwrite).
- Profile stats row: 72pt avatar + equal-width columns so "Friends" no longer wraps.
- Exercise rows in FeedDetail: show sets + total volume; expanded view uses compact `reps × weight` format; partial saves fall back to feed-payload rows.
- Rest timer ring: scaled countdown so `0:00` fits without truncating to `0…`.
- Active workout header: total time on top with an inline rest timer chip; Dynamic Island now only covers the dispensable workout name, not the live timers.
- Hide redundant Rest Timer config pill while rest is running.

## Test plan
- [ ] Profile shows matching Posts count between header and feed tab
- [ ] Stats row renders on one line (Posts / Friends / PRs)
- [ ] Feed post detail: exercise label shows `N sets · volume`, expanded rows read `R × Wlb`
- [ ] Start a workout with music playing (Dynamic Island expanded) — duration + rest timer both visible in header
- [ ] Rest timer ring shows full `0:00` / `-1:23` without truncation