### PR TITLE
#251 profile improvements: volume trend, consistency, top exercises, PR of the month

### DIFF
--- a/XomFitTests/ProfileViewModelStatsTests.swift
+++ b/XomFitTests/ProfileViewModelStatsTests.swift
@@ -1,0 +1,290 @@
+import XCTest
+@testable import XomFit
+
+@MainActor
+final class ProfileViewModelStatsTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    /// Builds a workout `n` days ago from the given exercise(s). Sets are simple
+    /// 5x5 unless overridden.
+    private func makeWorkout(
+        id: String = UUID().uuidString,
+        daysAgo: Int,
+        exercises: [WorkoutExercise]
+    ) -> Workout {
+        let start = Calendar.current.date(byAdding: .day, value: -daysAgo, to: Date()) ?? Date()
+        return Workout(
+            id: id,
+            userId: "user-1",
+            name: "Test",
+            exercises: exercises,
+            startTime: start,
+            endTime: start.addingTimeInterval(3600),
+            notes: nil,
+            location: nil,
+            rating: nil
+        )
+    }
+
+    private func makeExercise(
+        id: String = UUID().uuidString,
+        exercise: Exercise,
+        weight: Double,
+        reps: Int,
+        sets: Int,
+        laterality: Laterality = .bilateral
+    ) -> WorkoutExercise {
+        let setRows: [WorkoutSet] = (0..<sets).map { i in
+            WorkoutSet(
+                id: "\(id)-set-\(i)",
+                exerciseId: exercise.id,
+                weight: weight,
+                reps: reps,
+                rpe: 8,
+                isPersonalRecord: false,
+                completedAt: Date()
+            )
+        }
+        return WorkoutExercise(
+            id: id,
+            exercise: exercise,
+            sets: setRows,
+            notes: nil,
+            selectedLaterality: laterality
+        )
+    }
+
+    // MARK: - Volume Trend
+
+    func testVolumeTrend30dProducesFourBuckets() {
+        let sut = ProfileViewModel()
+        let workouts = [
+            makeWorkout(daysAgo: 2, exercises: [makeExercise(exercise: .benchPress, weight: 100, reps: 5, sets: 3)]),
+            makeWorkout(daysAgo: 10, exercises: [makeExercise(exercise: .benchPress, weight: 100, reps: 5, sets: 3)]),
+            makeWorkout(daysAgo: 18, exercises: [makeExercise(exercise: .benchPress, weight: 100, reps: 5, sets: 3)]),
+            makeWorkout(daysAgo: 25, exercises: [makeExercise(exercise: .benchPress, weight: 100, reps: 5, sets: 3)])
+        ]
+
+        sut.computeDerivedStats(workouts: workouts)
+
+        XCTAssertEqual(sut.volumeTrend30d.count, 4)
+        // Each bucket should have 1500 (100 * 5 * 3)
+        for bucket in sut.volumeTrend30d {
+            XCTAssertEqual(bucket.volume, 1500, accuracy: 0.01)
+        }
+    }
+
+    func testVolumeTrendExcludesWorkoutsOlderThan30Days() {
+        let sut = ProfileViewModel()
+        let workouts = [
+            makeWorkout(daysAgo: 60, exercises: [makeExercise(exercise: .benchPress, weight: 100, reps: 5, sets: 3)]),
+            makeWorkout(daysAgo: 5, exercises: [makeExercise(exercise: .benchPress, weight: 100, reps: 5, sets: 3)])
+        ]
+
+        sut.computeDerivedStats(workouts: workouts)
+
+        let total = sut.volumeTrend30d.reduce(0) { $0 + $1.volume }
+        XCTAssertEqual(total, 1500, accuracy: 0.01, "Only the recent workout should count")
+    }
+
+    // MARK: - Consistency
+
+    func testWorkoutsPerWeekAndAverage() {
+        let sut = ProfileViewModel()
+        // 1 workout in last 7d, 2 in week before, 0 in week before that, 3 in oldest week
+        let workouts = [
+            makeWorkout(daysAgo: 3, exercises: [makeExercise(exercise: .benchPress, weight: 100, reps: 5, sets: 3)]),
+            makeWorkout(daysAgo: 9, exercises: [makeExercise(exercise: .benchPress, weight: 100, reps: 5, sets: 3)]),
+            makeWorkout(daysAgo: 12, exercises: [makeExercise(exercise: .benchPress, weight: 100, reps: 5, sets: 3)]),
+            makeWorkout(daysAgo: 22, exercises: [makeExercise(exercise: .benchPress, weight: 100, reps: 5, sets: 3)]),
+            makeWorkout(daysAgo: 24, exercises: [makeExercise(exercise: .benchPress, weight: 100, reps: 5, sets: 3)]),
+            makeWorkout(daysAgo: 27, exercises: [makeExercise(exercise: .benchPress, weight: 100, reps: 5, sets: 3)])
+        ]
+
+        sut.computeDerivedStats(workouts: workouts)
+
+        XCTAssertEqual(sut.workoutsPerWeek4w.count, 4)
+        XCTAssertEqual(sut.workoutsPerWeek4w.reduce(0, +), 6)
+        XCTAssertEqual(sut.avgWorkoutsPerWeek, 6.0 / 4.0, accuracy: 0.001)
+    }
+
+    // MARK: - Top Exercises
+
+    func testTopExercisesSortedAndCappedAtFive() {
+        let sut = ProfileViewModel()
+        let exercises: [Exercise] = (0..<7).map { i in
+            Exercise(
+                id: "ex-\(i)",
+                name: "Exercise \(i)",
+                muscleGroups: [.chest],
+                equipment: .barbell,
+                category: .compound,
+                description: "",
+                tips: []
+            )
+        }
+        // Each subsequent exercise has more volume than the previous.
+        let workouts = exercises.enumerated().map { idx, ex in
+            makeWorkout(
+                daysAgo: idx,
+                exercises: [makeExercise(exercise: ex, weight: Double((idx + 1) * 100), reps: 5, sets: 3)]
+            )
+        }
+
+        sut.computeDerivedStats(workouts: workouts)
+
+        XCTAssertEqual(sut.topExercisesByVolume.count, 5)
+        // Highest volume should be first
+        let volumes = sut.topExercisesByVolume.map { $0.volume }
+        XCTAssertEqual(volumes, volumes.sorted(by: >))
+        // Top exercise is the last one we added (700 * 5 * 3 = 10500)
+        XCTAssertEqual(sut.topExercisesByVolume.first?.name, "Exercise 6")
+        XCTAssertEqual(sut.topExercisesByVolume.first?.volume, 10500, accuracy: 0.01)
+    }
+
+    func testTopExercisesLateralityMultiplierApplies() {
+        let sut = ProfileViewModel()
+        let bilateralWorkout = makeWorkout(
+            id: "bilateral",
+            daysAgo: 2,
+            exercises: [makeExercise(exercise: .benchPress, weight: 100, reps: 5, sets: 3, laterality: .bilateral)]
+        )
+        let unilateralWorkout = makeWorkout(
+            id: "unilateral",
+            daysAgo: 5,
+            exercises: [makeExercise(exercise: .squat, weight: 100, reps: 5, sets: 3, laterality: .unilateral)]
+        )
+
+        sut.computeDerivedStats(workouts: [bilateralWorkout, unilateralWorkout])
+
+        let bench = sut.topExercisesByVolume.first { $0.name == "Bench Press" }
+        let squat = sut.topExercisesByVolume.first { $0.name == "Squat" }
+        XCTAssertEqual(bench?.volume, 1500, accuracy: 0.01)
+        // Unilateral should double: 100 * 5 * 3 * 2 = 3000
+        XCTAssertEqual(squat?.volume, 3000, accuracy: 0.01)
+    }
+
+    func testTopExercisesAggregatesAcrossWorkouts() {
+        let sut = ProfileViewModel()
+        let workouts = (0..<3).map { i in
+            makeWorkout(
+                id: "w-\(i)",
+                daysAgo: i + 1,
+                exercises: [makeExercise(exercise: .benchPress, weight: 100, reps: 5, sets: 3)]
+            )
+        }
+
+        sut.computeDerivedStats(workouts: workouts)
+
+        XCTAssertEqual(sut.topExercisesByVolume.count, 1)
+        XCTAssertEqual(sut.topExercisesByVolume.first?.volume, 4500, accuracy: 0.01)
+        XCTAssertEqual(sut.topExercisesByVolume.first?.setCount, 9)
+    }
+
+    // MARK: - PR of the Month
+
+    func testPROfTheMonthPicksHighestPercentImprovement() {
+        let sut = ProfileViewModel()
+        sut.allPRs = [
+            // Within 30d, 10% improvement
+            PersonalRecord(
+                id: "pr-1", userId: "u", exerciseId: "e1", exerciseName: "Bench",
+                weight: 220, reps: 3,
+                date: Date().addingTimeInterval(-86400 * 5),
+                previousBest: 200
+            ),
+            // Within 30d, 20% improvement (should win)
+            PersonalRecord(
+                id: "pr-2", userId: "u", exerciseId: "e2", exerciseName: "Squat",
+                weight: 360, reps: 1,
+                date: Date().addingTimeInterval(-86400 * 10),
+                previousBest: 300
+            ),
+            // Within 30d, 5% improvement
+            PersonalRecord(
+                id: "pr-3", userId: "u", exerciseId: "e3", exerciseName: "Deadlift",
+                weight: 420, reps: 1,
+                date: Date().addingTimeInterval(-86400 * 2),
+                previousBest: 400
+            )
+        ]
+
+        sut.computeDerivedStats(workouts: [])
+
+        XCTAssertEqual(sut.prOfTheMonth?.id, "pr-2")
+    }
+
+    func testPROfTheMonthExcludesPRsOlderThan30Days() {
+        let sut = ProfileViewModel()
+        sut.allPRs = [
+            PersonalRecord(
+                id: "pr-old", userId: "u", exerciseId: "e1", exerciseName: "Old",
+                weight: 500, reps: 1,
+                date: Date().addingTimeInterval(-86400 * 60),
+                previousBest: 100
+            )
+        ]
+
+        sut.computeDerivedStats(workouts: [])
+
+        XCTAssertNil(sut.prOfTheMonth)
+    }
+
+    func testPROfTheMonthRequiresPositiveImprovement() {
+        let sut = ProfileViewModel()
+        sut.allPRs = [
+            // Equal weight = 0% improvement, should be filtered
+            PersonalRecord(
+                id: "pr-flat", userId: "u", exerciseId: "e1", exerciseName: "Flat",
+                weight: 200, reps: 1,
+                date: Date().addingTimeInterval(-86400 * 3),
+                previousBest: 200
+            ),
+            // No previousBest, should be filtered
+            PersonalRecord(
+                id: "pr-noprev", userId: "u", exerciseId: "e2", exerciseName: "First",
+                weight: 100, reps: 1,
+                date: Date(),
+                previousBest: nil
+            )
+        ]
+
+        sut.computeDerivedStats(workouts: [])
+
+        XCTAssertNil(sut.prOfTheMonth)
+    }
+
+    func testPROfTheMonthIsNilWhenNoPRs() {
+        let sut = ProfileViewModel()
+        sut.allPRs = []
+
+        sut.computeDerivedStats(workouts: [])
+
+        XCTAssertNil(sut.prOfTheMonth)
+    }
+
+    func testPROfTheMonthTiebreaksByMostRecentDate() {
+        let sut = ProfileViewModel()
+        sut.allPRs = [
+            // Same 10% improvement, older date
+            PersonalRecord(
+                id: "pr-old", userId: "u", exerciseId: "e1", exerciseName: "Old",
+                weight: 110, reps: 1,
+                date: Date().addingTimeInterval(-86400 * 10),
+                previousBest: 100
+            ),
+            // Same 10% improvement, newer date — should win
+            PersonalRecord(
+                id: "pr-new", userId: "u", exerciseId: "e2", exerciseName: "New",
+                weight: 220, reps: 1,
+                date: Date().addingTimeInterval(-86400 * 1),
+                previousBest: 200
+            )
+        ]
+
+        sut.computeDerivedStats(workouts: [])
+
+        XCTAssertEqual(sut.prOfTheMonth?.id, "pr-new")
+    }
+}

--- a/Xomfit/ViewModels/ProfileViewModel.swift
+++ b/Xomfit/ViewModels/ProfileViewModel.swift
@@ -32,6 +32,23 @@ enum ProfileTab: String, CaseIterable, Identifiable {
 @MainActor
 @Observable
 final class ProfileViewModel {
+    // MARK: - Derived stat types
+
+    /// One weekly bucket of training volume.
+    struct VolumeBucket: Identifiable {
+        let id = UUID()
+        let weekStart: Date
+        let volume: Double
+    }
+
+    /// Aggregated lifetime volume for a single exercise.
+    struct TopExercise: Identifiable {
+        let id = UUID()
+        let name: String
+        let volume: Double
+        let setCount: Int
+    }
+
     // MARK: - Profile fields
     var displayName: String = ""
     var username: String = ""
@@ -55,6 +72,20 @@ final class ProfileViewModel {
     var totalVolume: Double = 0
     var totalPRs: Int = 0
     var recentPRs: [PersonalRecord] = []
+    /// Full PR list (used for derived stats like PR-of-the-month).
+    var allPRs: [PersonalRecord] = []
+
+    // MARK: - Derived Stats (computed in `computeDerivedStats`)
+    /// 4 weekly buckets covering the last ~30 days, oldest first. Empty weeks emit a 0 bucket.
+    var volumeTrend30d: [VolumeBucket] = []
+    /// Workout count per week for last 4 weeks, oldest first.
+    var workoutsPerWeek4w: [Int] = []
+    /// Mean of `workoutsPerWeek4w`.
+    var avgWorkoutsPerWeek: Double = 0
+    /// Top 5 lifetime exercises ranked by total volume (laterality-aware).
+    var topExercisesByVolume: [TopExercise] = []
+    /// Highest %-improvement PR within the last 30 days, if any.
+    var prOfTheMonth: PersonalRecord? = nil
 
     // MARK: - Muscle Group Heatmap
     var muscleGroupSetsThisWeek: [String: Int] = [:]
@@ -191,6 +222,9 @@ final class ProfileViewModel {
         await prsTask
         await feedTask
         await friendsTask
+
+        // Compute derived stats after PRs load so PR-of-the-month has data.
+        computeDerivedStats(workouts: fetchedWorkouts)
 
         isLoading = false
     }
@@ -385,6 +419,7 @@ final class ProfileViewModel {
         do {
             let prs = try await PRService.shared.fetchPRs(userId: userId)
             totalPRs = prs.count
+            allPRs = prs
             recentPRs = Array(prs.prefix(5))
         } catch {
             // Non-fatal
@@ -471,6 +506,87 @@ final class ProfileViewModel {
             days[day, default: 0] += 1
         }
         workoutDays = days
+    }
+
+    // MARK: - Derived Stats
+
+    /// Computes the four derived stats surfaced on the Profile > Stats tab:
+    /// `volumeTrend30d`, `workoutsPerWeek4w` (+ `avgWorkoutsPerWeek`), `topExercisesByVolume`, `prOfTheMonth`.
+    /// Pure derivation over `workouts` and `allPRs` — no fetching, safe to re-run.
+    func computeDerivedStats(workouts: [Workout]) {
+        let calendar = Calendar.current
+        let now = Date()
+
+        // Build 4 weekly buckets ending today, oldest first. Each bucket spans 7 days.
+        // Bucket i covers [now - (4 - i) * 7d, now - (3 - i) * 7d).
+        let bucketCount = 4
+        var bucketStarts: [Date] = []
+        for i in 0..<bucketCount {
+            let daysBack = (bucketCount - i) * 7
+            if let start = calendar.date(byAdding: .day, value: -daysBack, to: now) {
+                bucketStarts.append(start)
+            }
+        }
+        // Bucket end is the next bucket's start (or `now` for the last bucket).
+        var bucketRanges: [(start: Date, end: Date)] = []
+        for i in 0..<bucketStarts.count {
+            let end = i + 1 < bucketStarts.count ? bucketStarts[i + 1] : now
+            bucketRanges.append((bucketStarts[i], end))
+        }
+
+        var volumeBuckets: [VolumeBucket] = []
+        var weekCounts: [Int] = []
+        for range in bucketRanges {
+            let inRange = workouts.filter { $0.startTime >= range.start && $0.startTime < range.end }
+            let volume = inRange.reduce(0.0) { $0 + $1.totalVolume }
+            volumeBuckets.append(VolumeBucket(weekStart: range.start, volume: volume))
+            weekCounts.append(inRange.count)
+        }
+        volumeTrend30d = volumeBuckets
+        workoutsPerWeek4w = weekCounts
+        avgWorkoutsPerWeek = weekCounts.isEmpty
+            ? 0
+            : Double(weekCounts.reduce(0, +)) / Double(weekCounts.count)
+
+        // Top exercises: group by name, sum laterality-aware volume + set counts.
+        var volumeByName: [String: Double] = [:]
+        var setsByName: [String: Int] = [:]
+        for workout in workouts {
+            for exercise in workout.exercises {
+                let name = exercise.exercise.name
+                volumeByName[name, default: 0] += exercise.totalVolume
+                setsByName[name, default: 0] += exercise.sets.count
+            }
+        }
+        topExercisesByVolume = volumeByName
+            .map { TopExercise(name: $0.key, volume: $0.value, setCount: setsByName[$0.key] ?? 0) }
+            .sorted { lhs, rhs in
+                if lhs.volume != rhs.volume { return lhs.volume > rhs.volume }
+                return lhs.name < rhs.name // stable tiebreak
+            }
+            .prefix(5)
+            .map { $0 }
+
+        // PR of the month: highest %-improvement PR within the last 30 days.
+        // Only PRs with a `previousBest > 0` qualify (need a measurable improvement baseline).
+        guard let thirtyDaysAgo = calendar.date(byAdding: .day, value: -30, to: now) else {
+            prOfTheMonth = nil
+            return
+        }
+        let recent = allPRs.filter { $0.date >= thirtyDaysAgo }
+        let scored: [(pr: PersonalRecord, pct: Double)] = recent.compactMap { pr in
+            guard let prev = pr.previousBest, prev > 0 else { return nil }
+            let pct = (pr.weight - prev) / prev
+            guard pct > 0 else { return nil }
+            return (pr, pct)
+        }
+        prOfTheMonth = scored
+            .sorted { lhs, rhs in
+                if lhs.pct != rhs.pct { return lhs.pct > rhs.pct }
+                return lhs.pr.date > rhs.pr.date // tiebreak: most recent
+            }
+            .first?
+            .pr
     }
 
 }

--- a/Xomfit/Views/Profile/ProfileStatsView.swift
+++ b/Xomfit/Views/Profile/ProfileStatsView.swift
@@ -7,6 +7,11 @@ struct ProfileStatsView: View {
     let recentPRs: [PersonalRecord]
     let muscleGroupSetsThisWeek: [String: Int]
     let muscleGroupSetsThisMonth: [String: Int]
+    let volumeTrend: [ProfileViewModel.VolumeBucket]
+    let workoutsPerWeek: [Int]
+    let avgWorkoutsPerWeek: Double
+    let topExercises: [ProfileViewModel.TopExercise]
+    let prOfTheMonth: PersonalRecord?
 
     @State private var heatmapFilter: HeatmapTimeFilter = .week
 
@@ -20,6 +25,9 @@ struct ProfileStatsView: View {
     var body: some View {
         VStack(spacing: Theme.Spacing.sm) {
             statsCards
+            volumeTrendSection
+            consistencySection
+            topExercisesSection
             heatmapSection
             prSection
         }
@@ -56,6 +64,107 @@ struct ProfileStatsView: View {
         .accessibilityLabel("\(count) \(label)")
     }
 
+    // MARK: - Volume Trend Section
+
+    @ViewBuilder
+    private var volumeTrendSection: some View {
+        let totalVolume = volumeTrend.reduce(0) { $0 + $1.volume }
+        if totalVolume > 0 {
+            VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+                Text("Volume Trend (30d)")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(Theme.textSecondary)
+                    .padding(.horizontal, Theme.Spacing.sm)
+
+                VolumeTrendChart(buckets: volumeTrend)
+                    .padding(.horizontal, Theme.Spacing.sm)
+            }
+            .cardStyle()
+        }
+    }
+
+    // MARK: - Consistency Section
+
+    @ViewBuilder
+    private var consistencySection: some View {
+        if !workoutsPerWeek.isEmpty && workoutsPerWeek.contains(where: { $0 > 0 }) {
+            VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+                HStack {
+                    Text("Consistency")
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(Theme.textSecondary)
+                    Spacer()
+                    Text(String(format: "Avg %.1f/wk", avgWorkoutsPerWeek))
+                        .font(Theme.fontSmall)
+                        .foregroundStyle(Theme.textSecondary)
+                }
+                .padding(.horizontal, Theme.Spacing.sm)
+
+                consistencyBars
+                    .padding(.horizontal, Theme.Spacing.sm)
+            }
+            .cardStyle()
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel(consistencyAccessibility)
+        }
+    }
+
+    private var consistencyBars: some View {
+        let maxCount = max(workoutsPerWeek.max() ?? 0, 1)
+        return HStack(alignment: .bottom, spacing: Theme.Spacing.sm) {
+            ForEach(Array(workoutsPerWeek.enumerated()), id: \.offset) { _, count in
+                consistencyBar(count: count, maxCount: maxCount)
+            }
+        }
+        .frame(height: 60)
+    }
+
+    private func consistencyBar(count: Int, maxCount: Int) -> some View {
+        VStack(spacing: 4) {
+            GeometryReader { proxy in
+                VStack {
+                    Spacer(minLength: 0)
+                    RoundedRectangle(cornerRadius: 4)
+                        .fill(count > 0 ? Theme.accent : Theme.hairline)
+                        .frame(height: max(4, proxy.size.height * CGFloat(count) / CGFloat(maxCount)))
+                }
+            }
+            Text("\(count)")
+                .font(.caption2.weight(.semibold))
+                .foregroundStyle(Theme.textSecondary)
+                .monospacedDigit()
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private var consistencyAccessibility: String {
+        let detail = workoutsPerWeek
+            .enumerated()
+            .map { "Week \($0.offset + 1): \($0.element) workouts" }
+            .joined(separator: ", ")
+        return "Consistency. Average \(String(format: "%.1f", avgWorkoutsPerWeek)) workouts per week. \(detail)"
+    }
+
+    // MARK: - Top Exercises Section
+
+    @ViewBuilder
+    private var topExercisesSection: some View {
+        if !topExercises.isEmpty {
+            let maxVolume = topExercises.first?.volume ?? 0
+            VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+                Text("Top Exercises")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(Theme.textSecondary)
+                    .padding(.horizontal, Theme.Spacing.sm)
+
+                ForEach(topExercises) { exercise in
+                    TopExerciseRow(exercise: exercise, maxVolume: maxVolume)
+                }
+            }
+            .cardStyle()
+        }
+    }
+
     // MARK: - Heatmap Section
 
     private var heatmapSection: some View {
@@ -86,21 +195,81 @@ struct ProfileStatsView: View {
 
     @ViewBuilder
     private var prSection: some View {
-        if recentPRs.isEmpty {
+        if recentPRs.isEmpty && prOfTheMonth == nil {
             emptyState
         } else {
             VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
-                Text("Recent PRs")
-                    .font(.subheadline.weight(.semibold))
-                    .foregroundStyle(Theme.textSecondary)
-                    .padding(.horizontal, Theme.Spacing.sm)
+                if let pr = prOfTheMonth {
+                    prOfTheMonthCard(pr: pr)
+                }
 
-                ForEach(recentPRs) { pr in
-                    PRBadgeRow(pr: pr)
+                if !recentPRs.isEmpty {
+                    Text("Recent PRs")
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(Theme.textSecondary)
+                        .padding(.horizontal, Theme.Spacing.sm)
+
+                    ForEach(recentPRs) { pr in
+                        PRBadgeRow(pr: pr)
+                    }
                 }
             }
             .cardStyle()
         }
+    }
+
+    @ViewBuilder
+    private func prOfTheMonthCard(pr: PersonalRecord) -> some View {
+        let pctText: String? = {
+            guard let prev = pr.previousBest, prev > 0 else { return nil }
+            let pct = (pr.weight - prev) / prev * 100
+            return String(format: "+%.1f%%", pct)
+        }()
+
+        VStack(alignment: .leading, spacing: Theme.Spacing.xs) {
+            HStack(spacing: Theme.Spacing.xs) {
+                Image(systemName: "crown.fill")
+                    .foregroundStyle(Theme.prGold)
+                XomMetricLabel("PR of the Month")
+            }
+
+            HStack(alignment: .firstTextBaseline) {
+                Text(pr.exerciseName)
+                    .font(.headline.weight(.bold))
+                    .foregroundStyle(Theme.textPrimary)
+                    .lineLimit(1)
+                Spacer()
+                if let pctText {
+                    Text(pctText)
+                        .font(Theme.fontNumberMedium)
+                        .foregroundStyle(Theme.prGold)
+                }
+            }
+
+            Text("\(pr.weight.formattedWeight) lbs \u{00D7} \(pr.reps)")
+                .font(Theme.fontNumberMedium)
+                .foregroundStyle(Theme.textPrimary)
+        }
+        .padding(Theme.Spacing.sm)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: Theme.Radius.sm)
+                .fill(Theme.prGold.opacity(0.10))
+                .overlay(
+                    RoundedRectangle(cornerRadius: Theme.Radius.sm)
+                        .strokeBorder(Theme.prGold.opacity(0.4), lineWidth: 0.5)
+                )
+        )
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(prOfTheMonthAccessibility(pr: pr, pctText: pctText))
+    }
+
+    private func prOfTheMonthAccessibility(pr: PersonalRecord, pctText: String?) -> String {
+        var parts = ["PR of the month: \(pr.exerciseName), \(pr.weight.formattedWeight) pounds for \(pr.reps) reps"]
+        if let pctText {
+            parts.append("\(pctText) improvement")
+        }
+        return parts.joined(separator: ", ")
     }
 
     private var emptyState: some View {

--- a/Xomfit/Views/Profile/ProfileView.swift
+++ b/Xomfit/Views/Profile/ProfileView.swift
@@ -187,7 +187,12 @@ struct ProfileView: View {
                 totalPRs: viewModel.totalPRs,
                 recentPRs: viewModel.recentPRs,
                 muscleGroupSetsThisWeek: viewModel.muscleGroupSetsThisWeek,
-                muscleGroupSetsThisMonth: viewModel.muscleGroupSetsThisMonth
+                muscleGroupSetsThisMonth: viewModel.muscleGroupSetsThisMonth,
+                volumeTrend: viewModel.volumeTrend30d,
+                workoutsPerWeek: viewModel.workoutsPerWeek4w,
+                avgWorkoutsPerWeek: viewModel.avgWorkoutsPerWeek,
+                topExercises: viewModel.topExercisesByVolume,
+                prOfTheMonth: viewModel.prOfTheMonth
             )
         }
     }

--- a/Xomfit/Views/Profile/TopExerciseRow.swift
+++ b/Xomfit/Views/Profile/TopExerciseRow.swift
@@ -1,0 +1,78 @@
+import SwiftUI
+
+/// Single row within the "Top Exercises" section: name, lifetime volume,
+/// set count, and a thin accent capsule showing relative volume vs. the leader.
+struct TopExerciseRow: View {
+    let exercise: ProfileViewModel.TopExercise
+    /// Max volume across the whole list — used to scale the capsule width.
+    let maxVolume: Double
+
+    private var fillFraction: CGFloat {
+        guard maxVolume > 0 else { return 0 }
+        return CGFloat(min(1, exercise.volume / maxVolume))
+    }
+
+    private var formattedVolume: String {
+        if exercise.volume >= 1_000_000 {
+            return String(format: "%.1fM", exercise.volume / 1_000_000)
+        } else if exercise.volume >= 1000 {
+            return String(format: "%.1fk", exercise.volume / 1000)
+        }
+        return "\(Int(exercise.volume))"
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.xs) {
+            HStack {
+                Text(exercise.name)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(Theme.textPrimary)
+                    .lineLimit(1)
+
+                Spacer()
+
+                VStack(alignment: .trailing, spacing: 2) {
+                    Text("\(formattedVolume) lbs")
+                        .font(Theme.fontNumberMedium)
+                        .foregroundStyle(Theme.textPrimary)
+                    XomMetricLabel("\(exercise.setCount) sets")
+                }
+            }
+
+            // Relative-volume capsule
+            GeometryReader { proxy in
+                ZStack(alignment: .leading) {
+                    Capsule()
+                        .fill(Theme.hairline)
+                    Capsule()
+                        .fill(Theme.accent.opacity(0.3))
+                        .frame(width: proxy.size.width * fillFraction)
+                }
+            }
+            .frame(height: 4)
+        }
+        .padding(.horizontal, Theme.Spacing.sm)
+        .padding(.vertical, Theme.Spacing.xs)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(exercise.name), \(formattedVolume) pounds, \(exercise.setCount) sets")
+    }
+}
+
+#Preview {
+    VStack {
+        TopExerciseRow(
+            exercise: .init(name: "Bench Press", volume: 24_500, setCount: 64),
+            maxVolume: 24_500
+        )
+        TopExerciseRow(
+            exercise: .init(name: "Squat", volume: 18_200, setCount: 48),
+            maxVolume: 24_500
+        )
+        TopExerciseRow(
+            exercise: .init(name: "Deadlift", volume: 15_900, setCount: 32),
+            maxVolume: 24_500
+        )
+    }
+    .padding()
+    .background(Theme.background)
+}

--- a/Xomfit/Views/Profile/VolumeTrendChart.swift
+++ b/Xomfit/Views/Profile/VolumeTrendChart.swift
@@ -1,0 +1,106 @@
+import Charts
+import SwiftUI
+
+/// Bar chart showing weekly volume buckets covering the last 30 days.
+/// The most recent bucket renders in `Theme.accent`; prior buckets fade to half opacity.
+struct VolumeTrendChart: View {
+    let buckets: [ProfileViewModel.VolumeBucket]
+
+    private static let dayMonthFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "M/d"
+        return f
+    }()
+
+    /// Percent change vs. previous bucket. Returns nil when there is no prior data
+    /// or the prior bucket has zero volume (avoids divide-by-zero / infinite jumps).
+    private var percentChange: Double? {
+        guard buckets.count >= 2 else { return nil }
+        let previous = buckets[buckets.count - 2].volume
+        let current = buckets[buckets.count - 1].volume
+        guard previous > 0 else { return nil }
+        return (current - previous) / previous
+    }
+
+    private var changeCaption: (text: String, color: Color)? {
+        guard let pct = percentChange else { return nil }
+        if pct > 0.001 {
+            return (String(format: "+%.0f%% vs last week", pct * 100), Theme.accent)
+        } else if pct < -0.001 {
+            return (String(format: "%.0f%% vs last week", pct * 100), Theme.destructive)
+        } else {
+            return ("0% vs last week", Theme.textSecondary)
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.xs) {
+            if let caption = changeCaption {
+                Text(caption.text)
+                    .font(Theme.fontSmall)
+                    .foregroundStyle(caption.color)
+                    .accessibilityLabel("Volume change: \(caption.text)")
+            }
+
+            Chart(buckets) { bucket in
+                BarMark(
+                    x: .value("Week", Self.dayMonthFormatter.string(from: bucket.weekStart)),
+                    y: .value("Volume", bucket.volume)
+                )
+                .foregroundStyle(barColor(for: bucket))
+                .cornerRadius(4)
+                .accessibilityLabel(Self.dayMonthFormatter.string(from: bucket.weekStart))
+                .accessibilityValue("\(formattedVolume(bucket.volume)) pounds")
+            }
+            .chartYAxis {
+                AxisMarks(position: .leading) { value in
+                    AxisGridLine().foregroundStyle(Theme.hairline)
+                    AxisValueLabel {
+                        if let v = value.as(Double.self) {
+                            Text(formattedVolume(v))
+                                .font(.caption2)
+                                .foregroundStyle(Theme.textTertiary)
+                        }
+                    }
+                }
+            }
+            .chartXAxis {
+                AxisMarks { _ in
+                    AxisValueLabel()
+                        .font(.caption2)
+                        .foregroundStyle(Theme.textTertiary)
+                }
+            }
+            .frame(height: 140)
+        }
+    }
+
+    private func barColor(for bucket: ProfileViewModel.VolumeBucket) -> Color {
+        if bucket.id == buckets.last?.id {
+            return Theme.accent
+        }
+        return Theme.accent.opacity(0.5)
+    }
+
+    private func formattedVolume(_ value: Double) -> String {
+        if value >= 1_000_000 {
+            return String(format: "%.1fM", value / 1_000_000)
+        } else if value >= 1000 {
+            return String(format: "%.1fk", value / 1000)
+        }
+        return "\(Int(value))"
+    }
+}
+
+#Preview {
+    VolumeTrendChart(
+        buckets: [
+            .init(weekStart: Date().addingTimeInterval(-86400 * 28), volume: 12_500),
+            .init(weekStart: Date().addingTimeInterval(-86400 * 21), volume: 9_800),
+            .init(weekStart: Date().addingTimeInterval(-86400 * 14), volume: 14_200),
+            .init(weekStart: Date().addingTimeInterval(-86400 * 7), volume: 16_400)
+        ]
+    )
+    .padding()
+    .background(Theme.background)
+}

--- a/docs/features/profile-improvements-251/EXECUTION_LOG.md
+++ b/docs/features/profile-improvements-251/EXECUTION_LOG.md
@@ -1,0 +1,50 @@
+# Execution Log — Profile Improvements (#251)
+
+**Branch**: `feat/251-profile-improvements`
+**Base**: `master` (rebased onto `origin/master` @ 4d5f3e9)
+**Date**: 2026-05-09
+
+## Steps Taken
+
+1. **Step 1 — Derivation models**: Added nested `VolumeBucket` and `TopExercise` structs at the top of `ProfileViewModel`. Added stored properties: `volumeTrend30d`, `workoutsPerWeek4w`, `avgWorkoutsPerWeek`, `topExercisesByVolume`, `prOfTheMonth`, plus `allPRs` for the full PR list.
+2. **Step 2 — `computeDerivedStats(workouts:)`**: Implemented in `ProfileViewModel.swift`. Builds 4 weekly buckets ending today (each spanning 7 days, oldest first), computes per-bucket volume + counts, sums laterality-aware top exercises (capped at 5, sorted desc with name tiebreak), and selects PR-of-the-month by highest %-improvement within last 30 days (date tiebreak).
+3. **Step 3 — Full PR list**: Updated `loadPRs` to populate `allPRs` (all PRs) alongside `recentPRs` (top 5). Moved `computeDerivedStats` call inside `loadAll` to AFTER `await prsTask` so PR-of-the-month has data.
+4. **Step 4 — `VolumeTrendChart.swift`**: New file using `Charts.BarMark`. Latest bucket renders in `Theme.accent`, others at half opacity. Caption above shows `"+N% vs last week"` (accent), `-N%` (destructive), or "0%" (textSecondary). Chart height 140pt.
+5. **Step 5 — `TopExerciseRow.swift`**: New file. HStack with name, formatted volume (`"12.4k lbs"`), `XomMetricLabel("N sets")`, plus a thin `Capsule()` filled to `volume / maxVolume` width in `Theme.accent.opacity(0.3)`.
+6. **Step 6 — Sections in `ProfileStatsView`**: Added `volumeTrendSection`, `consistencySection` (4 weekly bars + avg caption), `topExercisesSection`, plus a `prOfTheMonthCard` that prepends to `prSection` with `Theme.prGold` highlight. Each new section uses `cardStyle()` and auto-hides when its data is empty.
+7. **Step 7 — Wiring**: Updated `ProfileView.swift` to pass 5 new viewModel properties into `ProfileStatsView(...)`.
+8. **Step 8 — Tests**: Created `XomFitTests/ProfileViewModelStatsTests.swift` with 11 unit tests covering all four derivations (volume trend produces 4 buckets, excludes >30d workouts, top-exercises sort/cap/laterality/aggregation, PR-of-the-month happy path + exclusion of old/zero-improvement/nil-previousBest, tiebreak-by-date, nil-when-no-PRs).
+
+## Build
+
+- Command: `xcodebuild -project Xomfit.xcodeproj -scheme Xomfit -destination 'platform=iOS Simulator,name=iPhone 17' -configuration Debug build`
+- Result: `** BUILD SUCCEEDED **`
+- Warnings introduced: 0
+- Errors introduced: 0
+- Note: Had to drop in a local `Xomfit/Config.swift` (gitignored, copied from main worktree) so the project's Supabase/OAuth references resolve. Not part of this branch's diff.
+
+## Files Changed
+
+Modified:
+- `Xomfit/ViewModels/ProfileViewModel.swift` — nested types, stored props, `computeDerivedStats`, `loadPRs` keeps full list, `loadAll` calls `computeDerivedStats` after PRs.
+- `Xomfit/Views/Profile/ProfileStatsView.swift` — accepts 5 new params; adds `volumeTrendSection`, `consistencySection`, `topExercisesSection`, `prOfTheMonthCard`.
+- `Xomfit/Views/Profile/ProfileView.swift` — passes new props through to `ProfileStatsView`.
+
+Added:
+- `Xomfit/Views/Profile/VolumeTrendChart.swift`
+- `Xomfit/Views/Profile/TopExerciseRow.swift`
+- `XomFitTests/ProfileViewModelStatsTests.swift`
+
+## Files Untouched (per instructions)
+
+- `Xomfit/Views/Workout/ActiveWorkoutView.swift`
+- `Xomfit/Views/MainTabView.swift`
+- `Xomfit/ViewModels/WorkoutLoggerViewModel.swift`
+
+## Notes / Tradeoffs
+
+- Volume trend uses 4 fixed 7-day rolling windows ending now (not calendar weeks). Simpler, matches consistency view's bar count, no edge cases at week boundaries.
+- Top-exercises sort uses name as a stable tiebreak when volumes are equal — keeps unit-test ordering deterministic.
+- `prOfTheMonth` uses `> 0` improvement to filter (skips first-time PRs without a prior baseline, since they have no measurable %).
+- New sections auto-hide on empty data, so existing users with zero workouts/PRs see the same layout as before.
+- The XomFitTests target isn't actually wired into the Xcode scheme as a runnable test target (project has no `PBXNativeTarget` of type `bundle`), so the new tests document intent and will be picked up if/when a test target is added.


### PR DESCRIPTION
Closes #251. Adds Volume Trend (30d weekly buckets w/ %-change), Consistency (4-week workouts/week), Top Exercises (top 5 by volume), PR of the Month — all derived client-side. Sections auto-hide on empty data. Adds 11 unit tests.