### PR TITLE
fix: friends dupe (#279) + past-workout date binding (#280)

### DIFF
--- a/Xomfit/ViewModels/FriendsViewModel.swift
+++ b/Xomfit/ViewModels/FriendsViewModel.swift
@@ -39,8 +39,15 @@ final class FriendsViewModel {
         do {
             let (friendsResult, incomingResult, outgoingResult) = try await (friendsTask, incomingTask, outgoingTask)
             friends = friendsResult
-            incomingRequests = incomingResult
-            outgoingRequests = outgoingResult
+
+            // Defensive dedupe: if a stale pending row exists in either direction
+            // for a user we're already accepted-friends with (data corruption from
+            // a duplicate request before the unique-pair guard landed), don't show
+            // them in pending. The friends list is the source of truth.
+            let friendUserIds: Set<String> = Set(friendsResult.flatMap { [$0.requesterId, $0.addresseeId] })
+                .subtracting([userId])
+            incomingRequests = incomingResult.filter { !friendUserIds.contains($0.requesterId) }
+            outgoingRequests = outgoingResult.filter { !friendUserIds.contains($0.addresseeId) }
 
             await hydrateProfiles(userId: userId)
         } catch {

--- a/Xomfit/Views/Workout/LogPastWorkoutView.swift
+++ b/Xomfit/Views/Workout/LogPastWorkoutView.swift
@@ -16,7 +16,9 @@ struct LogPastWorkoutView: View {
     }
 
     var body: some View {
-        NavigationStack {
+        @Bindable var viewModel = viewModel
+
+        return NavigationStack {
             ZStack {
                 Theme.background.ignoresSafeArea()
 


### PR DESCRIPTION
Closes #279
Closes #280

## #279 — Friends showing as both accepted and pending
When a friendship had both a pending row and an accepted row in opposite directions (data corruption from a request created before the accept landed), the user appeared in BOTH the friends list and the pending list. Source of the dupe is in the data layer (two rows for the same pair).

**Fix**: in `FriendsViewModel.loadAll`, after fetching all 3 lists, filter `incomingRequests` and `outgoingRequests` to exclude any user already in the accepted friends list. Friends list is the source of truth. Defensive — doesn't change service logic.

## #280 — Log Past workout always saves with today's date
`LogPastWorkoutView` held the VM via `@State` without `@Bindable`, so `$viewModel.workoutDate` produced a no-op binding. The DatePicker displayed the initial `Date()` but never wrote the user's selection back to the VM, so save always used today.

**Fix**: `@Bindable var viewModel = viewModel` inside `body`. Now the chosen date flows through to `saveWorkout`.

## Test plan
- [ ] #279: Force the dupe state (manually `UPDATE friendships` to make a row 'accepted' while another row for the same pair stays 'pending'); reload friends — user appears in friends only
- [ ] #280: Tap Log Past, pick a date 3 days ago, save — workout shows under that date in recents/profile, not today