### PR TITLE
fix: make MARKETING_VERSION fallback actually work

### DIFF
--- a/.github/workflows/testflight-deploy.yml
+++ b/.github/workflows/testflight-deploy.yml
@@ -67,7 +67,8 @@ jobs:
       - name: Compute version and build number
         id: version
         run: |
-          MARKETING_VERSION=$(git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || echo "2.0.0")
+          MARKETING_VERSION=$(git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//')
+          MARKETING_VERSION=${MARKETING_VERSION:-2.0.0}
           BUILD_NUMBER=$(date +%Y%m%d%H%M)
           echo "marketing=$MARKETING_VERSION" >> "$GITHUB_OUTPUT"
           echo "build=$BUILD_NUMBER" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- `git describe ... | sed '' || echo "2.0.0"` never triggers the fallback because `sed` always succeeds on empty input.
- Result: `MARKETING_VERSION` is empty, the generated Info.plist omits `CFBundleShortVersionString`, and altool rejects the upload with `-27002`.
- Swap to `${VAR:-2.0.0}` so the default kicks in when no tags exist.

## Test plan
- [ ] Deploy workflow triggers on merge
- [ ] Archive step logs `MARKETING_VERSION=2.0.0`
- [ ] Upload to TestFlight succeeds
- [ ] Build is auto-assigned to Beta and Beta Friends groups
- [ ] Xcode Cloud still publishes its own build (both pipelines active)