### PR TITLE
fix: iOS 26 SDK via macos-26 runner

### DIFF
--- a/.github/workflows/testflight-deploy.yml
+++ b/.github/workflows/testflight-deploy.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   deploy:
     name: Build & Upload to TestFlight
-    runs-on: macos-15
+    runs-on: macos-26
     timeout-minutes: 60
 
     steps:


### PR DESCRIPTION
## Summary
- Switch runner from \`macos-15\` (Xcode 16.4) to \`macos-26\` (Xcode 26.2 default)

## Why
Apple 90725 warning — apps uploaded after April 28, 2026 must be built with iOS 26 SDK.

## Test plan
- [ ] Archive with Xcode 26.2
- [ ] Upload succeeds without 90725 warning