### PR TITLE
#281 workout view: Quick Hitters preview + See All category pages

### DIFF
--- a/Xomfit/Views/Workout/WorkoutCategoryPage.swift
+++ b/Xomfit/Views/Workout/WorkoutCategoryPage.swift
@@ -1,0 +1,311 @@
+import SwiftUI
+
+// MARK: - WorkoutCategory
+
+/// The three "Quick Hitter" sections surfaced on `WorkoutView`.
+///
+/// Each case identifies both the preview shown on the main page and the
+/// dedicated `WorkoutCategoryPage` reachable via "See All".
+enum WorkoutCategory: String, CaseIterable, Identifiable, Hashable {
+    /// The user's own recent past workouts.
+    case recents
+    /// Built-in templates shipped with the app (non-custom).
+    case preGenerated
+    /// Combination of: the user's custom + saved templates and friends' recent workouts.
+    case friendsAndSaved
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .recents:         return "Recents"
+        case .preGenerated:    return "Pre-generated"
+        case .friendsAndSaved: return "Friends & Saved"
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .recents:         return "clock.fill"
+        case .preGenerated:    return "list.bullet.rectangle.portrait"
+        case .friendsAndSaved: return "person.2.fill"
+        }
+    }
+
+    /// Empty-state copy when the user has no items in this category at all (no filter applied).
+    var emptyStateTitle: String {
+        switch self {
+        case .recents:         return "No recent workouts"
+        case .preGenerated:    return "No templates available"
+        case .friendsAndSaved: return "Nothing here yet"
+        }
+    }
+
+    var emptyStateMessage: String {
+        switch self {
+        case .recents:
+            return "Finished workouts will show up here."
+        case .preGenerated:
+            return "Built-in templates will appear once loaded."
+        case .friendsAndSaved:
+            return "Save a template or add friends to populate this list."
+        }
+    }
+}
+
+// MARK: - WorkoutCategoryPage
+
+/// Dedicated "See All" page for a single `WorkoutCategory`.
+///
+/// Reuses the shared `WorkoutTabViewModel` so filter state survives navigation
+/// while data is loaded once on the parent screen.
+struct WorkoutCategoryPage: View {
+    let category: WorkoutCategory
+
+    /// Shared view model owned by `WorkoutView`. Filters apply per-page via the
+    /// local `localFilter` state — we don't mutate the shared filter so each
+    /// "See All" page starts clean.
+    let viewModel: WorkoutTabViewModel
+
+    @Environment(AuthService.self) private var authService
+    @Environment(WorkoutLoggerViewModel.self) private var workoutSession
+
+    @State private var localFilter = WorkoutFilter()
+    @State private var previewTemplate: WorkoutTemplate?
+
+    /// Default warmup length in minutes (matches WorkoutView's setting).
+    @AppStorage("warmupMinutes") private var warmupMinutes: Int = 6
+    @AppStorage("warmupOptIn") private var warmupOptIn: String = ""
+
+    @State private var pendingStart: (() -> Void)?
+    @State private var pendingStretches: [Stretch] = []
+    @State private var showWarmupPrompt = false
+    @State private var showWarmup = false
+
+    private var userId: String {
+        authService.currentUser?.id.uuidString.lowercased() ?? ""
+    }
+
+    var body: some View {
+        ZStack {
+            Theme.background.ignoresSafeArea()
+
+            VStack(spacing: 0) {
+                WorkoutFilterBar(filter: $localFilter)
+
+                ScrollView {
+                    LazyVStack(spacing: Theme.Spacing.sm) {
+                        contentView
+                    }
+                    .padding(.horizontal, Theme.Spacing.md)
+                    .padding(.vertical, Theme.Spacing.sm)
+                }
+            }
+        }
+        .navigationTitle(category.title)
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbarColorScheme(.dark, for: .navigationBar)
+        .sheet(item: $previewTemplate) { template in
+            TemplateDetailView(template: template) {
+                let captured = template
+                previewTemplate = nil
+                requestStart(stretches: StretchDatabase.suggestedStretches(for: captured, target: TimeInterval(warmupMinutes * 60))) {
+                    workoutSession.startFromTemplate(captured, userId: userId)
+                    workoutSession.isPresented = true
+                }
+            }
+        }
+        .confirmationDialog(
+            "Warm up first?",
+            isPresented: $showWarmupPrompt,
+            titleVisibility: .visible
+        ) {
+            Button("Yes, \(warmupMinutes) min") {
+                warmupOptIn = "yes"
+                showWarmup = true
+            }
+            Button("No, skip") {
+                warmupOptIn = "no"
+                runPendingStartImmediately()
+            }
+            Button("Just this once", role: .cancel) {
+                runPendingStartImmediately()
+            }
+        } message: {
+            Text("A 5-10 minute stretch routine helps loosen up before lifting.")
+        }
+        .fullScreenCover(isPresented: $showWarmup) {
+            WarmupView(
+                stretches: pendingStretches.isEmpty ? StretchDatabase.defaultRoutine() : pendingStretches,
+                totalDuration: warmupMinutes * 60
+            ) {
+                runPendingStartImmediately()
+            }
+        }
+    }
+
+    // MARK: - Content
+
+    @ViewBuilder
+    private var contentView: some View {
+        switch category {
+        case .recents:
+            recentsContent
+        case .preGenerated:
+            preGeneratedContent
+        case .friendsAndSaved:
+            friendsAndSavedContent
+        }
+    }
+
+    @ViewBuilder
+    private var recentsContent: some View {
+        let items = viewModel.recent.filter(localFilter.matches)
+        if viewModel.recent.isEmpty {
+            emptyState
+        } else if items.isEmpty {
+            filteredEmptyState
+        } else {
+            ForEach(items) { workout in
+                NavigationLink {
+                    WorkoutDetailView(workout: workout)
+                } label: {
+                    RecentWorkoutCard(workout: workout, style: .row) { /* tap handled by NavigationLink */ }
+                        .allowsHitTesting(false)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("\(workout.name), \(workout.startTime.timeAgo)")
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var preGeneratedContent: some View {
+        let items = viewModel.builtInTemplates.filter(localFilter.matches)
+        if viewModel.builtInTemplates.isEmpty {
+            emptyState
+        } else if items.isEmpty {
+            filteredEmptyState
+        } else {
+            ForEach(items) { template in
+                TemplateCardView(template: template, style: .row) {
+                    previewTemplate = template
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var friendsAndSavedContent: some View {
+        let templates = (viewModel.myTemplates + viewModel.savedTemplates).filter(localFilter.matches)
+        let workouts = viewModel.friendWorkouts.filter(localFilter.matches)
+        let hasAnySource = !viewModel.myTemplates.isEmpty
+            || !viewModel.savedTemplates.isEmpty
+            || !viewModel.friendWorkouts.isEmpty
+        let hasAnyMatch = !templates.isEmpty || !workouts.isEmpty
+
+        if !hasAnySource {
+            emptyState
+        } else if !hasAnyMatch {
+            filteredEmptyState
+        } else {
+            if !templates.isEmpty {
+                sectionLabel("Saved Templates")
+                ForEach(templates) { template in
+                    TemplateCardView(template: template, style: .row) {
+                        previewTemplate = template
+                    }
+                }
+            }
+
+            if !workouts.isEmpty {
+                sectionLabel("From Friends")
+                ForEach(workouts) { workout in
+                    NavigationLink {
+                        WorkoutDetailView(workout: workout)
+                    } label: {
+                        RecentWorkoutCard(workout: workout, style: .row) { /* tap handled by NavigationLink */ }
+                            .allowsHitTesting(false)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Friend workout: \(workout.name)")
+                }
+            }
+        }
+    }
+
+    private func sectionLabel(_ title: String) -> some View {
+        HStack {
+            Text(title)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(Theme.textSecondary)
+                .textCase(.uppercase)
+            Spacer()
+        }
+        .padding(.top, Theme.Spacing.sm)
+    }
+
+    // MARK: - Empty States
+
+    private var emptyState: some View {
+        VStack(spacing: Theme.Spacing.sm) {
+            Image(systemName: category.icon)
+                .font(.largeTitle)
+                .foregroundStyle(Theme.textTertiary)
+            Text(category.emptyStateTitle)
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(Theme.textPrimary)
+            Text(category.emptyStateMessage)
+                .font(Theme.fontCaption)
+                .foregroundStyle(Theme.textSecondary)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 60)
+    }
+
+    private var filteredEmptyState: some View {
+        VStack(spacing: Theme.Spacing.sm) {
+            Image(systemName: "line.3.horizontal.decrease")
+                .font(.largeTitle)
+                .foregroundStyle(Theme.textTertiary)
+            Text("No matches")
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(Theme.textPrimary)
+            Text("Try clearing a filter or search term.")
+                .font(Theme.fontCaption)
+                .foregroundStyle(Theme.textSecondary)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 60)
+    }
+
+    // MARK: - Warmup gating (mirrors WorkoutView for template starts)
+
+    private func requestStart(stretches: [Stretch], action: @escaping () -> Void) {
+        pendingStart = action
+        pendingStretches = stretches
+
+        switch warmupOptIn {
+        case "yes":
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) {
+                showWarmup = true
+            }
+        case "no":
+            runPendingStartImmediately()
+        default:
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) {
+                showWarmupPrompt = true
+            }
+        }
+    }
+
+    private func runPendingStartImmediately() {
+        let action = pendingStart
+        pendingStart = nil
+        pendingStretches = []
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+            action?()
+        }
+    }
+}

--- a/Xomfit/Views/Workout/WorkoutView.swift
+++ b/Xomfit/Views/Workout/WorkoutView.swift
@@ -6,17 +6,21 @@ struct WorkoutView: View {
 
     @State private var showNameEntry = false
     @State private var pendingWorkoutName = ""
-    @State private var showTemplateList = false
     @State private var showBuilder = false
     @State private var showLogPastWorkout = false
     @State private var previewTemplate: WorkoutTemplate?
-    @State private var templateRefreshId = UUID()
-    @State private var recentWorkouts: [Workout] = []
+
+    /// Shared data store for the Quick Hitter previews and the See-All pages.
+    /// Owned here so the same loaded data backs both the previews and the
+    /// dedicated category pages without re-fetching on push.
+    @State private var viewModel = WorkoutTabViewModel()
+
     private var hasStartedFirstWorkout: Bool {
         UserDefaults.standard.bool(forKey: "xomfit_first_workout_started")
     }
-    @State private var myTemplates: [WorkoutTemplate] = []
-    @State private var savedTemplates: [WorkoutTemplate] = []
+
+    /// Number of items shown in each Quick Hitter preview before "See All".
+    private let previewCount = 4
 
     // MARK: - Warmup flow (#261)
 
@@ -99,27 +103,14 @@ struct WorkoutView: View {
                             .padding(.horizontal, Theme.Spacing.md)
 
                             // First workout guide for new users
-                            if recentWorkouts.isEmpty && !hasStartedFirstWorkout {
+                            if viewModel.recent.isEmpty && !hasStartedFirstWorkout {
                                 firstWorkoutCard
                             }
 
-                            // Quick Start templates
-                            templateSection
-
-                            // Recent workouts
-                            if !recentWorkouts.isEmpty {
-                                recentSection
-                            }
-
-                            // My Workouts (custom templates)
-                            if !myTemplates.isEmpty {
-                                myWorkoutsSection
-                            }
-
-                            // Saved Workouts
-                            if !savedTemplates.isEmpty {
-                                savedSection
-                            }
+                            // Quick Hitter sections (vertical previews + See All)
+                            recentsQuickHitters
+                            preGeneratedQuickHitters
+                            friendsAndSavedQuickHitters
                         }
                     }
                 }
@@ -128,11 +119,11 @@ struct WorkoutView: View {
             .navigationBarTitleDisplayMode(.large)
             .toolbarColorScheme(.dark, for: .navigationBar)
             .task {
-                await loadSections()
+                await viewModel.load(userId: userId)
             }
             .onChange(of: workoutSession.isPresented) { _, isPresented in
                 if !isPresented {
-                    Task { await loadSections() }
+                    Task { await viewModel.load(userId: userId) }
                 }
             }
         }
@@ -176,31 +167,22 @@ struct WorkoutView: View {
             }
         }
         .sheet(isPresented: $showBuilder, onDismiss: {
-            templateRefreshId = UUID()
-            Task { await loadSections() }
+            Task { await viewModel.load(userId: userId) }
         }) {
             WorkoutBuilderView()
         }
         .sheet(isPresented: $showLogPastWorkout, onDismiss: {
-            Task { await loadSections() }
+            Task { await viewModel.load(userId: userId) }
         }) {
             LogPastWorkoutView()
         }
         .sheet(item: $previewTemplate) { template in
             TemplateDetailView(template: template) {
+                let captured = template
                 previewTemplate = nil
-                requestStart(stretches: StretchDatabase.suggestedStretches(for: template, target: TimeInterval(warmupMinutes * 60))) {
-                    workoutSession.startFromTemplate(template, userId: userId)
+                requestStart(stretches: StretchDatabase.suggestedStretches(for: captured, target: TimeInterval(warmupMinutes * 60))) {
+                    workoutSession.startFromTemplate(captured, userId: userId)
                     workoutSession.isPresented = true
-                }
-            }
-        }
-        .sheet(isPresented: $showTemplateList) {
-            TemplateListView { template in
-                // Dismiss the list first, then show preview after a brief delay
-                showTemplateList = false
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-                    previewTemplate = template
                 }
             }
         }
@@ -254,111 +236,114 @@ struct WorkoutView: View {
         .padding(.horizontal, Theme.Spacing.md)
     }
 
-    // MARK: - Templates
+    // MARK: - Quick Hitter Sections
 
-    private var templateSection: some View {
-        VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
-            HStack {
-                Text("Quick Start")
-                    .font(.body.weight(.bold))
-                    .foregroundStyle(Theme.textPrimary)
-                Spacer()
-                Button {
-                    showTemplateList = true
+    /// Header row used by each Quick Hitter section. Tappable "See All" pushes
+    /// the dedicated category page.
+    private func sectionHeader(for category: WorkoutCategory, showSeeAll: Bool) -> some View {
+        HStack {
+            Text(category.title)
+                .font(.body.weight(.bold))
+                .foregroundStyle(Theme.textPrimary)
+            Spacer()
+            if showSeeAll {
+                NavigationLink {
+                    WorkoutCategoryPage(category: category, viewModel: viewModel)
                 } label: {
-                    Text("See All")
-                        .font(.caption.weight(.semibold))
-                        .foregroundStyle(Theme.accent)
-                }
-            }
-            .padding(.horizontal, Theme.Spacing.md)
-
-            ScrollView(.horizontal, showsIndicators: false) {
-                HStack(spacing: Theme.Spacing.sm) {
-                    ForEach(Array(TemplateService.shared.allTemplates().prefix(6).enumerated()), id: \.element.id) { index, template in
-                        TemplateCardView(template: template) {
-                            previewTemplate = template
-                        }
-                        .staggeredAppear(index: index)
+                    HStack(spacing: 4) {
+                        Text("See All")
+                            .font(.caption.weight(.semibold))
+                        Image(systemName: "chevron.right")
+                            .font(.caption2.weight(.semibold))
                     }
+                    .foregroundStyle(Theme.accent)
                 }
-                .padding(.horizontal, Theme.Spacing.md)
-                .id(templateRefreshId)
+                .accessibilityLabel("See all \(category.title.lowercased())")
             }
         }
-        .padding(.vertical, Theme.Spacing.sm)
+        .padding(.horizontal, Theme.Spacing.md)
     }
 
-    // MARK: - Recent Workouts
+    @ViewBuilder
+    private var recentsQuickHitters: some View {
+        if !viewModel.recent.isEmpty {
+            VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+                sectionHeader(for: .recents, showSeeAll: viewModel.recent.count > previewCount)
 
-    private var recentSection: some View {
-        VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
-            Text("Recent")
-                .font(.body.weight(.bold))
-                .foregroundStyle(Theme.textPrimary)
-                .padding(.horizontal, Theme.Spacing.md)
-
-            ScrollView(.horizontal, showsIndicators: false) {
-                HStack(spacing: Theme.Spacing.sm) {
-                    ForEach(Array(recentWorkouts.prefix(5).enumerated()), id: \.element.id) { index, workout in
-                        TemplateCardView(template: templateFromWorkout(workout)) {
-                            previewTemplate = templateFromWorkout(workout)
+                VStack(spacing: Theme.Spacing.xs) {
+                    ForEach(Array(viewModel.recent.prefix(previewCount))) { workout in
+                        NavigationLink {
+                            WorkoutDetailView(workout: workout)
+                        } label: {
+                            RecentWorkoutCard(workout: workout, style: .row) { /* handled by link */ }
+                                .allowsHitTesting(false)
                         }
-                        .staggeredAppear(index: index)
+                        .buttonStyle(.plain)
+                        .accessibilityLabel("\(workout.name), \(workout.startTime.timeAgo)")
                     }
                 }
                 .padding(.horizontal, Theme.Spacing.md)
             }
+            .padding(.vertical, Theme.Spacing.sm)
         }
-        .padding(.vertical, Theme.Spacing.sm)
     }
 
-    // MARK: - My Workouts
+    @ViewBuilder
+    private var preGeneratedQuickHitters: some View {
+        if !viewModel.builtInTemplates.isEmpty {
+            VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+                sectionHeader(for: .preGenerated, showSeeAll: viewModel.builtInTemplates.count > previewCount)
 
-    private var myWorkoutsSection: some View {
-        VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
-            Text("My Workouts")
-                .font(.body.weight(.bold))
-                .foregroundStyle(Theme.textPrimary)
-                .padding(.horizontal, Theme.Spacing.md)
-
-            ScrollView(.horizontal, showsIndicators: false) {
-                HStack(spacing: Theme.Spacing.sm) {
-                    ForEach(Array(myTemplates.enumerated()), id: \.element.id) { index, template in
-                        TemplateCardView(template: template) {
+                VStack(spacing: Theme.Spacing.xs) {
+                    ForEach(Array(viewModel.builtInTemplates.prefix(previewCount))) { template in
+                        TemplateCardView(template: template, style: .row) {
                             previewTemplate = template
                         }
-                        .staggeredAppear(index: index)
                     }
                 }
                 .padding(.horizontal, Theme.Spacing.md)
             }
+            .padding(.vertical, Theme.Spacing.sm)
         }
-        .padding(.vertical, Theme.Spacing.sm)
     }
 
-    // MARK: - Saved Workouts
+    @ViewBuilder
+    private var friendsAndSavedQuickHitters: some View {
+        let combinedTemplates = viewModel.myTemplates + viewModel.savedTemplates
+        let friendItems = viewModel.friendWorkouts
+        let totalCount = combinedTemplates.count + friendItems.count
 
-    private var savedSection: some View {
-        VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
-            Text("Saved Workouts")
-                .font(.body.weight(.bold))
-                .foregroundStyle(Theme.textPrimary)
-                .padding(.horizontal, Theme.Spacing.md)
+        if totalCount > 0 {
+            VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+                sectionHeader(for: .friendsAndSaved, showSeeAll: totalCount > previewCount)
 
-            ScrollView(.horizontal, showsIndicators: false) {
-                HStack(spacing: Theme.Spacing.sm) {
-                    ForEach(Array(savedTemplates.enumerated()), id: \.element.id) { index, template in
-                        TemplateCardView(template: template) {
+                VStack(spacing: Theme.Spacing.xs) {
+                    // Templates first (own + saved), then friend workouts, capped at previewCount total.
+                    let templatePreview = Array(combinedTemplates.prefix(previewCount))
+                    let remainingSlots = max(0, previewCount - templatePreview.count)
+                    let friendPreview = Array(friendItems.prefix(remainingSlots))
+
+                    ForEach(templatePreview) { template in
+                        TemplateCardView(template: template, style: .row) {
                             previewTemplate = template
                         }
-                        .staggeredAppear(index: index)
+                    }
+
+                    ForEach(friendPreview) { workout in
+                        NavigationLink {
+                            WorkoutDetailView(workout: workout)
+                        } label: {
+                            RecentWorkoutCard(workout: workout, style: .row) { /* handled by link */ }
+                                .allowsHitTesting(false)
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityLabel("Friend workout: \(workout.name)")
                     }
                 }
                 .padding(.horizontal, Theme.Spacing.md)
             }
+            .padding(.vertical, Theme.Spacing.sm)
         }
-        .padding(.vertical, Theme.Spacing.sm)
     }
 
     // MARK: - Warmup gating (#261)
@@ -397,36 +382,5 @@ struct WorkoutView: View {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
             action?()
         }
-    }
-
-    // MARK: - Data Loading
-
-    private func loadSections() async {
-        guard !userId.isEmpty else { return }
-        recentWorkouts = await WorkoutService.shared.fetchWorkouts(userId: userId)
-        let allCustom = TemplateService.shared.allTemplates().filter { $0.isCustom }
-        myTemplates = allCustom.filter { $0.category != .saved }
-        savedTemplates = allCustom.filter { $0.category == .saved }
-    }
-
-    private func templateFromWorkout(_ workout: Workout) -> WorkoutTemplate {
-        let exercises = workout.exercises.map { ex in
-            WorkoutTemplate.TemplateExercise(
-                id: UUID().uuidString,
-                exercise: ex.exercise,
-                targetSets: ex.sets.count,
-                targetReps: ex.bestSet.map { "\($0.reps)" } ?? "8",
-                notes: ex.notes
-            )
-        }
-        return WorkoutTemplate(
-            id: "recent-\(workout.id)",
-            name: workout.name,
-            description: "From \(workout.startTime.workoutDateString)",
-            exercises: exercises,
-            estimatedDuration: Int(workout.duration / 60),
-            category: .custom,
-            isCustom: false
-        )
     }
 }


### PR DESCRIPTION
Closes #249
Closes #281

## Summary
Replaces the 4 horizontal-scrolling carousels on the workout tab with 3 vertical **Quick Hitters** sections + dedicated **See All** category pages.

- Recents (last few past workouts)
- Pre-generated (built-in templates)
- Friends & Saved (your saved templates + friends' recent workouts)

Each preview shows ~4 items + a 'See All →' link. The See All page has search + the existing `WorkoutFilterBar` chips and lists every item in that category.

## What it reuses
- `WorkoutTabViewModel` (kept — already had every data slice we need)
- `WorkoutFilter` / `WorkoutFilterBar` (kept)
- `RecentWorkoutCard(style: .row)` / `TemplateCardView(style: .row)` (#249 foundation)

## Untouched
- Start Workout / Build / Log Past CTAs
- Warmup prompt + sheet (#261)
- `WorkoutLoggerViewModel`, `MainTabView`, `ActiveWorkoutView`

## Files
- modified: `Xomfit/Views/Workout/WorkoutView.swift`
- new: `Xomfit/Views/Workout/WorkoutCategoryPage.swift`

Closes the #249 follow-up since this is the new design.

## Test plan
- [ ] Workout tab loads — top action area unchanged, 3 vertical Quick Hitters sections appear
- [ ] Each See All button pushes a category page with the right list
- [ ] Filter chips on each page filter the list (filter is per-page, not shared)
- [ ] Tapping a recent workout opens the existing detail; tapping a template opens TemplateDetailView
- [ ] Warmup prompt still appears via Start Workout / template start (#261 unbroken)