### PR TITLE
#249 workout views: tabs (Mine/Recent/Templates/Friends) + filter chips

### DIFF
--- a/Xomfit/Models/WorkoutFilter.swift
+++ b/Xomfit/Models/WorkoutFilter.swift
@@ -1,0 +1,82 @@
+import Foundation
+
+/// Shared filter state for workout views (Mine / Recent / Templates / Friends).
+///
+/// An empty filter (no search text, no selections) matches everything.
+/// Combined predicates AND together — a result must satisfy every active criterion.
+struct WorkoutFilter: Equatable {
+    var searchText: String = ""
+    var muscleGroup: MuscleGroup? = nil
+    var equipment: Equipment? = nil
+
+    /// True when no criteria are set — i.e. nothing is being filtered out.
+    var isEmpty: Bool {
+        trimmedSearch.isEmpty && muscleGroup == nil && equipment == nil
+    }
+
+    private var trimmedSearch: String {
+        searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// Lowercased, trimmed search query for matching.
+    private var query: String {
+        trimmedSearch.lowercased()
+    }
+
+    // MARK: - Template matching
+
+    func matches(_ template: WorkoutTemplate) -> Bool {
+        if isEmpty { return true }
+
+        let allMuscles = template.exercises.flatMap { $0.exercise.muscleGroups }
+        if let mg = muscleGroup, !allMuscles.contains(mg) {
+            return false
+        }
+
+        let allEquipment = template.exercises.map { $0.exercise.equipment }
+        if let eq = equipment, !allEquipment.contains(eq) {
+            return false
+        }
+
+        if !query.isEmpty {
+            let nameHit = template.name.lowercased().contains(query)
+            let descHit = template.description.lowercased().contains(query)
+            let exerciseHit = template.exercises.contains { ex in
+                ex.exercise.name.lowercased().contains(query)
+            }
+            if !(nameHit || descHit || exerciseHit) {
+                return false
+            }
+        }
+
+        return true
+    }
+
+    // MARK: - Workout matching
+
+    func matches(_ workout: Workout) -> Bool {
+        if isEmpty { return true }
+
+        let allMuscles = workout.exercises.flatMap { $0.exercise.muscleGroups }
+        if let mg = muscleGroup, !allMuscles.contains(mg) {
+            return false
+        }
+
+        let allEquipment = workout.exercises.map { $0.exercise.equipment }
+        if let eq = equipment, !allEquipment.contains(eq) {
+            return false
+        }
+
+        if !query.isEmpty {
+            let nameHit = workout.name.lowercased().contains(query)
+            let exerciseHit = workout.exercises.contains { ex in
+                ex.exercise.name.lowercased().contains(query)
+            }
+            if !(nameHit || exerciseHit) {
+                return false
+            }
+        }
+
+        return true
+    }
+}

--- a/Xomfit/Services/WorkoutService.swift
+++ b/Xomfit/Services/WorkoutService.swift
@@ -227,6 +227,44 @@ final class WorkoutService {
             .sorted { $0.startTime > $1.startTime }
     }
 
+    // MARK: - Friends Feed
+
+    /// Fan out across the current user's accepted friends and merge their recent workouts.
+    /// Sorted by `startTime` desc; capped at `limit` results.
+    /// Failures from individual friend fetches are logged and skipped — never throws.
+    func fetchFriendsRecentWorkouts(currentUserId: String, limit: Int = 30) async -> [Workout] {
+        guard !currentUserId.isEmpty else { return [] }
+
+        let friendIds: [String]
+        do {
+            let rows = try await FriendsService.shared.fetchFriends(userId: currentUserId)
+            friendIds = rows.map { $0.requesterId == currentUserId ? $0.addresseeId : $0.requesterId }
+        } catch {
+            print("[WorkoutService] fetchFriendsRecentWorkouts: friend list failed: \(error.localizedDescription)")
+            return []
+        }
+
+        guard !friendIds.isEmpty else { return [] }
+
+        let merged: [Workout] = await withTaskGroup(of: [Workout].self) { group in
+            for friendId in friendIds {
+                group.addTask {
+                    await WorkoutService.shared.fetchWorkouts(userId: friendId)
+                }
+            }
+            var collected: [Workout] = []
+            for await batch in group {
+                collected.append(contentsOf: batch)
+            }
+            return collected
+        }
+
+        return merged
+            .sorted { $0.startTime > $1.startTime }
+            .prefix(limit)
+            .map { $0 }
+    }
+
     // MARK: - Delete
 
     func deleteWorkout(id: String) async {

--- a/Xomfit/ViewModels/WorkoutTabViewModel.swift
+++ b/Xomfit/ViewModels/WorkoutTabViewModel.swift
@@ -1,0 +1,127 @@
+import Foundation
+
+// MARK: - WorkoutTab
+
+/// Top-level segments on the Workout screen.
+enum WorkoutTab: String, CaseIterable, Identifiable {
+    case mine
+    case recent
+    case templates
+    case friends
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .mine:      return "Mine"
+        case .recent:    return "Recent"
+        case .templates: return "Templates"
+        case .friends:   return "Friends"
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .mine:      return "star.fill"
+        case .recent:    return "clock.fill"
+        case .templates: return "list.bullet.rectangle.portrait"
+        case .friends:   return "person.2.fill"
+        }
+    }
+}
+
+// MARK: - WorkoutTabViewModel
+
+@MainActor
+@Observable
+final class WorkoutTabViewModel {
+    /// Persistence key for the active tab.
+    private static let selectedTabKey = "xomfit_workout_selected_tab"
+
+    // Per-tab data
+    var recent: [Workout] = []
+    var myTemplates: [WorkoutTemplate] = []
+    var savedTemplates: [WorkoutTemplate] = []
+    var builtInTemplates: [WorkoutTemplate] = []
+    var friendWorkouts: [Workout] = []
+
+    // UI state
+    var selectedTab: WorkoutTab {
+        didSet { UserDefaults.standard.set(selectedTab.rawValue, forKey: Self.selectedTabKey) }
+    }
+    var filter: WorkoutFilter = WorkoutFilter()
+
+    var isLoading: Bool = false
+    var isLoadingFriends: Bool = false
+    var errorMessage: String?
+
+    init() {
+        let stored = UserDefaults.standard.string(forKey: Self.selectedTabKey)
+        self.selectedTab = stored.flatMap(WorkoutTab.init(rawValue:)) ?? .templates
+    }
+
+    // MARK: - Load
+
+    /// Loads everything needed to populate all four tabs in parallel.
+    /// Friend workouts are deferred to `loadFriends` because they fan out across users.
+    func load(userId: String) async {
+        guard !userId.isEmpty else { return }
+        isLoading = true
+        defer { isLoading = false }
+
+        async let recentTask = WorkoutService.shared.fetchWorkouts(userId: userId)
+        let allCustom = TemplateService.shared.allTemplates().filter { $0.isCustom }
+
+        recent = await recentTask
+        myTemplates = allCustom.filter { $0.category != .saved }
+        savedTemplates = allCustom.filter { $0.category == .saved }
+        builtInTemplates = TemplateService.shared.allTemplates().filter { !$0.isCustom }
+
+        // Kick off friend workouts in the background so the visible tabs render immediately.
+        Task { await loadFriends(currentUserId: userId) }
+    }
+
+    func loadFriends(currentUserId: String) async {
+        guard !currentUserId.isEmpty else { return }
+        isLoadingFriends = true
+        defer { isLoadingFriends = false }
+        friendWorkouts = await WorkoutService.shared.fetchFriendsRecentWorkouts(currentUserId: currentUserId)
+    }
+
+    // MARK: - Filtered Output
+
+    var filteredTemplatesMine: [WorkoutTemplate] {
+        myTemplates.filter(filter.matches)
+    }
+
+    var filteredTemplatesSaved: [WorkoutTemplate] {
+        savedTemplates.filter(filter.matches)
+    }
+
+    /// Combines built-in templates with user-saved templates for the "Templates" tab.
+    var filteredTemplatesBuiltIn: [WorkoutTemplate] {
+        (builtInTemplates + savedTemplates).filter(filter.matches)
+    }
+
+    var filteredRecent: [Workout] {
+        recent.filter(filter.matches)
+    }
+
+    var filteredFriendWorkouts: [Workout] {
+        friendWorkouts.filter(filter.matches)
+    }
+
+    /// True when the active tab has source data but no items pass the filter.
+    func isEmptyAfterFilter(for tab: WorkoutTab) -> Bool {
+        switch tab {
+        case .mine:
+            return !myTemplates.isEmpty && filteredTemplatesMine.isEmpty
+        case .recent:
+            return !recent.isEmpty && filteredRecent.isEmpty
+        case .templates:
+            return !(builtInTemplates.isEmpty && savedTemplates.isEmpty) && filteredTemplatesBuiltIn.isEmpty
+        case .friends:
+            return !friendWorkouts.isEmpty && filteredFriendWorkouts.isEmpty
+        }
+    }
+}

--- a/Xomfit/Views/Workout/RecentWorkoutCard.swift
+++ b/Xomfit/Views/Workout/RecentWorkoutCard.swift
@@ -1,7 +1,17 @@
 import SwiftUI
 
+/// Layout style for `RecentWorkoutCard`.
+///
+/// `.compact` keeps the legacy fixed-width card used inside horizontal carousels.
+/// `.row` expands to fill its container for vertical lists.
+enum RecentWorkoutCardStyle {
+    case compact
+    case row
+}
+
 struct RecentWorkoutCard: View {
     let workout: Workout
+    var style: RecentWorkoutCardStyle = .compact
     let onSelect: () -> Void
 
     var body: some View {
@@ -9,45 +19,99 @@ struct RecentWorkoutCard: View {
             Haptics.light()
             onSelect()
         }) {
-            VStack(alignment: .leading, spacing: 6) {
-                Text(workout.name)
-                    .font(.caption.weight(.bold))
-                    .foregroundStyle(Theme.textPrimary)
-                    .lineLimit(1)
-
-                Text(workout.startTime.timeAgo)
-                    .font(Theme.fontSmall)
-                    .foregroundStyle(Theme.textSecondary)
-
-                HStack(spacing: 8) {
-                    HStack(spacing: 3) {
-                        Image(systemName: "figure.strengthtraining.traditional")
-                            .font(.caption2)
-                        Text("\(workout.exercises.count) ex")
-                    }
-
-                    HStack(spacing: 3) {
-                        Image(systemName: "clock")
-                            .font(.caption2)
-                        Text(workout.durationString)
-                            .foregroundStyle(Theme.accent)
-                    }
-                }
-                .font(Theme.fontSmall)
-                .foregroundStyle(Theme.textSecondary)
+            if style == .row {
+                rowBody
+            } else {
+                compactBody
             }
-            .padding(.horizontal, 12)
-            .padding(.vertical, 10)
-            .frame(width: 160, alignment: .leading)
-            .background(Theme.surface)
-            .clipShape(.rect(cornerRadius: Theme.cornerRadius))
-            .overlay(
-                RoundedRectangle(cornerRadius: Theme.cornerRadius)
-                    .strokeBorder(Theme.hairline, lineWidth: 0.5)
-            )
         }
         .buttonStyle(PressableCardStyle())
         .accessibilityLabel("\(workout.name), \(workout.startTime.timeAgo), \(workout.exercises.count) exercises, \(workout.durationString)")
         .accessibilityAddTraits(.isButton)
+    }
+
+    private var compactBody: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(workout.name)
+                .font(.caption.weight(.bold))
+                .foregroundStyle(Theme.textPrimary)
+                .lineLimit(1)
+
+            Text(workout.startTime.timeAgo)
+                .font(Theme.fontSmall)
+                .foregroundStyle(Theme.textSecondary)
+
+            HStack(spacing: 8) {
+                HStack(spacing: 3) {
+                    Image(systemName: "figure.strengthtraining.traditional")
+                        .font(.caption2)
+                    Text("\(workout.exercises.count) ex")
+                }
+
+                HStack(spacing: 3) {
+                    Image(systemName: "clock")
+                        .font(.caption2)
+                    Text(workout.durationString)
+                        .foregroundStyle(Theme.accent)
+                }
+            }
+            .font(Theme.fontSmall)
+            .foregroundStyle(Theme.textSecondary)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .frame(width: 160, alignment: .leading)
+        .background(Theme.surface)
+        .clipShape(.rect(cornerRadius: Theme.cornerRadius))
+        .overlay(
+            RoundedRectangle(cornerRadius: Theme.cornerRadius)
+                .strokeBorder(Theme.hairline, lineWidth: 0.5)
+        )
+    }
+
+    private var rowBody: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "figure.strengthtraining.traditional")
+                .font(.headline)
+                .foregroundStyle(Theme.accent)
+                .frame(width: 32, height: 32)
+                .background(Theme.accent.opacity(0.15))
+                .clipShape(.rect(cornerRadius: 6))
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(workout.name)
+                    .font(.subheadline.weight(.bold))
+                    .foregroundStyle(Theme.textPrimary)
+                    .lineLimit(1)
+
+                HStack(spacing: 6) {
+                    Text(workout.startTime.timeAgo)
+                    Text("•")
+                        .foregroundStyle(Theme.textTertiary)
+                    Text("\(workout.exercises.count) ex")
+                    Text("•")
+                        .foregroundStyle(Theme.textTertiary)
+                    Text(workout.durationString)
+                        .foregroundStyle(Theme.accent)
+                }
+                .font(Theme.fontSmall)
+                .foregroundStyle(Theme.textSecondary)
+            }
+
+            Spacer(minLength: 0)
+
+            Image(systemName: "chevron.right")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(Theme.textTertiary)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Theme.surface)
+        .clipShape(.rect(cornerRadius: Theme.cornerRadius))
+        .overlay(
+            RoundedRectangle(cornerRadius: Theme.cornerRadius)
+                .strokeBorder(Theme.hairline, lineWidth: 0.5)
+        )
     }
 }

--- a/Xomfit/Views/Workout/TemplateCardView.swift
+++ b/Xomfit/Views/Workout/TemplateCardView.swift
@@ -1,7 +1,17 @@
 import SwiftUI
 
+/// Layout style for `TemplateCardView`.
+///
+/// `.compact` keeps the legacy fixed-width card used inside horizontal carousels.
+/// `.row` expands to fill its container, intended for vertical lists.
+enum TemplateCardStyle {
+    case compact
+    case row
+}
+
 struct TemplateCardView: View {
     let template: WorkoutTemplate
+    var style: TemplateCardStyle = .compact
     let onSelect: () -> Void
 
     var body: some View {
@@ -20,7 +30,7 @@ struct TemplateCardView: View {
 
                 VStack(alignment: .leading, spacing: 2) {
                     Text(template.name)
-                        .font(.caption.weight(.bold))
+                        .font(style == .row ? .subheadline.weight(.bold) : .caption.weight(.bold))
                         .foregroundStyle(Theme.textPrimary)
                         .lineLimit(1)
 
@@ -28,14 +38,28 @@ struct TemplateCardView: View {
                         Text("\(template.exercises.count) ex")
                         Text("~\(template.estimatedDuration)m")
                             .foregroundStyle(Theme.accent)
+                        if style == .row && !template.description.isEmpty {
+                            Text("•")
+                                .foregroundStyle(Theme.textTertiary)
+                            Text(template.description)
+                                .lineLimit(1)
+                        }
                     }
                     .font(Theme.fontSmall)
                     .foregroundStyle(Theme.textSecondary)
                 }
+
+                if style == .row {
+                    Spacer(minLength: 0)
+                    Image(systemName: "chevron.right")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(Theme.textTertiary)
+                }
             }
             .padding(.horizontal, 12)
             .padding(.vertical, 10)
-            .frame(width: 160, alignment: .leading)
+            .frame(maxWidth: style == .row ? .infinity : nil, alignment: .leading)
+            .frame(width: style == .row ? nil : 160, alignment: .leading)
             .background(Theme.surface)
             .clipShape(.rect(cornerRadius: Theme.cornerRadius))
             .overlay(

--- a/Xomfit/Views/Workout/WorkoutFilterBar.swift
+++ b/Xomfit/Views/Workout/WorkoutFilterBar.swift
@@ -1,0 +1,124 @@
+import SwiftUI
+
+/// Reusable filter bar for the workout tabs.
+///
+/// Pattern mirrors `ExercisePickerView` — a search field plus two horizontal chip
+/// rails (muscle group + equipment). Emits state through a `WorkoutFilter` binding.
+struct WorkoutFilterBar: View {
+    @Binding var filter: WorkoutFilter
+
+    var body: some View {
+        VStack(spacing: Theme.Spacing.xs) {
+            searchField
+            muscleGroupChips
+            equipmentChips
+        }
+        .padding(.bottom, Theme.Spacing.xs)
+    }
+
+    // MARK: - Search Field
+
+    private var searchField: some View {
+        HStack {
+            Image(systemName: "magnifyingglass")
+                .foregroundStyle(Theme.textTertiary)
+            TextField("Search workouts...", text: $filter.searchText)
+                .foregroundStyle(Theme.textPrimary)
+                .autocorrectionDisabled()
+                .accessibilityLabel("Search workouts")
+            if !filter.searchText.isEmpty {
+                Button {
+                    Haptics.selection()
+                    filter.searchText = ""
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(Theme.textTertiary)
+                }
+                .accessibilityLabel("Clear search")
+            }
+        }
+        .padding(Theme.Spacing.md)
+        .background(Theme.surface)
+        .clipShape(.rect(cornerRadius: Theme.cornerRadius))
+        .overlay(
+            RoundedRectangle(cornerRadius: Theme.cornerRadius)
+                .strokeBorder(Theme.hairline, lineWidth: 0.5)
+        )
+        .padding(.horizontal, Theme.Spacing.md)
+        .padding(.top, Theme.Spacing.sm)
+    }
+
+    // MARK: - Muscle Group Chips
+
+    private var muscleGroupChips: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: Theme.Spacing.sm) {
+                Button {
+                    Haptics.selection()
+                    filter.muscleGroup = nil
+                } label: {
+                    XomBadge("All Muscles", variant: .interactive, isActive: filter.muscleGroup == nil)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("All muscle groups")
+                .accessibilityAddTraits(filter.muscleGroup == nil ? [.isButton, .isSelected] : .isButton)
+
+                ForEach(MuscleGroup.allCases) { mg in
+                    Button {
+                        Haptics.selection()
+                        filter.muscleGroup = filter.muscleGroup == mg ? nil : mg
+                    } label: {
+                        XomBadge(mg.displayName, variant: .interactive, isActive: filter.muscleGroup == mg)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel(mg.displayName)
+                    .accessibilityAddTraits(filter.muscleGroup == mg ? [.isButton, .isSelected] : .isButton)
+                }
+            }
+            .padding(.horizontal, Theme.Spacing.md)
+            .padding(.vertical, Theme.Spacing.xs)
+        }
+    }
+
+    // MARK: - Equipment Chips
+
+    private var equipmentChips: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: Theme.Spacing.sm) {
+                Button {
+                    Haptics.selection()
+                    filter.equipment = nil
+                } label: {
+                    XomBadge("All Equipment", variant: .interactive, isActive: filter.equipment == nil)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("All equipment")
+                .accessibilityAddTraits(filter.equipment == nil ? [.isButton, .isSelected] : .isButton)
+
+                ForEach(Equipment.allCases, id: \.self) { eq in
+                    Button {
+                        Haptics.selection()
+                        filter.equipment = filter.equipment == eq ? nil : eq
+                    } label: {
+                        XomBadge(eq.displayName, variant: .interactive, isActive: filter.equipment == eq)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel(eq.displayName)
+                    .accessibilityAddTraits(filter.equipment == eq ? [.isButton, .isSelected] : .isButton)
+                }
+            }
+            .padding(.horizontal, Theme.Spacing.md)
+        }
+    }
+}
+
+#Preview {
+    @Previewable @State var filter = WorkoutFilter()
+    return ZStack {
+        Theme.background.ignoresSafeArea()
+        VStack {
+            WorkoutFilterBar(filter: $filter)
+            Spacer()
+        }
+    }
+}

--- a/Xomfit/Views/Workout/WorkoutView.swift
+++ b/Xomfit/Views/Workout/WorkoutView.swift
@@ -4,82 +4,79 @@ struct WorkoutView: View {
     @Environment(AuthService.self) private var authService
     @Environment(WorkoutLoggerViewModel.self) private var workoutSession
 
+    @State private var viewModel = WorkoutTabViewModel()
+
     @State private var showNameEntry = false
     @State private var pendingWorkoutName = ""
-    @State private var showTemplateList = false
     @State private var showBuilder = false
     @State private var previewTemplate: WorkoutTemplate?
-    @State private var templateRefreshId = UUID()
-    @State private var recentWorkouts: [Workout] = []
+    @State private var friendWorkoutDetail: Workout?
+
     private var hasStartedFirstWorkout: Bool {
         UserDefaults.standard.bool(forKey: "xomfit_first_workout_started")
     }
-    @State private var myTemplates: [WorkoutTemplate] = []
-    @State private var savedTemplates: [WorkoutTemplate] = []
 
     private var userId: String {
         authService.currentUser?.id.uuidString.lowercased() ?? ""
     }
 
     var body: some View {
-        NavigationStack {
+        @Bindable var viewModel = viewModel
+
+        return NavigationStack {
             ZStack {
                 Theme.background.ignoresSafeArea()
 
-                VStack(spacing: 0) {
-                    ScrollView {
-                        VStack(spacing: Theme.Spacing.sm) {
-                            // Start Workout CTA
-                            Button {
-                                Haptics.light()
-                                pendingWorkoutName = ""
-                                showNameEntry = true
-                            } label: {
-                                HStack(spacing: 10) {
-                                    Image(systemName: "play.fill")
-                                    Text("Start Workout")
-                                }
-                            }
-                            .buttonStyle(AccentButtonStyle())
-                            .padding(.horizontal, Theme.Spacing.md)
-                            .padding(.top, Theme.Spacing.md)
-
-                            // Build Workout
-                            Button {
-                                Haptics.light()
-                                showBuilder = true
-                            } label: {
-                                HStack(spacing: 10) {
-                                    Image(systemName: "hammer.fill")
-                                    Text("Build Workout")
-                                }
-                            }
-                            .buttonStyle(GhostButtonStyle())
-                            .padding(.horizontal, Theme.Spacing.md)
-
-                            // First workout guide for new users
-                            if recentWorkouts.isEmpty && !hasStartedFirstWorkout {
-                                firstWorkoutCard
-                            }
-
-                            // Quick Start templates
-                            templateSection
-
-                            // Recent workouts
-                            if !recentWorkouts.isEmpty {
-                                recentSection
-                            }
-
-                            // My Workouts (custom templates)
-                            if !myTemplates.isEmpty {
-                                myWorkoutsSection
-                            }
-
-                            // Saved Workouts
-                            if !savedTemplates.isEmpty {
-                                savedSection
+                ScrollView {
+                    VStack(spacing: Theme.Spacing.sm) {
+                        // Top-level CTAs — preserved per #257 coordination
+                        Button {
+                            Haptics.light()
+                            pendingWorkoutName = ""
+                            showNameEntry = true
+                        } label: {
+                            HStack(spacing: 10) {
+                                Image(systemName: "play.fill")
+                                Text("Start Workout")
                             }
                         }
+                        .buttonStyle(AccentButtonStyle())
+                        .padding(.horizontal, Theme.Spacing.md)
+                        .padding(.top, Theme.Spacing.md)
+
+                        Button {
+                            Haptics.light()
+                            showBuilder = true
+                        } label: {
+                            HStack(spacing: 10) {
+                                Image(systemName: "hammer.fill")
+                                Text("Build Workout")
+                            }
+                        }
+                        .buttonStyle(GhostButtonStyle())
+                        .padding(.horizontal, Theme.Spacing.md)
+
+                        // First-workout onboarding card — preserved
+                        if viewModel.recent.isEmpty && !hasStartedFirstWorkout {
+                            firstWorkoutCard
+                        }
+
+                        // Filter bar — applies to whichever tab is active
+                        WorkoutFilterBar(filter: $viewModel.filter)
+
+                        // Tab segmented control
+                        Picker("Workout Tab", selection: $viewModel.selectedTab) {
+                            ForEach(WorkoutTab.allCases) { tab in
+                                Text(tab.displayName).tag(tab)
+                            }
+                        }
+                        .pickerStyle(.segmented)
+                        .padding(.horizontal, Theme.Spacing.md)
+                        .accessibilityLabel("Workout tab")
+
+                        // Tab content
+                        tabContent
+                            .padding(.bottom, Theme.Spacing.xl)
                     }
                 }
             }
@@ -87,12 +84,23 @@ struct WorkoutView: View {
             .navigationBarTitleDisplayMode(.large)
             .toolbarColorScheme(.dark, for: .navigationBar)
             .task {
-                await loadSections()
+                await viewModel.load(userId: userId)
             }
             .onChange(of: workoutSession.isPresented) { _, isPresented in
                 if !isPresented {
-                    Task { await loadSections() }
+                    Task { await viewModel.load(userId: userId) }
                 }
+            }
+        }
+        .sheet(item: $friendWorkoutDetail) { workout in
+            NavigationStack {
+                WorkoutDetailView(workout: workout)
+                    .toolbar {
+                        ToolbarItem(placement: .cancellationAction) {
+                            Button("Close") { friendWorkoutDetail = nil }
+                                .foregroundStyle(Theme.accent)
+                        }
+                    }
             }
         }
         .alert("Name Your Workout", isPresented: $showNameEntry) {
@@ -105,8 +113,7 @@ struct WorkoutView: View {
             Button("Cancel", role: .cancel) {}
         }
         .sheet(isPresented: $showBuilder, onDismiss: {
-            templateRefreshId = UUID()
-            Task { await loadSections() }
+            Task { await viewModel.load(userId: userId) }
         }) {
             WorkoutBuilderView()
         }
@@ -117,15 +124,161 @@ struct WorkoutView: View {
                 workoutSession.isPresented = true
             }
         }
-        .sheet(isPresented: $showTemplateList) {
-            TemplateListView { template in
-                // Dismiss the list first, then show preview after a brief delay
-                showTemplateList = false
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-                    previewTemplate = template
+    }
+
+    // MARK: - Tab Content
+
+    @ViewBuilder
+    private var tabContent: some View {
+        switch viewModel.selectedTab {
+        case .mine:      mineTab
+        case .recent:    recentTab
+        case .templates: templatesTab
+        case .friends:   friendsTab
+        }
+    }
+
+    // MARK: - Mine Tab
+
+    private var mineTab: some View {
+        Group {
+            if viewModel.myTemplates.isEmpty {
+                XomEmptyState(
+                    icon: "star.fill",
+                    title: "No Custom Workouts Yet",
+                    subtitle: "Build a workout to save it here for quick access.",
+                    ctaLabel: "Build Workout",
+                    ctaAction: { showBuilder = true }
+                )
+            } else if viewModel.isEmptyAfterFilter(for: .mine) {
+                noMatchesState
+            } else {
+                LazyVStack(spacing: Theme.Spacing.sm) {
+                    ForEach(Array(viewModel.filteredTemplatesMine.enumerated()), id: \.element.id) { index, template in
+                        TemplateCardView(template: template, style: .row) {
+                            previewTemplate = template
+                        }
+                        .staggeredAppear(index: index)
+                        .contextMenu {
+                            Button(role: .destructive) {
+                                deleteTemplate(template)
+                            } label: {
+                                Label("Delete", systemImage: "trash")
+                            }
+                        }
+                    }
                 }
+                .padding(.horizontal, Theme.Spacing.md)
             }
         }
+    }
+
+    // MARK: - Recent Tab
+
+    private var recentTab: some View {
+        Group {
+            if viewModel.recent.isEmpty {
+                XomEmptyState(
+                    icon: "clock.arrow.circlepath",
+                    title: "No Recent Workouts",
+                    subtitle: "Complete your first workout to see it here.",
+                    ctaLabel: "Start Workout",
+                    ctaAction: {
+                        pendingWorkoutName = ""
+                        showNameEntry = true
+                    }
+                )
+            } else if viewModel.isEmptyAfterFilter(for: .recent) {
+                noMatchesState
+            } else {
+                LazyVStack(spacing: Theme.Spacing.sm) {
+                    ForEach(Array(viewModel.filteredRecent.enumerated()), id: \.element.id) { index, workout in
+                        RecentWorkoutCard(workout: workout, style: .row) {
+                            previewTemplate = templateFromWorkout(workout)
+                        }
+                        .staggeredAppear(index: index)
+                    }
+                }
+                .padding(.horizontal, Theme.Spacing.md)
+            }
+        }
+    }
+
+    // MARK: - Templates Tab
+
+    private var templatesTab: some View {
+        Group {
+            if viewModel.builtInTemplates.isEmpty && viewModel.savedTemplates.isEmpty {
+                XomEmptyState(
+                    icon: "list.bullet.rectangle.portrait",
+                    title: "No Templates",
+                    subtitle: "Templates will appear once they load."
+                )
+            } else if viewModel.isEmptyAfterFilter(for: .templates) {
+                noMatchesState
+            } else {
+                LazyVStack(spacing: Theme.Spacing.sm) {
+                    ForEach(Array(viewModel.filteredTemplatesBuiltIn.enumerated()), id: \.element.id) { index, template in
+                        TemplateCardView(template: template, style: .row) {
+                            previewTemplate = template
+                        }
+                        .staggeredAppear(index: index)
+                    }
+                }
+                .padding(.horizontal, Theme.Spacing.md)
+            }
+        }
+    }
+
+    // MARK: - Friends Tab
+
+    private var friendsTab: some View {
+        Group {
+            if viewModel.isLoadingFriends && viewModel.friendWorkouts.isEmpty {
+                VStack(spacing: Theme.Spacing.md) {
+                    XomFitLoaderPulse()
+                    Text("Loading friends' workouts...")
+                        .font(Theme.fontSmall)
+                        .foregroundStyle(Theme.textSecondary)
+                }
+                .frame(maxWidth: .infinity)
+                .padding(Theme.Spacing.xl)
+            } else if viewModel.friendWorkouts.isEmpty {
+                XomEmptyState(
+                    icon: "person.2.fill",
+                    title: "No Friend Activity",
+                    subtitle: "Add friends to see their recent workouts here.",
+                    ctaLabel: nil,
+                    ctaAction: nil
+                )
+            } else if viewModel.isEmptyAfterFilter(for: .friends) {
+                noMatchesState
+            } else {
+                LazyVStack(spacing: Theme.Spacing.sm) {
+                    ForEach(Array(viewModel.filteredFriendWorkouts.enumerated()), id: \.element.id) { index, workout in
+                        RecentWorkoutCard(workout: workout, style: .row) {
+                            friendWorkoutDetail = workout
+                        }
+                        .staggeredAppear(index: index)
+                    }
+                }
+                .padding(.horizontal, Theme.Spacing.md)
+            }
+        }
+    }
+
+    // MARK: - Shared Empty States
+
+    private var noMatchesState: some View {
+        XomEmptyState(
+            icon: "line.3.horizontal.decrease.circle",
+            title: "No Matches",
+            subtitle: "Try clearing the filter to see more results.",
+            ctaLabel: "Clear Filter",
+            ctaAction: {
+                viewModel.filter = WorkoutFilter()
+            }
+        )
     }
 
     // MARK: - First Workout Guide
@@ -174,121 +327,13 @@ struct WorkoutView: View {
         .padding(.horizontal, Theme.Spacing.md)
     }
 
-    // MARK: - Templates
+    // MARK: - Helpers
 
-    private var templateSection: some View {
-        VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
-            HStack {
-                Text("Quick Start")
-                    .font(.body.weight(.bold))
-                    .foregroundStyle(Theme.textPrimary)
-                Spacer()
-                Button {
-                    showTemplateList = true
-                } label: {
-                    Text("See All")
-                        .font(.caption.weight(.semibold))
-                        .foregroundStyle(Theme.accent)
-                }
-            }
-            .padding(.horizontal, Theme.Spacing.md)
-
-            ScrollView(.horizontal, showsIndicators: false) {
-                HStack(spacing: Theme.Spacing.sm) {
-                    ForEach(Array(TemplateService.shared.allTemplates().prefix(6).enumerated()), id: \.element.id) { index, template in
-                        TemplateCardView(template: template) {
-                            previewTemplate = template
-                        }
-                        .staggeredAppear(index: index)
-                    }
-                }
-                .padding(.horizontal, Theme.Spacing.md)
-                .id(templateRefreshId)
-            }
-        }
-        .padding(.vertical, Theme.Spacing.sm)
-    }
-
-    // MARK: - Recent Workouts
-
-    private var recentSection: some View {
-        VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
-            Text("Recent")
-                .font(.body.weight(.bold))
-                .foregroundStyle(Theme.textPrimary)
-                .padding(.horizontal, Theme.Spacing.md)
-
-            ScrollView(.horizontal, showsIndicators: false) {
-                HStack(spacing: Theme.Spacing.sm) {
-                    ForEach(Array(recentWorkouts.prefix(5).enumerated()), id: \.element.id) { index, workout in
-                        TemplateCardView(template: templateFromWorkout(workout)) {
-                            previewTemplate = templateFromWorkout(workout)
-                        }
-                        .staggeredAppear(index: index)
-                    }
-                }
-                .padding(.horizontal, Theme.Spacing.md)
-            }
-        }
-        .padding(.vertical, Theme.Spacing.sm)
-    }
-
-    // MARK: - My Workouts
-
-    private var myWorkoutsSection: some View {
-        VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
-            Text("My Workouts")
-                .font(.body.weight(.bold))
-                .foregroundStyle(Theme.textPrimary)
-                .padding(.horizontal, Theme.Spacing.md)
-
-            ScrollView(.horizontal, showsIndicators: false) {
-                HStack(spacing: Theme.Spacing.sm) {
-                    ForEach(Array(myTemplates.enumerated()), id: \.element.id) { index, template in
-                        TemplateCardView(template: template) {
-                            previewTemplate = template
-                        }
-                        .staggeredAppear(index: index)
-                    }
-                }
-                .padding(.horizontal, Theme.Spacing.md)
-            }
-        }
-        .padding(.vertical, Theme.Spacing.sm)
-    }
-
-    // MARK: - Saved Workouts
-
-    private var savedSection: some View {
-        VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
-            Text("Saved Workouts")
-                .font(.body.weight(.bold))
-                .foregroundStyle(Theme.textPrimary)
-                .padding(.horizontal, Theme.Spacing.md)
-
-            ScrollView(.horizontal, showsIndicators: false) {
-                HStack(spacing: Theme.Spacing.sm) {
-                    ForEach(Array(savedTemplates.enumerated()), id: \.element.id) { index, template in
-                        TemplateCardView(template: template) {
-                            previewTemplate = template
-                        }
-                        .staggeredAppear(index: index)
-                    }
-                }
-                .padding(.horizontal, Theme.Spacing.md)
-            }
-        }
-        .padding(.vertical, Theme.Spacing.sm)
-    }
-
-    // MARK: - Data Loading
-
-    private func loadSections() async {
-        guard !userId.isEmpty else { return }
-        recentWorkouts = await WorkoutService.shared.fetchWorkouts(userId: userId)
-        let allCustom = TemplateService.shared.allTemplates().filter { $0.isCustom }
-        myTemplates = allCustom.filter { $0.category != .saved }
-        savedTemplates = allCustom.filter { $0.category == .saved }
+    private func deleteTemplate(_ template: WorkoutTemplate) {
+        guard template.isCustom else { return }
+        Haptics.medium()
+        TemplateService.shared.deleteCustomTemplate(id: template.id)
+        Task { await viewModel.load(userId: userId) }
     }
 
     private func templateFromWorkout(_ workout: Workout) -> WorkoutTemplate {

--- a/docs/features/workout-views-249/EXECUTION_LOG.md
+++ b/docs/features/workout-views-249/EXECUTION_LOG.md
@@ -1,0 +1,63 @@
+# Execution Log: #249 Workout Views — Tabs + Filter Chips
+
+**Branch**: `feat/249-workout-views-filter` (off `master`)
+**Date**: 2026-05-09
+
+## Steps Completed
+
+- [x] Step 1 — Added `WorkoutFilter` struct (`Xomfit/Models/WorkoutFilter.swift`) with `matches(_ template:)` and `matches(_ workout:)`. Empty filter passes everything; combined criteria AND together. Search hits name + description + exercise names.
+- [x] Step 2 — Added `WorkoutFilterBar` (`Xomfit/Views/Workout/WorkoutFilterBar.swift`): search field with clear button + horizontal `XomBadge(.interactive)` rails for `MuscleGroup` and `Equipment`. Mirrors `ExercisePickerView` pattern. VoiceOver-aware (`isSelected` trait on chips).
+- [x] Step 3 — Added `WorkoutTab` enum in `Xomfit/ViewModels/WorkoutTabViewModel.swift` (`.mine`, `.recent`, `.templates`, `.friends`) with `displayName` and `icon`.
+- [x] Step 4 — Added `WorkoutTabViewModel` (`@Observable`, `@MainActor`) holding all four data arrays + `selectedTab` (persisted to `UserDefaults`) + `filter`. Exposes `filteredTemplatesMine`, `filteredTemplatesBuiltIn`, `filteredRecent`, `filteredFriendWorkouts` and `isEmptyAfterFilter(for:)`.
+- [x] Step 5 — Added `WorkoutService.fetchFriendsRecentWorkouts(currentUserId:limit:)`. Fans out via `withTaskGroup` over `FriendsService.fetchFriends` IDs, merges, sorts by `startTime` desc, caps at 30. Never throws — failures logged.
+- [x] Step 6 — Refactored `WorkoutView`: kept `Start Workout` + `Build Workout` CTAs and the first-workout onboarding card untouched at top (preserves #257 entry-point coordination). Added `WorkoutFilterBar` + `Picker(.segmented)` + per-tab `LazyVStack` of row-style cards.
+- [x] Step 7 — Wired tap actions: Mine / Recent / Templates open `previewTemplate` sheet → `TemplateDetailView`. Friends open a read-only `WorkoutDetailView` in a `NavigationStack`-wrapped sheet (no edit/delete UI). `Workout` is `Identifiable` only (not `Hashable`), so a sheet is required — `navigationDestination(item:)` would need a `Hashable` conformance change we didn't want to risk in this PR.
+- [x] Step 8 — Per-tab empty states using `XomEmptyState`:
+  - Mine empty → CTA to Build Workout
+  - Recent empty → CTA to Start Workout
+  - Friends empty → "Add friends to see their recent workouts here" (no nav CTA — Friends lives behind Feed's nav stack and is not directly addressable from here)
+  - Filter empty (any tab) → CTA to clear the filter
+- [x] Step 9 — `selectedTab` persisted to `UserDefaults` key `xomfit_workout_selected_tab` via `didSet`. Default tab is `.templates` for first launch.
+- [x] Step 10 — Clean build, zero warnings.
+
+## Build Result
+
+```
+xcodebuild -project Xomfit.xcodeproj -scheme Xomfit \
+  -destination 'platform=iOS Simulator,name=iPhone 17' \
+  -configuration Debug build
+```
+
+`** BUILD SUCCEEDED **` — 0 warnings, 0 errors.
+
+## Files Touched
+
+**Created**
+- `Xomfit/Models/WorkoutFilter.swift`
+- `Xomfit/Views/Workout/WorkoutFilterBar.swift`
+- `Xomfit/ViewModels/WorkoutTabViewModel.swift`
+
+**Modified**
+- `Xomfit/Services/WorkoutService.swift` — new `fetchFriendsRecentWorkouts` method
+- `Xomfit/Views/Workout/TemplateCardView.swift` — added `style: .compact | .row` parameter (default `.compact`, preserves all existing carousel callsites)
+- `Xomfit/Views/Workout/RecentWorkoutCard.swift` — added `style: .compact | .row` parameter (default `.compact`)
+- `Xomfit/Views/Workout/WorkoutView.swift` — full refactor from stacked carousels to tabs + filter, kept CTAs and onboarding card
+
+## Coordination Notes (#257)
+
+- `Start Workout` CTA — kept at top, untouched.
+- `Build Workout` CTA — kept at top, untouched.
+- First-workout onboarding card — kept at top, untouched.
+- Layout changed from stacked carousels → segmented tabs + filter bar + vertical list. Entry points preserved; only the discovery surfaces (carousel sections) refactored into tabs.
+- The other agent adding "Log Past Workout" can append a new button alongside the existing two CTAs without touching the new tab/filter logic.
+
+## Out of Scope (per plan)
+
+- Rating filter — no `WorkoutTemplate` rating field.
+- Save-friend's-workout — separate model/feature.
+- Server-side filtering / pagination — client-side over fetched arrays.
+- Friends backend RPC — current fan-out is acceptable at <50 friends with the 30-item cap.
+
+## Manual Test Plan Status
+
+Manual UI verification deferred to user — build is green and structure matches the plan. Test cases enumerated in `PLAN.md` Manual Test Plan section.


### PR DESCRIPTION
Partial implementation of #249.

## Summary
Lands the foundation files (filter model, filter bar, tab view model, friends-workouts service fetch, card style variants). The actual tab UI in WorkoutView.swift was conflict-resolved to master's existing carousel — **the tabs do NOT yet replace the workout list UI**. A follow-up PR will wire WorkoutFilterBar + WorkoutTabViewModel into WorkoutView.

This unblocks #250, #251, #261, #257, #258 which all merged ahead of this PR.

## Foundation shipped
- `Models/WorkoutFilter.swift`
- `ViewModels/WorkoutTabViewModel.swift`
- `Views/Workout/WorkoutFilterBar.swift`
- `Services/WorkoutService.swift` — `fetchFriendsRecentWorkouts(currentUserId:limit:)`
- `Views/Workout/TemplateCardView.swift` — `style: .compact | .row`
- `Views/Workout/RecentWorkoutCard.swift` — same `style` param

## Remaining work (filed as follow-up)
- Refactor WorkoutView.swift to use WorkoutTabViewModel + tabs + filter chips, while preserving:
  - Start Workout / Build / Log Past CTAs (#257)
  - Warmup prompt + sheet (#261)
  - Existing carousel content reorganized into tabs

Closes part of #249.