### PR TITLE
#255 add workout pause (freeze elapsed + rest timer)

### DIFF
--- a/Xomfit/Models/XomfitWidgetAttributes.swift
+++ b/Xomfit/Models/XomfitWidgetAttributes.swift
@@ -20,6 +20,7 @@ struct XomfitWidgetAttributes: ActivityAttributes {
         var restTimeRemaining: Int = 0
         var restEndDate: Date? = nil
         var isOvertime: Bool = false
+        var isPaused: Bool = false
     }
 
     var workoutName: String

--- a/Xomfit/ViewModels/WorkoutLoggerViewModel.swift
+++ b/Xomfit/ViewModels/WorkoutLoggerViewModel.swift
@@ -25,6 +25,12 @@ final class WorkoutLoggerViewModel {
     var restDuration: Double = 0
     var isRestTimerActive: Bool = false
 
+    // Pause state — freezes elapsed timer + rest countdown without ending the workout.
+    // In-memory only (not persisted).
+    var isPaused: Bool = false
+    var pausedAt: Date? = nil
+    var totalPausedDuration: TimeInterval = 0
+
     /// Default rest duration in seconds. Reactive stored property; syncs to UserDefaults via didSet.
     var defaultRestDuration: Double = WorkoutLoggerViewModel.loadRestDuration() {
         didSet { UserDefaults.standard.set(defaultRestDuration, forKey: "restDuration") }
@@ -101,7 +107,13 @@ final class WorkoutLoggerViewModel {
     // MARK: - Computed
 
     var duration: TimeInterval {
-        Date().timeIntervalSince(startTime)
+        var elapsed = Date().timeIntervalSince(startTime) - totalPausedDuration
+        // If currently paused, also subtract the in-progress paused interval so the
+        // displayed time stays frozen at the moment of pausing.
+        if isPaused, let pausedAt {
+            elapsed -= Date().timeIntervalSince(pausedAt)
+        }
+        return max(0, elapsed)
     }
 
     var durationString: String {
@@ -142,6 +154,9 @@ final class WorkoutLoggerViewModel {
         focusMode = false
         focusExerciseIndex = 0
         focusSetIndex = 0
+        isPaused = false
+        pausedAt = nil
+        totalPausedDuration = 0
         skipRestTimer()
         startLiveActivity()
     }
@@ -163,6 +178,9 @@ final class WorkoutLoggerViewModel {
         focusMode = false
         focusExerciseIndex = 0
         focusSetIndex = 0
+        isPaused = false
+        pausedAt = nil
+        totalPausedDuration = 0
         location = ""
         rating = 0
         skipRestTimer()
@@ -482,14 +500,15 @@ final class WorkoutLoggerViewModel {
     }
 
     /// Called when the app returns to foreground. Recalculates rest timer based on wall-clock time elapsed.
+    /// Skipped while paused — the countdown is frozen.
     func recalculateRestTimer() {
-        guard isRestTimerActive, let startDate = restTimerStartDate else { return }
+        guard isRestTimerActive, !isPaused, let startDate = restTimerStartDate else { return }
         let elapsed = Date().timeIntervalSince(startDate)
         restTimeRemaining = restDuration - elapsed
     }
 
     func tickRestTimer() {
-        guard isRestTimerActive else { return }
+        guard isRestTimerActive, !isPaused else { return }
         restTimeRemaining -= 1
     }
 
@@ -502,6 +521,33 @@ final class WorkoutLoggerViewModel {
     func extendRestTimer(_ seconds: Double = 30) {
         restTimeRemaining += seconds
         restDuration += seconds
+        updateLiveActivity()
+    }
+
+    // MARK: - Pause / Resume
+
+    /// Freeze (or resume) the elapsed-time counter and the rest-timer countdown without
+    /// ending the workout. Pause state is in-memory only — not persisted.
+    func togglePause() {
+        if isPaused {
+            // Resume: account for the time spent paused
+            if let pausedAt {
+                let pausedFor = Date().timeIntervalSince(pausedAt)
+                totalPausedDuration += pausedFor
+
+                // Roll the rest timer's start anchor forward by the paused duration so
+                // recalculateRestTimer() and Live Activity restEndDate math stay correct.
+                if let start = restTimerStartDate {
+                    restTimerStartDate = start.addingTimeInterval(pausedFor)
+                }
+            }
+            pausedAt = nil
+            isPaused = false
+        } else {
+            // Pause
+            pausedAt = Date()
+            isPaused = true
+        }
         updateLiveActivity()
     }
 
@@ -584,14 +630,16 @@ final class WorkoutLoggerViewModel {
             ex.sets.contains(where: { $0.completedAt == Date.distantPast })
         })?.exercise.name ?? "Finishing up"
 
-        let restEnd: Date? = isRestTimerActive && restTimeRemaining > 0
+        // While paused, suppress restEndDate so the widget renders a static "Paused" pill
+        // instead of an active countdown.
+        let restEnd: Date? = (isRestTimerActive && restTimeRemaining > 0 && !isPaused)
             ? Date().addingTimeInterval(restTimeRemaining)
             : nil
 
-        let overtime = isRestTimerActive && restTimeRemaining <= 0
+        let overtime = isRestTimerActive && restTimeRemaining <= 0 && !isPaused
 
         let state = XomfitWidgetAttributes.ContentState(
-            elapsedSeconds: Int(Date().timeIntervalSince(startTime)),
+            elapsedSeconds: Int(duration),
             completedSets: completedSets,
             totalSets: totalSets,
             currentExercise: currentExName,
@@ -599,7 +647,8 @@ final class WorkoutLoggerViewModel {
             isResting: isRestTimerActive,
             restTimeRemaining: Int(self.restTimeRemaining),
             restEndDate: restEnd,
-            isOvertime: overtime
+            isOvertime: overtime,
+            isPaused: isPaused
         )
 
         Task {

--- a/Xomfit/Views/MainTabView.swift
+++ b/Xomfit/Views/MainTabView.swift
@@ -37,6 +37,7 @@ struct MainTabView: View {
                     WorkoutResumeBar(
                         workoutName: workoutSession.workoutName,
                         durationString: workoutSession.durationString,
+                        isPaused: workoutSession.isPaused,
                         tickId: tickId,
                         onTap: {
                             withAnimation(.spring(response: 0.35, dampingFraction: 0.82)) {
@@ -106,6 +107,7 @@ extension View {
 private struct WorkoutResumeBar: View {
     let workoutName: String
     let durationString: String
+    let isPaused: Bool
     /// Drives re-render of the duration string every second. Owner updates this.
     let tickId: UUID
     let onTap: () -> Void
@@ -116,7 +118,7 @@ private struct WorkoutResumeBar: View {
             onTap()
         } label: {
             HStack(spacing: Theme.Spacing.sm) {
-                Image(systemName: "dumbbell.fill")
+                Image(systemName: isPaused ? "pause.fill" : "dumbbell.fill")
                     .font(.subheadline.weight(.semibold))
                     .foregroundStyle(Theme.accent)
                     .frame(width: 28, height: 28)
@@ -128,11 +130,17 @@ private struct WorkoutResumeBar: View {
                         .font(.subheadline.weight(.semibold))
                         .foregroundStyle(Theme.textPrimary)
                         .lineLimit(1)
-                    Text(durationString)
-                        .font(.caption.weight(.medium))
-                        .foregroundStyle(Theme.textSecondary)
-                        .monospacedDigit()
-                        .id(tickId)
+                    if isPaused {
+                        Text("Paused")
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(Theme.textSecondary)
+                    } else {
+                        Text(durationString)
+                            .font(.caption.weight(.medium))
+                            .foregroundStyle(Theme.textSecondary)
+                            .monospacedDigit()
+                            .id(tickId)
+                    }
                 }
 
                 Spacer(minLength: 0)
@@ -155,7 +163,9 @@ private struct WorkoutResumeBar: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .accessibilityLabel("Resume workout \(workoutName.isEmpty ? "Workout" : workoutName)")
+        .accessibilityLabel(isPaused
+            ? "Paused workout \(workoutName.isEmpty ? "Workout" : workoutName)"
+            : "Resume workout \(workoutName.isEmpty ? "Workout" : workoutName)")
         .accessibilityHint("Reopens the active workout screen")
     }
 }

--- a/Xomfit/Views/Workout/ActiveWorkoutView.swift
+++ b/Xomfit/Views/Workout/ActiveWorkoutView.swift
@@ -297,6 +297,24 @@ struct ActiveWorkoutView: View {
 
             Spacer()
 
+            // Pause / Resume toggle — freezes elapsed time + rest timer
+            Button {
+                Haptics.light()
+                withAnimation(.xomChill) {
+                    viewModel.togglePause()
+                }
+            } label: {
+                Image(systemName: viewModel.isPaused ? "play.circle.fill" : "pause.circle.fill")
+                    .font(.title3.weight(.semibold))
+                    .foregroundStyle(viewModel.isPaused ? Theme.accent : Theme.textPrimary)
+                    .frame(width: 44, height: 44)
+                    .contentShape(Rectangle())
+            }
+            .accessibilityLabel(viewModel.isPaused ? "Resume workout" : "Pause workout")
+            .accessibilityHint(viewModel.isPaused
+                ? "Resumes the elapsed timer and rest countdown"
+                : "Freezes the elapsed timer and rest countdown")
+
             // Focus mode toggle
             Button {
                 withAnimation {

--- a/XomfitWidget/XomfitWidgetAttributes.swift
+++ b/XomfitWidget/XomfitWidgetAttributes.swift
@@ -21,6 +21,7 @@ struct XomfitWidgetAttributes: ActivityAttributes {
         var restTimeRemaining: Int = 0
         var restEndDate: Date? = nil
         var isOvertime: Bool = false
+        var isPaused: Bool = false
     }
 
     var workoutName: String

--- a/XomfitWidget/XomfitWidgetLiveActivity.swift
+++ b/XomfitWidget/XomfitWidgetLiveActivity.swift
@@ -23,6 +23,18 @@ struct XomfitWidgetLiveActivity: Widget {
         state.isOvertime ? .red : Self.accentGreen
     }
 
+    /// Static "Paused" label used in place of live timers when the workout is paused.
+    @ViewBuilder
+    private func pausedLabel(font: Font) -> some View {
+        HStack(spacing: 3) {
+            Image(systemName: "pause.fill")
+                .font(font)
+            Text("Paused")
+                .font(font)
+        }
+        .foregroundStyle(.white.opacity(0.85))
+    }
+
     var body: some WidgetConfiguration {
         ActivityConfiguration(for: XomfitWidgetAttributes.self) { context in
             // Lock screen / banner UI
@@ -38,13 +50,17 @@ struct XomfitWidgetLiveActivity: Widget {
                         .lineLimit(1)
                 }
                 DynamicIslandExpandedRegion(.trailing) {
-                    Text(context.attributes.startTime, style: .timer)
-                        .font(.system(size: 14, weight: .semibold, design: .monospaced))
-                        .foregroundStyle(Self.accentGreen)
-                        .multilineTextAlignment(.trailing)
+                    if context.state.isPaused {
+                        pausedLabel(font: .system(size: 14, weight: .semibold))
+                    } else {
+                        Text(context.attributes.startTime, style: .timer)
+                            .font(.system(size: 14, weight: .semibold, design: .monospaced))
+                            .foregroundStyle(Self.accentGreen)
+                            .multilineTextAlignment(.trailing)
+                    }
                 }
                 DynamicIslandExpandedRegion(.center) {
-                    Text(context.state.isResting ? "Resting" : context.state.currentExercise)
+                    Text(centerText(for: context.state))
                         .font(.system(size: 13, weight: .medium))
                         .foregroundStyle(.white.opacity(0.8))
                         .lineLimit(1)
@@ -57,7 +73,9 @@ struct XomfitWidgetLiveActivity: Widget {
                     .font(.system(size: 12))
                     .foregroundStyle(Self.accentGreen)
             } compactTrailing: {
-                if context.state.isResting, let endDate = context.state.restEndDate {
+                if context.state.isPaused {
+                    pausedLabel(font: .system(size: 12, weight: .semibold))
+                } else if context.state.isResting, let endDate = context.state.restEndDate {
                     Text(timerInterval: Date.now...endDate, countsDown: true)
                         .font(.system(size: 12, weight: .semibold, design: .monospaced))
                         .foregroundStyle(restColor(context.state))
@@ -69,7 +87,11 @@ struct XomfitWidgetLiveActivity: Widget {
                         .multilineTextAlignment(.trailing)
                 }
             } minimal: {
-                if context.state.isResting, let endDate = context.state.restEndDate {
+                if context.state.isPaused {
+                    Image(systemName: "pause.fill")
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundStyle(.white.opacity(0.85))
+                } else if context.state.isResting, let endDate = context.state.restEndDate {
                     Text(timerInterval: Date.now...endDate, countsDown: true)
                         .font(.system(size: 11, weight: .semibold, design: .monospaced))
                         .foregroundStyle(restColor(context.state))
@@ -112,15 +134,24 @@ struct XomfitWidgetLiveActivity: Widget {
 
                 Spacer()
 
-                Text(context.attributes.startTime, style: .timer)
-                    .font(.system(size: 15, weight: .semibold, design: .monospaced))
-                    .foregroundStyle(Self.accentGreen)
-                    .multilineTextAlignment(.trailing)
+                if state.isPaused {
+                    pausedLabel(font: .system(size: 15, weight: .semibold))
+                } else {
+                    Text(context.attributes.startTime, style: .timer)
+                        .font(.system(size: 15, weight: .semibold, design: .monospaced))
+                        .foregroundStyle(Self.accentGreen)
+                        .multilineTextAlignment(.trailing)
+                }
             }
 
             // Middle row: current exercise + set/exercise progress
             HStack(spacing: 0) {
-                if state.isResting, let endDate = state.restEndDate {
+                if state.isPaused {
+                    Text("Paused")
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundStyle(.white.opacity(0.85))
+                        .lineLimit(1)
+                } else if state.isResting, let endDate = state.restEndDate {
                     HStack(spacing: 4) {
                         Text("Resting")
                         Text(timerInterval: Date.now...endDate, countsDown: true)
@@ -178,7 +209,17 @@ struct XomfitWidgetLiveActivity: Widget {
             : 0
 
         VStack(alignment: .leading, spacing: 6) {
-            if state.isResting, let endDate = state.restEndDate {
+            if state.isPaused {
+                HStack {
+                    Image(systemName: "pause.fill")
+                        .font(.system(size: 11))
+                        .foregroundStyle(.white.opacity(0.85))
+                    Text("Paused")
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(.white.opacity(0.85))
+                    Spacer()
+                }
+            } else if state.isResting, let endDate = state.restEndDate {
                 HStack {
                     Image(systemName: "timer")
                         .font(.system(size: 11))
@@ -214,6 +255,12 @@ struct XomfitWidgetLiveActivity: Widget {
     }
 
     // MARK: - Helpers
+
+    private func centerText(for state: XomfitWidgetAttributes.ContentState) -> String {
+        if state.isPaused { return "Paused" }
+        if state.isResting { return "Resting" }
+        return state.currentExercise
+    }
 
     private func formatTime(_ totalSeconds: Int) -> String {
         let hours = totalSeconds / 3600


### PR DESCRIPTION
Closes #255 (pause half — cross-app navigation already shipped via #239 mini-bar).

## Summary
Pause/resume toggle on `ActiveWorkoutView` headerBar. While paused:
- elapsed-time counter freezes
- rest timer countdown freezes (rolls forward on resume so math stays accurate)
- Live Activity (compact / expanded / lock-screen / minimal) shows "Paused" pill instead of running timer
- WorkoutResumeBar in MainTabView shows "Paused" instead of live timer

In-memory only — no Supabase changes, resets on `startWorkout` / `discardWorkout`.

## Test plan
- [ ] Start workout, tap pause → timer stops, button flips to play
- [ ] Resume → timer continues from frozen value (not from start)
- [ ] Trigger rest timer, pause → countdown freezes, resume picks up correctly
- [ ] Switch tabs while paused → resume bar shows "Paused" not a counting timer
- [ ] Live Activity (compact + expanded + lock-screen + minimal) shows "Paused" while paused