### PR TITLE
#257 add retroactive workout logging

### DIFF
--- a/Xomfit/ViewModels/LogPastWorkoutViewModel.swift
+++ b/Xomfit/ViewModels/LogPastWorkoutViewModel.swift
@@ -1,0 +1,187 @@
+import Foundation
+import SwiftUI
+
+/// View model for retroactively logging a workout that already happened.
+/// No live timer, no rest timer — pure data entry that ends with a save through the
+/// same path used by `WorkoutLoggerViewModel.finishWorkout` (`WorkoutService.shared.saveWorkout`).
+@MainActor
+@Observable
+final class LogPastWorkoutViewModel {
+    // MARK: - Form State
+
+    var workoutDate: Date = Date()
+    var name: String = ""
+    /// Optional duration in minutes. `nil` when the field is empty.
+    var durationMinutes: Int? = nil
+    var exercises: [WorkoutExercise] = []
+
+    // MARK: - Save State
+
+    var isSaving: Bool = false
+    var errorMessage: String? = nil
+
+    // MARK: - Defaults
+
+    static let defaultName = "Logged Workout"
+
+    // MARK: - Validation
+
+    /// At least one exercise with at least one set with reps > 0 is required.
+    var canSave: Bool {
+        guard !exercises.isEmpty else { return false }
+        return exercises.contains { ex in
+            ex.sets.contains { $0.reps > 0 }
+        }
+    }
+
+    // MARK: - Exercise Management
+
+    func addExercise(_ exercise: Exercise) {
+        let defaultSetCount = 3
+        var sets: [WorkoutSet] = []
+        for _ in 0..<defaultSetCount {
+            sets.append(WorkoutSet(
+                id: UUID().uuidString,
+                exerciseId: exercise.id,
+                weight: 0,
+                reps: 0,
+                rpe: nil,
+                isPersonalRecord: false,
+                completedAt: Date.distantPast
+            ))
+        }
+        var workoutExercise = WorkoutExercise(
+            id: UUID().uuidString,
+            exercise: exercise,
+            sets: sets,
+            notes: nil
+        )
+        workoutExercise.selectedLaterality = exercise.defaultLaterality
+        exercises.append(workoutExercise)
+    }
+
+    func removeExercise(at index: Int) {
+        guard exercises.indices.contains(index) else { return }
+        exercises.remove(at: index)
+    }
+
+    // MARK: - Set Management
+
+    func addSet(to exerciseIndex: Int) {
+        guard exercises.indices.contains(exerciseIndex) else { return }
+        let exercise = exercises[exerciseIndex]
+        let lastSet = exercise.sets.last
+        let newSet = WorkoutSet(
+            id: UUID().uuidString,
+            exerciseId: exercise.exercise.id,
+            weight: lastSet?.weight ?? 0,
+            reps: lastSet?.reps ?? 0,
+            rpe: nil,
+            isPersonalRecord: false,
+            completedAt: Date.distantPast
+        )
+        exercises[exerciseIndex].sets.append(newSet)
+    }
+
+    func updateSet(exerciseIndex: Int, setIndex: Int, weight: Double, reps: Int) {
+        guard exercises.indices.contains(exerciseIndex),
+              exercises[exerciseIndex].sets.indices.contains(setIndex) else { return }
+        exercises[exerciseIndex].sets[setIndex].weight = weight
+        exercises[exerciseIndex].sets[setIndex].reps = reps
+    }
+
+    func removeSet(exerciseIndex: Int, setIndex: Int) {
+        guard exercises.indices.contains(exerciseIndex),
+              exercises[exerciseIndex].sets.indices.contains(setIndex) else { return }
+        exercises[exerciseIndex].sets.remove(at: setIndex)
+    }
+
+    // MARK: - Save
+
+    /// Persists the workout via the same path `WorkoutLoggerViewModel.finishWorkout` uses:
+    /// `WorkoutService.shared.saveWorkout` (cache + Supabase) plus `FeedService.postWorkoutToFeed` on success.
+    /// Sets are stamped completed at the workout's `startTime` so they show up in history.
+    func saveWorkout(userId: String) async -> Bool {
+        guard canSave else { return false }
+        isSaving = true
+        errorMessage = nil
+        defer { isSaving = false }
+
+        let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        let resolvedName = trimmedName.isEmpty ? Self.defaultName : trimmedName
+
+        let startTime = workoutDate
+
+        // Only keep sets with reps > 0 — empty rows are noise. Stamp them completed at startTime
+        // so history queries treat them as real sets (matches behavior of `finishWorkout`,
+        // which filters out distant-past completedAt sets before save).
+        let savedExercises: [WorkoutExercise] = exercises.compactMap { ex in
+            let validSets = ex.sets.enumerated().compactMap { (offset, set) -> WorkoutSet? in
+                guard set.reps > 0 else { return nil }
+                var stamped = set
+                // Tiny offset per set so identical timestamps don't collide in PR/sort logic.
+                stamped.completedAt = startTime.addingTimeInterval(Double(offset))
+                return stamped
+            }
+            guard !validSets.isEmpty else { return nil }
+            return WorkoutExercise(
+                id: ex.id,
+                exercise: ex.exercise,
+                sets: validSets,
+                notes: ex.notes,
+                selectedGrip: ex.selectedGrip,
+                selectedAttachment: ex.selectedAttachment,
+                selectedPosition: ex.selectedPosition,
+                selectedLaterality: ex.selectedLaterality
+            )
+        }
+
+        guard !savedExercises.isEmpty else {
+            errorMessage = "Add at least one set with reps before saving."
+            return false
+        }
+
+        let endTime: Date? = durationMinutes.map { startTime.addingTimeInterval(TimeInterval($0) * 60) }
+
+        let workout = Workout(
+            id: UUID().uuidString,
+            userId: userId,
+            name: resolvedName,
+            exercises: savedExercises,
+            startTime: startTime,
+            endTime: endTime,
+            notes: nil,
+            location: nil,
+            rating: nil
+        )
+
+        // Reuse the same persistence path as the live workout flow.
+        let persisted = await WorkoutService.shared.saveWorkout(workout)
+        if persisted {
+            do {
+                try await FeedService.shared.postWorkoutToFeed(
+                    workout: workout,
+                    userId: userId,
+                    caption: nil,
+                    photoURLs: nil
+                )
+            } catch {
+                // Feed post failure shouldn't block save success — log and continue.
+                print("[LogPastWorkout] Feed post failed: \(error.localizedDescription)")
+            }
+        }
+
+        return true
+    }
+
+    // MARK: - Reset
+
+    func reset() {
+        workoutDate = Date()
+        name = ""
+        durationMinutes = nil
+        exercises = []
+        isSaving = false
+        errorMessage = nil
+    }
+}

--- a/Xomfit/Views/Workout/LogPastWorkoutView.swift
+++ b/Xomfit/Views/Workout/LogPastWorkoutView.swift
@@ -1,0 +1,482 @@
+import SwiftUI
+
+/// Manual data-entry sheet for logging a workout that already happened.
+/// No live timer, no rest timer — just date, optional duration, optional name,
+/// and a list of exercises with weight/reps for each set.
+struct LogPastWorkoutView: View {
+    @Environment(AuthService.self) private var authService
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var viewModel = LogPastWorkoutViewModel()
+    @State private var showExercisePicker = false
+    @State private var showDiscardAlert = false
+
+    private var userId: String {
+        authService.currentUser?.id.uuidString.lowercased() ?? ""
+    }
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Theme.background.ignoresSafeArea()
+
+                ScrollView {
+                    VStack(spacing: Theme.Spacing.md) {
+                        metadataCard
+                        exerciseList
+                        addExerciseButton
+                        if let error = viewModel.errorMessage {
+                            errorBanner(error)
+                        }
+                    }
+                    .padding(.horizontal, Theme.Spacing.md)
+                    .padding(.vertical, Theme.Spacing.sm)
+                    .padding(.bottom, Theme.Spacing.xxl)
+                }
+                .scrollDismissesKeyboard(.interactively)
+            }
+            .navigationTitle("Log Past Workout")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbarColorScheme(.dark, for: .navigationBar)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") {
+                        if hasContent {
+                            showDiscardAlert = true
+                        } else {
+                            dismiss()
+                        }
+                    }
+                    .foregroundStyle(Theme.accent)
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button {
+                        Task { await save() }
+                    } label: {
+                        if viewModel.isSaving {
+                            ProgressView()
+                                .tint(Theme.accent)
+                        } else {
+                            Text("Save")
+                                .fontWeight(.bold)
+                        }
+                    }
+                    .foregroundStyle(viewModel.canSave ? Theme.accent : Theme.textSecondary)
+                    .disabled(!viewModel.canSave || viewModel.isSaving)
+                }
+                ToolbarItemGroup(placement: .keyboard) {
+                    Spacer()
+                    Button("Done") {
+                        UIApplication.shared.sendAction(
+                            #selector(UIResponder.resignFirstResponder),
+                            to: nil, from: nil, for: nil
+                        )
+                    }
+                    .foregroundStyle(Theme.accent)
+                }
+            }
+        }
+        .interactiveDismissDisabled(hasContent)
+        .sheet(isPresented: $showExercisePicker) {
+            ExercisePickerView { exercise in
+                viewModel.addExercise(exercise)
+            }
+        }
+        .alert("Discard entry?", isPresented: $showDiscardAlert) {
+            Button("Discard", role: .destructive) {
+                viewModel.reset()
+                dismiss()
+            }
+            Button("Keep Editing", role: .cancel) {}
+        } message: {
+            Text("Your entered data will be lost.")
+        }
+    }
+
+    // MARK: - Save
+
+    private func save() async {
+        guard !userId.isEmpty else {
+            viewModel.errorMessage = "Sign in required to save."
+            return
+        }
+        Haptics.medium()
+        let ok = await viewModel.saveWorkout(userId: userId)
+        if ok {
+            Haptics.success()
+            dismiss()
+        } else {
+            Haptics.error()
+        }
+    }
+
+    private var hasContent: Bool {
+        !viewModel.exercises.isEmpty
+            || !viewModel.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            || viewModel.durationMinutes != nil
+    }
+
+    // MARK: - Metadata Card
+
+    private var metadataCard: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.md) {
+            // Name
+            VStack(alignment: .leading, spacing: Theme.Spacing.xs) {
+                Text("Name")
+                    .font(Theme.fontCaption)
+                    .foregroundStyle(Theme.textSecondary)
+                TextField(LogPastWorkoutViewModel.defaultName, text: $viewModel.name)
+                    .font(.body.weight(.semibold))
+                    .foregroundStyle(Theme.textPrimary)
+                    .padding(Theme.Spacing.sm)
+                    .background(Theme.surfaceElevated)
+                    .clipShape(.rect(cornerRadius: Theme.Radius.sm))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: Theme.Radius.sm)
+                            .strokeBorder(Theme.hairline, lineWidth: 0.5)
+                    )
+            }
+
+            // Date
+            VStack(alignment: .leading, spacing: Theme.Spacing.xs) {
+                Text("Date & Time")
+                    .font(Theme.fontCaption)
+                    .foregroundStyle(Theme.textSecondary)
+                DatePicker(
+                    "",
+                    selection: $viewModel.workoutDate,
+                    in: ...Date(),
+                    displayedComponents: [.date, .hourAndMinute]
+                )
+                .labelsHidden()
+                .datePickerStyle(.compact)
+                .tint(Theme.accent)
+                .accessibilityLabel("Workout date and time")
+            }
+
+            // Duration
+            VStack(alignment: .leading, spacing: Theme.Spacing.xs) {
+                Text("Duration (minutes, optional)")
+                    .font(Theme.fontCaption)
+                    .foregroundStyle(Theme.textSecondary)
+                DurationField(durationMinutes: $viewModel.durationMinutes)
+            }
+        }
+        .padding(Theme.Spacing.md)
+        .background(Theme.surface)
+        .clipShape(.rect(cornerRadius: Theme.cornerRadius))
+    }
+
+    // MARK: - Exercises
+
+    private var exerciseList: some View {
+        Group {
+            if viewModel.exercises.isEmpty {
+                emptyState
+            } else {
+                VStack(spacing: Theme.Spacing.md) {
+                    ForEach(viewModel.exercises.indices, id: \.self) { index in
+                        PastExerciseCard(
+                            exercise: viewModel.exercises[index],
+                            onAddSet: { viewModel.addSet(to: index) },
+                            onRemoveSet: { setIdx in viewModel.removeSet(exerciseIndex: index, setIndex: setIdx) },
+                            onUpdateSet: { setIdx, weight, reps in
+                                viewModel.updateSet(exerciseIndex: index, setIndex: setIdx, weight: weight, reps: reps)
+                            },
+                            onDelete: { viewModel.removeExercise(at: index) }
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: Theme.Spacing.sm) {
+            Image(systemName: "calendar.badge.clock")
+                .font(.largeTitle)
+                .foregroundStyle(Theme.textSecondary.opacity(0.5))
+            Text("No exercises yet")
+                .font(Theme.fontBody)
+                .foregroundStyle(Theme.textSecondary)
+            Text("Add the lifts you did")
+                .font(Theme.fontCaption)
+                .foregroundStyle(Theme.textSecondary.opacity(0.7))
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, Theme.Spacing.lg * 2)
+    }
+
+    private var addExerciseButton: some View {
+        Button {
+            Haptics.light()
+            showExercisePicker = true
+        } label: {
+            HStack(spacing: 8) {
+                Image(systemName: "plus.circle.fill")
+                Text("Add Exercise")
+                    .font(.subheadline.weight(.semibold))
+            }
+            .foregroundStyle(Theme.accent)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 14)
+            .background(Theme.accent.opacity(0.1))
+            .clipShape(.rect(cornerRadius: Theme.cornerRadius))
+            .overlay(
+                RoundedRectangle(cornerRadius: Theme.cornerRadius)
+                    .strokeBorder(Theme.accent.opacity(0.3), lineWidth: 1)
+            )
+        }
+        .accessibilityLabel("Add exercise to past workout")
+    }
+
+    private func errorBanner(_ text: String) -> some View {
+        HStack(spacing: Theme.Spacing.sm) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(Theme.destructive)
+            Text(text)
+                .font(Theme.fontCaption)
+                .foregroundStyle(Theme.textPrimary)
+        }
+        .padding(Theme.Spacing.md)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Theme.destructive.opacity(0.12))
+        .clipShape(.rect(cornerRadius: Theme.Radius.sm))
+    }
+}
+
+// MARK: - Duration Field
+
+private struct DurationField: View {
+    @Binding var durationMinutes: Int?
+    @State private var text: String = ""
+    @FocusState private var focused: Bool
+
+    var body: some View {
+        TextField("e.g. 45", text: $text)
+            .keyboardType(.numberPad)
+            .font(Theme.fontNumberMedium)
+            .foregroundStyle(Theme.textPrimary)
+            .padding(Theme.Spacing.sm)
+            .background(Theme.surfaceElevated)
+            .clipShape(.rect(cornerRadius: Theme.Radius.sm))
+            .overlay(
+                RoundedRectangle(cornerRadius: Theme.Radius.sm)
+                    .strokeBorder(focused ? Theme.hairlineStrong : Theme.hairline, lineWidth: 0.5)
+            )
+            .focused($focused)
+            .onAppear {
+                if let m = durationMinutes { text = "\(m)" }
+            }
+            .onChange(of: text) { _, newValue in
+                let digits = newValue.filter { $0.isNumber }
+                if digits != newValue { text = digits }
+                durationMinutes = digits.isEmpty ? nil : Int(digits)
+            }
+            .accessibilityLabel("Duration in minutes, optional")
+    }
+}
+
+// MARK: - Past Exercise Card
+
+private struct PastExerciseCard: View {
+    let exercise: WorkoutExercise
+    let onAddSet: () -> Void
+    let onRemoveSet: (Int) -> Void
+    let onUpdateSet: (Int, Double, Int) -> Void
+    let onDelete: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+            // Header
+            HStack {
+                Image(systemName: exercise.exercise.icon)
+                    .font(.headline)
+                    .foregroundStyle(Theme.accent)
+                    .frame(width: 32, height: 32)
+                    .background(Theme.accentMuted)
+                    .clipShape(.rect(cornerRadius: 8))
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(exercise.exercise.name)
+                        .font(.subheadline.weight(.bold))
+                        .foregroundStyle(Theme.textPrimary)
+                    Text(exercise.exercise.muscleGroups.first?.displayName ?? "")
+                        .font(Theme.fontSmall)
+                        .foregroundStyle(Theme.textSecondary)
+                }
+
+                Spacer()
+
+                Button {
+                    Haptics.light()
+                    onDelete()
+                } label: {
+                    Image(systemName: "trash")
+                        .font(.subheadline)
+                        .foregroundStyle(Theme.destructive.opacity(0.8))
+                        .frame(width: 44, height: 44)
+                        .contentShape(Rectangle())
+                }
+                .accessibilityLabel("Remove \(exercise.exercise.name)")
+            }
+
+            // Column header
+            HStack(spacing: Theme.Spacing.sm) {
+                Text("SET")
+                    .frame(width: 36, alignment: .center)
+                Text("WEIGHT (LBS)")
+                    .frame(maxWidth: .infinity)
+                Text("REPS")
+                    .frame(maxWidth: .infinity)
+                // Spacer matching trailing delete button width in PastSetRow
+                Color.clear.frame(width: 32)
+            }
+            .font(.caption2.weight(.semibold))
+            .foregroundStyle(Theme.textSecondary)
+            .padding(.horizontal, Theme.Spacing.xs)
+
+            // Sets
+            VStack(spacing: Theme.Spacing.xs) {
+                ForEach(exercise.sets.indices, id: \.self) { setIdx in
+                    PastSetRow(
+                        setNumber: setIdx + 1,
+                        workoutSet: exercise.sets[setIdx],
+                        onWeightChange: { w in
+                            onUpdateSet(setIdx, w, exercise.sets[setIdx].reps)
+                        },
+                        onRepsChange: { r in
+                            onUpdateSet(setIdx, exercise.sets[setIdx].weight, r)
+                        },
+                        onDelete: { onRemoveSet(setIdx) }
+                    )
+                }
+            }
+
+            // Add set
+            Button {
+                Haptics.light()
+                onAddSet()
+            } label: {
+                HStack(spacing: 6) {
+                    Image(systemName: "plus")
+                    Text("Add Set")
+                }
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(Theme.accent)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 10)
+                .background(Theme.accent.opacity(0.08))
+                .clipShape(.rect(cornerRadius: Theme.Radius.sm))
+            }
+            .accessibilityLabel("Add set to \(exercise.exercise.name)")
+        }
+        .padding(Theme.Spacing.md)
+        .background(Theme.surface)
+        .clipShape(.rect(cornerRadius: Theme.cornerRadius))
+    }
+}
+
+// MARK: - Past Set Row (no checkmark, no rest timer)
+
+private struct PastSetRow: View {
+    let setNumber: Int
+    let workoutSet: WorkoutSet
+    let onWeightChange: (Double) -> Void
+    let onRepsChange: (Int) -> Void
+    let onDelete: () -> Void
+
+    @State private var weightText: String
+    @State private var repsText: String
+    @FocusState private var isWeightFocused: Bool
+    @FocusState private var isRepsFocused: Bool
+
+    init(
+        setNumber: Int,
+        workoutSet: WorkoutSet,
+        onWeightChange: @escaping (Double) -> Void,
+        onRepsChange: @escaping (Int) -> Void,
+        onDelete: @escaping () -> Void
+    ) {
+        self.setNumber = setNumber
+        self.workoutSet = workoutSet
+        self.onWeightChange = onWeightChange
+        self.onRepsChange = onRepsChange
+        self.onDelete = onDelete
+        let w = workoutSet.weight
+        let r = workoutSet.reps
+        _weightText = State(initialValue: w > 0 ? w.formattedWeight : "")
+        _repsText   = State(initialValue: r > 0 ? "\(r)" : "")
+    }
+
+    var body: some View {
+        HStack(spacing: Theme.Spacing.sm) {
+            Text("\(setNumber)")
+                .font(.subheadline.weight(.bold).monospaced())
+                .foregroundStyle(Theme.textSecondary)
+                .frame(width: 36, alignment: .center)
+
+            TextField("0", text: $weightText)
+                .keyboardType(.decimalPad)
+                .multilineTextAlignment(.center)
+                .font(Theme.fontNumberMedium)
+                .padding(.vertical, 8)
+                .padding(.horizontal, 6)
+                .background(Theme.surfaceElevated)
+                .clipShape(.rect(cornerRadius: Theme.cornerRadiusSmall))
+                .overlay(
+                    RoundedRectangle(cornerRadius: Theme.cornerRadiusSmall)
+                        .strokeBorder(isWeightFocused ? Theme.hairlineStrong : Theme.hairline, lineWidth: 0.5)
+                )
+                .foregroundStyle(Theme.textPrimary)
+                .frame(maxWidth: .infinity)
+                .focused($isWeightFocused)
+                .onChange(of: weightText) { _, newValue in
+                    if newValue.isEmpty {
+                        onWeightChange(0)
+                    } else if let w = Double(newValue) {
+                        onWeightChange(w)
+                    }
+                }
+                .accessibilityLabel("Weight for set \(setNumber)")
+
+            TextField("0", text: $repsText)
+                .keyboardType(.numberPad)
+                .multilineTextAlignment(.center)
+                .font(Theme.fontNumberMedium)
+                .padding(.vertical, 8)
+                .padding(.horizontal, 6)
+                .background(Theme.surfaceElevated)
+                .clipShape(.rect(cornerRadius: Theme.cornerRadiusSmall))
+                .overlay(
+                    RoundedRectangle(cornerRadius: Theme.cornerRadiusSmall)
+                        .strokeBorder(isRepsFocused ? Theme.hairlineStrong : Theme.hairline, lineWidth: 0.5)
+                )
+                .foregroundStyle(Theme.textPrimary)
+                .frame(maxWidth: .infinity)
+                .focused($isRepsFocused)
+                .onChange(of: repsText) { _, newValue in
+                    if newValue.isEmpty {
+                        onRepsChange(0)
+                    } else if let r = Int(newValue) {
+                        onRepsChange(r)
+                    }
+                }
+                .accessibilityLabel("Reps for set \(setNumber)")
+
+            Button {
+                Haptics.light()
+                onDelete()
+            } label: {
+                Image(systemName: "minus.circle.fill")
+                    .foregroundStyle(Theme.destructive)
+                    .font(.headline)
+                    .frame(width: 32, height: 32)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Delete set \(setNumber)")
+        }
+        .frame(minHeight: 44)
+    }
+}

--- a/Xomfit/Views/Workout/WorkoutView.swift
+++ b/Xomfit/Views/Workout/WorkoutView.swift
@@ -8,6 +8,7 @@ struct WorkoutView: View {
     @State private var pendingWorkoutName = ""
     @State private var showTemplateList = false
     @State private var showBuilder = false
+    @State private var showLogPastWorkout = false
     @State private var previewTemplate: WorkoutTemplate?
     @State private var templateRefreshId = UUID()
     @State private var recentWorkouts: [Workout] = []
@@ -44,17 +45,31 @@ struct WorkoutView: View {
                             .padding(.horizontal, Theme.Spacing.md)
                             .padding(.top, Theme.Spacing.md)
 
-                            // Build Workout
-                            Button {
-                                Haptics.light()
-                                showBuilder = true
-                            } label: {
-                                HStack(spacing: 10) {
-                                    Image(systemName: "hammer.fill")
-                                    Text("Build Workout")
+                            // Build Workout + Log Past Workout (side-by-side)
+                            HStack(spacing: Theme.Spacing.sm) {
+                                Button {
+                                    Haptics.light()
+                                    showBuilder = true
+                                } label: {
+                                    HStack(spacing: 8) {
+                                        Image(systemName: "hammer.fill")
+                                        Text("Build")
+                                    }
                                 }
+                                .buttonStyle(GhostButtonStyle())
+
+                                Button {
+                                    Haptics.light()
+                                    showLogPastWorkout = true
+                                } label: {
+                                    HStack(spacing: 8) {
+                                        Image(systemName: "calendar.badge.clock")
+                                        Text("Log Past")
+                                    }
+                                }
+                                .buttonStyle(GhostButtonStyle())
+                                .accessibilityLabel("Log a past workout")
                             }
-                            .buttonStyle(GhostButtonStyle())
                             .padding(.horizontal, Theme.Spacing.md)
 
                             // First workout guide for new users
@@ -109,6 +124,11 @@ struct WorkoutView: View {
             Task { await loadSections() }
         }) {
             WorkoutBuilderView()
+        }
+        .sheet(isPresented: $showLogPastWorkout, onDismiss: {
+            Task { await loadSections() }
+        }) {
+            LogPastWorkoutView()
         }
         .sheet(item: $previewTemplate) { template in
             TemplateDetailView(template: template) {


### PR DESCRIPTION
Closes #257.

## Summary
New "Log Past" entry on the Workout tab that opens a sheet for manually entering a past workout: date/time, name, optional duration, exercises with weight/reps. Reuses `ExercisePickerView` and the same `WorkoutService.shared.saveWorkout(...)` path as live workouts so it persists to Supabase + the local cache identically.

- New: `LogPastWorkoutView.swift`, `LogPastWorkoutViewModel.swift`
- Wired: `WorkoutView.swift` → "Log Past" button next to "Build"
- Sets stamped completed at `startTime + index seconds`
- Save also posts to feed via `FeedService.postWorkoutToFeed` (caption + photos `nil`)

## Test plan
- [ ] Tap Log Past → form opens with today's date prefilled
- [ ] Add an exercise, fill weight + reps on a set → Save enabled
- [ ] Save with no reps anywhere → Save stays disabled
- [ ] Save success → workout shows in profile/recent list with the chosen date
- [ ] Try future date → DatePicker capped to today