### PR TITLE
#261 add 25+ exercises and pre-workout stretch warmup flow

### DIFF
--- a/Xomfit/Models/Exercise+Icons.swift
+++ b/Xomfit/Models/Exercise+Icons.swift
@@ -154,6 +154,42 @@ extension Exercise {
         "ex-side-plank":              "figure.core.training",
         "ex-copenhagen-plank":        "figure.core.training",
         "ex-suitcase-deadlift":       "figure.strengthtraining.traditional",
+
+        // MARK: Machine & Cable Extras (#261)
+        "ex-smith-bench-press":         "gearshape.fill",
+        "ex-smith-incline-press":       "gearshape.fill",
+        "ex-smith-shoulder-press":      "gearshape.fill",
+        "ex-smith-row":                 "gearshape.fill",
+        "ex-iso-lateral-row":           "gearshape.fill",
+        "ex-iso-lateral-chest-press":   "gearshape.fill",
+        "ex-belt-squat":                "gearshape.fill",
+        "ex-cable-crossover":           "figure.arms.open",
+        "ex-cable-pull-through":        "arrow.up.and.down",
+        "ex-cable-upright-row":         "arrow.up.and.down",
+        "ex-cable-shrug":               "arrow.up.and.down",
+        "ex-trap-bar-deadlift":         "figure.strengthtraining.traditional",
+        "ex-zercher-squat":             "figure.strengthtraining.traditional",
+        "ex-good-morning":              "figure.strengthtraining.traditional",
+        "ex-box-squat":                 "figure.strengthtraining.traditional",
+        "ex-kb-swing":                  "figure.strengthtraining.functional",
+        "ex-kb-goblet-squat":           "figure.strengthtraining.functional",
+
+        // MARK: Bodyweight Extras (#261)
+        "ex-pike-pushup":               "figure.strengthtraining.functional",
+        "ex-diamond-pushup":            "figure.strengthtraining.functional",
+        "ex-decline-pushup":            "figure.strengthtraining.functional",
+        "ex-inverted-row":              "figure.indoor.rowing",
+        "ex-band-pullover":             "circle.dashed",
+        "ex-glute-bridge":              "figure.strengthtraining.functional",
+        "ex-side-lying-hip-abduction":  "figure.strengthtraining.functional",
+        "ex-nordic-curl":               "figure.strengthtraining.functional",
+        "ex-reverse-hyper":             "figure.strengthtraining.functional",
+        "ex-glute-ham-raise":           "gearshape.fill",
+
+        // MARK: Mobility / Stretching (#261)
+        "ex-worlds-greatest-stretch":   "figure.flexibility",
+        "ex-cat-cow":                   "figure.flexibility",
+        "ex-90-90-hip-stretch":         "figure.flexibility",
     ]
 
     /// Resolved SF Symbol name for this exercise.

--- a/Xomfit/Models/ExerciseDatabase.swift
+++ b/Xomfit/Models/ExerciseDatabase.swift
@@ -3,7 +3,7 @@ import Foundation
 /// Complete exercise database for XomFit
 /// Organized by muscle group with form tips
 struct ExerciseDatabase {
-    static let all: [Exercise] = chest + back + shoulders + legs + arms + core + unilateral
+    static let all: [Exercise] = chest + back + shoulders + legs + arms + core + unilateral + machineAndCableExtras + bodyweightExtras + mobility
     
     // MARK: - Chest
     static let chest: [Exercise] = [
@@ -590,6 +590,128 @@ struct ExerciseDatabase {
                  description: "Deadlift holding weight on one side only to challenge core anti-lateral-flexion.",
                  tips: ["Hold the dumbbell at your side like a suitcase", "Stand tall, resist leaning toward the weight", "Same mechanics as a regular deadlift"],
                  supportsUnilateral: true, defaultLaterality: .unilateral),
+    ]
+
+    // MARK: - Machine & Cable Extras (added in #261)
+    static let machineAndCableExtras: [Exercise] = [
+        // Smith machine variations
+        Exercise(id: "ex-smith-bench-press", name: "Smith Machine Bench Press", muscleGroups: [.chest, .triceps, .shoulders], equipment: .machine, category: .compound,
+                 description: "Flat bench press on the Smith machine — guided bar path lets you push closer to failure safely.",
+                 tips: ["Set bench so bar lines up with mid-chest", "Unrack by twisting the hooks off", "Don't bounce the bar off your chest"]),
+        Exercise(id: "ex-smith-incline-press", name: "Smith Machine Incline Press", muscleGroups: [.chest, .shoulders, .triceps], equipment: .machine, category: .compound,
+                 description: "Incline bench press on the Smith machine for upper chest with a fixed bar path.",
+                 tips: ["Set bench to 30-45 degrees", "Bar should line up over upper chest", "Drive feet into the floor for stability"]),
+        Exercise(id: "ex-smith-shoulder-press", name: "Smith Machine Shoulder Press", muscleGroups: [.shoulders, .triceps], equipment: .machine, category: .compound,
+                 description: "Seated overhead press on the Smith machine for controlled shoulder work.",
+                 tips: ["Adjust seat so the bar starts at chin level", "Press to full lockout overhead", "Brace core to avoid arching"],
+                 supportedPositions: [.seated, .standing]),
+        Exercise(id: "ex-smith-row", name: "Smith Machine Bent-Over Row", muscleGroups: [.back, .lats], equipment: .machine, category: .compound,
+                 description: "Bent-over row with the Smith machine for a stable bar path and heavier loading.",
+                 tips: ["Hinge at the hips to roughly 45 degrees", "Pull the bar to your lower ribs", "Keep your back flat throughout"],
+                 supportedGrips: [.overhand, .underhand]),
+
+        // Hammer Strength / iso-lateral plate-loaded
+        Exercise(id: "ex-iso-lateral-row", name: "Hammer Strength Iso-Lateral Row", muscleGroups: [.back, .lats, .biceps], equipment: .machine, category: .compound,
+                 description: "Plate-loaded iso-lateral row that lets each side work independently for balanced back development.",
+                 tips: ["Adjust chest pad so arms fully extend", "Pull elbows back and squeeze shoulder blades", "Can be done bilaterally or one arm at a time"],
+                 supportsUnilateral: true),
+        Exercise(id: "ex-iso-lateral-chest-press", name: "Hammer Strength Iso-Lateral Chest Press", muscleGroups: [.chest, .triceps, .shoulders], equipment: .machine, category: .compound,
+                 description: "Plate-loaded iso-lateral chest press for independent left/right pressing.",
+                 tips: ["Adjust seat so handles align with mid-chest", "Press without locking out elbows", "Squeeze chest at full extension"],
+                 supportsUnilateral: true),
+
+        // Belt squat
+        Exercise(id: "ex-belt-squat", name: "Belt Squat", muscleGroups: [.quads, .glutes], equipment: .machine, category: .compound,
+                 description: "Squat loaded with a belt around the hips — heavy leg work without spinal compression.",
+                 tips: ["Stand on the platform with belt around your waist", "Keep torso upright throughout", "Sit back and down through full range of motion"]),
+
+        // Cable variations
+        Exercise(id: "ex-cable-crossover", name: "Cable Crossover", muscleGroups: [.chest], equipment: .cable, category: .isolation,
+                 description: "Mid-height cable fly bringing handles together in front of the chest.",
+                 tips: ["Set pulleys at chest height", "Slight forward lean", "Bring handles together and pause for a squeeze"],
+                 supportedAttachments: [.dHandle]),
+        Exercise(id: "ex-cable-pull-through", name: "Cable Pull-Through", muscleGroups: [.glutes, .hamstrings], equipment: .cable, category: .compound,
+                 description: "Hip hinge facing away from a low cable for posterior chain work.",
+                 tips: ["Set cable at the lowest pulley", "Hinge at the hips, don't squat", "Squeeze glutes hard at the top"],
+                 supportedAttachments: [.rope]),
+        Exercise(id: "ex-cable-upright-row", name: "Cable Upright Row", muscleGroups: [.shoulders, .traps], equipment: .cable, category: .compound,
+                 description: "Upright row using a low cable for constant tension on shoulders and traps.",
+                 tips: ["Use a wider grip to reduce shoulder impingement", "Pull to upper chest height", "Lead with elbows"],
+                 supportedAttachments: [.straightBar, .rope]),
+        Exercise(id: "ex-cable-shrug", name: "Cable Shrug", muscleGroups: [.traps], equipment: .cable, category: .isolation,
+                 description: "Cable shrug for constant tension trap development.",
+                 tips: ["Use a straight bar at the lowest pulley", "Shrug straight up", "Pause at the top for a count"],
+                 supportedAttachments: [.straightBar]),
+
+        // Free-weight extras
+        Exercise(id: "ex-trap-bar-deadlift", name: "Trap Bar Deadlift", muscleGroups: [.quads, .glutes, .hamstrings, .back, .traps], equipment: .barbell, category: .compound,
+                 description: "Deadlift performed with a hex/trap bar — easier on the lower back, more quad-dominant than conventional.",
+                 tips: ["Stand inside the bar with feet shoulder width", "Grip handles at your sides", "Drive through the floor with neutral spine"]),
+        Exercise(id: "ex-zercher-squat", name: "Zercher Squat", muscleGroups: [.quads, .glutes, .abs], equipment: .barbell, category: .compound,
+                 description: "Squat with the bar held in the crooks of the elbows — brutal on the core and upper back.",
+                 tips: ["Hold bar in crooks of elbows, hands together", "Keep elbows up and torso upright", "Use a pad or sleeve for elbow comfort"]),
+        Exercise(id: "ex-good-morning", name: "Good Morning", muscleGroups: [.hamstrings, .glutes, .back], equipment: .barbell, category: .compound,
+                 description: "Hip-hinge with bar on the back for hamstring and posterior chain strength.",
+                 tips: ["Bar high on traps", "Soft knees, hinge at the hips", "Stop when torso is parallel to floor"]),
+        Exercise(id: "ex-box-squat", name: "Box Squat", muscleGroups: [.quads, .glutes, .hamstrings], equipment: .barbell, category: .compound,
+                 description: "Squat to a box for fixed depth and explosive concentric strength.",
+                 tips: ["Sit back fully onto the box — don't crash down", "Pause briefly without losing tightness", "Drive up explosively"]),
+
+        // Kettlebell extras
+        Exercise(id: "ex-kb-swing", name: "Kettlebell Swing", muscleGroups: [.glutes, .hamstrings, .back], equipment: .kettlebell, category: .compound,
+                 description: "Two-handed kettlebell swing — explosive hip hinge for posterior chain power.",
+                 tips: ["Hinge at the hips, don't squat", "Snap hips through to drive the bell up", "Bell finishes at chest/eye height, not overhead"]),
+        Exercise(id: "ex-kb-goblet-squat", name: "Kettlebell Goblet Squat", muscleGroups: [.quads, .glutes], equipment: .kettlebell, category: .compound,
+                 description: "Goblet squat holding a kettlebell at chest height.",
+                 tips: ["Hold kettlebell by the horns at chest", "Elbows inside knees at the bottom", "Keep torso upright"]),
+    ]
+
+    // MARK: - Bodyweight Extras (added in #261)
+    static let bodyweightExtras: [Exercise] = [
+        Exercise(id: "ex-pike-pushup", name: "Pike Pushup", muscleGroups: [.shoulders, .triceps], equipment: .bodyweight, category: .compound,
+                 description: "Pushup with hips piked high to shift load to the shoulders — bodyweight overhead press progression.",
+                 tips: ["Form an inverted V with your body", "Lower the top of your head toward the floor", "Elevate feet to increase difficulty"]),
+        Exercise(id: "ex-diamond-pushup", name: "Diamond Pushup", muscleGroups: [.triceps, .chest], equipment: .bodyweight, category: .compound,
+                 description: "Close-stance pushup with hands forming a diamond — tricep-focused bodyweight press.",
+                 tips: ["Form a diamond with thumbs and index fingers", "Keep elbows close to your ribs", "Lower chest to your hands"]),
+        Exercise(id: "ex-decline-pushup", name: "Decline Pushup", muscleGroups: [.chest, .shoulders, .triceps], equipment: .bodyweight, category: .compound,
+                 description: "Pushup with feet elevated on a bench or box for upper chest emphasis.",
+                 tips: ["Feet on bench, hands on floor", "Keep core braced", "Lower chest to the floor"]),
+        Exercise(id: "ex-inverted-row", name: "Inverted Row", muscleGroups: [.back, .lats, .biceps], equipment: .bodyweight, category: .compound,
+                 description: "Bodyweight horizontal row under a fixed bar — great pull-up progression and mid-back builder.",
+                 tips: ["Set a bar at hip height", "Hang underneath with arms extended", "Pull chest to the bar, body in a straight line"]),
+        Exercise(id: "ex-band-pullover", name: "Band Pullover", muscleGroups: [.lats, .chest], equipment: .bands, category: .isolation,
+                 description: "Lat-focused pullover using a resistance band anchored overhead.",
+                 tips: ["Anchor the band overhead and grab with both hands", "Keep arms nearly straight", "Pull the band down to your thighs with your lats"]),
+        Exercise(id: "ex-glute-bridge", name: "Glute Bridge", muscleGroups: [.glutes, .hamstrings], equipment: .bodyweight, category: .compound,
+                 description: "Bodyweight bridge driving hips up — foundational glute activation drill.",
+                 tips: ["Lie on your back, knees bent, feet flat", "Drive hips up by squeezing glutes", "Pause at the top, don't hyperextend"]),
+        Exercise(id: "ex-side-lying-hip-abduction", name: "Side-Lying Hip Abduction", muscleGroups: [.glutes], equipment: .bodyweight, category: .isolation,
+                 description: "Lying on your side, raise the top leg straight up to target the glute medius.",
+                 tips: ["Keep top leg straight and toes pointed slightly down", "Raise leg slowly with no swinging", "Squeeze the side glute at the top"],
+                 supportsUnilateral: true, defaultLaterality: .unilateral),
+        Exercise(id: "ex-nordic-curl", name: "Nordic Hamstring Curl", muscleGroups: [.hamstrings], equipment: .bodyweight, category: .isolation,
+                 description: "Kneeling, lower yourself slowly with feet anchored — eccentric hamstring builder.",
+                 tips: ["Anchor feet under a bench or pads", "Lower yourself slowly using only your hamstrings", "Catch with your hands and push back up"]),
+        Exercise(id: "ex-reverse-hyper", name: "Reverse Hyperextension", muscleGroups: [.glutes, .hamstrings, .back], equipment: .bodyweight, category: .isolation,
+                 description: "Hip extension on a bench or reverse hyper machine for glutes and lower back.",
+                 tips: ["Hips hang off the bench, hold the front", "Squeeze glutes to lift legs to parallel", "Don't hyperextend the lower back"]),
+        Exercise(id: "ex-glute-ham-raise", name: "Glute Ham Raise", muscleGroups: [.hamstrings, .glutes, .calves], equipment: .machine, category: .compound,
+                 description: "GHR machine hamstring raise — knee flexion + hip extension for full hamstring development.",
+                 tips: ["Set the pad just under your hips", "Lower under control with arms crossed", "Drive yourself back up using your hamstrings"]),
+    ]
+
+    // MARK: - Mobility / Stretching (added in #261)
+    static let mobility: [Exercise] = [
+        Exercise(id: "ex-worlds-greatest-stretch", name: "World's Greatest Stretch", muscleGroups: [.hamstrings, .glutes, .back, .shoulders], equipment: .bodyweight, category: .stretching,
+                 description: "Multi-plane mobility flow combining a lunge, thoracic rotation, and hip opener.",
+                 tips: ["Step into a deep lunge", "Drop opposite hand to the floor", "Rotate top arm up toward the ceiling, then alternate"]),
+        Exercise(id: "ex-cat-cow", name: "Cat-Cow", muscleGroups: [.back, .abs], equipment: .bodyweight, category: .stretching,
+                 description: "Spinal flexion and extension drill on hands and knees.",
+                 tips: ["Start in a tabletop position", "Inhale: drop belly, lift chest and tailbone", "Exhale: round spine and tuck chin"]),
+        Exercise(id: "ex-90-90-hip-stretch", name: "90/90 Hip Stretch", muscleGroups: [.glutes, .hamstrings], equipment: .bodyweight, category: .stretching,
+                 description: "Seated hip mobility drill with both legs at 90-degree angles.",
+                 tips: ["Front leg bent at 90 degrees, back leg also at 90", "Sit tall and lean forward over the front shin", "Switch sides for equal time"]),
     ]
 
     // MARK: - Search

--- a/Xomfit/Models/Stretch.swift
+++ b/Xomfit/Models/Stretch.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// A pre-workout stretch with a suggested hold time and the muscle groups it loosens up.
+/// Used by the warmup flow to build a short stretch routine before a workout.
+struct Stretch: Codable, Identifiable, Hashable {
+    let id: String
+    var name: String
+    var description: String
+    /// Suggested hold time in seconds for one cycle/side.
+    var durationSeconds: Int
+    /// Muscle groups this stretch primarily targets.
+    var targetMuscleGroups: [MuscleGroup]
+
+    /// SF Symbol icon for this stretch (defaults to a flexibility figure).
+    var icon: String { "figure.flexibility" }
+}

--- a/Xomfit/Models/StretchDatabase.swift
+++ b/Xomfit/Models/StretchDatabase.swift
@@ -1,0 +1,277 @@
+import Foundation
+
+/// Built-in stretch routines for the pre-workout warmup flow.
+/// Stretches are mapped to muscle groups so we can suggest the right ones
+/// for whatever workout the user is starting.
+struct StretchDatabase {
+    static let all: [Stretch] = [
+        // MARK: - Full body / dynamic
+        Stretch(
+            id: "st-worlds-greatest", name: "World's Greatest Stretch",
+            description: "Step into a deep lunge, drop the opposite hand to the floor, then rotate the top arm up toward the ceiling. Alternate sides.",
+            durationSeconds: 45,
+            targetMuscleGroups: [.hamstrings, .glutes, .back, .shoulders, .quads]
+        ),
+        Stretch(
+            id: "st-cat-cow", name: "Cat-Cow",
+            description: "On hands and knees, alternate between rounding the spine (cat) and arching while lifting the chest (cow). Move with your breath.",
+            durationSeconds: 40,
+            targetMuscleGroups: [.back, .abs]
+        ),
+        Stretch(
+            id: "st-leg-swings", name: "Leg Swings",
+            description: "Hold a wall or rack and swing one leg front-to-back, then side-to-side. Keep the swing controlled, not forced.",
+            durationSeconds: 40,
+            targetMuscleGroups: [.hamstrings, .glutes, .quads]
+        ),
+        Stretch(
+            id: "st-arm-circles", name: "Arm Circles",
+            description: "Extend arms out to the sides and make slow forward circles for half the time, then reverse. Increase the size gradually.",
+            durationSeconds: 30,
+            targetMuscleGroups: [.shoulders]
+        ),
+
+        // MARK: - Upper body
+        Stretch(
+            id: "st-shoulder-dislocates", name: "Shoulder Dislocates",
+            description: "Hold a band, broomstick, or PVC pipe wide overhead and slowly pass it from in front of your hips to behind your back, then return.",
+            durationSeconds: 45,
+            targetMuscleGroups: [.shoulders, .chest]
+        ),
+        Stretch(
+            id: "st-doorway-chest", name: "Doorway Chest Stretch",
+            description: "Place forearms on a doorway frame at shoulder height and step one foot through to feel a stretch across the chest and front delts.",
+            durationSeconds: 30,
+            targetMuscleGroups: [.chest, .shoulders]
+        ),
+        Stretch(
+            id: "st-cross-body-shoulder", name: "Cross-Body Shoulder Stretch",
+            description: "Pull one arm across your chest with the other arm, holding just above the elbow. Feel the stretch in the rear delt.",
+            durationSeconds: 30,
+            targetMuscleGroups: [.shoulders, .back]
+        ),
+        Stretch(
+            id: "st-overhead-tricep", name: "Overhead Tricep Stretch",
+            description: "Reach one arm overhead and bend the elbow so the hand drops behind your head. Use the other hand to gently pull the elbow back.",
+            durationSeconds: 30,
+            targetMuscleGroups: [.triceps, .shoulders]
+        ),
+        Stretch(
+            id: "st-thoracic-rotation", name: "Thoracic Rotation",
+            description: "On hands and knees, place one hand behind your head and rotate that elbow up toward the ceiling, then back under the opposite arm.",
+            durationSeconds: 40,
+            targetMuscleGroups: [.back, .abs, .shoulders]
+        ),
+        Stretch(
+            id: "st-wrist-circles", name: "Wrist Circles & Stretch",
+            description: "Extend arms forward and slowly circle the wrists in both directions, then gently pull each hand back to stretch the forearms.",
+            durationSeconds: 30,
+            targetMuscleGroups: [.forearms]
+        ),
+        Stretch(
+            id: "st-neck-rolls", name: "Neck Rolls",
+            description: "Slowly drop your chin to your chest and roll your head from one shoulder to the other. Keep the motion gentle.",
+            durationSeconds: 25,
+            targetMuscleGroups: [.traps, .shoulders]
+        ),
+
+        // MARK: - Lower body
+        Stretch(
+            id: "st-90-90-hip", name: "90/90 Hip Stretch",
+            description: "Sit with both legs at 90-degree angles — front leg out, back leg behind. Sit tall and lean forward over the front shin, then switch.",
+            durationSeconds: 45,
+            targetMuscleGroups: [.glutes, .hamstrings]
+        ),
+        Stretch(
+            id: "st-pigeon", name: "Pigeon Pose",
+            description: "Bring one shin in front of you with the foot under the opposite hip. Extend the back leg straight behind. Lean over the front shin.",
+            durationSeconds: 45,
+            targetMuscleGroups: [.glutes, .hamstrings]
+        ),
+        Stretch(
+            id: "st-deep-squat-hold", name: "Deep Squat Hold",
+            description: "Drop into a deep bodyweight squat, drive elbows against the inside of your knees, and stay tall. Pry the knees out.",
+            durationSeconds: 45,
+            targetMuscleGroups: [.glutes, .hamstrings, .quads, .calves]
+        ),
+        Stretch(
+            id: "st-hamstring-stretch", name: "Standing Hamstring Stretch",
+            description: "Place one heel on a low surface and hinge at the hips with a flat back until you feel the hamstring stretch.",
+            durationSeconds: 40,
+            targetMuscleGroups: [.hamstrings, .glutes]
+        ),
+        Stretch(
+            id: "st-quad-pull", name: "Standing Quad Stretch",
+            description: "Pull one heel toward your glute and hold. Keep knees together and stand tall — don't arch the lower back.",
+            durationSeconds: 30,
+            targetMuscleGroups: [.quads]
+        ),
+        Stretch(
+            id: "st-couch-stretch", name: "Couch Stretch",
+            description: "Place the top of one foot on a bench or wall behind you with the knee on the floor. Drive hips forward and stay tall.",
+            durationSeconds: 45,
+            targetMuscleGroups: [.quads, .glutes]
+        ),
+        Stretch(
+            id: "st-figure-four", name: "Figure-Four Glute Stretch",
+            description: "Lying on your back, cross one ankle over the opposite knee and pull the bottom thigh in toward your chest.",
+            durationSeconds: 40,
+            targetMuscleGroups: [.glutes]
+        ),
+        Stretch(
+            id: "st-calf-wall", name: "Calf Wall Stretch",
+            description: "Place hands on a wall, step one foot back with the heel pressed down and the leg straight. Lean in to stretch the calf.",
+            durationSeconds: 30,
+            targetMuscleGroups: [.calves]
+        ),
+        Stretch(
+            id: "st-hip-flexor-lunge", name: "Half-Kneeling Hip Flexor Stretch",
+            description: "Drop into a half-kneeling lunge. Squeeze the back glute and gently push the hips forward to stretch the front hip.",
+            durationSeconds: 40,
+            targetMuscleGroups: [.quads, .glutes, .abs]
+        ),
+
+        // MARK: - Core / back
+        Stretch(
+            id: "st-childs-pose", name: "Child's Pose",
+            description: "Kneel and sit back on your heels, then fold forward and reach arms overhead on the floor. Breathe and let the back relax.",
+            durationSeconds: 45,
+            targetMuscleGroups: [.back, .lats, .shoulders]
+        ),
+        Stretch(
+            id: "st-cobra", name: "Cobra Stretch",
+            description: "Lie face down with hands under your shoulders and gently press up, lifting your chest. Keep hips on the floor.",
+            durationSeconds: 30,
+            targetMuscleGroups: [.abs, .back]
+        ),
+    ]
+
+    // MARK: - Lookup
+
+    static func byMuscleGroup(_ group: MuscleGroup) -> [Stretch] {
+        all.filter { $0.targetMuscleGroups.contains(group) }
+    }
+
+    static func byId(_ id: String) -> Stretch? {
+        all.first(where: { $0.id == id })
+    }
+
+    // MARK: - Suggestions
+
+    /// Pick a routine of stretches that covers the muscle groups hit by a workout,
+    /// summing roughly to `target` seconds (default ~6 minutes).
+    /// - Parameters:
+    ///   - workout: the workout being warmed up for. We look at every exercise and
+    ///     collect the muscle groups it targets.
+    ///   - target: the total time budget for the routine, in seconds.
+    /// - Returns: an ordered list of 5-7 stretches, deduplicated and prioritized
+    ///   by the muscle groups that show up most frequently in the workout.
+    static func suggestedStretches(for workout: Workout, target: TimeInterval = 360) -> [Stretch] {
+        let groups = workout.exercises.flatMap { $0.exercise.muscleGroups }
+        return suggestedStretches(forMuscleGroups: groups, target: target)
+    }
+
+    /// Pick a routine of stretches for a list of target muscle groups (e.g. from a template
+    /// before the workout has actually started).
+    static func suggestedStretches(for template: WorkoutTemplate, target: TimeInterval = 360) -> [Stretch] {
+        let groups = template.exercises.flatMap { $0.exercise.muscleGroups }
+        return suggestedStretches(forMuscleGroups: groups, target: target)
+    }
+
+    /// Underlying selection logic: rank stretches by how many of the workout's
+    /// muscle groups they cover (weighted by how often each group appears),
+    /// then pack them up to the time budget.
+    static func suggestedStretches(forMuscleGroups groups: [MuscleGroup], target: TimeInterval = 360) -> [Stretch] {
+        // Start with a sensible default if the workout has no muscle group data.
+        guard !groups.isEmpty else {
+            return defaultRoutine(target: target)
+        }
+
+        // How many times does each muscle group appear in the workout?
+        var frequency: [MuscleGroup: Int] = [:]
+        for group in groups {
+            frequency[group, default: 0] += 1
+        }
+
+        // Score each stretch by the total frequency it covers.
+        let scored: [(stretch: Stretch, score: Int)] = all.map { stretch in
+            let score = stretch.targetMuscleGroups.reduce(0) { acc, g in acc + (frequency[g] ?? 0) }
+            return (stretch, score)
+        }
+
+        // Stretches that cover at least one muscle group, sorted by score (desc), then duration (asc)
+        // so we don't blow the time budget early on long stretches.
+        let candidates = scored
+            .filter { $0.score > 0 }
+            .sorted { lhs, rhs in
+                if lhs.score != rhs.score { return lhs.score > rhs.score }
+                return lhs.stretch.durationSeconds < rhs.stretch.durationSeconds
+            }
+            .map(\.stretch)
+
+        var picked: [Stretch] = []
+        var pickedIds = Set<String>()
+        var remaining = target
+
+        // Always lead with a dynamic full-body stretch if we have one and there's room.
+        if let opener = all.first(where: { $0.id == "st-worlds-greatest" }),
+           remaining >= TimeInterval(opener.durationSeconds) {
+            picked.append(opener)
+            pickedIds.insert(opener.id)
+            remaining -= TimeInterval(opener.durationSeconds)
+        }
+
+        for stretch in candidates {
+            if pickedIds.contains(stretch.id) { continue }
+            let cost = TimeInterval(stretch.durationSeconds)
+            if cost > remaining { continue }
+            picked.append(stretch)
+            pickedIds.insert(stretch.id)
+            remaining -= cost
+            // Cap the routine length so we don't end up with a 12-stretch list.
+            if picked.count >= 7 { break }
+        }
+
+        // Aim for at least 5 stretches when the budget allows; pad with fillers.
+        if picked.count < 5 {
+            let fillers = all
+                .filter { !pickedIds.contains($0.id) }
+                .sorted { $0.durationSeconds < $1.durationSeconds }
+            for stretch in fillers {
+                let cost = TimeInterval(stretch.durationSeconds)
+                if cost > remaining { continue }
+                picked.append(stretch)
+                pickedIds.insert(stretch.id)
+                remaining -= cost
+                if picked.count >= 5 { break }
+            }
+        }
+
+        // If we still got nothing useful (e.g. workout used a muscle group with no stretches),
+        // fall back to the default routine.
+        return picked.isEmpty ? defaultRoutine(target: target) : picked
+    }
+
+    /// A balanced full-body warmup used when we have no workout-specific info.
+    static func defaultRoutine(target: TimeInterval = 360) -> [Stretch] {
+        let preferredOrder = [
+            "st-worlds-greatest",
+            "st-cat-cow",
+            "st-shoulder-dislocates",
+            "st-deep-squat-hold",
+            "st-90-90-hip",
+            "st-childs-pose",
+            "st-leg-swings",
+        ]
+        var picked: [Stretch] = []
+        var remaining = target
+        for id in preferredOrder {
+            guard let stretch = byId(id) else { continue }
+            let cost = TimeInterval(stretch.durationSeconds)
+            if cost > remaining { continue }
+            picked.append(stretch)
+            remaining -= cost
+        }
+        return picked
+    }
+}

--- a/Xomfit/Views/Workout/WarmupView.swift
+++ b/Xomfit/Views/Workout/WarmupView.swift
@@ -1,0 +1,344 @@
+import SwiftUI
+
+/// Pre-workout stretch flow.
+///
+/// Shows a total countdown at the top and walks the user through ~5-7 stretches,
+/// auto-advancing as each per-stretch sub-timer hits zero. Users can skip the
+/// remaining time at any point and jump straight into the workout.
+struct WarmupView: View {
+    let stretches: [Stretch]
+    /// Total warmup duration in seconds (default 6 minutes).
+    let totalDuration: Int
+    /// Called when the user completes or skips the warmup. The caller should
+    /// dismiss this view and start the actual workout.
+    let onFinish: () -> Void
+
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var totalRemaining: Int
+    @State private var stretchRemaining: Int
+    @State private var currentIndex: Int = 0
+    @State private var timer: Timer?
+    @State private var isFinished: Bool = false
+
+    init(stretches: [Stretch], totalDuration: Int = 360, onFinish: @escaping () -> Void) {
+        self.stretches = stretches
+        self.totalDuration = totalDuration
+        self.onFinish = onFinish
+        _totalRemaining = State(initialValue: totalDuration)
+        _stretchRemaining = State(initialValue: stretches.first?.durationSeconds ?? 30)
+    }
+
+    private var currentStretch: Stretch? {
+        guard currentIndex < stretches.count else { return stretches.last }
+        return stretches[currentIndex]
+    }
+
+    private var totalProgress: Double {
+        guard totalDuration > 0 else { return 0 }
+        return 1 - (Double(totalRemaining) / Double(totalDuration))
+    }
+
+    private var stretchProgress: Double {
+        guard let stretch = currentStretch, stretch.durationSeconds > 0 else { return 0 }
+        return 1 - (Double(stretchRemaining) / Double(stretch.durationSeconds))
+    }
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Theme.background.ignoresSafeArea()
+
+                ScrollView {
+                    VStack(spacing: Theme.Spacing.lg) {
+                        header
+                        totalTimerCard
+                        currentStretchCard
+                        upcomingList
+                    }
+                    .padding(Theme.Spacing.md)
+                    .padding(.bottom, 100)
+                }
+
+                VStack {
+                    Spacer()
+                    skipButton
+                }
+            }
+            .navigationTitle("Warmup")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbarColorScheme(.dark, for: .navigationBar)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") {
+                        Haptics.light()
+                        stopTimer()
+                        dismiss()
+                    }
+                    .foregroundStyle(Theme.textSecondary)
+                }
+            }
+            .onAppear {
+                startTimer()
+            }
+            .onDisappear {
+                stopTimer()
+            }
+        }
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        VStack(spacing: 4) {
+            Text("Loosen up first")
+                .font(Theme.fontTitle2)
+                .foregroundStyle(Theme.textPrimary)
+            Text("\(stretches.count) stretches to get you ready")
+                .font(Theme.fontSubheadline)
+                .foregroundStyle(Theme.textSecondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .center)
+        .padding(.top, Theme.Spacing.sm)
+        .accessibilityElement(children: .combine)
+        .accessibilityAddTraits(.isHeader)
+    }
+
+    // MARK: - Total timer
+
+    private var totalTimerCard: some View {
+        VStack(spacing: Theme.Spacing.sm) {
+            XomMetricLabel("Total Time")
+
+            ZStack {
+                RestTimerRingView(progress: totalProgress, color: Theme.accent, lineWidth: 8)
+                Text(formatTime(totalRemaining))
+                    .font(.system(size: 36, weight: .heavy, design: .rounded))
+                    .monospacedDigit()
+                    .foregroundStyle(Theme.textPrimary)
+            }
+            .frame(width: 140, height: 140)
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel("Total warmup time remaining: \(formatTime(totalRemaining))")
+        }
+        .padding(Theme.Spacing.md)
+        .frame(maxWidth: .infinity)
+        .background(Theme.surface)
+        .clipShape(.rect(cornerRadius: Theme.cornerRadius))
+    }
+
+    // MARK: - Current stretch
+
+    @ViewBuilder
+    private var currentStretchCard: some View {
+        if let stretch = currentStretch {
+            VStack(alignment: .leading, spacing: Theme.Spacing.md) {
+                HStack(alignment: .top, spacing: Theme.Spacing.md) {
+                    Image(systemName: stretch.icon)
+                        .font(.title2)
+                        .foregroundStyle(Theme.accent)
+                        .frame(width: 44, height: 44)
+                        .background(Theme.accent.opacity(0.15))
+                        .clipShape(.rect(cornerRadius: 10))
+
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Now: \(stretch.name)")
+                            .font(Theme.fontHeadline)
+                            .foregroundStyle(Theme.textPrimary)
+                        Text(muscleGroupSummary(stretch.targetMuscleGroups))
+                            .font(Theme.fontCaption)
+                            .foregroundStyle(Theme.textSecondary)
+                    }
+
+                    Spacer()
+
+                    ZStack {
+                        RestTimerRingView(progress: stretchProgress, color: Theme.accent, lineWidth: 4)
+                        Text("\(stretchRemaining)")
+                            .font(.system(size: 20, weight: .bold, design: .rounded))
+                            .monospacedDigit()
+                            .foregroundStyle(Theme.textPrimary)
+                    }
+                    .frame(width: 56, height: 56)
+                    .accessibilityElement(children: .ignore)
+                    .accessibilityLabel("\(stretchRemaining) seconds left on this stretch")
+                }
+
+                Text(stretch.description)
+                    .font(Theme.fontBody)
+                    .foregroundStyle(Theme.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                HStack(spacing: Theme.Spacing.sm) {
+                    Button {
+                        Haptics.light()
+                        advanceToNextStretch()
+                    } label: {
+                        HStack(spacing: 6) {
+                            Image(systemName: "forward.fill")
+                            Text("Next stretch")
+                        }
+                    }
+                    .buttonStyle(GhostButtonStyle())
+                    .accessibilityLabel("Skip to next stretch")
+                }
+            }
+            .padding(Theme.Spacing.md)
+            .background(Theme.surface)
+            .clipShape(.rect(cornerRadius: Theme.cornerRadius))
+        } else {
+            EmptyView()
+        }
+    }
+
+    // MARK: - Upcoming
+
+    @ViewBuilder
+    private var upcomingList: some View {
+        if currentIndex + 1 < stretches.count {
+            VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+                Text("Up next")
+                    .font(.body.weight(.bold))
+                    .foregroundStyle(Theme.textPrimary)
+
+                ForEach(Array(stretches.enumerated()), id: \.element.id) { index, stretch in
+                    if index > currentIndex {
+                        upcomingRow(index: index, stretch: stretch)
+                    }
+                }
+            }
+        }
+    }
+
+    private func upcomingRow(index: Int, stretch: Stretch) -> some View {
+        HStack(spacing: 12) {
+            Text("\(index + 1)")
+                .font(.caption.weight(.bold).monospaced())
+                .foregroundStyle(Theme.textSecondary)
+                .frame(width: 24, height: 24)
+                .background(Theme.surfaceElevated)
+                .clipShape(.rect(cornerRadius: 6))
+
+            Text(stretch.name)
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(Theme.textPrimary)
+
+            Spacer()
+
+            Text("\(stretch.durationSeconds)s")
+                .font(.caption.weight(.semibold).monospacedDigit())
+                .foregroundStyle(Theme.textSecondary)
+        }
+        .padding(.horizontal, Theme.Spacing.md)
+        .padding(.vertical, Theme.Spacing.sm)
+        .background(Theme.surface)
+        .clipShape(.rect(cornerRadius: Theme.cornerRadiusSmall))
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Up next: \(stretch.name), \(stretch.durationSeconds) seconds")
+    }
+
+    // MARK: - Skip button
+
+    private var skipButton: some View {
+        Button {
+            Haptics.medium()
+            finish()
+        } label: {
+            HStack(spacing: 10) {
+                Image(systemName: "play.fill")
+                Text("Skip to workout")
+            }
+        }
+        .buttonStyle(AccentButtonStyle())
+        .padding(.horizontal, Theme.Spacing.md)
+        .padding(.bottom, Theme.Spacing.md)
+        .accessibilityLabel("Skip remaining warmup and start workout")
+    }
+
+    // MARK: - Timer
+
+    private func startTimer() {
+        // Bail early if there are no stretches at all.
+        guard !stretches.isEmpty else {
+            finish()
+            return
+        }
+        stopTimer()
+        timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { _ in
+            tick()
+        }
+    }
+
+    private func stopTimer() {
+        timer?.invalidate()
+        timer = nil
+    }
+
+    private func tick() {
+        guard !isFinished else { return }
+
+        if totalRemaining > 0 {
+            totalRemaining -= 1
+        }
+
+        if stretchRemaining > 0 {
+            stretchRemaining -= 1
+        }
+
+        // Move to next stretch when this one expires.
+        if stretchRemaining <= 0 {
+            advanceToNextStretch()
+        }
+
+        // Total timer hit zero — wrap up and start the workout.
+        if totalRemaining <= 0 {
+            finish()
+        }
+    }
+
+    private func advanceToNextStretch() {
+        let nextIndex = currentIndex + 1
+        if nextIndex < stretches.count {
+            currentIndex = nextIndex
+            stretchRemaining = stretches[nextIndex].durationSeconds
+            Haptics.light()
+        } else {
+            // No more stretches but the total timer still has time — hold the last stretch
+            // until the total timer expires so we don't snap to "Done" too early.
+            stretchRemaining = max(totalRemaining, 0)
+        }
+    }
+
+    private func finish() {
+        guard !isFinished else { return }
+        isFinished = true
+        stopTimer()
+        Haptics.success()
+        onFinish()
+        dismiss()
+    }
+
+    // MARK: - Helpers
+
+    private func formatTime(_ seconds: Int) -> String {
+        let s = max(seconds, 0)
+        let mins = s / 60
+        let secs = s % 60
+        return String(format: "%d:%02d", mins, secs)
+    }
+
+    private func muscleGroupSummary(_ groups: [MuscleGroup]) -> String {
+        let names = groups.prefix(3).map { $0.displayName }
+        return names.joined(separator: " · ")
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    WarmupView(
+        stretches: StretchDatabase.defaultRoutine(target: 360),
+        totalDuration: 360,
+        onFinish: {}
+    )
+}

--- a/Xomfit/Views/Workout/WorkoutView.swift
+++ b/Xomfit/Views/Workout/WorkoutView.swift
@@ -18,6 +18,22 @@ struct WorkoutView: View {
     @State private var myTemplates: [WorkoutTemplate] = []
     @State private var savedTemplates: [WorkoutTemplate] = []
 
+    // MARK: - Warmup flow (#261)
+
+    /// Persisted preference: "" = ask each time, "yes" = always warm up, "no" = always skip.
+    @AppStorage("warmupOptIn") private var warmupOptIn: String = ""
+    /// Default warmup length in minutes — kept here so we can tweak via settings later.
+    @AppStorage("warmupMinutes") private var warmupMinutes: Int = 6
+
+    /// Captured action that runs after the warmup (or immediately if skipped).
+    @State private var pendingStart: (() -> Void)?
+    /// Stretches we'll show during the warmup, computed before presenting the sheet.
+    @State private var pendingStretches: [Stretch] = []
+    /// Whether to ask the user about warming up right now.
+    @State private var showWarmupPrompt = false
+    /// Whether to present the warmup sheet right now.
+    @State private var showWarmup = false
+
     private var userId: String {
         authService.currentUser?.id.uuidString.lowercased() ?? ""
     }
@@ -44,6 +60,16 @@ struct WorkoutView: View {
                             .buttonStyle(AccentButtonStyle())
                             .padding(.horizontal, Theme.Spacing.md)
                             .padding(.top, Theme.Spacing.md)
+                            .simultaneousGesture(
+                                LongPressGesture(minimumDuration: 0.6).onEnded { _ in
+                                    // Long-press resets the warmup preference so the prompt shows again.
+                                    Haptics.medium()
+                                    warmupOptIn = ""
+                                    pendingWorkoutName = ""
+                                    showNameEntry = true
+                                }
+                            )
+                            .accessibilityHint("Long press to reset warmup preference")
 
                             // Build Workout + Log Past Workout (side-by-side)
                             HStack(spacing: Theme.Spacing.sm) {
@@ -114,10 +140,40 @@ struct WorkoutView: View {
             TextField("e.g. Push Day", text: $pendingWorkoutName)
             Button("Start") {
                 let name = pendingWorkoutName.isEmpty ? "Workout" : pendingWorkoutName
-                workoutSession.startWorkout(name: name, userId: userId)
-                workoutSession.isPresented = true
+                requestStart(stretches: StretchDatabase.defaultRoutine(target: TimeInterval(warmupMinutes * 60))) {
+                    workoutSession.startWorkout(name: name, userId: userId)
+                    workoutSession.isPresented = true
+                }
             }
             Button("Cancel", role: .cancel) {}
+        }
+        .confirmationDialog(
+            "Warm up first?",
+            isPresented: $showWarmupPrompt,
+            titleVisibility: .visible
+        ) {
+            Button("Yes, \(warmupMinutes) min") {
+                warmupOptIn = "yes"
+                showWarmup = true
+            }
+            Button("No, skip") {
+                warmupOptIn = "no"
+                runPendingStartImmediately()
+            }
+            Button("Just this once", role: .cancel) {
+                // Don't persist a preference — start without warmup but ask again next time.
+                runPendingStartImmediately()
+            }
+        } message: {
+            Text("A 5-10 minute stretch routine helps loosen up before lifting.")
+        }
+        .fullScreenCover(isPresented: $showWarmup) {
+            WarmupView(
+                stretches: pendingStretches.isEmpty ? StretchDatabase.defaultRoutine() : pendingStretches,
+                totalDuration: warmupMinutes * 60
+            ) {
+                runPendingStartImmediately()
+            }
         }
         .sheet(isPresented: $showBuilder, onDismiss: {
             templateRefreshId = UUID()
@@ -133,8 +189,10 @@ struct WorkoutView: View {
         .sheet(item: $previewTemplate) { template in
             TemplateDetailView(template: template) {
                 previewTemplate = nil
-                workoutSession.startFromTemplate(template, userId: userId)
-                workoutSession.isPresented = true
+                requestStart(stretches: StretchDatabase.suggestedStretches(for: template, target: TimeInterval(warmupMinutes * 60))) {
+                    workoutSession.startFromTemplate(template, userId: userId)
+                    workoutSession.isPresented = true
+                }
             }
         }
         .sheet(isPresented: $showTemplateList) {
@@ -169,8 +227,10 @@ struct WorkoutView: View {
                 Haptics.medium()
                 UserDefaults.standard.set(true, forKey: "xomfit_first_workout_started")
                 if let template = WorkoutTemplate.builtIn.first(where: { $0.id == "tpl-fb-a" }) {
-                    workoutSession.startFromTemplate(template, userId: userId)
-                    workoutSession.isPresented = true
+                    requestStart(stretches: StretchDatabase.suggestedStretches(for: template, target: TimeInterval(warmupMinutes * 60))) {
+                        workoutSession.startFromTemplate(template, userId: userId)
+                        workoutSession.isPresented = true
+                    }
                 }
             } label: {
                 HStack(spacing: 8) {
@@ -299,6 +359,44 @@ struct WorkoutView: View {
             }
         }
         .padding(.vertical, Theme.Spacing.sm)
+    }
+
+    // MARK: - Warmup gating (#261)
+
+    /// Entry point used by every "start workout" path. Either prompts the user about
+    /// warming up first, presents the warmup, or runs the start action directly,
+    /// depending on the user's saved preference.
+    private func requestStart(stretches: [Stretch], action: @escaping () -> Void) {
+        pendingStart = action
+        pendingStretches = stretches
+
+        switch warmupOptIn {
+        case "yes":
+            // User opted into warmups — present the warmup sheet.
+            // Defer slightly so any presenting sheet has time to dismiss.
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) {
+                showWarmup = true
+            }
+        case "no":
+            // User opted out — start immediately.
+            runPendingStartImmediately()
+        default:
+            // First time (or user reset via long-press) — ask.
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) {
+                showWarmupPrompt = true
+            }
+        }
+    }
+
+    /// Run the captured pending start action and clear it.
+    private func runPendingStartImmediately() {
+        let action = pendingStart
+        pendingStart = nil
+        pendingStretches = []
+        // Slight delay so any prompt/sheet dismissal lands cleanly before the workout cover.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+            action?()
+        }
     }
 
     // MARK: - Data Loading


### PR DESCRIPTION
Closes #261. 30 new exercises (Smith/Hammer Strength, cable/free-weight/bodyweight/mobility) + 22 stretches in StretchDatabase. New WarmupView with total ring + per-stretch sub-timer. Warmup prompt before workout start; @AppStorage('warmupOptIn') persists choice; long-press Start to reset.