### PR TITLE
#253 add tappable current-exercise pill + jumper sheet

### DIFF
--- a/Xomfit/ViewModels/WorkoutLoggerViewModel.swift
+++ b/Xomfit/ViewModels/WorkoutLoggerViewModel.swift
@@ -420,6 +420,47 @@ final class WorkoutLoggerViewModel {
         focusSetIndex = 0
     }
 
+    // MARK: - Current-Exercise Pill Accessors (#253)
+    //
+    // These additive computed properties drive the persistent "current exercise"
+    // pill in `ActiveWorkoutView`. They never mutate state and are safe to call
+    // even when `focusExerciseIndex` is out of bounds.
+
+    /// Name of the exercise currently in focus, or `nil` when there is no valid focus.
+    var currentExerciseName: String? {
+        focusExercise?.exercise.name
+    }
+
+    /// 1-based set number of the focused set, clamped to `[1, totalSets]`.
+    /// Returns `1` when there is no focused exercise (caller should branch on `currentExerciseName`).
+    var currentSetNumber: Int {
+        let total = currentExerciseTotalSets
+        guard total > 0 else { return 1 }
+        return min(max(focusSetIndex + 1, 1), total)
+    }
+
+    /// Total number of sets in the focused exercise. `0` when no exercise in focus.
+    var currentExerciseTotalSets: Int {
+        focusExercise?.sets.count ?? 0
+    }
+
+    /// Free navigation jump used by the exercise-jumper sheet (#253).
+    ///
+    /// Distinct from `moveToExercise(index:)`, which is part of the post-set
+    /// transition-card flow. `jumpToExercise` deliberately does NOT toggle
+    /// `showExerciseTransition` — the user is mid-workout and explicitly chose
+    /// to switch exercises, not completing one.
+    func jumpToExercise(index: Int) {
+        guard exercises.indices.contains(index) else { return }
+        focusExerciseIndex = index
+        // Land on the first incomplete set; fall back to set 0 when fully complete.
+        if let setIdx = exercises[index].sets.firstIndex(where: { $0.completedAt == Date.distantPast }) {
+            focusSetIndex = setIdx
+        } else {
+            focusSetIndex = 0
+        }
+    }
+
     /// Sync focus indices to the first incomplete exercise/set. Called when entering focus mode from list mode.
     func syncFocusToCurrentExercise() {
         // Find first exercise with an incomplete set

--- a/Xomfit/Views/Workout/ActiveWorkoutView.swift
+++ b/Xomfit/Views/Workout/ActiveWorkoutView.swift
@@ -17,6 +17,11 @@ struct ActiveWorkoutView: View {
     @State private var timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
     @State private var restTimerHapticFired = false
     @State private var showStartingExercisePicker = false
+    /// Mid-workout exercise jumper (#253). Reachable any time via the persistent pill.
+    @State private var showExerciseJumper = false
+    /// Set after `jumpToExercise` runs; consumed by the list-mode `ScrollViewReader`
+    /// to scroll to the picked card, then cleared.
+    @State private var pendingScrollIndex: Int?
 
     var body: some View {
         @Bindable var viewModel = viewModel
@@ -28,6 +33,12 @@ struct ActiveWorkoutView: View {
                 VStack(spacing: 0) {
                     // Header bar
                     headerBar
+
+                    // Persistent current-exercise pill (#253). Sits below the header so it
+                    // doesn't fight any other header controls (pause button, etc.).
+                    if !viewModel.exercises.isEmpty {
+                        currentExercisePill
+                    }
 
                     // Rest timer config — hidden when rest timer is running (redundant with the active card)
                     if !viewModel.isRestTimerActive && !viewModel.focusMode {
@@ -58,24 +69,35 @@ struct ActiveWorkoutView: View {
                         if viewModel.exercises.isEmpty {
                             emptyState
                         } else {
-                            ScrollView {
-                                LazyVStack(spacing: Theme.Spacing.md) {
-                                    ForEach(viewModel.exercises.indices, id: \.self) { exIdx in
-                                        ExerciseCard(
-                                            exerciseIndex: exIdx,
-                                            viewModel: viewModel
-                                        )
+                            ScrollViewReader { proxy in
+                                ScrollView {
+                                    LazyVStack(spacing: Theme.Spacing.md) {
+                                        ForEach(viewModel.exercises.indices, id: \.self) { exIdx in
+                                            ExerciseCard(
+                                                exerciseIndex: exIdx,
+                                                viewModel: viewModel
+                                            )
+                                            .id(exIdx)
+                                        }
                                     }
+                                    .padding(Theme.Spacing.md)
+                                    // Bottom padding so FAB doesn't overlap last card
+                                    .padding(.bottom, 80)
                                 }
-                                .padding(Theme.Spacing.md)
-                                // Bottom padding so FAB doesn't overlap last card
-                                .padding(.bottom, 80)
-                            }
-                            .onTapGesture {
-                                UIApplication.shared.sendAction(
-                                    #selector(UIResponder.resignFirstResponder),
-                                    to: nil, from: nil, for: nil
-                                )
+                                .onTapGesture {
+                                    UIApplication.shared.sendAction(
+                                        #selector(UIResponder.resignFirstResponder),
+                                        to: nil, from: nil, for: nil
+                                    )
+                                }
+                                .onChange(of: pendingScrollIndex) { _, newValue in
+                                    guard let idx = newValue else { return }
+                                    withAnimation(.xomChill) {
+                                        proxy.scrollTo(idx, anchor: .top)
+                                    }
+                                    // Clear after the scroll has been kicked off.
+                                    pendingScrollIndex = nil
+                                }
                             }
                         }
                     }
@@ -195,6 +217,14 @@ struct ActiveWorkoutView: View {
             )
             .presentationDetents([.large])
             .presentationDragIndicator(.visible)
+        }
+        .sheet(isPresented: $showExerciseJumper) {
+            ExerciseJumperSheet(viewModel: viewModel) { idx in
+                // Trigger list-mode scroll. In focus mode this is harmless —
+                // `.id(viewModel.focusExerciseIndex)` on the focus view drives
+                // the visual transition independently.
+                pendingScrollIndex = idx
+            }
         }
         .sheet(isPresented: $showStartingExercisePicker) {
             NavigationStack {
@@ -346,6 +376,83 @@ struct ActiveWorkoutView: View {
         .padding(.top, Theme.Spacing.md)
         .padding(.bottom, Theme.Spacing.md)
         .background(Theme.surface)
+    }
+
+    // MARK: - Current Exercise Pill (#253)
+
+    /// Persistent, tappable indicator of the current exercise + set.
+    /// Sits directly below the header bar (intentionally not inside the headerBar
+    /// to avoid colliding with other header controls).
+    private var currentExercisePill: some View {
+        Button {
+            Haptics.selection()
+            showExerciseJumper = true
+        } label: {
+            HStack(spacing: Theme.Spacing.sm) {
+                Image(systemName: "figure.strengthtraining.traditional")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(Theme.accent)
+
+                if viewModel.allExercisesComplete {
+                    Text("All exercises complete")
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(Theme.textPrimary)
+                        .lineLimit(1)
+                } else if let name = viewModel.currentExerciseName {
+                    Text(name)
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(Theme.textPrimary)
+                        .lineLimit(1)
+
+                    Text("\u{2022}")
+                        .font(.caption.weight(.bold))
+                        .foregroundStyle(Theme.textTertiary)
+
+                    Text("Set \(viewModel.currentSetNumber)/\(max(viewModel.currentExerciseTotalSets, 1))")
+                        .font(.subheadline.weight(.medium))
+                        .foregroundStyle(Theme.textSecondary)
+                        .lineLimit(1)
+                } else {
+                    Text("—")
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(Theme.textSecondary)
+                }
+
+                Spacer(minLength: Theme.Spacing.sm)
+
+                Image(systemName: "chevron.up.chevron.down")
+                    .font(.caption.weight(.bold))
+                    .foregroundStyle(Theme.textSecondary)
+            }
+            .padding(.horizontal, Theme.Spacing.md)
+            .padding(.vertical, Theme.Spacing.sm)
+            .frame(minHeight: 44)
+            .frame(maxWidth: .infinity)
+            .background(Theme.surface)
+            .clipShape(.capsule)
+            .overlay(
+                Capsule()
+                    .stroke(Theme.accent.opacity(0.2), lineWidth: 1)
+            )
+            .contentShape(Capsule())
+        }
+        .buttonStyle(.plain)
+        .padding(.horizontal, Theme.Spacing.md)
+        .padding(.top, Theme.Spacing.xs)
+        .accessibilityLabel(pillAccessibilityLabel)
+        .accessibilityHint("Opens the exercise list to switch exercises")
+    }
+
+    /// Voice-over label that names the current exercise + set context.
+    private var pillAccessibilityLabel: String {
+        if viewModel.allExercisesComplete {
+            return "All exercises complete. Tap to switch exercises."
+        }
+        guard let name = viewModel.currentExerciseName else {
+            return "No current exercise. Tap to choose one."
+        }
+        let total = max(viewModel.currentExerciseTotalSets, 1)
+        return "Current exercise: \(name), set \(viewModel.currentSetNumber) of \(total). Tap to switch exercises."
     }
 
     /// Compact rest countdown string for the header chip (matches RestTimerView format).

--- a/Xomfit/Views/Workout/ExerciseJumperSheet.swift
+++ b/Xomfit/Views/Workout/ExerciseJumperSheet.swift
@@ -1,0 +1,168 @@
+import SwiftUI
+
+/// Bottom-sheet exercise jumper for mid-workout switching (#253).
+///
+/// Lists every exercise in the active workout with completion state and
+/// per-set dots. Tapping a row jumps focus and dismisses the sheet, then
+/// hands the picked index back to the parent via `onJump` so list mode can
+/// scroll to the corresponding card.
+///
+/// Distinct from the post-set transition card and the focus-mode entry
+/// picker — this sheet is reachable any time during the workout via the
+/// persistent current-exercise pill.
+struct ExerciseJumperSheet: View {
+    let viewModel: WorkoutLoggerViewModel
+    /// Called with the picked index after the VM jump completes. Parent uses
+    /// this to scroll the list-mode `ScrollViewReader` to the card.
+    var onJump: (Int) -> Void
+
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Theme.background.ignoresSafeArea()
+
+                ScrollView {
+                    LazyVStack(spacing: Theme.Spacing.sm) {
+                        ForEach(Array(viewModel.exercises.enumerated()), id: \.element.id) { idx, exercise in
+                            row(idx: idx, exercise: exercise)
+                        }
+                    }
+                    .padding(Theme.Spacing.md)
+                }
+            }
+            .navigationTitle("Switch Exercise")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Done") { dismiss() }
+                        .foregroundStyle(Theme.accent)
+                }
+            }
+        }
+        .presentationDetents([.medium, .large])
+        .presentationDragIndicator(.visible)
+    }
+
+    // MARK: - Row
+
+    @ViewBuilder
+    private func row(idx: Int, exercise: WorkoutExercise) -> some View {
+        let allComplete = !exercise.sets.isEmpty && exercise.sets.allSatisfy { $0.completedAt != Date.distantPast }
+        let isCurrent = idx == viewModel.focusExerciseIndex
+        let completedCount = exercise.sets.filter { $0.completedAt != Date.distantPast }.count
+        let totalCount = exercise.sets.count
+
+        Button {
+            Haptics.selection()
+            viewModel.jumpToExercise(index: idx)
+            onJump(idx)
+            dismiss()
+        } label: {
+            HStack(alignment: .center, spacing: Theme.Spacing.md) {
+                // Leading status icon
+                Image(systemName: leadingIconName(allComplete: allComplete, completedCount: completedCount))
+                    .font(.title3.weight(.semibold))
+                    .foregroundStyle(leadingIconColor(allComplete: allComplete, completedCount: completedCount))
+                    .frame(width: 28, height: 28)
+
+                VStack(alignment: .leading, spacing: 6) {
+                    HStack(spacing: 6) {
+                        Text(exercise.exercise.name)
+                            .font(.body.weight(.semibold))
+                            .foregroundStyle(allComplete ? Theme.textSecondary : Theme.textPrimary)
+                            .lineLimit(2)
+                            .multilineTextAlignment(.leading)
+
+                        if isCurrent {
+                            Text("Current")
+                                .font(.caption2.weight(.bold))
+                                .foregroundStyle(.black)
+                                .padding(.horizontal, 6)
+                                .padding(.vertical, 2)
+                                .background(Theme.accent)
+                                .clipShape(.capsule)
+                        }
+                    }
+
+                    HStack(spacing: 6) {
+                        // Per-set dots
+                        ForEach(Array(exercise.sets.enumerated()), id: \.element.id) { setIdx, set in
+                            let setDone = set.completedAt != Date.distantPast
+                            Circle()
+                                .strokeBorder(setDone ? Color.clear : Theme.textSecondary.opacity(0.6), lineWidth: 1)
+                                .background(
+                                    Circle().fill(setDone ? Theme.accent : Color.clear)
+                                )
+                                .frame(width: 8, height: 8)
+                                .accessibilityHidden(true)
+                                .id(setIdx)
+                        }
+
+                        Text("\(completedCount)/\(totalCount)")
+                            .font(.caption.weight(.medium))
+                            .foregroundStyle(Theme.textSecondary)
+                            .padding(.leading, 4)
+                    }
+                }
+
+                Spacer(minLength: 0)
+
+                Image(systemName: "chevron.right")
+                    .font(.caption.weight(.bold))
+                    .foregroundStyle(Theme.textTertiary)
+            }
+            .padding(.horizontal, Theme.Spacing.md)
+            .padding(.vertical, Theme.Spacing.sm)
+            .frame(minHeight: 56)
+            .background(rowBackground(isCurrent: isCurrent, allComplete: allComplete))
+            .clipShape(.rect(cornerRadius: Theme.cornerRadiusSmall))
+            .overlay(
+                RoundedRectangle(cornerRadius: Theme.cornerRadiusSmall)
+                    .stroke(isCurrent ? Theme.accent : Color.clear, lineWidth: 1.5)
+            )
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(accessibilityLabel(
+            name: exercise.exercise.name,
+            completed: completedCount,
+            total: totalCount,
+            isCurrent: isCurrent,
+            allComplete: allComplete
+        ))
+        .accessibilityHint("Switches focus to this exercise")
+    }
+
+    // MARK: - Styling helpers
+
+    private func leadingIconName(allComplete: Bool, completedCount: Int) -> String {
+        if allComplete { return "checkmark.circle.fill" }
+        if completedCount > 0 { return "circle.lefthalf.filled" }
+        return "circle"
+    }
+
+    private func leadingIconColor(allComplete: Bool, completedCount: Int) -> Color {
+        if allComplete { return Theme.accent }
+        if completedCount > 0 { return Theme.accent }
+        return Theme.textSecondary
+    }
+
+    private func rowBackground(isCurrent: Bool, allComplete: Bool) -> Color {
+        if isCurrent { return Theme.accent.opacity(0.10) }
+        if allComplete { return Theme.surface.opacity(0.5) }
+        return Theme.surface
+    }
+
+    private func accessibilityLabel(name: String, completed: Int, total: Int, isCurrent: Bool, allComplete: Bool) -> String {
+        var parts: [String] = [name]
+        if isCurrent { parts.append("current exercise") }
+        if allComplete {
+            parts.append("all \(total) sets complete")
+        } else {
+            parts.append("\(completed) of \(total) sets complete")
+        }
+        return parts.joined(separator: ", ")
+    }
+}

--- a/docs/features/mid-workout-switch-253/EXECUTION_LOG.md
+++ b/docs/features/mid-workout-switch-253/EXECUTION_LOG.md
@@ -1,0 +1,40 @@
+# Execution Log: Mid-Workout Exercise Switcher (#253)
+
+**Branch**: `feat/253-mid-workout-switch`
+**Base**: `master`
+**Date**: 2026-05-09
+
+## Summary
+Implemented the persistent current-exercise pill + jumper sheet end-to-end per the plan. All steps 1-7 complete. Step 8 (manual smoke test) is left to the user; build is clean.
+
+## Steps Completed
+
+- **Step 1 — VM helpers.** Added `currentExerciseName`, `currentSetNumber`, `currentExerciseTotalSets`, and `jumpToExercise(index:)` to `WorkoutLoggerViewModel`. The new method explicitly does NOT toggle `showExerciseTransition` (documented inline) so it stays decoupled from `moveToExercise(index:)`.
+- **Step 2 — Jumper sheet.** Created `Xomfit/Views/Workout/ExerciseJumperSheet.swift`. Lists every exercise with leading status icon, per-set dots, completion fraction, "Current" badge for the focused exercise, and a chevron. Uses `.medium`/`.large` detents with drag indicator. VoiceOver label + hint per row.
+- **Step 3 — Pill.** Added `currentExercisePill` private view in `ActiveWorkoutView`. Capsule on `Theme.surface` with `figure.strengthtraining.traditional` icon, exercise name, "Set N/M" framing, trailing `chevron.up.chevron.down`. Min 44pt tap target. Falls back to "All exercises complete" copy when `viewModel.allExercisesComplete` is true. Includes accessibility label + hint.
+- **Step 4 — Sheet wiring.** Added `@State showExerciseJumper` and `@State pendingScrollIndex`. New `.sheet(isPresented: $showExerciseJumper)` modifier presents `ExerciseJumperSheet`, passing an `onJump` closure that sets `pendingScrollIndex`.
+- **Step 5 — Scroll-to-card.** Wrapped the list-mode `LazyVStack` in a `ScrollViewReader`, assigned `.id(exIdx)` to each `ExerciseCard`, and added `.onChange(of: pendingScrollIndex)` that calls `proxy.scrollTo(idx, anchor: .top)` inside `withAnimation(.xomChill)`, then clears `pendingScrollIndex`.
+- **Step 6 — Focus mode handling.** No code changes needed. `WorkoutFocusView` already keys on `viewModel.focusExerciseIndex` (`.id(...)` line 55) so the existing push transition fires when the jumper updates `focusExerciseIndex`.
+- **Step 7 — Don't double-trigger transition card.** Confirmed `jumpToExercise` does not set `showExerciseTransition`. Inline comment in the VM documents the distinction between `moveToExercise` (transition-flow path) and `jumpToExercise` (free navigation).
+
+## Coordination With #255
+- Pill placed below the `headerBar`, NOT inside it. The pause button being added to `headerBar` will not collide.
+- `WorkoutLoggerViewModel` was extended additively only (new computed properties + new method). I did not add or reference any `isPaused` property; the concurrent agent owns that.
+
+## Build
+- Command: `xcodebuild -project Xomfit.xcodeproj -scheme Xomfit -destination 'platform=iOS Simulator,name=iPhone 17' -configuration Debug build`
+- Result: **BUILD SUCCEEDED**
+- New/modified files: zero compiler warnings.
+- Pre-existing warnings in unrelated files (Onboarding, FriendsViewModel, ProfileViewModel) untouched.
+- One pre-existing environment dependency (`Xomfit/Config.swift`) had to be created from `Config.swift.template` to make the build pass; this file is gitignored and not part of the commit.
+
+## Files Changed
+- `Xomfit/ViewModels/WorkoutLoggerViewModel.swift` — additive: 4 new members.
+- `Xomfit/Views/Workout/ActiveWorkoutView.swift` — added pill, jumper sheet wiring, ScrollViewReader.
+- `Xomfit/Views/Workout/ExerciseJumperSheet.swift` — new file.
+
+## Test Plan Status
+Steps T1-T9 in `PLAN.md` are manual smoke tests that require launching the simulator and exercising the UI. Build verifies type-correctness; manual passes are deferred to the user.
+
+## Out of Scope (per plan)
+Reordering, renaming, search/filter, persistence, Live Activity surface, extra haptics — all left untouched.

--- a/docs/features/mid-workout-switch-253/PLAN.md
+++ b/docs/features/mid-workout-switch-253/PLAN.md
@@ -1,0 +1,104 @@
+# Plan: Mid-Workout Exercise Switcher
+
+**Status**: Ready
+**Created**: 2026-05-09
+**Last updated**: 2026-05-09
+**Issue**: [#253](https://github.com/Xomware/xomfit-ios/issues/253)
+**Branch**: `feature/253-mid-workout-switch`
+
+## Summary
+Mid-workout it is hard to switch between exercises — the only "choose different" affordance lives inside the post-set transition card, and the focus mode entry picker only appears when starting fresh (post #238 fix). Add a persistent, tappable "current exercise" pill at the top of the active workout that opens a bottom-sheet jumper listing every exercise with completion state, working in both list mode and focus mode. Success: at any point during a workout the user can see what they're on, tap it, pick another exercise, and land there in one gesture.
+
+## Approach
+Reuse the same VM state already in place (`focusExerciseIndex`, `focusSetIndex`, `syncFocusToCurrentExercise`, `moveToExercise`). No new persistence, no new model fields.
+
+- Add a compact `CurrentExercisePill` rendered between the existing header bar and the rest-timer config / focus-view content. Visible whenever `viewModel.exercises` is non-empty.
+- Pill content: exercise name + "Set N/M" (where N is the current set, M is total sets for that exercise).
+- Tap → presents an `ExerciseJumperSheet` (bottom sheet, `.medium` detent) listing every exercise with status (completed / in-progress / not-started) and per-set dots.
+- Tapping an exercise in the sheet sets `focusExerciseIndex` and `focusSetIndex` (first incomplete set, or set 0 if all complete) and dismisses the sheet. In list mode this scrolls the list to that exercise card; in focus mode the existing `id`-driven push transition already handles the visual jump.
+- This replaces no existing UI — the post-set transition card and the focus-mode entry picker continue to work unchanged.
+
+The existing `showStartingExercisePicker` sheet (lines 199-241 of `ActiveWorkoutView.swift`) is the closest existing pattern. The new jumper is a generalized version of it: shows all exercises (not just incomplete), works any time (not just at focus-mode entry), and is reachable from a persistent pill (not just from the eye toggle).
+
+## Affected Files / Components
+
+| File / Component | Change | Why |
+|------------------|--------|-----|
+| `Xomfit/Views/Workout/ActiveWorkoutView.swift` | Add `currentExercisePill` view + `showExerciseJumper` `@State` + `.sheet` for jumper. Insert pill below `headerBar` in both branches of the `if viewModel.focusMode` block. | Persistent indicator + tap target in both modes. |
+| `Xomfit/Views/Workout/ExerciseJumperSheet.swift` (new) | New file: bottom-sheet view listing all exercises with per-exercise completion summary + per-set dots. Tap jumps focus indices. | Centralized, reusable jumper UI. |
+| `Xomfit/ViewModels/WorkoutLoggerViewModel.swift` | Add a small computed `currentExerciseSummary: (name: String, setNumber: Int, totalSets: Int)?` or two computed accessors driving the pill text. Add `jumpToExercise(index:)` that mirrors `moveToExercise` but does not depend on the transition card flow. | Single source of truth for "what's current"; clean call site for the jumper. |
+| `Xomfit/Views/Workout/ActiveWorkoutView.swift` (list-mode `ScrollView`) | Wrap `LazyVStack` in a `ScrollViewReader` and assign each `ExerciseCard` an `.id(exIdx)` so the jumper can `proxy.scrollTo(idx, anchor: .top)` when the user picks from list mode. | Tap-to-jump is meaningless in list mode without scrolling to the card. |
+
+## Implementation Steps
+
+- [ ] **Step 1 — VM helpers.** In `WorkoutLoggerViewModel.swift`, add:
+  - `var currentExerciseName: String?` — name of `exercises[focusExerciseIndex]` if that index is valid, else `nil`.
+  - `var currentSetNumber: Int` — `focusSetIndex + 1` clamped to `[1, focusExercise?.sets.count ?? 1]`.
+  - `var currentExerciseTotalSets: Int` — `focusExercise?.sets.count ?? 0`.
+  - `func jumpToExercise(index: Int)` — guards `exercises.indices.contains(index)`, sets `focusExerciseIndex = index`, then sets `focusSetIndex` to the first incomplete set in that exercise (mirror `syncFocusToCurrentExercise` logic for a single exercise) — fallback to `0` if all complete. Does **not** toggle `showExerciseTransition`.
+  - These do not change existing behavior; they're additive.
+
+- [ ] **Step 2 — Build the jumper sheet.** Create `Xomfit/Views/Workout/ExerciseJumperSheet.swift`. Mirror the styling of the existing `showStartingExercisePicker` sheet (lines 199-241) but iterate over **all** `viewModel.exercises`. Per row:
+  - Exercise name (bold).
+  - Per-set dots: small filled circles for completed sets (`Theme.accent`), hollow stroked circles for incomplete (`Theme.textSecondary`). Reuse the visual language from `WorkoutFocusView.setIndicator` at smaller scale.
+  - Trailing "current" badge when `idx == viewModel.focusExerciseIndex`.
+  - Completed-state row tint (subtle dimming) when all sets for that exercise are done — they remain tappable (user might want to add another set or just look back).
+  - Tap → call `viewModel.jumpToExercise(index: idx)` then dismiss the sheet.
+  - Use `.presentationDetents([.medium, .large])` and `.presentationDragIndicator(.visible)`.
+
+- [ ] **Step 3 — Add the pill.** In `ActiveWorkoutView.swift`, inside the outer `VStack(spacing: 0)`, immediately after `headerBar` and before the `if !viewModel.isRestTimerActive && !viewModel.focusMode { restTimerConfig }` line, insert a private `currentExercisePill` view.
+  - Layout: rounded capsule, `Theme.surface` background, `.padding(.horizontal, Theme.Spacing.md)`, `.padding(.top, Theme.Spacing.xs)`. Inner `HStack`: small `figure.strengthtraining.traditional` icon, `Text(viewModel.currentExerciseName ?? "—")` (semibold), middle dot separator, `Text("Set \(viewModel.currentSetNumber)/\(viewModel.currentExerciseTotalSets)")` muted, `Spacer()`, trailing `chevron.up.chevron.down` to signal interactivity.
+  - Hidden when `viewModel.exercises.isEmpty` (the empty state already handles that case).
+  - Hidden when `viewModel.allExercisesComplete` — replace with a small "All exercises complete" row (still tappable to open the jumper) so the user can re-enter a finished exercise to add another set.
+  - Min 44pt tap target. `.accessibilityLabel("Current: \(name), set \(N) of \(M). Tap to switch exercises.")` `.accessibilityHint("Opens exercise list")`.
+  - Wrap as a `Button { showExerciseJumper = true; Haptics.selection() } label: { ... }.buttonStyle(.plain)`.
+
+- [ ] **Step 4 — Wire the sheet.** Add `@State private var showExerciseJumper = false` near the other sheet flags (around line 10-19). Add a new `.sheet(isPresented: $showExerciseJumper) { ExerciseJumperSheet(viewModel: viewModel) }` modifier alongside the existing sheets at the bottom of `body`.
+
+- [ ] **Step 5 — Scroll-to-card in list mode.** Wrap the list-mode `LazyVStack` (lines 62-72) inside a `ScrollViewReader`. Assign each `ExerciseCard` an `.id(exIdx)`. Expose a callback or use a `@State var pendingScrollIndex: Int?` driven by the jumper. After `jumpToExercise` runs, set `pendingScrollIndex` and use `.onChange(of: pendingScrollIndex)` inside the `ScrollViewReader` to call `proxy.scrollTo(idx, anchor: .top)` then clear it.
+  - Simpler alternative: have `ExerciseJumperSheet` accept an `onJump: (Int) -> Void` closure that the parent uses to set `pendingScrollIndex`. Closure approach keeps the sheet decoupled from `ScrollViewReader`. Use this.
+
+- [ ] **Step 6 — Focus mode handling.** No extra work — `WorkoutFocusView` already keys its content on `viewModel.focusExerciseIndex` (`.id(viewModel.focusExerciseIndex)` line 55) with a push transition. Setting `focusExerciseIndex` from the jumper triggers the existing animation. Verify in T2 below.
+
+- [ ] **Step 7 — Don't double-trigger transition card.** Confirm `jumpToExercise` does NOT set `showExerciseTransition = true`. The jumper is independent of post-set flow. Add a comment in the VM to document the distinction between `moveToExercise` (transition-flow path) and `jumpToExercise` (free navigation).
+
+- [ ] **Step 8 — Manual smoke test pass.** Run T1-T6 (below) on simulator.
+
+- [ ] **Step 9 — Commit.** `#253 active workout: persistent current-exercise pill + jumper sheet`
+
+## Test Plan (manual)
+
+- **T1 — Pill renders.** Start workout with 3 exercises. Pill shows first exercise name + "Set 1/3".
+- **T2 — Updates on set complete.** Complete set 1 → pill updates to "Set 2/3". Complete all 3 → pill updates to next exercise (after dismissing the existing transition card).
+- **T3 — List-mode jump.** Scroll to the bottom (4th+ exercise). Tap pill → sheet opens. Tap first exercise → sheet dismisses, list scrolls to first exercise card. `focusExerciseIndex` is updated.
+- **T4 — Focus-mode jump.** Toggle focus (eye icon). Pill still visible above focus content. Tap pill → sheet opens. Tap a different exercise → sheet dismisses, focus view animates to that exercise (existing push transition).
+- **T5 — Completed-exercise tap.** Complete all sets of exercise 1. Tap pill, tap exercise 1 in jumper → focus lands on its last set; user can `addSet` if they want another. No transition card pops.
+- **T6 — Existing flows untouched.** (a) Eye-toggle starting picker still appears on fresh multi-exercise workouts (#238 logic). (b) Post-set transition card still appears when completing all sets of an exercise. (c) "Choose Different" inside the transition card still works.
+- **T7 — Empty state.** Start a workout with no exercises queued. Pill is hidden. Add an exercise → pill appears.
+- **T8 — All complete state.** Complete every set across every exercise. Pill shows "All exercises complete" row, still tappable. Tapping opens the jumper; tapping any exercise jumps focus to its last set.
+- **T9 — Accessibility.** VoiceOver reads pill label; double-tap opens jumper. Dynamic Type at largest size doesn't truncate the pill into a broken layout (test at AccessibilityExtraExtraExtraLarge).
+
+## Out of Scope
+- Reordering exercises from inside the jumper sheet (use existing card up/down chevrons).
+- Renaming or removing exercises from the jumper.
+- Filter/search in the jumper — workouts have <20 exercises in practice.
+- Persisting jumper UI state across app launches.
+- Live Activity surface changes (Dynamic Island still shows current exercise via existing `currentExercise` field).
+- Haptics beyond a single `.selection` on pill tap.
+
+## Risks / Tradeoffs
+- **Conflict with #238 focus-mode entry picker.** The eye-toggle picker (`showStartingExercisePicker`) only fires on fresh workouts (`completedSets == 0`). The new jumper is reachable any time. Both can coexist — they target different moments — but we must not auto-open the jumper from the eye toggle. **Mitigation**: T6a covers this. Do not modify the eye-toggle logic in this PR.
+- **Visual crowding under the Dynamic Island.** Pill sits directly under `headerBar`. On smaller devices with island present + rest-timer chip in header, the area gets dense. **Mitigation**: pill uses subtle `Theme.surface` (not accent) and small font. If Test T1 shows visual collision, reduce vertical padding to `Theme.Spacing.xs`.
+- **List-mode scroll jank.** Wrapping `LazyVStack` in `ScrollViewReader` and assigning `.id(idx)` to each card is fine, but `LazyVStack` can mis-target `scrollTo` if a card is far off-screen and not yet rendered. **Mitigation**: use `anchor: .top` and call `scrollTo` inside `withAnimation(.xomChill)`. If jank appears, fall back to `ScrollView` with eager rendering for workouts <10 exercises.
+- **Pill state drift.** If `focusExerciseIndex` ever points outside `exercises.indices`, the pill must not crash. **Mitigation**: VM helpers guard with `exercises.indices.contains`; pill renders "—" / hides gracefully.
+- **Don't break the eye/focus-picker flow added in #238.** The new code path (`jumpToExercise`) is purely additive — `syncFocusToCurrentExercise()` and `showStartingExercisePicker` logic remain untouched. **Mitigation**: T6a explicitly checks the #238 flow still triggers exactly when expected.
+- **Focus-mode set indicator shows the same thing.** The horizontal set-dots strip in `WorkoutFocusView.setIndicator` already shows current set within current exercise. The pill is somewhat redundant in focus mode but provides the cross-exercise jumper entry point that focus mode currently lacks. Accepted tradeoff — small redundancy is worth a consistent affordance across modes.
+
+## Open Questions
+- [ ] Should pill text on a multi-set in-progress exercise show "Set 2/3" (current set focused) or "1/3 done" (sets completed)? Plan picks the former for parity with the focus-mode set dots; revisit if user feedback prefers progress phrasing.
+- [ ] Should the jumper sheet auto-open the first time a user enters list mode mid-workout, as a discoverability nudge? Default: no. Reconsider after a week of use.
+
+## Skills / Agents to Use
+- **ios-standards skill**: confirm `@Observable` patterns and the new sheet conforms to project SwiftUI conventions (`foregroundStyle`, `clipShape(.rect())`, `NavigationStack`).
+- **swift-ios-engineer agent**: implement Steps 1-7 end-to-end (single file additions + one new file + two cross-cutting edits in `ActiveWorkoutView`).
+- **code-reviewer agent**: post-implementation review focused on (a) `jumpToExercise` does not interact with `showExerciseTransition`, (b) `ScrollViewReader` does not regress list-mode rendering, (c) accessibility labels are present on the pill and jumper rows.


### PR DESCRIPTION
Closes #253.

## Summary
Adds a persistent pill below the workout header showing current exercise + set N/M. Tapping opens an `ExerciseJumperSheet` (bottom sheet, `.medium` / `.large` detents) with all exercises listed — completion status, set dots, "Current" badge — tap to jump.

VM additions (additive only): `currentExerciseName`, `currentSetNumber`, `currentExerciseTotalSets`, `jumpToExercise(index:)`. List mode wraps `LazyVStack` in `ScrollViewReader` and scrolls to the selected card on jump.

Coordinated with #255: pill placed BELOW the headerBar (not inside it) so the pause button stays where it is.

## Test plan
- [ ] Pill shows current exercise + set during workout (list and focus modes)
- [ ] Tap pill → jumper sheet, completion icons + set dots match VM state
- [ ] Tap an exercise → sheet dismisses, list mode scrolls to that card; focus mode swaps focused exercise
- [ ] Existing #238 transition card still fires on last-set completion
- [ ] Pause button (#255) still works without UI conflict