### PR TITLE
#262 live activity: show timer in minimal Dynamic Island view

### DIFF
--- a/XomfitWidget/XomfitWidgetLiveActivity.swift
+++ b/XomfitWidget/XomfitWidgetLiveActivity.swift
@@ -69,9 +69,19 @@ struct XomfitWidgetLiveActivity: Widget {
                         .multilineTextAlignment(.trailing)
                 }
             } minimal: {
-                Image(systemName: "dumbbell.fill")
-                    .font(.system(size: 12))
-                    .foregroundStyle(Self.accentGreen)
+                if context.state.isResting, let endDate = context.state.restEndDate {
+                    Text(timerInterval: Date.now...endDate, countsDown: true)
+                        .font(.system(size: 11, weight: .semibold, design: .monospaced))
+                        .foregroundStyle(restColor(context.state))
+                        .multilineTextAlignment(.center)
+                        .monospacedDigit()
+                } else {
+                    Text(context.attributes.startTime, style: .timer)
+                        .font(.system(size: 11, weight: .semibold, design: .monospaced))
+                        .foregroundStyle(Self.accentGreen)
+                        .multilineTextAlignment(.center)
+                        .monospacedDigit()
+                }
             }
             .widgetURL(URL(string: "xomfit://workout"))
             .keylineTint(restColor(context.state))


### PR DESCRIPTION
Closes #262.

## Summary
When another app's Live Activity takes priority and ours shrinks to the minimal Dynamic Island view, show the timer instead of a static dumbbell icon. Per the issue: *"timer is most important."*

- Rest countdown when resting (red when overtime, green otherwise)
- Elapsed time when not resting (green)
- 11pt monospaced digits to fit the minimal size

## Test plan
- [ ] Start a workout, open Timer app to force our activity into minimal mode → minimal view shows elapsed timer (green)
- [ ] Trigger rest timer, repeat → minimal shows countdown (green)
- [ ] Let rest timer expire while minimal is up → minimal text turns red
- [ ] No regression on compactLeading, compactTrailing, expanded, or lock-screen views