### PR TITLE
#263 add exercise details sheet (description + form tips)

### DIFF
--- a/Xomfit/Views/Workout/ActiveWorkoutView.swift
+++ b/Xomfit/Views/Workout/ActiveWorkoutView.swift
@@ -506,6 +506,8 @@ private struct ExerciseCard: View {
     let exerciseIndex: Int
     let viewModel: WorkoutLoggerViewModel
 
+    @State private var showDetails = false
+
     @ViewBuilder
     var body: some View {
         if viewModel.exercises.indices.contains(exerciseIndex) {
@@ -529,6 +531,19 @@ private struct ExerciseCard: View {
                         }
                     }
                 }
+
+                Button {
+                    Haptics.selection()
+                    showDetails = true
+                } label: {
+                    Image(systemName: "info.circle")
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(Theme.textSecondary)
+                        .frame(width: 32, height: 32)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Show details for \(exercise.exercise.name)")
 
                 Spacer()
 
@@ -682,6 +697,9 @@ private struct ExerciseCard: View {
         .padding(Theme.Spacing.md)
         .background(Theme.surface)
         .clipShape(.rect(cornerRadius: Theme.cornerRadius))
+        .sheet(isPresented: $showDetails) {
+            ExerciseDetailSheet(exercise: exercise.exercise)
+        }
         }
     }
 }

--- a/Xomfit/Views/Workout/ExerciseDetailSheet.swift
+++ b/Xomfit/Views/Workout/ExerciseDetailSheet.swift
@@ -1,0 +1,156 @@
+import SwiftUI
+
+/// Read-only sheet showing how to perform an exercise: description, form tips,
+/// muscle groups, and equipment. Surfaced from the exercise picker and the
+/// active workout view so users can check form mid-set.
+struct ExerciseDetailSheet: View {
+    let exercise: Exercise
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Theme.background.ignoresSafeArea()
+
+                ScrollView {
+                    VStack(alignment: .leading, spacing: Theme.Spacing.lg) {
+                        header
+                        muscleAndEquipment
+                        howToSection
+                        if !exercise.tips.isEmpty {
+                            tipsSection
+                        }
+                        if exercise.supportsUnilateral {
+                            unilateralNote
+                        }
+                    }
+                    .padding(.horizontal, Theme.Spacing.md)
+                    .padding(.vertical, Theme.Spacing.md)
+                }
+            }
+            .navigationTitle(exercise.name)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbarColorScheme(.dark, for: .navigationBar)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { dismiss() }
+                        .foregroundStyle(Theme.accent)
+                }
+            }
+        }
+    }
+
+    private var header: some View {
+        HStack(spacing: Theme.Spacing.md) {
+            Image(systemName: exercise.icon)
+                .font(.system(size: 32))
+                .foregroundStyle(Theme.accent)
+                .frame(width: 64, height: 64)
+                .background(Theme.accentMuted)
+                .clipShape(.rect(cornerRadius: Theme.cornerRadius))
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(exercise.name)
+                    .font(Theme.fontTitle2)
+                    .foregroundStyle(Theme.textPrimary)
+                Text(exercise.category.displayName)
+                    .font(Theme.fontCaption)
+                    .foregroundStyle(Theme.textSecondary)
+            }
+            Spacer()
+        }
+    }
+
+    private var muscleAndEquipment: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+            metaRow(label: "Equipment", value: exercise.equipment.displayName, icon: exercise.equipment.icon)
+            metaRow(
+                label: exercise.muscleGroups.count > 1 ? "Muscles" : "Muscle",
+                value: exercise.muscleGroups.map(\.displayName).joined(separator: ", "),
+                icon: exercise.muscleGroups.first?.icon ?? "figure.strengthtraining.traditional"
+            )
+        }
+        .padding(Theme.Spacing.md)
+        .background(Theme.surface)
+        .clipShape(.rect(cornerRadius: Theme.cornerRadius))
+    }
+
+    private func metaRow(label: String, value: String, icon: String) -> some View {
+        HStack(spacing: Theme.Spacing.sm) {
+            Image(systemName: icon)
+                .font(.subheadline)
+                .foregroundStyle(Theme.accent)
+                .frame(width: 24)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(label)
+                    .font(Theme.fontSmall)
+                    .foregroundStyle(Theme.textSecondary)
+                Text(value)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(Theme.textPrimary)
+            }
+            Spacer()
+        }
+    }
+
+    private var howToSection: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+            Text("How To")
+                .font(Theme.fontHeadline)
+                .foregroundStyle(Theme.textPrimary)
+            Text(exercise.description)
+                .font(Theme.fontBody)
+                .foregroundStyle(Theme.textPrimary.opacity(0.9))
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(Theme.Spacing.md)
+        .background(Theme.surface)
+        .clipShape(.rect(cornerRadius: Theme.cornerRadius))
+    }
+
+    private var tipsSection: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+            Text("Form Tips")
+                .font(Theme.fontHeadline)
+                .foregroundStyle(Theme.textPrimary)
+            VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+                ForEach(exercise.tips, id: \.self) { tip in
+                    HStack(alignment: .top, spacing: Theme.Spacing.sm) {
+                        Image(systemName: "checkmark.circle.fill")
+                            .font(.subheadline)
+                            .foregroundStyle(Theme.accent)
+                            .padding(.top, 2)
+                        Text(tip)
+                            .font(Theme.fontBody)
+                            .foregroundStyle(Theme.textPrimary.opacity(0.9))
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(Theme.Spacing.md)
+        .background(Theme.surface)
+        .clipShape(.rect(cornerRadius: Theme.cornerRadius))
+    }
+
+    private var unilateralNote: some View {
+        HStack(alignment: .top, spacing: Theme.Spacing.sm) {
+            Image(systemName: "info.circle.fill")
+                .foregroundStyle(Theme.accent)
+            Text("Can be performed one side at a time. Toggle laterality from the exercise config.")
+                .font(Theme.fontCaption)
+                .foregroundStyle(Theme.textSecondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(Theme.Spacing.md)
+        .background(Theme.accentMuted)
+        .clipShape(.rect(cornerRadius: Theme.cornerRadius))
+    }
+}
+
+#Preview {
+    ExerciseDetailSheet(exercise: Exercise.benchPress)
+        .preferredColorScheme(.dark)
+}

--- a/Xomfit/Views/Workout/ExercisePickerView.swift
+++ b/Xomfit/Views/Workout/ExercisePickerView.swift
@@ -180,6 +180,8 @@ private struct ExerciseRow: View {
     let exercise: Exercise
     let onTap: () -> Void
 
+    @State private var showDetails = false
+
     var body: some View {
         Button(action: onTap) {
             HStack(spacing: Theme.Spacing.md) {
@@ -202,6 +204,20 @@ private struct ExerciseRow: View {
                     }
                 }
                 Spacer()
+
+                Button {
+                    Haptics.selection()
+                    showDetails = true
+                } label: {
+                    Image(systemName: "info.circle")
+                        .font(.title3)
+                        .foregroundStyle(Theme.textSecondary)
+                        .frame(width: 44, height: 44)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Show details for \(exercise.name)")
+
                 Image(systemName: "plus.circle")
                     .foregroundStyle(Theme.accent)
             }
@@ -209,5 +225,8 @@ private struct ExerciseRow: View {
             .padding(.vertical, 4)
         }
         .buttonStyle(.plain)
+        .sheet(isPresented: $showDetails) {
+            ExerciseDetailSheet(exercise: exercise)
+        }
     }
 }


### PR DESCRIPTION
Closes #263.

## Summary
Surfaces the per-exercise `description` and `tips` (already populated for all 115 exercises in `ExerciseDatabase`) behind an info button so users can check form mid-workout or while picking exercises.

**New file**: `Xomfit/Views/Workout/ExerciseDetailSheet.swift` — read-only sheet with:
- Icon + category
- Equipment + muscle groups (chips)
- How-to description
- Form tips checklist
- Unilateral note when supported

**Wired in**:
- `ExercisePickerView.ExerciseRow` — info button alongside the add (+) action
- `ActiveWorkoutView.ExerciseCard` header — info button next to the exercise name

## Out of scope
- Animations / video demos (issue mentions "would be great" — separate feature)
- Editing details in-app (data is in source today)

## Test plan
- [ ] Open exercise picker, tap info on a row → sheet shows description + tips for that exercise
- [ ] In an active workout, tap info button on an exercise card → sheet shows the same details
- [ ] Verify Done button dismisses sheet without affecting workout state
- [ ] Confirm unilateral note shows for exercises like Concentration Curl, Bulgarian Split Squat