### PR TITLE
#238 workout bugs: focus picker, overtime color, island padding, VM hoist

### DIFF
--- a/Xomfit/Models/XomfitWidgetAttributes.swift
+++ b/Xomfit/Models/XomfitWidgetAttributes.swift
@@ -19,6 +19,7 @@ struct XomfitWidgetAttributes: ActivityAttributes {
         var isResting: Bool = false
         var restTimeRemaining: Int = 0
         var restEndDate: Date? = nil
+        var isOvertime: Bool = false
     }
 
     var workoutName: String

--- a/Xomfit/ViewModels/WorkoutLoggerViewModel.swift
+++ b/Xomfit/ViewModels/WorkoutLoggerViewModel.swift
@@ -586,6 +586,8 @@ final class WorkoutLoggerViewModel {
             ? Date().addingTimeInterval(restTimeRemaining)
             : nil
 
+        let overtime = isRestTimerActive && restTimeRemaining <= 0
+
         let state = XomfitWidgetAttributes.ContentState(
             elapsedSeconds: Int(Date().timeIntervalSince(startTime)),
             completedSets: completedSets,
@@ -594,7 +596,8 @@ final class WorkoutLoggerViewModel {
             totalExercises: exercises.count,
             isResting: isRestTimerActive,
             restTimeRemaining: Int(self.restTimeRemaining),
-            restEndDate: restEnd
+            restEndDate: restEnd,
+            isOvertime: overtime
         )
 
         Task {

--- a/Xomfit/ViewModels/WorkoutLoggerViewModel.swift
+++ b/Xomfit/ViewModels/WorkoutLoggerViewModel.swift
@@ -14,6 +14,7 @@ final class WorkoutLoggerViewModel {
     var exercises: [WorkoutExercise] = []
     var startTime = Date()
     var isActive = false
+    var isPresented: Bool = false
     var isSaving = false
     var errorMessage: String?
     var location: String = ""
@@ -150,6 +151,7 @@ final class WorkoutLoggerViewModel {
         workoutName = ""
         exercises = []
         isActive = false
+        isPresented = false
         isSaving = false
         errorMessage = nil
         newPR = nil

--- a/Xomfit/Views/MainTabView.swift
+++ b/Xomfit/Views/MainTabView.swift
@@ -1,10 +1,18 @@
 import SwiftUI
 
 struct MainTabView: View {
+    @Environment(AuthService.self) private var authService
+    @Environment(WorkoutLoggerViewModel.self) private var workoutSession
+
     @State private var selectedTab = 0
     @State private var tabBarVisible = true
+    @State private var tickId = UUID()
+
+    private let resumeTimer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
 
     var body: some View {
+        @Bindable var workoutSession = workoutSession
+
         ZStack {
             Group {
                 switch selectedTab {
@@ -24,10 +32,38 @@ struct MainTabView: View {
             .animation(.spring(response: 0.4, dampingFraction: 0.82), value: selectedTab)
         }
         .safeAreaInset(edge: .bottom) {
-            if tabBarVisible {
-                FloatingTabBar(selectedTab: $selectedTab)
+            VStack(spacing: Theme.Spacing.sm) {
+                if workoutSession.isActive && !workoutSession.isPresented {
+                    WorkoutResumeBar(
+                        workoutName: workoutSession.workoutName,
+                        durationString: workoutSession.durationString,
+                        tickId: tickId,
+                        onTap: {
+                            withAnimation(.spring(response: 0.35, dampingFraction: 0.82)) {
+                                workoutSession.isPresented = true
+                            }
+                        }
+                    )
                     .transition(.move(edge: .bottom).combined(with: .opacity))
+                }
+
+                if tabBarVisible {
+                    FloatingTabBar(selectedTab: $selectedTab)
+                        .transition(.move(edge: .bottom).combined(with: .opacity))
+                }
             }
+            .animation(.spring(response: 0.4, dampingFraction: 0.82), value: workoutSession.isActive)
+            .animation(.spring(response: 0.4, dampingFraction: 0.82), value: workoutSession.isPresented)
+        }
+        .onReceive(resumeTimer) { _ in
+            if workoutSession.isActive && !workoutSession.isPresented {
+                tickId = UUID()
+            }
+        }
+        .fullScreenCover(isPresented: $workoutSession.isPresented) {
+            ActiveWorkoutView()
+                .environment(authService)
+                .environment(workoutSession)
         }
         .environment(\.tabBarVisible, $tabBarVisible)
     }
@@ -60,6 +96,67 @@ struct HideTabBar: ViewModifier {
 extension View {
     func hideTabBar() -> some View {
         modifier(HideTabBar())
+    }
+}
+
+// MARK: - Workout Resume Bar
+
+/// Compact "Workout in progress" pill shown above the tab bar when a workout is active
+/// but the active workout cover is dismissed. Tap to re-present the cover.
+private struct WorkoutResumeBar: View {
+    let workoutName: String
+    let durationString: String
+    /// Drives re-render of the duration string every second. Owner updates this.
+    let tickId: UUID
+    let onTap: () -> Void
+
+    var body: some View {
+        Button {
+            Haptics.light()
+            onTap()
+        } label: {
+            HStack(spacing: Theme.Spacing.sm) {
+                Image(systemName: "dumbbell.fill")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(Theme.accent)
+                    .frame(width: 28, height: 28)
+                    .background(Theme.accent.opacity(0.15))
+                    .clipShape(Circle())
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(workoutName.isEmpty ? "Workout" : workoutName)
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(Theme.textPrimary)
+                        .lineLimit(1)
+                    Text(durationString)
+                        .font(.caption.weight(.medium))
+                        .foregroundStyle(Theme.textSecondary)
+                        .monospacedDigit()
+                        .id(tickId)
+                }
+
+                Spacer(minLength: 0)
+
+                Image(systemName: "chevron.up")
+                    .font(.caption.weight(.bold))
+                    .foregroundStyle(Theme.textSecondary)
+            }
+            .padding(.horizontal, Theme.Spacing.md)
+            .padding(.vertical, 10)
+            .background(
+                RoundedRectangle(cornerRadius: Theme.Radius.lg)
+                    .fill(.ultraThinMaterial)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: Theme.Radius.lg)
+                            .stroke(Theme.hairline, lineWidth: 0.5)
+                    )
+            )
+            .padding(.horizontal, Theme.Spacing.md)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Resume workout \(workoutName.isEmpty ? "Workout" : workoutName)")
+        .accessibilityHint("Reopens the active workout screen")
     }
 }
 

--- a/Xomfit/Views/Workout/ActiveWorkoutView.swift
+++ b/Xomfit/Views/Workout/ActiveWorkoutView.swift
@@ -312,16 +312,8 @@ struct ActiveWorkoutView: View {
                 withAnimation {
                     viewModel.focusMode.toggle()
                     if viewModel.focusMode {
-                        // Default to first incomplete exercise
-                        if let firstIncomplete = viewModel.exercises.firstIndex(where: { ex in
-                            ex.sets.contains { $0.completedAt == Date.distantPast }
-                        }) {
-                            viewModel.focusExerciseIndex = firstIncomplete
-                            viewModel.focusSetIndex = 0
-                        } else {
-                            viewModel.syncFocusToCurrentExercise()
-                        }
-                        if viewModel.exercises.count > 1 {
+                        viewModel.syncFocusToCurrentExercise()
+                        if viewModel.completedSets == 0 && viewModel.exercises.count > 1 {
                             showStartingExercisePicker = true
                         }
                     }

--- a/Xomfit/Views/Workout/ActiveWorkoutView.swift
+++ b/Xomfit/Views/Workout/ActiveWorkoutView.swift
@@ -353,7 +353,7 @@ struct ActiveWorkoutView: View {
             .disabled(viewModel.isSaving)
         }
         .padding(.horizontal, Theme.Spacing.md)
-        .padding(.top, Theme.Spacing.sm)
+        .padding(.top, Theme.Spacing.md)
         .padding(.bottom, Theme.Spacing.md)
         .background(Theme.surface)
     }

--- a/Xomfit/Views/Workout/ActiveWorkoutView.swift
+++ b/Xomfit/Views/Workout/ActiveWorkoutView.swift
@@ -3,10 +3,10 @@ import PhotosUI
 
 struct ActiveWorkoutView: View {
     @Environment(AuthService.self) private var authService
+    @Environment(WorkoutLoggerViewModel.self) private var viewModel
     @Environment(\.dismiss) private var dismiss
     @Environment(\.scenePhase) private var scenePhase
 
-    @State private var viewModel = WorkoutLoggerViewModel()
     @State private var showExercisePicker = false
     @State private var showDiscardAlert = false
     @State private var showFinishSheet = false
@@ -18,11 +18,9 @@ struct ActiveWorkoutView: View {
     @State private var restTimerHapticFired = false
     @State private var showStartingExercisePicker = false
 
-    // Passed in from WorkoutView
-    let workoutName: String
-    var template: WorkoutTemplate? = nil
-
     var body: some View {
+        @Bindable var viewModel = viewModel
+
         NavigationStack {
             ZStack {
                 Theme.background.ignoresSafeArea()
@@ -148,14 +146,6 @@ struct ActiveWorkoutView: View {
             .safeAreaInset(edge: .bottom, spacing: 0) {
                 // Empty — just ensures keyboard inset is respected; actual toolbar is above
                 Color.clear.frame(height: 0)
-            }
-        }
-        .onAppear {
-            let userId = authService.currentUser?.id.uuidString.lowercased() ?? ""
-            if let template {
-                viewModel.startFromTemplate(template, userId: userId)
-            } else {
-                viewModel.startWorkout(name: workoutName, userId: userId)
             }
         }
         .onReceive(timer) { _ in

--- a/Xomfit/Views/Workout/WorkoutFocusView.swift
+++ b/Xomfit/Views/Workout/WorkoutFocusView.swift
@@ -61,6 +61,7 @@ struct WorkoutFocusView: View {
                     Spacer().frame(height: viewModel.isRestTimerActive && isRestTimerMinimized ? 100 : 0)
                 }
                 .safeAreaPadding(.top)
+                .padding(.top, Theme.Spacing.sm)
                 .padding(.horizontal, Theme.Spacing.lg)
 
                 // Rest timer overlay

--- a/Xomfit/Views/Workout/WorkoutView.swift
+++ b/Xomfit/Views/Workout/WorkoutView.swift
@@ -2,11 +2,10 @@ import SwiftUI
 
 struct WorkoutView: View {
     @Environment(AuthService.self) private var authService
+    @Environment(WorkoutLoggerViewModel.self) private var workoutSession
 
-    @State private var showActiveWorkout = false
     @State private var showNameEntry = false
     @State private var pendingWorkoutName = ""
-    @State private var selectedTemplate: WorkoutTemplate?
     @State private var showTemplateList = false
     @State private var showBuilder = false
     @State private var previewTemplate: WorkoutTemplate?
@@ -90,28 +89,20 @@ struct WorkoutView: View {
             .task {
                 await loadSections()
             }
+            .onChange(of: workoutSession.isPresented) { _, isPresented in
+                if !isPresented {
+                    Task { await loadSections() }
+                }
+            }
         }
         .alert("Name Your Workout", isPresented: $showNameEntry) {
             TextField("e.g. Push Day", text: $pendingWorkoutName)
-            Button("Start") { showActiveWorkout = true }
+            Button("Start") {
+                let name = pendingWorkoutName.isEmpty ? "Workout" : pendingWorkoutName
+                workoutSession.startWorkout(name: name, userId: userId)
+                workoutSession.isPresented = true
+            }
             Button("Cancel", role: .cancel) {}
-        }
-        .fullScreenCover(isPresented: $showActiveWorkout, onDismiss: {
-            Task { await loadSections() }
-        }) {
-            ActiveWorkoutView(
-                workoutName: pendingWorkoutName.isEmpty ? "Workout" : pendingWorkoutName
-            )
-            .environment(authService)
-        }
-        .fullScreenCover(item: $selectedTemplate, onDismiss: {
-            Task { await loadSections() }
-        }) { template in
-            ActiveWorkoutView(
-                workoutName: template.name,
-                template: template
-            )
-            .environment(authService)
         }
         .sheet(isPresented: $showBuilder, onDismiss: {
             templateRefreshId = UUID()
@@ -121,7 +112,9 @@ struct WorkoutView: View {
         }
         .sheet(item: $previewTemplate) { template in
             TemplateDetailView(template: template) {
-                selectedTemplate = template
+                previewTemplate = nil
+                workoutSession.startFromTemplate(template, userId: userId)
+                workoutSession.isPresented = true
             }
         }
         .sheet(isPresented: $showTemplateList) {
@@ -155,7 +148,10 @@ struct WorkoutView: View {
             Button {
                 Haptics.medium()
                 UserDefaults.standard.set(true, forKey: "xomfit_first_workout_started")
-                selectedTemplate = WorkoutTemplate.builtIn.first(where: { $0.id == "tpl-fb-a" })
+                if let template = WorkoutTemplate.builtIn.first(where: { $0.id == "tpl-fb-a" }) {
+                    workoutSession.startFromTemplate(template, userId: userId)
+                    workoutSession.isPresented = true
+                }
             } label: {
                 HStack(spacing: 8) {
                     Image(systemName: "play.fill")

--- a/Xomfit/XomfitApp.swift
+++ b/Xomfit/XomfitApp.swift
@@ -4,6 +4,7 @@ import SwiftUI
 struct XomFitApp: App {
     @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
     @State private var authService = AuthService()
+    @State private var workoutSession = WorkoutLoggerViewModel()
 
     var body: some Scene {
         WindowGroup {
@@ -22,6 +23,7 @@ struct XomFitApp: App {
                 } else if authService.isAuthenticated {
                     MainTabView()
                         .environment(authService)
+                        .environment(workoutSession)
                         .task {
                             await NotificationService.shared.requestPermission()
                         }
@@ -42,6 +44,12 @@ struct XomFitApp: App {
             }
             .preferredColorScheme(.dark)
             .onOpenURL { url in
+                if url.scheme == "xomfit", url.host == "workout" {
+                    if workoutSession.isActive {
+                        workoutSession.isPresented = true
+                    }
+                    return
+                }
                 Task {
                     try? await supabase.auth.session(from: url)
                 }

--- a/XomfitWidget/XomfitWidgetAttributes.swift
+++ b/XomfitWidget/XomfitWidgetAttributes.swift
@@ -20,6 +20,7 @@ struct XomfitWidgetAttributes: ActivityAttributes {
         var isResting: Bool = false
         var restTimeRemaining: Int = 0
         var restEndDate: Date? = nil
+        var isOvertime: Bool = false
     }
 
     var workoutName: String

--- a/XomfitWidget/XomfitWidgetLiveActivity.swift
+++ b/XomfitWidget/XomfitWidgetLiveActivity.swift
@@ -19,6 +19,10 @@ struct XomfitWidgetLiveActivity: Widget {
     private static let accentGreen = Color(red: 0.2, green: 1.0, blue: 0.4)     // #33FF66
     private static let darkBackground = Color(red: 0.039, green: 0.039, blue: 0.059) // #0A0A0F
 
+    private func restColor(_ state: XomfitWidgetAttributes.ContentState) -> Color {
+        state.isOvertime ? .red : Self.accentGreen
+    }
+
     var body: some WidgetConfiguration {
         ActivityConfiguration(for: XomfitWidgetAttributes.self) { context in
             // Lock screen / banner UI
@@ -56,7 +60,7 @@ struct XomfitWidgetLiveActivity: Widget {
                 if context.state.isResting, let endDate = context.state.restEndDate {
                     Text(timerInterval: Date.now...endDate, countsDown: true)
                         .font(.system(size: 12, weight: .semibold, design: .monospaced))
-                        .foregroundStyle(Self.accentGreen)
+                        .foregroundStyle(restColor(context.state))
                         .multilineTextAlignment(.trailing)
                 } else {
                     Text(context.attributes.startTime, style: .timer)
@@ -70,7 +74,7 @@ struct XomfitWidgetLiveActivity: Widget {
                     .foregroundStyle(Self.accentGreen)
             }
             .widgetURL(URL(string: "xomfit://workout"))
-            .keylineTint(Self.accentGreen)
+            .keylineTint(restColor(context.state))
         }
     }
 
@@ -112,7 +116,7 @@ struct XomfitWidgetLiveActivity: Widget {
                         Text(timerInterval: Date.now...endDate, countsDown: true)
                     }
                     .font(.system(size: 13, weight: .medium))
-                    .foregroundStyle(.white.opacity(0.8))
+                    .foregroundStyle(restColor(state))
                     .lineLimit(1)
                 } else {
                     Text(state.currentExercise)
@@ -168,13 +172,13 @@ struct XomfitWidgetLiveActivity: Widget {
                 HStack {
                     Image(systemName: "timer")
                         .font(.system(size: 11))
-                        .foregroundStyle(Self.accentGreen)
+                        .foregroundStyle(restColor(state))
                     Text("Rest:")
                         .font(.system(size: 12, weight: .semibold))
-                        .foregroundStyle(Self.accentGreen)
+                        .foregroundStyle(restColor(state))
                     Text(timerInterval: Date.now...endDate, countsDown: true)
                         .font(.system(size: 12, weight: .semibold, design: .monospaced))
-                        .foregroundStyle(Self.accentGreen)
+                        .foregroundStyle(restColor(state))
                     Spacer()
                 }
             }


### PR DESCRIPTION
## Summary
Bundle of 4 workout-session bug fixes (see `docs/features/workout-bugs-238/PLAN.md`):

1. **Focus picker** — no longer re-prompts mid-workout; only appears on a fresh multi-exercise start. Uses existing `syncFocusToCurrentExercise()` so focus lands on the current incomplete set.
2. **Live Activity overtime red** — added `isOvertime` to `ContentState` (both duplicate files). Compact trailing, expanded rest row, lock-screen label+timer, and `keylineTint` render red when the rest timer is expired. Progress bar stays green.
3. **Dynamic Island padding** — bumped top padding on `ActiveWorkoutView` header and added the missing cushion to `WorkoutFocusView` so headers clear the island pill.
4. **VM hoist + resume mini-bar + deep link** — `WorkoutLoggerViewModel` is now app-scoped (instantiated in `XomFitApp`, injected via environment). The `.fullScreenCover` moved from `WorkoutView` to `MainTabView`, bound to `workoutSession.isPresented`. Dismissing the cover leaves the VM intact, shows a "Workout in progress" mini-bar above the tab bar, and lets the user navigate other tabs mid-workout. `xomfit://workout` deep link (already on the widget) now opens the active workout.

## Test plan
- [ ] T1a — fresh multi-exercise workout, tap eye → picker appears.
- [ ] T1b — complete one set in a multi-exercise workout, tap eye → NO picker; focus view lands on current incomplete set.
- [ ] T2a — run rest timer to zero, compact island trailing text turns red.
- [ ] T2b — long-press island during overtime, expanded rest row renders red.
- [ ] T2c — lock device during overtime, "Resting" label + timer red.
- [ ] T2d — keyline edge red during overtime.
- [ ] T3 — with another app's Live Activity running (Timer), open Xomfit workout; both `ActiveWorkoutView` and `WorkoutFocusView` headers clear the island pill.
- [ ] T4 — during active workout, switch Feed/Progress/Profile tabs — VM state (sets, rest timer, elapsed) intact.
- [ ] T5 — during active workout, dismiss cover (swipe down). Mini-bar appears above tab bar. Tap mini-bar → cover re-presents with same VM state.
- [ ] T6 — tap the Dynamic Island (or open `xomfit://workout` via Safari) while a workout is active → cover re-presents.
- [ ] Finish → save succeeds → cover dismisses, mini-bar hidden.
- [ ] Discard → confirm → cover dismisses, mini-bar hidden.

Closes #238