### PR TITLE
#252 add AI Coach chat (Anthropic API stub + profile context)

### DIFF
--- a/Xomfit/Config.swift.template
+++ b/Xomfit/Config.swift.template
@@ -6,12 +6,18 @@ enum Config {
     // Settings > API > Project URL and Anon Key
     static let supabaseURL = "YOUR_SUPABASE_URL"
     static let supabaseAnonKey = "YOUR_SUPABASE_ANON_KEY"
-    
+
+    // MARK: - Anthropic Configuration
+    // AI Coach uses Anthropic's Claude API. Build-time fallback only —
+    // users can also set their own key via Settings (stored in @AppStorage / Keychain).
+    // Get a key from https://console.anthropic.com/.
+    static let anthropicAPIKey = "YOUR_ANTHROPIC_API_KEY"
+
     // MARK: - OAuth Configuration
     // Custom URL scheme for OAuth redirects
     static let oauthScheme = "xomfit"
     static let oauthCallbackURL = "xomfit://login-callback"
-    
+
     // MARK: - App Configuration
     static let appName = "XomFit"
     static let bundleIdentifier = "com.Xomware.Xomfit"
@@ -33,5 +39,11 @@ enum Config {
     // MARK: - Configuration Status
     static var isConfigured: Bool {
         return !supabaseURL.contains("YOUR_") && !supabaseAnonKey.contains("YOUR_")
+    }
+
+    /// True when a build-time Anthropic key is present. Users can also provide
+    /// their own key at runtime via Settings — see `AICoachService`.
+    static var hasAnthropicKey: Bool {
+        return !anthropicAPIKey.contains("YOUR_") && !anthropicAPIKey.isEmpty
     }
 }

--- a/Xomfit/Models/AICoachMessage.swift
+++ b/Xomfit/Models/AICoachMessage.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// A single message in the AI Coach chat session. In-memory only for v1.
+struct AICoachMessage: Identifiable, Equatable {
+    enum Role: String {
+        case user
+        case assistant
+    }
+
+    let id: UUID
+    let role: Role
+    var text: String
+    let createdAt: Date
+    /// True while the assistant is actively streaming tokens into `text`.
+    var isStreaming: Bool
+
+    init(
+        id: UUID = UUID(),
+        role: Role,
+        text: String,
+        createdAt: Date = Date(),
+        isStreaming: Bool = false
+    ) {
+        self.id = id
+        self.role = role
+        self.text = text
+        self.createdAt = createdAt
+        self.isStreaming = isStreaming
+    }
+}

--- a/Xomfit/Models/UserFitnessProfile.swift
+++ b/Xomfit/Models/UserFitnessProfile.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/// Lightweight UserDefaults-backed profile capturing what the user told us about
+/// their lifting goals. Used to seed the AI Coach system prompt with context.
+///
+/// Defined as part of the AI Coach groundwork slice (#252). Issue #259 may
+/// replace this with a richer/Supabase-backed model — keep field names stable.
+struct UserFitnessProfile: Codable, Equatable {
+    var primaryGoal: String?
+    var experience: String?
+    var workoutsPerWeek: Int?
+    var preferredSplit: String?
+    var sessionLengthMin: Int?
+    var completedAt: Date?
+
+    init(
+        primaryGoal: String? = nil,
+        experience: String? = nil,
+        workoutsPerWeek: Int? = nil,
+        preferredSplit: String? = nil,
+        sessionLengthMin: Int? = nil,
+        completedAt: Date? = nil
+    ) {
+        self.primaryGoal = primaryGoal
+        self.experience = experience
+        self.workoutsPerWeek = workoutsPerWeek
+        self.preferredSplit = preferredSplit
+        self.sessionLengthMin = sessionLengthMin
+        self.completedAt = completedAt
+    }
+
+    // MARK: - Persistence
+
+    private static let storageKey = "userFitnessProfile.v1"
+
+    /// The currently stored profile, or an empty one if nothing is persisted.
+    static var current: UserFitnessProfile {
+        get { load() ?? UserFitnessProfile() }
+        set { newValue.save() }
+    }
+
+    private static func load() -> UserFitnessProfile? {
+        guard let data = UserDefaults.standard.data(forKey: storageKey) else { return nil }
+        return try? JSONDecoder().decode(UserFitnessProfile.self, from: data)
+    }
+
+    func save() {
+        guard let data = try? JSONEncoder().encode(self) else { return }
+        UserDefaults.standard.set(data, forKey: Self.storageKey)
+    }
+
+    // MARK: - Derived
+
+    /// True when the user has saved at least one onboarding pass.
+    var isComplete: Bool { completedAt != nil }
+}

--- a/Xomfit/Services/AICoachService.swift
+++ b/Xomfit/Services/AICoachService.swift
@@ -1,0 +1,215 @@
+import Foundation
+
+// MARK: - Errors
+
+enum AICoachServiceError: LocalizedError {
+    case missingAPIKey
+    case invalidResponse
+    case http(status: Int, message: String?)
+    case decoding(Error)
+    case transport(Error)
+
+    var errorDescription: String? {
+        switch self {
+        case .missingAPIKey:
+            return "No Anthropic API key configured. Add one in Settings → Anthropic API Key."
+        case .invalidResponse:
+            return "The Anthropic API returned an unexpected response."
+        case .http(let status, let message):
+            if let message, !message.isEmpty {
+                return "Anthropic error (\(status)): \(message)"
+            }
+            return "Anthropic error (HTTP \(status))."
+        case .decoding(let error):
+            return "Couldn't decode Anthropic response: \(error.localizedDescription)"
+        case .transport(let error):
+            return error.localizedDescription
+        }
+    }
+}
+
+// MARK: - Service
+
+/// Direct REST client for Anthropic's Messages API.
+///
+/// v1 scope: non-streaming text replies. Streaming via SSE (`stream: true`)
+/// is a TODO — wire it through `URLSession.bytes(for:)` and parse
+/// `content_block_delta` / `message_delta` events.
+///
+/// API docs: https://docs.claude.com/en/api/messages
+final class AICoachService {
+    // MARK: Public
+
+    static let shared = AICoachService()
+
+    /// Default model. Override per-request via the `model` argument.
+    static let defaultModel = "claude-sonnet-4-6"
+    static let defaultMaxTokens = 1024
+
+    /// Base system prompt. Profile context is appended on top of this when present.
+    static let baseSystemPrompt = """
+    You are an expert lifting coach. Be terse. Output structured workout \
+    suggestions when relevant. Reference the user's profile data provided.
+    """
+
+    // MARK: Init
+
+    private init(session: URLSession = .shared) {
+        self.session = session
+    }
+
+    private let session: URLSession
+    private let endpoint = URL(string: "https://api.anthropic.com/v1/messages")!
+    private let anthropicVersion = "2023-06-01"
+
+    // MARK: - Key resolution
+
+    /// Resolves an API key from runtime override (Settings) → build-time `Config`.
+    /// Returns nil when neither is set.
+    static func resolvedAPIKey(runtimeOverride: String?) -> String? {
+        if let trimmed = runtimeOverride?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !trimmed.isEmpty {
+            return trimmed
+        }
+        if Config.hasAnthropicKey {
+            return Config.anthropicAPIKey
+        }
+        return nil
+    }
+
+    // MARK: - System prompt builder
+
+    /// Builds the system prompt by prepending the user's fitness profile (if any).
+    static func systemPrompt(profile: UserFitnessProfile) -> String {
+        guard profile.isComplete else { return baseSystemPrompt }
+
+        var lines: [String] = ["User profile:"]
+        if let goal = profile.primaryGoal, !goal.isEmpty {
+            lines.append("- Primary goal: \(goal)")
+        }
+        if let experience = profile.experience, !experience.isEmpty {
+            lines.append("- Experience: \(experience)")
+        }
+        if let workouts = profile.workoutsPerWeek {
+            lines.append("- Workouts per week: \(workouts)")
+        }
+        if let split = profile.preferredSplit, !split.isEmpty {
+            lines.append("- Preferred split: \(split)")
+        }
+        if let length = profile.sessionLengthMin {
+            lines.append("- Session length: \(length) min")
+        }
+
+        // No profile fields filled in despite completedAt — fall back to base.
+        if lines.count == 1 { return baseSystemPrompt }
+
+        return lines.joined(separator: "\n") + "\n\n" + baseSystemPrompt
+    }
+
+    // MARK: - Send (non-streaming)
+
+    /// Sends the conversation to Anthropic and returns the assistant's text reply.
+    /// - Parameters:
+    ///   - messages: prior chat history, in order. User and assistant only — no system.
+    ///   - profile: user fitness profile to seed the system prompt.
+    ///   - apiKeyOverride: optional runtime key (Settings). Falls back to Config.
+    ///   - model: model id; defaults to `defaultModel`.
+    ///   - maxTokens: response cap; defaults to `defaultMaxTokens`.
+    func sendMessage(
+        messages: [AICoachMessage],
+        profile: UserFitnessProfile = .current,
+        apiKeyOverride: String? = nil,
+        model: String = AICoachService.defaultModel,
+        maxTokens: Int = AICoachService.defaultMaxTokens
+    ) async throws -> String {
+        guard let apiKey = Self.resolvedAPIKey(runtimeOverride: apiKeyOverride) else {
+            throw AICoachServiceError.missingAPIKey
+        }
+
+        let body = AnthropicRequest(
+            model: model,
+            maxTokens: maxTokens,
+            system: Self.systemPrompt(profile: profile),
+            messages: messages.map { AnthropicMessage(role: $0.role.rawValue, content: $0.text) }
+        )
+
+        var request = URLRequest(url: endpoint)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue(apiKey, forHTTPHeaderField: "x-api-key")
+        request.setValue(anthropicVersion, forHTTPHeaderField: "anthropic-version")
+
+        do {
+            request.httpBody = try JSONEncoder().encode(body)
+        } catch {
+            throw AICoachServiceError.decoding(error)
+        }
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await session.data(for: request)
+        } catch {
+            throw AICoachServiceError.transport(error)
+        }
+
+        guard let http = response as? HTTPURLResponse else {
+            throw AICoachServiceError.invalidResponse
+        }
+
+        guard (200..<300).contains(http.statusCode) else {
+            let message = Self.extractErrorMessage(from: data)
+            throw AICoachServiceError.http(status: http.statusCode, message: message)
+        }
+
+        do {
+            let decoded = try JSONDecoder().decode(AnthropicResponse.self, from: data)
+            return decoded.content
+                .compactMap { $0.type == "text" ? $0.text : nil }
+                .joined()
+        } catch {
+            throw AICoachServiceError.decoding(error)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private static func extractErrorMessage(from data: Data) -> String? {
+        // Anthropic error shape: { "type": "error", "error": { "type": ..., "message": ... } }
+        if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+           let error = json["error"] as? [String: Any],
+           let message = error["message"] as? String {
+            return message
+        }
+        return String(data: data, encoding: .utf8)
+    }
+}
+
+// MARK: - Wire types
+
+private struct AnthropicMessage: Encodable {
+    let role: String
+    let content: String
+}
+
+private struct AnthropicRequest: Encodable {
+    let model: String
+    let maxTokens: Int
+    let system: String
+    let messages: [AnthropicMessage]
+
+    enum CodingKeys: String, CodingKey {
+        case model
+        case maxTokens = "max_tokens"
+        case system
+        case messages
+    }
+}
+
+private struct AnthropicResponse: Decodable {
+    struct Block: Decodable {
+        let type: String
+        let text: String?
+    }
+    let content: [Block]
+}

--- a/Xomfit/ViewModels/AICoachViewModel.swift
+++ b/Xomfit/ViewModels/AICoachViewModel.swift
@@ -1,0 +1,104 @@
+import Foundation
+import Observation
+
+/// View model for the AI Coach chat. In-memory message list per app launch (v1).
+@MainActor
+@Observable
+final class AICoachViewModel {
+    // MARK: - State
+
+    /// Conversation history. Renders top → bottom in the chat view.
+    var messages: [AICoachMessage] = []
+
+    /// Current draft text in the composer.
+    var draft: String = ""
+
+    /// True while waiting on (or streaming from) Anthropic.
+    var isSending: Bool = false
+
+    /// Latest user-visible error message. Cleared automatically on next send.
+    var errorMessage: String?
+
+    /// Suggested prompts shown when the conversation is empty.
+    let suggestionChips: [String] = [
+        "Build me today's workout",
+        "Suggest a 4-day split",
+        "Help me hit a 225 bench"
+    ]
+
+    // MARK: - Dependencies
+
+    private let service: AICoachService
+    /// Runtime override for the API key (read from Settings via @AppStorage).
+    /// The view passes this in on each send.
+    init(service: AICoachService = .shared) {
+        self.service = service
+    }
+
+    // MARK: - Derived
+
+    var isEmpty: Bool { messages.isEmpty }
+
+    var canSend: Bool {
+        !isSending && !draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    // MARK: - Actions
+
+    /// Append a chip's text to the draft and immediately send it.
+    func sendSuggestion(_ text: String, apiKeyOverride: String?) async {
+        draft = text
+        await send(apiKeyOverride: apiKeyOverride)
+    }
+
+    /// Send the current draft. No-op when nothing to send.
+    func send(apiKeyOverride: String?) async {
+        let trimmed = draft.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, !isSending else { return }
+
+        errorMessage = nil
+        let userMessage = AICoachMessage(role: .user, text: trimmed)
+        messages.append(userMessage)
+        draft = ""
+        isSending = true
+
+        // Insert a placeholder assistant bubble that we'll replace when the
+        // reply arrives. Marked streaming so the UI can show a typing dot.
+        let placeholderId = UUID()
+        messages.append(
+            AICoachMessage(id: placeholderId, role: .assistant, text: "", isStreaming: true)
+        )
+
+        do {
+            // Send everything except the placeholder (last entry).
+            let history = Array(messages.dropLast())
+            let reply = try await service.sendMessage(
+                messages: history,
+                apiKeyOverride: apiKeyOverride
+            )
+            replacePlaceholder(id: placeholderId, with: reply)
+        } catch {
+            // Drop the placeholder and surface the error.
+            messages.removeAll { $0.id == placeholderId }
+            errorMessage = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+        }
+
+        isSending = false
+    }
+
+    /// Clear the conversation and any pending error.
+    func reset() {
+        messages.removeAll()
+        draft = ""
+        errorMessage = nil
+        isSending = false
+    }
+
+    // MARK: - Private
+
+    private func replacePlaceholder(id: UUID, with text: String) {
+        guard let index = messages.firstIndex(where: { $0.id == id }) else { return }
+        messages[index].text = text
+        messages[index].isStreaming = false
+    }
+}

--- a/Xomfit/Views/AICoach/AICoachView.swift
+++ b/Xomfit/Views/AICoach/AICoachView.swift
@@ -1,0 +1,332 @@
+import SwiftUI
+
+/// Chat interface for the AI Coach. Hits Anthropic's Messages API directly
+/// via `AICoachService` and seeds the system prompt with the user's
+/// `UserFitnessProfile` when available.
+///
+/// v1 scope:
+/// - Plain-text replies (no streaming yet — TODO)
+/// - In-memory chat history per app launch (no persistence)
+/// - 3 suggestion chips when empty
+struct AICoachView: View {
+    @State private var viewModel = AICoachViewModel()
+    @FocusState private var inputFocused: Bool
+
+    /// Optional override key persisted by the user in Settings.
+    /// Stored in `@AppStorage` for v1 — TODO Keychain.
+    @AppStorage("aiCoach.anthropicAPIKey") private var apiKeyOverride: String = ""
+
+    var body: some View {
+        ZStack {
+            Theme.background.ignoresSafeArea()
+
+            VStack(spacing: 0) {
+                if viewModel.isEmpty {
+                    emptyState
+                } else {
+                    transcript
+                }
+
+                if let error = viewModel.errorMessage {
+                    errorBanner(error)
+                }
+
+                composer
+            }
+        }
+        .navigationTitle("Coach")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbarColorScheme(.dark, for: .navigationBar)
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                if !viewModel.isEmpty {
+                    Button {
+                        Haptics.light()
+                        viewModel.reset()
+                    } label: {
+                        Image(systemName: "arrow.counterclockwise")
+                            .foregroundStyle(Theme.textPrimary)
+                    }
+                    .accessibilityLabel("Start new conversation")
+                }
+            }
+        }
+    }
+
+    // MARK: - Empty state
+
+    private var emptyState: some View {
+        ScrollView {
+            VStack(spacing: Theme.Spacing.lg) {
+                XomEmptyState(
+                    symbolStack: ["sparkles", "dumbbell.fill"],
+                    title: "Your AI Lifting Coach",
+                    subtitle: "Ask for a workout, a weekly plan, or how to push past a plateau.",
+                    floatingLoop: true
+                )
+
+                VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+                    XomMetricLabel("Try Asking")
+                        .padding(.horizontal, Theme.Spacing.md)
+
+                    VStack(spacing: Theme.Spacing.sm) {
+                        ForEach(viewModel.suggestionChips, id: \.self) { chip in
+                            suggestionChip(chip)
+                        }
+                    }
+                    .padding(.horizontal, Theme.Spacing.md)
+                }
+            }
+            .padding(.vertical, Theme.Spacing.lg)
+        }
+    }
+
+    private func suggestionChip(_ text: String) -> some View {
+        Button {
+            Haptics.light()
+            Task { await viewModel.sendSuggestion(text, apiKeyOverride: apiKeyOverride) }
+        } label: {
+            HStack(spacing: Theme.Spacing.sm) {
+                Image(systemName: "sparkle")
+                    .foregroundStyle(Theme.accent)
+                Text(text)
+                    .font(Theme.fontBody)
+                    .foregroundStyle(Theme.textPrimary)
+                    .multilineTextAlignment(.leading)
+                Spacer(minLength: 0)
+                Image(systemName: "arrow.up.right")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(Theme.textTertiary)
+            }
+            .padding(Theme.Spacing.md)
+            .frame(minHeight: 52)
+            .background(
+                RoundedRectangle(cornerRadius: Theme.Radius.md)
+                    .fill(Theme.surface)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: Theme.Radius.md)
+                            .strokeBorder(Theme.hairline, lineWidth: 0.5)
+                    )
+            )
+        }
+        .buttonStyle(PressableCardStyle())
+        .disabled(viewModel.isSending)
+        .accessibilityLabel(text)
+        .accessibilityHint("Sends this prompt to your AI Coach")
+    }
+
+    // MARK: - Transcript
+
+    private var transcript: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(spacing: Theme.Spacing.md) {
+                    ForEach(viewModel.messages) { message in
+                        AICoachMessageBubble(message: message)
+                            .id(message.id)
+                    }
+                }
+                .padding(.horizontal, Theme.Spacing.md)
+                .padding(.vertical, Theme.Spacing.md)
+            }
+            .onChange(of: viewModel.messages.count) { _, _ in
+                scrollToBottom(proxy: proxy)
+            }
+            .onChange(of: viewModel.messages.last?.text) { _, _ in
+                scrollToBottom(proxy: proxy)
+            }
+        }
+    }
+
+    private func scrollToBottom(proxy: ScrollViewProxy) {
+        guard let last = viewModel.messages.last else { return }
+        withAnimation(.xomChill) {
+            proxy.scrollTo(last.id, anchor: .bottom)
+        }
+    }
+
+    // MARK: - Error banner
+
+    private func errorBanner(_ message: String) -> some View {
+        HStack(alignment: .top, spacing: Theme.Spacing.sm) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(Theme.alert)
+            Text(message)
+                .font(Theme.fontCaption)
+                .foregroundStyle(Theme.textPrimary)
+                .multilineTextAlignment(.leading)
+            Spacer(minLength: 0)
+            Button {
+                viewModel.errorMessage = nil
+            } label: {
+                Image(systemName: "xmark")
+                    .font(.caption.weight(.bold))
+                    .foregroundStyle(Theme.textSecondary)
+            }
+            .accessibilityLabel("Dismiss error")
+        }
+        .padding(Theme.Spacing.md)
+        .background(
+            RoundedRectangle(cornerRadius: Theme.Radius.md)
+                .fill(Theme.alert.opacity(0.12))
+                .overlay(
+                    RoundedRectangle(cornerRadius: Theme.Radius.md)
+                        .strokeBorder(Theme.alert.opacity(0.4), lineWidth: 0.5)
+                )
+        )
+        .padding(.horizontal, Theme.Spacing.md)
+        .padding(.bottom, Theme.Spacing.sm)
+    }
+
+    // MARK: - Composer
+
+    private var composer: some View {
+        HStack(alignment: .bottom, spacing: Theme.Spacing.sm) {
+            TextField("Ask your coach…", text: Bindable(viewModel).draft, axis: .vertical)
+                .textFieldStyle(.plain)
+                .font(Theme.fontBody)
+                .foregroundStyle(Theme.textPrimary)
+                .tint(Theme.accent)
+                .lineLimit(1...5)
+                .padding(.horizontal, Theme.Spacing.md)
+                .padding(.vertical, 10)
+                .background(
+                    RoundedRectangle(cornerRadius: Theme.Radius.lg)
+                        .fill(Theme.surface)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: Theme.Radius.lg)
+                                .strokeBorder(Theme.hairline, lineWidth: 0.5)
+                        )
+                )
+                .focused($inputFocused)
+                .submitLabel(.send)
+                .onSubmit { triggerSend() }
+                .disabled(viewModel.isSending)
+                .accessibilityLabel("Message")
+
+            Button {
+                triggerSend()
+            } label: {
+                Image(systemName: viewModel.isSending ? "stop.fill" : "arrow.up")
+                    .font(.body.weight(.bold))
+                    .foregroundStyle(.black)
+                    .frame(width: 44, height: 44)
+                    .background(
+                        Circle().fill(viewModel.canSend ? Theme.accent : Theme.surfaceElevated)
+                    )
+            }
+            .disabled(!viewModel.canSend)
+            .accessibilityLabel("Send message")
+        }
+        .padding(.horizontal, Theme.Spacing.md)
+        .padding(.vertical, Theme.Spacing.sm)
+        .background(
+            Theme.background
+                .overlay(alignment: .top) {
+                    Rectangle()
+                        .fill(Theme.hairline)
+                        .frame(height: 0.5)
+                }
+        )
+    }
+
+    private func triggerSend() {
+        guard viewModel.canSend else { return }
+        Haptics.light()
+        Task { await viewModel.send(apiKeyOverride: apiKeyOverride) }
+    }
+}
+
+// MARK: - Message bubble
+
+private struct AICoachMessageBubble: View {
+    let message: AICoachMessage
+
+    var body: some View {
+        HStack(alignment: .top, spacing: Theme.Spacing.sm) {
+            if message.role == .user {
+                Spacer(minLength: 40)
+                bubble
+                    .frame(maxWidth: .infinity, alignment: .trailing)
+            } else {
+                assistantAvatar
+                bubble
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                Spacer(minLength: 40)
+            }
+        }
+    }
+
+    private var assistantAvatar: some View {
+        Image(systemName: "sparkles")
+            .font(.subheadline.weight(.bold))
+            .foregroundStyle(Theme.accent)
+            .frame(width: 32, height: 32)
+            .background(Theme.accent.opacity(0.18))
+            .clipShape(Circle())
+            .accessibilityHidden(true)
+    }
+
+    @ViewBuilder
+    private var bubble: some View {
+        if message.isStreaming && message.text.isEmpty {
+            TypingDots()
+                .padding(.horizontal, Theme.Spacing.md)
+                .padding(.vertical, 10)
+                .background(
+                    RoundedRectangle(cornerRadius: Theme.Radius.md)
+                        .fill(Theme.surface)
+                )
+        } else {
+            Text(message.text)
+                .font(Theme.fontBody)
+                .foregroundStyle(message.role == .user ? .black : Theme.textPrimary)
+                .multilineTextAlignment(.leading)
+                .padding(.horizontal, Theme.Spacing.md)
+                .padding(.vertical, 10)
+                .background(
+                    RoundedRectangle(cornerRadius: Theme.Radius.md)
+                        .fill(message.role == .user ? Theme.accent : Theme.surface)
+                )
+                .textSelection(.enabled)
+                .accessibilityLabel(
+                    "\(message.role == .user ? "You" : "Coach") said: \(message.text)"
+                )
+        }
+    }
+}
+
+// MARK: - Typing dots
+
+private struct TypingDots: View {
+    @State private var phase: Int = 0
+
+    var body: some View {
+        HStack(spacing: 4) {
+            ForEach(0..<3, id: \.self) { index in
+                Circle()
+                    .fill(Theme.textSecondary)
+                    .frame(width: 6, height: 6)
+                    .opacity(phase == index ? 1 : 0.3)
+            }
+        }
+        .onAppear {
+            Timer.scheduledTimer(withTimeInterval: 0.35, repeats: true) { timer in
+                Task { @MainActor in
+                    phase = (phase + 1) % 3
+                }
+                _ = timer
+            }
+        }
+        .accessibilityLabel("Coach is typing")
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    NavigationStack {
+        AICoachView()
+    }
+    .preferredColorScheme(.dark)
+}

--- a/Xomfit/Views/Profile/ProfileView.swift
+++ b/Xomfit/Views/Profile/ProfileView.swift
@@ -198,6 +198,15 @@ struct ProfileView: View {
     private var ownProfileToolbar: some ToolbarContent {
         ToolbarItem(placement: .topBarTrailing) {
             HStack(spacing: 16) {
+                NavigationLink {
+                    AICoachView()
+                        .hideTabBar()
+                } label: {
+                    Image(systemName: "sparkles")
+                        .foregroundStyle(Theme.accent)
+                }
+                .accessibilityLabel("AI Coach")
+
                 Button {
                     viewModel.beginEditing()
                     showEditSheet = true

--- a/Xomfit/Views/Profile/SettingsView.swift
+++ b/Xomfit/Views/Profile/SettingsView.swift
@@ -4,6 +4,10 @@ struct SettingsView: View {
     @Environment(AuthService.self) private var authService
     @State private var showSignOutConfirm = false
 
+    /// Anthropic API key override (per-user). v1: stored via @AppStorage —
+    /// not secure. TODO: migrate to Keychain.
+    @AppStorage("aiCoach.anthropicAPIKey") private var anthropicAPIKey: String = ""
+
     private var appVersion: String {
         let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0"
         let build = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "1"
@@ -40,6 +44,43 @@ struct SettingsView: View {
                     .tint(Theme.textTertiary)
                 } header: {
                     XomMetricLabel("Notifications")
+                }
+                .listRowBackground(Theme.surface)
+                .listRowSeparatorTint(Theme.hairline)
+
+                Section {
+                    NavigationLink {
+                        AICoachView()
+                            .hideTabBar()
+                    } label: {
+                        HStack(spacing: Theme.Spacing.md) {
+                            Image(systemName: "sparkles")
+                                .frame(width: 24)
+                                .foregroundStyle(Theme.accent)
+                            Text("AI Coach")
+                                .foregroundStyle(Theme.textPrimary)
+                        }
+                    }
+                    .tint(Theme.textTertiary)
+
+                    HStack(spacing: Theme.Spacing.md) {
+                        Image(systemName: "key.fill")
+                            .frame(width: 24)
+                            .foregroundStyle(Theme.accent)
+                        SecureField("Anthropic API Key", text: $anthropicAPIKey)
+                            .foregroundStyle(Theme.textPrimary)
+                            .font(Theme.fontBody)
+                            .textInputAutocapitalization(.never)
+                            .autocorrectionDisabled()
+                            .accessibilityLabel("Anthropic API Key")
+                            .accessibilityHint("Stored on this device only")
+                    }
+                } header: {
+                    XomMetricLabel("AI Coach")
+                } footer: {
+                    Text("Stored on this device only. Get a key at console.anthropic.com.")
+                        .font(Theme.fontCaption)
+                        .foregroundStyle(Theme.textTertiary)
                 }
                 .listRowBackground(Theme.surface)
                 .listRowSeparatorTint(Theme.hairline)

--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -32,6 +32,8 @@ enum Config {
     static let supabaseURL = "${SUPABASE_URL}"
     static let supabaseAnonKey = "${SUPABASE_ANON_KEY}"
 
+    static let anthropicAPIKey = "${ANTHROPIC_API_KEY:-YOUR_ANTHROPIC_API_KEY}"
+
     static let oauthScheme = "xomfit"
     static let oauthCallbackURL = "xomfit://login-callback"
 
@@ -47,6 +49,10 @@ enum Config {
 
     static var isConfigured: Bool {
         return !supabaseURL.contains("YOUR_") && !supabaseAnonKey.contains("YOUR_")
+    }
+
+    static var hasAnthropicKey: Bool {
+        return !anthropicAPIKey.contains("YOUR_") && !anthropicAPIKey.isEmpty
     }
 }
 EOF


### PR DESCRIPTION
First slice of #252. Productionization (streaming, Keychain, persistence, tool use) lands later.

## Summary
Working chat UI that hits Anthropic's `claude-sonnet-4-6` model, prepends user fitness goals from `UserFitnessProfile.current` (#259) to the system prompt, and renders text replies as bubbles. Empty state shows 3 suggestion chips: "Build me today's workout" / "Suggest a 4-day split" / "Help me hit a 225 bench."

- Entry: sparkles button in `ProfileView` toolbar + Settings → AI Coach
- Service: direct `URLSession` REST → `https://api.anthropic.com/v1/messages` (no SDK)
- Key: `Config.anthropicAPIKey` (from `ANTHROPIC_API_KEY` env in `ci_post_clone.sh`) with runtime override via Settings (`@AppStorage`, TODO Keychain)
- Default model: `claude-sonnet-4-6`, max tokens 1024

## Deferred (TODOs in code)
- SSE streaming
- Keychain for API key
- Conversation persistence across launches
- Tool use / structured workout output

## Test plan
- [ ] Tap sparkles in Profile → AICoach opens with empty state + 3 chips
- [ ] Tap a chip → message sends → reply renders
- [ ] Without API key → error banner explains how to set it
- [ ] Settings → AI Coach → secure TextField saves key, chat works after
- [ ] If `UserFitnessProfile.current.isComplete`, the system prompt includes goals (verify by inspecting service)