### PR TITLE
fix: --break-system-packages for pip3 (unblock beta group assignment)

### DIFF
--- a/.github/workflows/testflight-deploy.yml
+++ b/.github/workflows/testflight-deploy.yml
@@ -149,7 +149,7 @@ jobs:
             --apiIssuer "$ASC_API_ISSUER_ID"
 
       - name: Install Python deps for TestFlight group assignment
-        run: pip3 install --quiet PyJWT cryptography requests
+        run: pip3 install --quiet --break-system-packages PyJWT cryptography requests
 
       - name: Assign build to TestFlight groups
         env:


### PR DESCRIPTION
## Summary
pip3 install on macos-15 now errors with PEP 668 'externally-managed-environment', failing the post-upload beta-group assignment step. Pass \`--break-system-packages\` so helper deps install.

## Test plan
- [ ] pip3 step succeeds
- [ ] Build is assigned to Beta and Beta Friends groups