### PR TITLE
#259 add fitness goals questionnaire (onboarding + profile edit)

### DIFF
--- a/Xomfit/Models/UserFitnessProfile.swift
+++ b/Xomfit/Models/UserFitnessProfile.swift
@@ -1,0 +1,201 @@
+import Foundation
+
+// MARK: - Question Enums
+
+/// Primary lifting goal — drives AI helper recommendations (#252).
+enum FitnessPrimaryGoal: String, Codable, CaseIterable, Identifiable {
+    case buildMuscle
+    case getStronger
+    case loseFat
+    case maintain
+    case generalFitness
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .buildMuscle:    "Build muscle"
+        case .getStronger:    "Get stronger"
+        case .loseFat:        "Lose fat"
+        case .maintain:       "Maintain"
+        case .generalFitness: "General fitness"
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .buildMuscle:    "dumbbell.fill"
+        case .getStronger:    "figure.strengthtraining.traditional"
+        case .loseFat:        "flame.fill"
+        case .maintain:       "checkmark.seal.fill"
+        case .generalFitness: "figure.mixed.cardio"
+        }
+    }
+}
+
+/// Lifting experience bucket.
+enum FitnessExperience: String, Codable, CaseIterable, Identifiable {
+    case beginner
+    case intermediate
+    case advanced
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .beginner:     "Beginner"
+        case .intermediate: "Intermediate"
+        case .advanced:     "Advanced"
+        }
+    }
+
+    var subtitle: String {
+        switch self {
+        case .beginner:     "Less than 6 months"
+        case .intermediate: "6 months – 2 years"
+        case .advanced:     "2+ years"
+        }
+    }
+}
+
+/// How many sessions per week the user wants to commit to.
+enum FitnessWorkoutsPerWeek: String, Codable, CaseIterable, Identifiable {
+    case two
+    case three
+    case four
+    case five
+    case sixPlus
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .two:     "2"
+        case .three:   "3"
+        case .four:    "4"
+        case .five:    "5"
+        case .sixPlus: "6+"
+        }
+    }
+}
+
+/// Preferred training split.
+enum FitnessSplit: String, Codable, CaseIterable, Identifiable {
+    case fullBody
+    case upperLower
+    case pushPullLegs
+    case broSplit
+    case custom
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .fullBody:     "Full body"
+        case .upperLower:   "Upper / Lower"
+        case .pushPullLegs: "Push / Pull / Legs"
+        case .broSplit:     "Bro split"
+        case .custom:       "Custom"
+        }
+    }
+
+    var subtitle: String {
+        switch self {
+        case .fullBody:     "Hit everything each session"
+        case .upperLower:   "Alternate upper and lower"
+        case .pushPullLegs: "Classic 3- or 6-day split"
+        case .broSplit:     "One muscle group per day"
+        case .custom:       "I'll define my own"
+        }
+    }
+}
+
+/// Preferred session duration.
+enum FitnessSessionLength: String, Codable, CaseIterable, Identifiable {
+    case thirty
+    case fortyFive
+    case sixty
+    case seventyFivePlus
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .thirty:           "30 min"
+        case .fortyFive:        "45 min"
+        case .sixty:            "60 min"
+        case .seventyFivePlus:  "75+ min"
+        }
+    }
+}
+
+// MARK: - User Fitness Profile
+
+/// Captured by the onboarding questionnaire (#259) and consumed by the AI helper (#252).
+/// Local-first: persisted via `UserDefaults` JSON. Supabase sync may come later.
+struct UserFitnessProfile: Codable, Equatable {
+    var primaryGoal: FitnessPrimaryGoal?
+    var experience: FitnessExperience?
+    var workoutsPerWeek: FitnessWorkoutsPerWeek?
+    var preferredSplit: FitnessSplit?
+    var sessionLength: FitnessSessionLength?
+
+    /// Set when the user finishes the questionnaire. `nil` until completed.
+    var completedAt: Date?
+
+    init(
+        primaryGoal: FitnessPrimaryGoal? = nil,
+        experience: FitnessExperience? = nil,
+        workoutsPerWeek: FitnessWorkoutsPerWeek? = nil,
+        preferredSplit: FitnessSplit? = nil,
+        sessionLength: FitnessSessionLength? = nil,
+        completedAt: Date? = nil
+    ) {
+        self.primaryGoal = primaryGoal
+        self.experience = experience
+        self.workoutsPerWeek = workoutsPerWeek
+        self.preferredSplit = preferredSplit
+        self.sessionLength = sessionLength
+        self.completedAt = completedAt
+    }
+
+    /// True when every required answer is set.
+    var isComplete: Bool {
+        primaryGoal != nil
+            && experience != nil
+            && workoutsPerWeek != nil
+            && preferredSplit != nil
+            && sessionLength != nil
+    }
+}
+
+// MARK: - UserDefaults-backed singleton accessor
+
+extension UserFitnessProfile {
+    /// Single source of truth for the user's fitness questionnaire answers.
+    /// Reading always returns a value (empty profile if nothing stored).
+    /// Writing JSON-encodes and persists under `userFitnessProfile`.
+    static var current: UserFitnessProfile {
+        get {
+            guard let data = UserDefaults.standard.data(forKey: storageKey) else {
+                return UserFitnessProfile()
+            }
+            do {
+                return try JSONDecoder().decode(UserFitnessProfile.self, from: data)
+            } catch {
+                return UserFitnessProfile()
+            }
+        }
+        set {
+            do {
+                let data = try JSONEncoder().encode(newValue)
+                UserDefaults.standard.set(data, forKey: storageKey)
+            } catch {
+                // Encoding a small struct of enums + Date should never fail.
+                assertionFailure("Failed to encode UserFitnessProfile: \(error)")
+            }
+        }
+    }
+
+    static let storageKey = "userFitnessProfile"
+}

--- a/Xomfit/Views/Onboarding/FitnessQuestionnaireView.swift
+++ b/Xomfit/Views/Onboarding/FitnessQuestionnaireView.swift
@@ -1,0 +1,450 @@
+import SwiftUI
+
+// MARK: - Mode
+
+enum FitnessQuestionnaireMode {
+    /// First-launch flow: shows "Maybe later" skip option, calls onFinish on save/skip.
+    case onboarding
+    /// Profile edit mode: no skip option, dismisses on save.
+    case edit
+}
+
+// MARK: - View
+
+struct FitnessQuestionnaireView: View {
+    let mode: FitnessQuestionnaireMode
+    let onFinish: () -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @AppStorage("onboardingSkipped") private var onboardingSkipped = false
+
+    @State private var draft: UserFitnessProfile
+    @State private var currentPage = 0
+
+    private let totalPages = 5
+
+    init(
+        mode: FitnessQuestionnaireMode = .onboarding,
+        onFinish: @escaping () -> Void = {}
+    ) {
+        self.mode = mode
+        self.onFinish = onFinish
+        // Seed with whatever is persisted so edit mode shows current answers,
+        // and onboarding mode preserves partial selections across sessions.
+        _draft = State(initialValue: UserFitnessProfile.current)
+    }
+
+    var body: some View {
+        ZStack(alignment: .bottom) {
+            Theme.background.ignoresSafeArea()
+
+            // Subtle accent gradient
+            RadialGradient(
+                colors: [Theme.accent.opacity(0.04), .clear],
+                center: .top,
+                startRadius: 50,
+                endRadius: 600
+            )
+            .ignoresSafeArea()
+
+            TabView(selection: $currentPage) {
+                primaryGoalPage.tag(0)
+                experiencePage.tag(1)
+                workoutsPerWeekPage.tag(2)
+                splitPage.tag(3)
+                sessionLengthPage.tag(4)
+            }
+            .tabViewStyle(.page(indexDisplayMode: .never))
+            .animation(.xomChill, value: currentPage)
+
+            bottomBar
+        }
+        .preferredColorScheme(.dark)
+        .toolbar(mode == .edit ? .visible : .hidden, for: .navigationBar)
+    }
+
+    // MARK: - Pages
+
+    private var primaryGoalPage: some View {
+        QuestionPage(
+            title: "What's your primary goal?",
+            subtitle: "We'll tailor your plan around this.",
+            stepIndex: 0,
+            totalSteps: totalPages
+        ) {
+            ChoiceList(
+                options: FitnessPrimaryGoal.allCases,
+                selection: $draft.primaryGoal,
+                label: { $0.title },
+                icon: { $0.icon }
+            )
+        }
+    }
+
+    private var experiencePage: some View {
+        QuestionPage(
+            title: "How experienced are you?",
+            subtitle: "Be honest — beginners get the best gains.",
+            stepIndex: 1,
+            totalSteps: totalPages
+        ) {
+            ChoiceList(
+                options: FitnessExperience.allCases,
+                selection: $draft.experience,
+                label: { $0.title },
+                subtitle: { $0.subtitle }
+            )
+        }
+    }
+
+    private var workoutsPerWeekPage: some View {
+        QuestionPage(
+            title: "How many workouts per week?",
+            subtitle: "Pick a realistic target.",
+            stepIndex: 2,
+            totalSteps: totalPages
+        ) {
+            ChipGrid(
+                options: FitnessWorkoutsPerWeek.allCases,
+                selection: $draft.workoutsPerWeek,
+                label: { $0.title }
+            )
+        }
+    }
+
+    private var splitPage: some View {
+        QuestionPage(
+            title: "Preferred split?",
+            subtitle: "How do you like to organize your sessions?",
+            stepIndex: 3,
+            totalSteps: totalPages
+        ) {
+            ChoiceList(
+                options: FitnessSplit.allCases,
+                selection: $draft.preferredSplit,
+                label: { $0.title },
+                subtitle: { $0.subtitle }
+            )
+        }
+    }
+
+    private var sessionLengthPage: some View {
+        QuestionPage(
+            title: "How long per session?",
+            subtitle: "Including warm-ups and rest.",
+            stepIndex: 4,
+            totalSteps: totalPages
+        ) {
+            ChipGrid(
+                options: FitnessSessionLength.allCases,
+                selection: $draft.sessionLength,
+                label: { $0.title }
+            )
+        }
+    }
+
+    // MARK: - Bottom bar
+
+    private var bottomBar: some View {
+        VStack(spacing: Theme.Spacing.md) {
+            // Progress dots
+            HStack(spacing: Theme.Spacing.sm) {
+                ForEach(0..<totalPages, id: \.self) { index in
+                    Circle()
+                        .fill(index == currentPage ? Theme.accent : Theme.surfaceElevated)
+                        .frame(width: 8, height: 8)
+                        .overlay(
+                            Circle()
+                                .strokeBorder(
+                                    index == currentPage ? Theme.accent : Theme.hairline,
+                                    lineWidth: 0.5
+                                )
+                        )
+                        .scaleEffect(index == currentPage ? 1.2 : 1)
+                        .animation(.xomPlayful, value: currentPage)
+                }
+            }
+
+            // Primary CTA
+            XomButton(primaryButtonTitle, action: advance)
+                .disabled(!canAdvance)
+                .opacity(canAdvance ? 1 : 0.5)
+
+            // Secondary actions
+            HStack {
+                if currentPage > 0 {
+                    Button("Back") {
+                        Haptics.light()
+                        withAnimation(.xomChill) { currentPage -= 1 }
+                    }
+                    .font(.subheadline.weight(.medium))
+                    .foregroundStyle(Theme.textSecondary)
+                }
+
+                Spacer()
+
+                if mode == .onboarding {
+                    Button("Maybe later", action: skip)
+                        .font(.subheadline.weight(.medium))
+                        .foregroundStyle(Theme.textSecondary)
+                } else if mode == .edit {
+                    Button("Cancel") { dismiss() }
+                        .font(.subheadline.weight(.medium))
+                        .foregroundStyle(Theme.textSecondary)
+                }
+            }
+        }
+        .padding(.horizontal, Theme.Spacing.lg)
+        .padding(.bottom, Theme.Spacing.xl)
+    }
+
+    // MARK: - Logic
+
+    private var canAdvance: Bool {
+        switch currentPage {
+        case 0: draft.primaryGoal != nil
+        case 1: draft.experience != nil
+        case 2: draft.workoutsPerWeek != nil
+        case 3: draft.preferredSplit != nil
+        case 4: draft.sessionLength != nil
+        default: false
+        }
+    }
+
+    private var primaryButtonTitle: String {
+        currentPage == totalPages - 1 ? "Save" : "Continue"
+    }
+
+    private func advance() {
+        Haptics.light()
+        if currentPage < totalPages - 1 {
+            withAnimation(.xomChill) { currentPage += 1 }
+        } else {
+            save()
+        }
+    }
+
+    private func save() {
+        var saved = draft
+        saved.completedAt = Date()
+        UserFitnessProfile.current = saved
+        // Once they've completed, they're not "skipped" anymore.
+        onboardingSkipped = false
+        Haptics.success()
+
+        if mode == .edit {
+            dismiss()
+        } else {
+            onFinish()
+        }
+    }
+
+    private func skip() {
+        Haptics.light()
+        onboardingSkipped = true
+        onFinish()
+    }
+}
+
+// MARK: - Question Page Container
+
+private struct QuestionPage<Content: View>: View {
+    let title: String
+    let subtitle: String
+    let stepIndex: Int
+    let totalSteps: Int
+    @ViewBuilder var content: () -> Content
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: Theme.Spacing.lg) {
+                Spacer().frame(height: Theme.Spacing.xl)
+
+                VStack(spacing: Theme.Spacing.sm) {
+                    Text("Step \(stepIndex + 1) of \(totalSteps)")
+                        .font(Theme.fontMetricLabel)
+                        .foregroundStyle(Theme.textSecondary)
+                        .textCase(.uppercase)
+                        .kerning(0.5)
+
+                    Text(title)
+                        .font(Theme.fontTitle)
+                        .foregroundStyle(Theme.textPrimary)
+                        .multilineTextAlignment(.center)
+
+                    Text(subtitle)
+                        .font(Theme.fontSubheadline)
+                        .foregroundStyle(Theme.textSecondary)
+                        .multilineTextAlignment(.center)
+                }
+                .padding(.horizontal, Theme.Spacing.lg)
+                .staggeredAppear(index: 0)
+
+                content()
+                    .padding(.horizontal, Theme.Spacing.lg)
+                    .staggeredAppear(index: 1)
+
+                // Leave room for the bottom bar.
+                Spacer().frame(height: 180)
+            }
+        }
+        .scrollIndicators(.hidden)
+    }
+}
+
+// MARK: - Choice List (vertical card list with optional subtitle/icon)
+
+private struct ChoiceList<Option: Identifiable & Hashable>: View {
+    let options: [Option]
+    @Binding var selection: Option?
+    let label: (Option) -> String
+    var subtitle: ((Option) -> String)? = nil
+    var icon: ((Option) -> String)? = nil
+
+    var body: some View {
+        VStack(spacing: Theme.Spacing.sm) {
+            ForEach(options) { option in
+                ChoiceRow(
+                    label: label(option),
+                    subtitle: subtitle?(option),
+                    icon: icon?(option),
+                    isSelected: selection == option,
+                    onTap: {
+                        Haptics.selection()
+                        withAnimation(.xomPlayful) {
+                            selection = option
+                        }
+                    }
+                )
+            }
+        }
+    }
+}
+
+private struct ChoiceRow: View {
+    let label: String
+    let subtitle: String?
+    let icon: String?
+    let isSelected: Bool
+    let onTap: () -> Void
+
+    var body: some View {
+        Button(action: onTap) {
+            HStack(spacing: Theme.Spacing.md) {
+                if let icon {
+                    Image(systemName: icon)
+                        .font(.title3)
+                        .foregroundStyle(isSelected ? Theme.accent : Theme.textSecondary)
+                        .frame(width: 32, height: 32)
+                }
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(label)
+                        .font(.body.weight(.semibold))
+                        .foregroundStyle(Theme.textPrimary)
+
+                    if let subtitle {
+                        Text(subtitle)
+                            .font(Theme.fontSmall)
+                            .foregroundStyle(Theme.textSecondary)
+                    }
+                }
+
+                Spacer()
+
+                Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                    .font(.title3)
+                    .foregroundStyle(isSelected ? Theme.accent : Theme.textTertiary)
+            }
+            .padding(Theme.Spacing.md)
+            .frame(minHeight: 56)
+            .background(
+                RoundedRectangle(cornerRadius: Theme.Radius.md)
+                    .fill(isSelected ? Theme.accent.opacity(0.08) : Theme.surface)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: Theme.Radius.md)
+                    .strokeBorder(
+                        isSelected ? Theme.accent : Theme.hairline,
+                        lineWidth: isSelected ? 1.5 : 0.5
+                    )
+            )
+        }
+        .buttonStyle(PressableCardStyle())
+        .accessibilityLabel(label)
+        .accessibilityValue(isSelected ? "Selected" : "Not selected")
+        .accessibilityAddTraits(isSelected ? [.isSelected] : [])
+    }
+}
+
+// MARK: - Chip Grid (compact options like 30/45/60 min)
+
+private struct ChipGrid<Option: Identifiable & Hashable>: View {
+    let options: [Option]
+    @Binding var selection: Option?
+    let label: (Option) -> String
+
+    private let columns = [
+        GridItem(.flexible(), spacing: Theme.Spacing.sm),
+        GridItem(.flexible(), spacing: Theme.Spacing.sm),
+        GridItem(.flexible(), spacing: Theme.Spacing.sm)
+    ]
+
+    var body: some View {
+        LazyVGrid(columns: columns, spacing: Theme.Spacing.sm) {
+            ForEach(options) { option in
+                ChipButton(
+                    label: label(option),
+                    isSelected: selection == option,
+                    onTap: {
+                        Haptics.selection()
+                        withAnimation(.xomPlayful) {
+                            selection = option
+                        }
+                    }
+                )
+            }
+        }
+    }
+}
+
+private struct ChipButton: View {
+    let label: String
+    let isSelected: Bool
+    let onTap: () -> Void
+
+    var body: some View {
+        Button(action: onTap) {
+            Text(label)
+                .font(.body.weight(.semibold))
+                .foregroundStyle(isSelected ? .black : Theme.textPrimary)
+                .frame(maxWidth: .infinity, minHeight: 56)
+                .background(
+                    RoundedRectangle(cornerRadius: Theme.Radius.md)
+                        .fill(isSelected ? Theme.accent : Theme.surface)
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: Theme.Radius.md)
+                        .strokeBorder(
+                            isSelected ? Color.clear : Theme.hairline,
+                            lineWidth: 0.5
+                        )
+                )
+        }
+        .buttonStyle(PressableCardStyle())
+        .accessibilityLabel(label)
+        .accessibilityAddTraits(isSelected ? [.isSelected] : [])
+    }
+}
+
+// MARK: - Preview
+
+#Preview("Onboarding") {
+    FitnessQuestionnaireView(mode: .onboarding, onFinish: {})
+}
+
+#Preview("Edit") {
+    NavigationStack {
+        FitnessQuestionnaireView(mode: .edit, onFinish: {})
+    }
+}

--- a/Xomfit/Views/Profile/SettingsView.swift
+++ b/Xomfit/Views/Profile/SettingsView.swift
@@ -10,6 +10,15 @@ struct SettingsView: View {
         return "\(version) (\(build))"
     }
 
+    /// Short summary of the current fitness questionnaire state for the row trailing label.
+    private var fitnessGoalsSummary: String {
+        let profile = UserFitnessProfile.current
+        guard profile.completedAt != nil, let goal = profile.primaryGoal else {
+            return "Not set"
+        }
+        return goal.title
+    }
+
     var body: some View {
         ZStack {
             Theme.background.ignoresSafeArea()
@@ -40,6 +49,33 @@ struct SettingsView: View {
                     .tint(Theme.textTertiary)
                 } header: {
                     XomMetricLabel("Notifications")
+                }
+                .listRowBackground(Theme.surface)
+                .listRowSeparatorTint(Theme.hairline)
+
+                Section {
+                    NavigationLink {
+                        FitnessQuestionnaireView(mode: .edit)
+                            .navigationTitle("Fitness Goals")
+                            .navigationBarTitleDisplayMode(.inline)
+                            .hideTabBar()
+                    } label: {
+                        HStack(spacing: Theme.Spacing.md) {
+                            Image(systemName: "target")
+                                .frame(width: 24)
+                                .foregroundStyle(Theme.accent)
+                            Text("Fitness Goals")
+                                .foregroundStyle(Theme.textPrimary)
+                            Spacer()
+                            Text(fitnessGoalsSummary)
+                                .font(Theme.fontCaption)
+                                .foregroundStyle(Theme.textTertiary)
+                                .lineLimit(1)
+                        }
+                    }
+                    .tint(Theme.textTertiary)
+                } header: {
+                    XomMetricLabel("Training")
                 }
                 .listRowBackground(Theme.surface)
                 .listRowSeparatorTint(Theme.hairline)

--- a/Xomfit/XomfitApp.swift
+++ b/Xomfit/XomfitApp.swift
@@ -6,6 +6,11 @@ struct XomFitApp: App {
     @State private var authService = AuthService()
     @State private var workoutSession = WorkoutLoggerViewModel()
 
+    /// Drives the fitness-profile questionnaire (#259). Bumped after dismissal so
+    /// the cover doesn't re-present unless the user explicitly opens it again.
+    @State private var showFitnessQuestionnaire = false
+    @AppStorage("onboardingSkipped") private var onboardingSkipped = false
+
     var body: some Scene {
         WindowGroup {
             Group {
@@ -26,16 +31,25 @@ struct XomFitApp: App {
                         .environment(workoutSession)
                         .task {
                             await NotificationService.shared.requestPermission()
+                            evaluateFitnessQuestionnaireGate()
                         }
                         .sheet(isPresented: Bindable(authService).needsProfileCompletion) {
                             ProfileCompletionView()
                                 .environment(authService)
                                 .interactiveDismissDisabled()
+                                .onDisappear { evaluateFitnessQuestionnaireGate() }
                         }
                         .fullScreenCover(isPresented: Bindable(authService).needsOnboarding) {
                             OnboardingView()
                                 .environment(authService)
                                 .interactiveDismissDisabled()
+                                .onDisappear { evaluateFitnessQuestionnaireGate() }
+                        }
+                        .fullScreenCover(isPresented: $showFitnessQuestionnaire) {
+                            FitnessQuestionnaireView(mode: .onboarding) {
+                                showFitnessQuestionnaire = false
+                            }
+                            .interactiveDismissDisabled()
                         }
                 } else {
                     LoginView()
@@ -55,5 +69,17 @@ struct XomFitApp: App {
                 }
             }
         }
+    }
+
+    /// Decide whether to present the fitness questionnaire on this launch.
+    /// Don't re-prompt once the user finishes it OR explicitly skipped — they can
+    /// always reopen it from Settings -> Fitness Goals.
+    private func evaluateFitnessQuestionnaireGate() {
+        guard authService.isAuthenticated else { return }
+        guard !authService.needsProfileCompletion else { return }
+        guard !authService.needsOnboarding else { return }
+        guard UserFitnessProfile.current.completedAt == nil else { return }
+        guard !onboardingSkipped else { return }
+        showFitnessQuestionnaire = true
     }
 }


### PR DESCRIPTION
Closes #259.

## Summary
Captures lifting goals via a 5-question paged questionnaire. Used as a first-launch gate (skippable) and editable later from Settings → Training → Fitness Goals. Data lands in `UserDefaults` under `userFitnessProfile` and is read by #252 (AI Coach).

Questions: primary goal / experience / workouts per week / split / session length.

- New: `Models/UserFitnessProfile.swift` (Codable + `static var current` + 5 enums + `.isComplete`)
- New: `Views/Onboarding/FitnessQuestionnaireView.swift` (paged TabView, modes: `.onboarding` / `.edit`)
- Modified: `XomfitApp.swift` — fullScreenCover gate after auth/onboarding
- Modified: `Profile/SettingsView.swift` — Training section row

## Test plan
- [ ] Fresh install → after auth, questionnaire appears full-screen
- [ ] Fill 5 questions → Save → main app appears, settings shows current goal
- [ ] Skip → main app appears, no re-prompt next launch (`onboardingSkipped` set)
- [ ] Settings → Fitness Goals → opens in edit mode, existing answers prefilled
- [ ] `UserFitnessProfile.current.isComplete` returns true after save (consumed by #252)