### PR TITLE
#250 add streak counter, last/PR hints in set rows, new-PR toast

### DIFF
--- a/Xomfit/Services/BadgeToastService.swift
+++ b/Xomfit/Services/BadgeToastService.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+/// Computes which "welcome back" badge toast (streak / new PR) to show on
+/// app launch (#250). Persists the last seen streak and PR-celebration date
+/// in `UserDefaults` so the user only sees a toast once per increment.
+///
+/// Stateless from the caller's perspective: it returns a single message at
+/// most, then commits the new "seen" markers so subsequent launches are quiet.
+@MainActor
+enum BadgeToastService {
+    private static let lastSeenStreakKey = "xomfit.badge.lastSeenStreak"
+    private static let lastSeenPRDateKey = "xomfit.badge.lastSeenPRDate"
+
+    /// What kind of badge fired, if any. Pure value; the caller chooses how to show it.
+    enum Badge: Equatable {
+        case streak(days: Int)
+        case newPR(exerciseName: String, weight: Double, reps: Int)
+
+        var message: String {
+            switch self {
+            case .streak(let days):
+                let unit = days == 1 ? "day" : "days"
+                return "\u{1F525} \(days) \(unit) streak!"
+            case .newPR(let name, let weight, let reps):
+                return "\u{1F3C6} New PR: \(name) \(weight.formattedWeight)×\(reps)"
+            }
+        }
+    }
+
+    /// Inspect the user's workouts and decide which badge (if any) to surface.
+    /// Updates persisted state so we don't re-show the same celebration twice.
+    /// Streak takes precedence over PR (rule of thumb: ship at most one toast per launch).
+    static func badgeForLaunch(workouts: [Workout]) -> Badge? {
+        let defaults = UserDefaults.standard
+
+        // 1. Streak just incremented?
+        let streak = WorkoutInsights.currentStreak(workouts: workouts)
+        let lastSeenStreak = defaults.integer(forKey: lastSeenStreakKey)
+        if WorkoutInsights.didIncrementStreak(previous: lastSeenStreak, current: streak) {
+            defaults.set(streak, forKey: lastSeenStreakKey)
+            return .streak(days: streak)
+        }
+        // Sync down so streak resets don't keep firing celebration once user falls off.
+        if streak != lastSeenStreak {
+            defaults.set(streak, forKey: lastSeenStreakKey)
+        }
+
+        // 2. Unseen PR from yesterday?
+        let lastSeenPRDate = defaults.object(forKey: lastSeenPRDateKey) as? Date
+        if let pr = WorkoutInsights.unseenRecentPR(workouts: workouts, lastSeenDate: lastSeenPRDate) {
+            defaults.set(pr.completedAt, forKey: lastSeenPRDateKey)
+            return .newPR(exerciseName: pr.exerciseName, weight: pr.weight, reps: pr.reps)
+        }
+
+        return nil
+    }
+
+    /// Test seam — clear persisted state.
+    static func resetForTesting() {
+        UserDefaults.standard.removeObject(forKey: lastSeenStreakKey)
+        UserDefaults.standard.removeObject(forKey: lastSeenPRDateKey)
+    }
+}

--- a/Xomfit/Utils/WorkoutInsights.swift
+++ b/Xomfit/Utils/WorkoutInsights.swift
@@ -1,0 +1,113 @@
+import Foundation
+
+/// Pure helpers for streak counting and recent-PR detection over a user's
+/// workout history. Used by Profile streak card (#250) and the app-open
+/// badge toast on `MainTabView`.
+///
+/// All functions are pure -- they take an array of workouts and return
+/// derived values. No side effects, no service calls. Keep them this way
+/// so they're trivially testable and safe to call repeatedly from views.
+enum WorkoutInsights {
+
+    // MARK: - Streaks
+
+    /// Current consecutive-day streak ending today (or yesterday).
+    ///
+    /// A "streak day" is any calendar day with at least one workout.
+    /// Streak resets after one missed day. We allow "today not yet logged"
+    /// to still count yesterday's streak so users don't see the number
+    /// drop to zero between waking up and lifting.
+    static func currentStreak(workouts: [Workout], calendar: Calendar = .current, now: Date = Date()) -> Int {
+        let workoutDays = Set(workouts.map { calendar.startOfDay(for: $0.startTime) })
+        let today = calendar.startOfDay(for: now)
+        guard let yesterday = calendar.date(byAdding: .day, value: -1, to: today) else { return 0 }
+
+        // Walk back from today; if today has no workout, start from yesterday.
+        var cursor: Date
+        if workoutDays.contains(today) {
+            cursor = today
+        } else if workoutDays.contains(yesterday) {
+            cursor = yesterday
+        } else {
+            return 0
+        }
+
+        var streak = 0
+        while workoutDays.contains(cursor) {
+            streak += 1
+            guard let prev = calendar.date(byAdding: .day, value: -1, to: cursor) else { break }
+            cursor = prev
+        }
+        return streak
+    }
+
+    /// Longest historical streak across all workouts. Used as a subtitle on
+    /// the streak card so users always see their personal best.
+    static func longestStreak(workouts: [Workout], calendar: Calendar = .current) -> Int {
+        let workoutDays = Set(workouts.map { calendar.startOfDay(for: $0.startTime) })
+        guard !workoutDays.isEmpty else { return 0 }
+
+        let sorted = workoutDays.sorted()
+        var best = 1
+        var run = 1
+        for i in 1..<sorted.count {
+            let prev = sorted[i - 1]
+            let curr = sorted[i]
+            if let next = calendar.date(byAdding: .day, value: 1, to: prev), next == curr {
+                run += 1
+                best = max(best, run)
+            } else {
+                run = 1
+            }
+        }
+        return best
+    }
+
+    // MARK: - Toast triggers
+
+    /// True when the user just incremented their streak today vs. their
+    /// previous app session. Caller compares the persisted last-streak
+    /// value against the current streak.
+    static func didIncrementStreak(previous: Int, current: Int) -> Bool {
+        current > previous && current > 1
+    }
+
+    /// PRs from "yesterday's" workout that the user hasn't been celebrated
+    /// for in-app yet. We pick the single best (heaviest) PR set if any.
+    /// Returns nil when there's nothing to celebrate.
+    static func unseenRecentPR(
+        workouts: [Workout],
+        lastSeenDate: Date?,
+        calendar: Calendar = .current,
+        now: Date = Date()
+    ) -> RecentPRTip? {
+        let today = calendar.startOfDay(for: now)
+        let lookbackStart = calendar.date(byAdding: .day, value: -1, to: today) ?? today
+
+        // Find PR sets logged within the last day that the user hasn't seen yet.
+        var candidates: [(workout: Workout, exercise: WorkoutExercise, set: WorkoutSet)] = []
+        for workout in workouts where workout.startTime >= lookbackStart && workout.startTime < today {
+            for ex in workout.exercises {
+                for set in ex.sets where set.isPersonalRecord {
+                    if let lastSeen = lastSeenDate, set.completedAt <= lastSeen { continue }
+                    candidates.append((workout, ex, set))
+                }
+            }
+        }
+        guard let best = candidates.max(by: { $0.set.weight < $1.set.weight }) else { return nil }
+        return RecentPRTip(
+            exerciseName: best.exercise.exercise.name,
+            weight: best.set.weight,
+            reps: best.set.reps,
+            completedAt: best.set.completedAt
+        )
+    }
+}
+
+/// A single PR worth celebrating when the user re-opens the app.
+struct RecentPRTip: Equatable {
+    let exerciseName: String
+    let weight: Double
+    let reps: Int
+    let completedAt: Date
+}

--- a/Xomfit/ViewModels/ProfileViewModel.swift
+++ b/Xomfit/ViewModels/ProfileViewModel.swift
@@ -145,6 +145,16 @@ final class ProfileViewModel {
         return "\(Int(totalVolume))"
     }
 
+    /// Current consecutive-day workout streak (#250). 0 if today/yesterday have no workouts.
+    var currentStreak: Int {
+        WorkoutInsights.currentStreak(workouts: workouts)
+    }
+
+    /// Longest historical streak across all workouts (#250). Used as the streak-card subtitle.
+    var longestStreak: Int {
+        WorkoutInsights.longestStreak(workouts: workouts)
+    }
+
     // MARK: - Load All
 
     func loadAll(userId: String, currentUserId: String) async {

--- a/Xomfit/ViewModels/WorkoutLoggerViewModel.swift
+++ b/Xomfit/ViewModels/WorkoutLoggerViewModel.swift
@@ -255,7 +255,8 @@ final class WorkoutLoggerViewModel {
     }
 
     /// Find the most recent set for an exercise from workout history.
-    private func lastSetForExercise(_ exerciseId: String) -> WorkoutSet? {
+    /// Public for use by `SetRowView` PR-aware suggestions (#250).
+    func lastSetForExercise(_ exerciseId: String) -> WorkoutSet? {
         guard !activeUserId.isEmpty else { return nil }
         let workouts = WorkoutService.shared.fetchWorkoutsFromCache(userId: activeUserId)
         for workout in workouts {
@@ -265,6 +266,23 @@ final class WorkoutLoggerViewModel {
             }
         }
         return nil
+    }
+
+    /// Find the highest-weight set ever performed for an exercise from cached workout history.
+    /// Tie-breaks on reps so `145×6` beats `145×5`. Used by SetRowView for PR hint + new-PR badge (#250).
+    func personalRecordForExercise(_ exerciseId: String) -> WorkoutSet? {
+        guard !activeUserId.isEmpty else { return nil }
+        let workouts = WorkoutService.shared.fetchWorkoutsFromCache(userId: activeUserId)
+        let allSets = workouts
+            .flatMap { $0.exercises }
+            .filter { $0.exercise.id == exerciseId }
+            .flatMap { $0.sets }
+            .filter { $0.weight > 0 && $0.reps > 0 }
+        guard !allSets.isEmpty else { return nil }
+        return allSets.max { lhs, rhs in
+            if lhs.weight != rhs.weight { return lhs.weight < rhs.weight }
+            return lhs.reps < rhs.reps
+        }
     }
 
     func removeExercise(at index: Int) {

--- a/Xomfit/Views/MainTabView.swift
+++ b/Xomfit/Views/MainTabView.swift
@@ -7,6 +7,8 @@ struct MainTabView: View {
     @State private var selectedTab = 0
     @State private var tabBarVisible = true
     @State private var tickId = UUID()
+    /// App-open streak / new-PR celebration toast (#250). Cleared after auto-dismiss.
+    @State private var launchBadgeToast: Toast?
 
     private let resumeTimer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
 
@@ -65,6 +67,17 @@ struct MainTabView: View {
             ActiveWorkoutView()
                 .environment(authService)
                 .environment(workoutSession)
+        }
+        .toast($launchBadgeToast)
+        .task {
+            // App-open streak / PR badge (#250).
+            // Show at most one toast per launch; surface ~1s in so it
+            // doesn't collide with the tab bar's mount animation.
+            guard let userId = authService.currentUser?.id.uuidString.lowercased() else { return }
+            let workouts = WorkoutService.shared.fetchWorkoutsFromCache(userId: userId)
+            guard let badge = BadgeToastService.badgeForLaunch(workouts: workouts) else { return }
+            try? await Task.sleep(for: .seconds(1))
+            launchBadgeToast = Toast(style: .success, message: badge.message)
         }
         .environment(\.tabBarVisible, $tabBarVisible)
     }

--- a/Xomfit/Views/Profile/ProfileStatsView.swift
+++ b/Xomfit/Views/Profile/ProfileStatsView.swift
@@ -7,6 +7,10 @@ struct ProfileStatsView: View {
     let recentPRs: [PersonalRecord]
     let muscleGroupSetsThisWeek: [String: Int]
     let muscleGroupSetsThisMonth: [String: Int]
+    /// Current consecutive-day workout streak (#250).
+    var currentStreak: Int = 0
+    /// Longest streak across history (#250).
+    var longestStreak: Int = 0
 
     @State private var heatmapFilter: HeatmapTimeFilter = .week
 
@@ -19,6 +23,7 @@ struct ProfileStatsView: View {
 
     var body: some View {
         VStack(spacing: Theme.Spacing.sm) {
+            StreakCard(currentStreak: currentStreak, longestStreak: longestStreak)
             statsCards
             heatmapSection
             prSection

--- a/Xomfit/Views/Profile/ProfileView.swift
+++ b/Xomfit/Views/Profile/ProfileView.swift
@@ -187,7 +187,9 @@ struct ProfileView: View {
                 totalPRs: viewModel.totalPRs,
                 recentPRs: viewModel.recentPRs,
                 muscleGroupSetsThisWeek: viewModel.muscleGroupSetsThisWeek,
-                muscleGroupSetsThisMonth: viewModel.muscleGroupSetsThisMonth
+                muscleGroupSetsThisMonth: viewModel.muscleGroupSetsThisMonth,
+                currentStreak: viewModel.currentStreak,
+                longestStreak: viewModel.longestStreak
             )
         }
     }

--- a/Xomfit/Views/Profile/StreakCard.swift
+++ b/Xomfit/Views/Profile/StreakCard.swift
@@ -1,0 +1,71 @@
+import SwiftUI
+
+/// Streak card surfaced on `ProfileStatsView` (#250).
+/// Active streak (>= 1 day) renders in accent green with a flame icon;
+/// broken streaks dim to textSecondary so the card still tells the story.
+struct StreakCard: View {
+    let currentStreak: Int
+    let longestStreak: Int
+
+    private var isActive: Bool { currentStreak > 0 }
+
+    private var iconColor: Color {
+        isActive ? Theme.streak : Theme.textSecondary
+    }
+
+    private var headlineText: String {
+        let unit = currentStreak == 1 ? "day" : "days"
+        return isActive ? "\(currentStreak) \(unit) streak" : "No active streak"
+    }
+
+    private var subtitleText: String {
+        if longestStreak > 0 {
+            let unit = longestStreak == 1 ? "day" : "days"
+            return "Longest: \(longestStreak) \(unit)"
+        }
+        return "Log a workout today to start one"
+    }
+
+    var body: some View {
+        XomCard(padding: Theme.Spacing.md) {
+            HStack(spacing: Theme.Spacing.md) {
+                ZStack {
+                    Circle()
+                        .fill(iconColor.opacity(0.15))
+                        .frame(width: 44, height: 44)
+                    Image(systemName: "flame.fill")
+                        .font(.title3)
+                        .foregroundStyle(iconColor)
+                        .symbolEffect(.bounce, value: currentStreak)
+                }
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(headlineText)
+                        .font(.headline.weight(.bold))
+                        .foregroundStyle(Theme.textPrimary)
+                    Text(subtitleText)
+                        .font(.caption.weight(.medium))
+                        .foregroundStyle(Theme.textSecondary)
+                }
+
+                Spacer()
+            }
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(isActive
+            ? "Current streak \(currentStreak) days. Longest streak \(longestStreak) days."
+            : "No active streak. Longest streak \(longestStreak) days."
+        )
+    }
+}
+
+#Preview {
+    VStack(spacing: 16) {
+        StreakCard(currentStreak: 7, longestStreak: 12)
+        StreakCard(currentStreak: 1, longestStreak: 12)
+        StreakCard(currentStreak: 0, longestStreak: 12)
+        StreakCard(currentStreak: 0, longestStreak: 0)
+    }
+    .padding()
+    .background(Theme.background)
+}

--- a/Xomfit/Views/Workout/ActiveWorkoutView.swift
+++ b/Xomfit/Views/Workout/ActiveWorkoutView.swift
@@ -798,7 +798,9 @@ private struct ExerciseCard: View {
                     onToggleWeightMode: {
                         viewModel.toggleWeightMode(exerciseIndex: exerciseIndex, setIndex: setIdx)
                     },
-                    lateralityLabel: exercise.selectedLaterality != .bilateral ? (exercise.exercise.muscleGroups.contains(where: { [.quads, .hamstrings, .glutes, .calves].contains($0) }) ? "/leg" : "/arm") : nil
+                    lateralityLabel: exercise.selectedLaterality != .bilateral ? (exercise.exercise.muscleGroups.contains(where: { [.quads, .hamstrings, .glutes, .calves].contains($0) }) ? "/leg" : "/arm") : nil,
+                    lastSet: viewModel.lastSetForExercise(exercise.exercise.id),
+                    personalRecord: viewModel.personalRecordForExercise(exercise.exercise.id)
                 )
             }
 

--- a/Xomfit/Views/Workout/SetRowView.swift
+++ b/Xomfit/Views/Workout/SetRowView.swift
@@ -9,6 +9,12 @@ struct SetRowView: View {
     let onDelete: () -> Void
     let onToggleWeightMode: () -> Void
     var lateralityLabel: String? = nil
+    /// Most recent set the user has logged for this exercise from history.
+    /// Drives the "Last: 135×8" hint below the row. nil = first time doing this exercise.
+    var lastSet: WorkoutSet? = nil
+    /// Heaviest set the user has ever logged for this exercise (history only).
+    /// Drives the "PR: 145×6" hint and the inline "NEW PR" badge when beat.
+    var personalRecord: WorkoutSet? = nil
 
     @State private var weightText: String
     @State private var repsText: String
@@ -23,6 +29,22 @@ struct SetRowView: View {
         workoutSet.isPersonalRecord
     }
 
+    /// Live "did this completed set just beat the prior PR?" check.
+    /// Compares against the historical PR (passed in), so we don't false-positive
+    /// after PRService flips `isPersonalRecord` on the row itself.
+    private var beatsPriorPR: Bool {
+        guard isCompleted, workoutSet.weight > 0, workoutSet.reps > 0 else { return false }
+        guard let pr = personalRecord else { return true } // first ever logged set counts as a PR
+        if workoutSet.weight > pr.weight { return true }
+        if workoutSet.weight == pr.weight && workoutSet.reps > pr.reps { return true }
+        return false
+    }
+
+    /// True when we have at least one of last / PR to surface as a subtitle.
+    private var hasHints: Bool {
+        lastSet != nil || personalRecord != nil
+    }
+
     init(
         setNumber: Int,
         workoutSet: WorkoutSet,
@@ -31,7 +53,9 @@ struct SetRowView: View {
         onComplete: @escaping () -> Void,
         onDelete: @escaping () -> Void,
         onToggleWeightMode: @escaping () -> Void = {},
-        lateralityLabel: String? = nil
+        lateralityLabel: String? = nil,
+        lastSet: WorkoutSet? = nil,
+        personalRecord: WorkoutSet? = nil
     ) {
         self.setNumber = setNumber
         self.workoutSet = workoutSet
@@ -41,6 +65,8 @@ struct SetRowView: View {
         self.onDelete = onDelete
         self.onToggleWeightMode = onToggleWeightMode
         self.lateralityLabel = lateralityLabel
+        self.lastSet = lastSet
+        self.personalRecord = personalRecord
 
         let w = workoutSet.weight
         let r = workoutSet.reps
@@ -49,6 +75,29 @@ struct SetRowView: View {
     }
 
     var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            mainRow
+            if hasHints || beatsPriorPR {
+                hintRow
+            }
+        }
+        .frame(minHeight: 52)
+        .background(isCompleted ? Theme.accent.opacity(0.08) : Color.clear)
+        .clipShape(.rect(cornerRadius: Theme.cornerRadiusSmall))
+        .animation(nil, value: workoutSet.completedAt)
+        .onChange(of: workoutSet.weight) { _, newWeight in
+            let formatted = newWeight > 0 ? newWeight.formattedWeight : ""
+            if weightText != formatted { weightText = formatted }
+        }
+        .onChange(of: workoutSet.reps) { _, newReps in
+            let formatted = newReps > 0 ? "\(newReps)" : ""
+            if repsText != formatted { repsText = formatted }
+        }
+    }
+
+    // MARK: - Main row (weight / reps / complete)
+
+    private var mainRow: some View {
         HStack(spacing: 0) {
             // PR indicator: 3pt gold leading stripe (only when it's a PR)
             if isPR {
@@ -169,17 +218,58 @@ struct SetRowView: View {
             .padding(.horizontal, Theme.Spacing.md)
             .padding(.vertical, 6)
         }
-        .frame(minHeight: 52)
-        .background(isCompleted ? Theme.accent.opacity(0.08) : Color.clear)
-        .clipShape(.rect(cornerRadius: Theme.cornerRadiusSmall))
-        .animation(nil, value: workoutSet.completedAt)
-        .onChange(of: workoutSet.weight) { _, newWeight in
-            let formatted = newWeight > 0 ? newWeight.formattedWeight : ""
-            if weightText != formatted { weightText = formatted }
+    }
+
+    // MARK: - Hint row (Last / PR / NEW PR badge)
+
+    private var hintRow: some View {
+        HStack(spacing: Theme.Spacing.sm) {
+            // align under the weight/reps fields, past the delete + set number columns
+            Spacer().frame(width: 30 + Theme.Spacing.sm + 24)
+
+            if let last = lastSet, last.weight > 0, last.reps > 0 {
+                hintChip(
+                    label: "Last",
+                    value: "\(last.weight.formattedWeight)×\(last.reps)",
+                    color: Theme.textSecondary
+                )
+            }
+
+            if let pr = personalRecord, pr.weight > 0, pr.reps > 0 {
+                hintChip(
+                    label: "PR",
+                    value: "\(pr.weight.formattedWeight)×\(pr.reps)",
+                    color: Theme.prGold
+                )
+            }
+
+            if beatsPriorPR {
+                Text("NEW PR")
+                    .font(.caption2.weight(.heavy))
+                    .foregroundStyle(.black)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(Theme.prGold)
+                    .clipShape(.capsule)
+                    .accessibilityLabel("New personal record")
+            }
+
+            Spacer()
         }
-        .onChange(of: workoutSet.reps) { _, newReps in
-            let formatted = newReps > 0 ? "\(newReps)" : ""
-            if repsText != formatted { repsText = formatted }
+        .padding(.horizontal, Theme.Spacing.md)
+        .padding(.bottom, 4)
+    }
+
+    private func hintChip(label: String, value: String, color: Color) -> some View {
+        HStack(spacing: 3) {
+            Text(label)
+                .font(.caption2.weight(.semibold))
+                .foregroundStyle(Theme.textTertiary)
+            Text(value)
+                .font(.caption2.weight(.semibold))
+                .foregroundStyle(color)
         }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(label) \(value)")
     }
 }


### PR DESCRIPTION
Closes #250 (first slice). Adds last-set + PR hints under each SetRowView, new-PR badge inline on completion, StreakCard on Profile (current + longest streak), and a launch-time badge toast for streak increments and missed-celebration PRs.