### PR TITLE
fix: use Apple Distribution signing identity for release archive

### DIFF
--- a/.github/workflows/testflight-deploy.yml
+++ b/.github/workflows/testflight-deploy.yml
@@ -93,7 +93,8 @@ jobs:
             -authenticationKeyPath "$HOME/.appstoreconnect/private_keys/AuthKey_${ASC_API_KEY_ID}.p8" \
             MARKETING_VERSION=${{ steps.version.outputs.marketing }} \
             CURRENT_PROJECT_VERSION=${{ steps.version.outputs.build }} \
-            IPHONEOS_DEPLOYMENT_TARGET=18.0
+            IPHONEOS_DEPLOYMENT_TARGET=18.0 \
+            CODE_SIGN_IDENTITY="Apple Distribution"
 
       - name: Create ExportOptions.plist
         env:


### PR DESCRIPTION
## Summary
The Release build settings in the project still use \`CODE_SIGN_IDENTITY='Apple Development'\` (same as Debug). That makes \`xcodebuild archive\` request a Development provisioning profile, which fails when the team is at Apple's cert limit:

> Your account has reached the maximum number of certificates.
> No profiles for 'com.Xomware.Xomfit' were found

Override \`CODE_SIGN_IDENTITY='Apple Distribution'\` on the xcodebuild invocation so we reuse the existing distribution cert (the same one Xcode Cloud uses today).

## Test plan
- [ ] Archive succeeds
- [ ] Upload to TestFlight succeeds
- [ ] Build assigned to Beta + Beta Friends groups