### PR TITLE
#252 ai coach: streaming, conversation persistence, build_workout tool

### DIFF
--- a/Xomfit/Models/AICoachMessage.swift
+++ b/Xomfit/Models/AICoachMessage.swift
@@ -1,8 +1,9 @@
 import Foundation
 
-/// A single message in the AI Coach chat session. In-memory only for v1.
-struct AICoachMessage: Identifiable, Equatable {
-    enum Role: String {
+/// A single message in the AI Coach chat session.
+/// Persisted to UserDefaults via `AICoachViewModel.persist()`.
+struct AICoachMessage: Identifiable, Equatable, Codable {
+    enum Role: String, Codable {
         case user
         case assistant
     }
@@ -13,18 +14,41 @@ struct AICoachMessage: Identifiable, Equatable {
     let createdAt: Date
     /// True while the assistant is actively streaming tokens into `text`.
     var isStreaming: Bool
+    /// Populated when the assistant emitted a `build_workout` tool use call
+    /// during this turn. Used by the chat view to render a Save/Start card
+    /// inline under the message.
+    var workoutPayload: WorkoutBuildPayload?
 
     init(
         id: UUID = UUID(),
         role: Role,
         text: String,
         createdAt: Date = Date(),
-        isStreaming: Bool = false
+        isStreaming: Bool = false,
+        workoutPayload: WorkoutBuildPayload? = nil
     ) {
         self.id = id
         self.role = role
         self.text = text
         self.createdAt = createdAt
         self.isStreaming = isStreaming
+        self.workoutPayload = workoutPayload
+    }
+}
+
+// MARK: - Tool-use payload
+
+/// Decoded `build_workout` tool input emitted by Claude.
+/// Mirrors the JSON schema declared in `AICoachService.buildWorkoutTool`.
+struct WorkoutBuildPayload: Codable, Equatable {
+    var name: String
+    var estimatedDurationMinutes: Int?
+    var exercises: [Exercise]
+
+    struct Exercise: Codable, Equatable {
+        var exerciseId: String
+        var sets: Int
+        var targetReps: Int
+        var targetWeight: Double?
     }
 }

--- a/Xomfit/Services/AICoachService.swift
+++ b/Xomfit/Services/AICoachService.swift
@@ -28,13 +28,32 @@ enum AICoachServiceError: LocalizedError {
     }
 }
 
+// MARK: - Streaming events
+
+/// Higher-level events surfaced to the view model from a streaming SSE response.
+/// We collapse Anthropic's lower-level event taxonomy into something the view
+/// model can act on directly (append text, capture a tool-use payload, finish).
+enum AICoachStreamEvent {
+    /// Text delta for the assistant bubble. Append to the in-progress message.
+    case textDelta(String)
+    /// A `build_workout` tool call resolved to a parseable payload.
+    /// Attach it to the assistant message so the chat can render the action card.
+    case toolUse(WorkoutBuildPayload)
+    /// Stream finished cleanly (`message_stop`).
+    case done
+}
+
 // MARK: - Service
 
 /// Direct REST client for Anthropic's Messages API.
 ///
-/// v1 scope: non-streaming text replies. Streaming via SSE (`stream: true`)
-/// is a TODO — wire it through `URLSession.bytes(for:)` and parse
-/// `content_block_delta` / `message_delta` events.
+/// - Streaming via SSE (`stream: true`) using `URLSession.bytes(for:)`.
+///   `sendMessageStream` parses `content_block_delta` / `input_json_delta` /
+///   `message_stop` and yields `AICoachStreamEvent`s the view model can apply
+///   token-by-token.
+/// - Tool use: declares a single `build_workout` tool. When the model calls it,
+///   we accumulate `input_json_delta` chunks and emit a single `.toolUse` event
+///   with the decoded `WorkoutBuildPayload` once `content_block_stop` arrives.
 ///
 /// API docs: https://docs.claude.com/en/api/messages
 final class AICoachService {
@@ -46,10 +65,15 @@ final class AICoachService {
     static let defaultModel = "claude-sonnet-4-6"
     static let defaultMaxTokens = 1024
 
-    /// Base system prompt. Profile context is appended on top of this when present.
+    /// Base system prompt. Profile and exercise catalog context are appended
+    /// on top of this when present.
     static let baseSystemPrompt = """
     You are an expert lifting coach. Be terse. Output structured workout \
-    suggestions when relevant. Reference the user's profile data provided.
+    suggestions when relevant. Reference the user's profile data provided. \
+    When the user asks for a workout, plan, or routine, call the \
+    `build_workout` tool with concrete exercises so the app can render a \
+    Save / Start card under your reply. Only use exerciseIds present in the \
+    provided exercise catalog.
     """
 
     // MARK: Init
@@ -79,49 +103,107 @@ final class AICoachService {
 
     // MARK: - System prompt builder
 
-    /// Builds the system prompt by prepending the user's fitness profile (if any).
+    /// Builds the system prompt by prepending the user's fitness profile (if any)
+    /// and appending a compressed exercise-catalog hint so the model can pick
+    /// valid `exerciseId`s for `build_workout` calls.
     static func systemPrompt(profile: UserFitnessProfile) -> String {
-        guard profile.isComplete else { return baseSystemPrompt }
+        var prompt = baseSystemPrompt
 
-        var lines: [String] = ["User profile:"]
-        if let goal = profile.primaryGoal {
-            lines.append("- Primary goal: \(goal.title)")
-        }
-        if let experience = profile.experience {
-            lines.append("- Experience: \(experience.title)")
-        }
-        if let workouts = profile.workoutsPerWeek {
-            lines.append("- Workouts per week: \(workouts.title)")
-        }
-        if let split = profile.preferredSplit {
-            lines.append("- Preferred split: \(split.title)")
-        }
-        if let length = profile.sessionLength {
-            lines.append("- Session length: \(length.title)")
+        if profile.isComplete {
+            var lines: [String] = ["User profile:"]
+            if let goal = profile.primaryGoal {
+                lines.append("- Primary goal: \(goal.title)")
+            }
+            if let experience = profile.experience {
+                lines.append("- Experience: \(experience.title)")
+            }
+            if let workouts = profile.workoutsPerWeek {
+                lines.append("- Workouts per week: \(workouts.title)")
+            }
+            if let split = profile.preferredSplit {
+                lines.append("- Preferred split: \(split.title)")
+            }
+            if let length = profile.sessionLength {
+                lines.append("- Session length: \(length.title)")
+            }
+            // Only prepend if we actually got fields out (defensive).
+            if lines.count > 1 {
+                prompt = lines.joined(separator: "\n") + "\n\n" + prompt
+            }
         }
 
-        // No profile fields filled in despite completedAt — fall back to base.
-        if lines.count == 1 { return baseSystemPrompt }
+        let catalog = exerciseCatalogHint()
+        if !catalog.isEmpty {
+            prompt += "\n\nExercise catalog (id, name, equipment):\n" + catalog
+        }
 
-        return lines.joined(separator: "\n") + "\n\n" + baseSystemPrompt
+        return prompt
     }
 
-    // MARK: - Send (non-streaming)
+    /// Compressed exercise catalog used to seed the system prompt so the model
+    /// knows which `exerciseId`s are valid for `build_workout`.
+    /// Truncated to ~3000 chars to keep token usage bounded.
+    static func exerciseCatalogHint(maxChars: Int = 3000) -> String {
+        let entries = ExerciseDatabase.all.map { ex in
+            "\(ex.id)|\(ex.name)|\(ex.equipment.rawValue)"
+        }
+        let joined = entries.joined(separator: ", ")
+        if joined.count <= maxChars { return joined }
+        // Truncate at the last comma boundary so we don't slice an id mid-string.
+        let cut = joined.prefix(maxChars)
+        if let lastComma = cut.lastIndex(of: ",") {
+            return String(cut[..<lastComma])
+        }
+        return String(cut)
+    }
 
-    /// Sends the conversation to Anthropic and returns the assistant's text reply.
+    // MARK: - Send (streaming)
+
+    /// Sends the conversation to Anthropic with SSE streaming enabled and yields
+    /// higher-level `AICoachStreamEvent`s. Throws on transport / HTTP / decode
+    /// failures.
+    ///
     /// - Parameters:
     ///   - messages: prior chat history, in order. User and assistant only — no system.
     ///   - profile: user fitness profile to seed the system prompt.
-    ///   - apiKeyOverride: optional runtime key (Settings). Falls back to Config.
+    ///   - apiKeyOverride: optional runtime key (Settings).
     ///   - model: model id; defaults to `defaultModel`.
     ///   - maxTokens: response cap; defaults to `defaultMaxTokens`.
-    func sendMessage(
+    func sendMessageStream(
         messages: [AICoachMessage],
         profile: UserFitnessProfile = .current,
         apiKeyOverride: String? = nil,
         model: String = AICoachService.defaultModel,
         maxTokens: Int = AICoachService.defaultMaxTokens
-    ) async throws -> String {
+    ) -> AsyncThrowingStream<AICoachStreamEvent, Error> {
+        AsyncThrowingStream { continuation in
+            let task = Task { [self] in
+                do {
+                    try await self.runStream(
+                        messages: messages,
+                        profile: profile,
+                        apiKeyOverride: apiKeyOverride,
+                        model: model,
+                        maxTokens: maxTokens,
+                        continuation: continuation
+                    )
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+            continuation.onTermination = { _ in task.cancel() }
+        }
+    }
+
+    private func runStream(
+        messages: [AICoachMessage],
+        profile: UserFitnessProfile,
+        apiKeyOverride: String?,
+        model: String,
+        maxTokens: Int,
+        continuation: AsyncThrowingStream<AICoachStreamEvent, Error>.Continuation
+    ) async throws {
         guard let apiKey = Self.resolvedAPIKey(runtimeOverride: apiKeyOverride) else {
             throw AICoachServiceError.missingAPIKey
         }
@@ -130,12 +212,15 @@ final class AICoachService {
             model: model,
             maxTokens: maxTokens,
             system: Self.systemPrompt(profile: profile),
-            messages: messages.map { AnthropicMessage(role: $0.role.rawValue, content: $0.text) }
+            messages: messages.map { AnthropicMessage(role: $0.role.rawValue, content: $0.text) },
+            stream: true,
+            tools: [Self.buildWorkoutTool]
         )
 
         var request = URLRequest(url: endpoint)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("text/event-stream", forHTTPHeaderField: "Accept")
         request.setValue(apiKey, forHTTPHeaderField: "x-api-key")
         request.setValue(anthropicVersion, forHTTPHeaderField: "anthropic-version")
 
@@ -145,10 +230,10 @@ final class AICoachService {
             throw AICoachServiceError.decoding(error)
         }
 
-        let data: Data
+        let bytes: URLSession.AsyncBytes
         let response: URLResponse
         do {
-            (data, response) = try await session.data(for: request)
+            (bytes, response) = try await session.bytes(for: request)
         } catch {
             throw AICoachServiceError.transport(error)
         }
@@ -158,21 +243,92 @@ final class AICoachService {
         }
 
         guard (200..<300).contains(http.statusCode) else {
+            // On error responses Anthropic still returns JSON (not SSE).
+            let data = try await Self.collect(bytes)
             let message = Self.extractErrorMessage(from: data)
             throw AICoachServiceError.http(status: http.statusCode, message: message)
         }
 
-        do {
-            let decoded = try JSONDecoder().decode(AnthropicResponse.self, from: data)
-            return decoded.content
-                .compactMap { $0.type == "text" ? $0.text : nil }
-                .joined()
-        } catch {
-            throw AICoachServiceError.decoding(error)
+        // SSE parser state.
+        // Anthropic content blocks are indexed; we track the in-progress
+        // tool_use block (only one expected for build_workout) and append
+        // input_json_delta partials until content_block_stop fires.
+        var pendingToolJSON = ""
+        var inToolBlock = false
+
+        for try await line in bytes.lines {
+            if Task.isCancelled { return }
+            // SSE event format: lines starting with "data: " carry JSON payloads.
+            // "event:" lines are informational — the JSON payload also contains a
+            // `type` field, so we key off that and ignore the event line.
+            guard line.hasPrefix("data:") else { continue }
+            let payload = line.dropFirst("data:".count)
+                .trimmingCharacters(in: .whitespaces)
+            if payload.isEmpty || payload == "[DONE]" { continue }
+
+            guard let data = payload.data(using: .utf8) else { continue }
+
+            // Decode the discriminator first; lots of event shapes share fields.
+            let envelope: SSEEnvelope
+            do {
+                envelope = try JSONDecoder().decode(SSEEnvelope.self, from: data)
+            } catch {
+                // Skip lines we can't parse — keep streaming.
+                continue
+            }
+
+            switch envelope.type {
+            case "content_block_start":
+                if let block = envelope.content_block {
+                    if block.type == "tool_use" {
+                        inToolBlock = true
+                        pendingToolJSON = ""
+                    } else {
+                        inToolBlock = false
+                    }
+                }
+
+            case "content_block_delta":
+                guard let delta = envelope.delta else { continue }
+                if delta.type == "text_delta", let text = delta.text {
+                    continuation.yield(.textDelta(text))
+                } else if delta.type == "input_json_delta", let partial = delta.partial_json {
+                    pendingToolJSON += partial
+                }
+
+            case "content_block_stop":
+                if inToolBlock {
+                    inToolBlock = false
+                    if let payload = Self.decodeWorkoutPayload(json: pendingToolJSON) {
+                        continuation.yield(.toolUse(payload))
+                    }
+                    pendingToolJSON = ""
+                }
+
+            case "message_stop":
+                continuation.yield(.done)
+                return
+
+            default:
+                continue
+            }
         }
     }
 
     // MARK: - Helpers
+
+    private static func collect(_ bytes: URLSession.AsyncBytes) async throws -> Data {
+        var data = Data()
+        for try await byte in bytes {
+            data.append(byte)
+        }
+        return data
+    }
+
+    private static func decodeWorkoutPayload(json: String) -> WorkoutBuildPayload? {
+        guard let data = json.data(using: .utf8) else { return nil }
+        return try? JSONDecoder().decode(WorkoutBuildPayload.self, from: data)
+    }
 
     private static func extractErrorMessage(from data: Data) -> String? {
         // Anthropic error shape: { "type": "error", "error": { "type": ..., "message": ... } }
@@ -183,6 +339,49 @@ final class AICoachService {
         }
         return String(data: data, encoding: .utf8)
     }
+}
+
+// MARK: - Tool definition
+
+extension AICoachService {
+    /// `build_workout` tool. The model calls this when the user asks for a
+    /// workout, plan, or routine. Returned `exerciseId`s must come from the
+    /// catalog injected into the system prompt.
+    static let buildWorkoutTool: AnthropicTool = AnthropicTool(
+        name: "build_workout",
+        description: "Create a workout plan with exercises and target sets/reps/weight. Return when the user asks for a workout, plan, or routine.",
+        inputSchema: .object([
+            "type": .string("object"),
+            "properties": .object([
+                "name": .object(["type": .string("string")]),
+                "estimatedDurationMinutes": .object(["type": .string("integer")]),
+                "exercises": .object([
+                    "type": .string("array"),
+                    "items": .object([
+                        "type": .string("object"),
+                        "properties": .object([
+                            "exerciseId": .object([
+                                "type": .string("string"),
+                                "description": .string("id from ExerciseDatabase")
+                            ]),
+                            "sets": .object(["type": .string("integer")]),
+                            "targetReps": .object(["type": .string("integer")]),
+                            "targetWeight": .object(["type": .string("number")])
+                        ]),
+                        "required": .array([
+                            .string("exerciseId"),
+                            .string("sets"),
+                            .string("targetReps")
+                        ])
+                    ])
+                ])
+            ]),
+            "required": .array([
+                .string("name"),
+                .string("exercises")
+            ])
+        ])
+    )
 }
 
 // MARK: - Wire types
@@ -197,19 +396,72 @@ private struct AnthropicRequest: Encodable {
     let maxTokens: Int
     let system: String
     let messages: [AnthropicMessage]
+    let stream: Bool
+    let tools: [AnthropicTool]?
 
     enum CodingKeys: String, CodingKey {
         case model
         case maxTokens = "max_tokens"
         case system
         case messages
+        case stream
+        case tools
     }
 }
 
-private struct AnthropicResponse: Decodable {
-    struct Block: Decodable {
-        let type: String
-        let text: String?
+/// Tool definition payload. Encoded as `{ name, description, input_schema }`.
+struct AnthropicTool: Encodable {
+    let name: String
+    let description: String
+    let inputSchema: JSONValue
+
+    enum CodingKeys: String, CodingKey {
+        case name
+        case description
+        case inputSchema = "input_schema"
     }
-    let content: [Block]
+}
+
+/// Minimal JSON value type so we can encode the tool's `input_schema` declaratively
+/// without leaking `Any` into the request body.
+enum JSONValue: Encodable {
+    case string(String)
+    case number(Double)
+    case bool(Bool)
+    case array([JSONValue])
+    case object([String: JSONValue])
+    case null
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .string(let v): try container.encode(v)
+        case .number(let v): try container.encode(v)
+        case .bool(let v): try container.encode(v)
+        case .array(let v): try container.encode(v)
+        case .object(let v): try container.encode(v)
+        case .null: try container.encodeNil()
+        }
+    }
+}
+
+// MARK: - SSE event decoding
+
+private struct SSEEnvelope: Decodable {
+    let type: String
+    let index: Int?
+    let content_block: ContentBlock?
+    let delta: Delta?
+
+    struct ContentBlock: Decodable {
+        let type: String
+        let id: String?
+        let name: String?
+    }
+
+    struct Delta: Decodable {
+        let type: String?
+        let text: String?
+        let partial_json: String?
+    }
 }

--- a/Xomfit/ViewModels/AICoachViewModel.swift
+++ b/Xomfit/ViewModels/AICoachViewModel.swift
@@ -1,7 +1,11 @@
 import Foundation
 import Observation
 
-/// View model for the AI Coach chat. In-memory message list per app launch (v1).
+/// View model for the AI Coach chat.
+/// - Streams replies token-by-token via `AICoachService.sendMessageStream`.
+/// - Persists the last 50 messages to UserDefaults under `aiCoach.conversation`.
+/// - Captures `build_workout` tool calls and surfaces them on the assistant
+///   message so the chat view can render an inline Save / Start card.
 @MainActor
 @Observable
 final class AICoachViewModel {
@@ -26,13 +30,22 @@ final class AICoachViewModel {
         "Help me hit a 225 bench"
     ]
 
+    // MARK: - Persistence
+
+    /// Storage key for the conversation history.
+    private static let storageKey = "aiCoach.conversation"
+    /// Cap on stored history so the UserDefaults blob doesn't grow unbounded.
+    private static let historyCap = 50
+
     // MARK: - Dependencies
 
     private let service: AICoachService
-    /// Runtime override for the API key (read from Settings via @AppStorage).
-    /// The view passes this in on each send.
-    init(service: AICoachService = .shared) {
+    private let defaults: UserDefaults
+
+    init(service: AICoachService = .shared, defaults: UserDefaults = .standard) {
         self.service = service
+        self.defaults = defaults
+        self.messages = Self.loadPersisted(from: defaults)
     }
 
     // MARK: - Derived
@@ -52,6 +65,7 @@ final class AICoachViewModel {
     }
 
     /// Send the current draft. No-op when nothing to send.
+    /// Streams the response and updates the placeholder bubble in place.
     func send(apiKeyOverride: String?) async {
         let trimmed = draft.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty, !isSending else { return }
@@ -62,43 +76,159 @@ final class AICoachViewModel {
         draft = ""
         isSending = true
 
-        // Insert a placeholder assistant bubble that we'll replace when the
-        // reply arrives. Marked streaming so the UI can show a typing dot.
+        // Insert a placeholder assistant bubble that we'll stream into.
         let placeholderId = UUID()
         messages.append(
             AICoachMessage(id: placeholderId, role: .assistant, text: "", isStreaming: true)
         )
+        persist()
 
         do {
             // Send everything except the placeholder (last entry).
             let history = Array(messages.dropLast())
-            let reply = try await service.sendMessage(
+            let stream = service.sendMessageStream(
                 messages: history,
                 apiKeyOverride: apiKeyOverride
             )
-            replacePlaceholder(id: placeholderId, with: reply)
+
+            for try await event in stream {
+                switch event {
+                case .textDelta(let chunk):
+                    appendText(chunk, to: placeholderId)
+                case .toolUse(let payload):
+                    attachWorkoutPayload(payload, to: placeholderId)
+                case .done:
+                    finishStreaming(id: placeholderId)
+                }
+            }
+            // If the stream ended without an explicit `message_stop` (rare),
+            // still flip off the streaming flag.
+            finishStreaming(id: placeholderId)
         } catch {
             // Drop the placeholder and surface the error.
             messages.removeAll { $0.id == placeholderId }
             errorMessage = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+            persist()
         }
 
         isSending = false
     }
 
-    /// Clear the conversation and any pending error.
-    func reset() {
+    /// Clear the conversation, wipe the persisted blob, and reset transient state.
+    func clearConversation() {
         messages.removeAll()
         draft = ""
         errorMessage = nil
         isSending = false
+        persist()
     }
 
-    // MARK: - Private
+    /// Back-compat alias used by existing views.
+    func reset() { clearConversation() }
 
-    private func replacePlaceholder(id: UUID, with text: String) {
+    // MARK: - Tool actions
+
+    /// Build a `WorkoutTemplate` from a streamed `build_workout` payload.
+    /// Skips exercises whose ids aren't present in `ExerciseDatabase.all`
+    /// rather than failing the whole tool call. Returns nil if no usable
+    /// exercises survive the filter.
+    func buildTemplate(from payload: WorkoutBuildPayload) -> WorkoutTemplate? {
+        let templateExercises: [WorkoutTemplate.TemplateExercise] = payload.exercises.compactMap { item in
+            guard let exercise = ExerciseDatabase.all.first(where: { $0.id == item.exerciseId }) else {
+                return nil
+            }
+            let notes: String?
+            if let weight = item.targetWeight, weight > 0 {
+                notes = "Target weight: \(formatWeight(weight)) lb"
+            } else {
+                notes = nil
+            }
+            return WorkoutTemplate.TemplateExercise(
+                id: UUID().uuidString,
+                exercise: exercise,
+                targetSets: max(1, item.sets),
+                targetReps: "\(max(1, item.targetReps))",
+                notes: notes
+            )
+        }
+
+        guard !templateExercises.isEmpty else { return nil }
+
+        return WorkoutTemplate(
+            id: "tpl-ai-\(UUID().uuidString.prefix(8))",
+            name: payload.name,
+            description: "Built by AI Coach",
+            exercises: templateExercises,
+            estimatedDuration: payload.estimatedDurationMinutes ?? 45,
+            category: .custom,
+            isCustom: true
+        )
+    }
+
+    /// Save the AI-built template via `TemplateService`. Returns the persisted
+    /// template (or nil when no exercises mapped).
+    @discardableResult
+    func saveTemplate(from payload: WorkoutBuildPayload) -> WorkoutTemplate? {
+        guard let template = buildTemplate(from: payload) else {
+            errorMessage = "Couldn't save — none of the suggested exercises matched the catalog."
+            return nil
+        }
+        TemplateService.shared.saveCustomTemplate(template)
+        return template
+    }
+
+    // MARK: - Private (streaming)
+
+    private func appendText(_ chunk: String, to id: UUID) {
         guard let index = messages.firstIndex(where: { $0.id == id }) else { return }
-        messages[index].text = text
-        messages[index].isStreaming = false
+        messages[index].text += chunk
+        // Persist on each delta so a crash mid-stream still keeps progress.
+        // UserDefaults coalesces writes so this is cheap.
+        persist()
+    }
+
+    private func attachWorkoutPayload(_ payload: WorkoutBuildPayload, to id: UUID) {
+        guard let index = messages.firstIndex(where: { $0.id == id }) else { return }
+        messages[index].workoutPayload = payload
+        persist()
+    }
+
+    private func finishStreaming(id: UUID) {
+        guard let index = messages.firstIndex(where: { $0.id == id }) else { return }
+        if messages[index].isStreaming {
+            messages[index].isStreaming = false
+            persist()
+        }
+    }
+
+    // MARK: - Private (persistence)
+
+    private func persist() {
+        // Cap to last `historyCap` messages so the blob stays bounded.
+        let capped = messages.suffix(Self.historyCap)
+        let payload = Array(capped)
+        guard let data = try? JSONEncoder().encode(payload) else { return }
+        defaults.set(data, forKey: Self.storageKey)
+    }
+
+    private static func loadPersisted(from defaults: UserDefaults) -> [AICoachMessage] {
+        guard let data = defaults.data(forKey: storageKey) else { return [] }
+        guard var decoded = try? JSONDecoder().decode([AICoachMessage].self, from: data) else {
+            return []
+        }
+        // Defensive: never restore with a dangling streaming flag.
+        for i in decoded.indices where decoded[i].isStreaming {
+            decoded[i].isStreaming = false
+        }
+        return decoded
+    }
+
+    // MARK: - Private (formatting)
+
+    private func formatWeight(_ value: Double) -> String {
+        if value.rounded() == value {
+            return String(Int(value))
+        }
+        return String(format: "%.1f", value)
     }
 }

--- a/Xomfit/Views/AICoach/AICoachView.swift
+++ b/Xomfit/Views/AICoach/AICoachView.swift
@@ -4,13 +4,21 @@ import SwiftUI
 /// via `AICoachService` and seeds the system prompt with the user's
 /// `UserFitnessProfile` when available.
 ///
-/// v1 scope:
-/// - Plain-text replies (no streaming yet — TODO)
-/// - In-memory chat history per app launch (no persistence)
-/// - 3 suggestion chips when empty
+/// Scope:
+/// - Streaming replies (token-by-token) via SSE.
+/// - Conversation persisted to UserDefaults (last 50 messages).
+/// - `build_workout` tool: when the model calls it, an inline Save / Start
+///   card is rendered under the assistant message.
 struct AICoachView: View {
     @State private var viewModel = AICoachViewModel()
+    @State private var savedToast: Toast?
+    @State private var showClearConfirm = false
     @FocusState private var inputFocused: Bool
+
+    /// Workout session is optional — the chat is also reachable from Settings,
+    /// where it's not in scope. When absent, the "Start Now" card button is hidden.
+    @Environment(WorkoutLoggerViewModel.self) private var workoutSession: WorkoutLoggerViewModel?
+    @Environment(AuthService.self) private var authService: AuthService?
 
     /// Optional override key persisted by the user in Settings.
     /// Stored in `@AppStorage` for v1 — TODO Keychain.
@@ -40,17 +48,31 @@ struct AICoachView: View {
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
                 if !viewModel.isEmpty {
-                    Button {
+                    Button(role: .destructive) {
                         Haptics.light()
-                        viewModel.reset()
+                        showClearConfirm = true
                     } label: {
-                        Image(systemName: "arrow.counterclockwise")
+                        Image(systemName: "trash")
                             .foregroundStyle(Theme.textPrimary)
                     }
-                    .accessibilityLabel("Start new conversation")
+                    .accessibilityLabel("Clear conversation")
                 }
             }
         }
+        .confirmationDialog(
+            "Clear conversation?",
+            isPresented: $showClearConfirm,
+            titleVisibility: .visible
+        ) {
+            Button("Clear", role: .destructive) {
+                Haptics.medium()
+                viewModel.clearConversation()
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("This deletes the saved chat history on this device.")
+        }
+        .toast($savedToast)
     }
 
     // MARK: - Empty state
@@ -122,8 +144,19 @@ struct AICoachView: View {
             ScrollView {
                 LazyVStack(spacing: Theme.Spacing.md) {
                     ForEach(viewModel.messages) { message in
-                        AICoachMessageBubble(message: message)
-                            .id(message.id)
+                        VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+                            AICoachMessageBubble(message: message)
+                            if message.role == .assistant, let payload = message.workoutPayload {
+                                WorkoutBuildCard(
+                                    payload: payload,
+                                    canStart: workoutSession != nil && authService?.currentUser != nil,
+                                    onSave: { handleSave(payload: payload) },
+                                    onStart: { handleStart(payload: payload) }
+                                )
+                                .padding(.leading, 40) // align with bubble (past avatar)
+                            }
+                        }
+                        .id(message.id)
                     }
                 }
                 .padding(.horizontal, Theme.Spacing.md)
@@ -143,6 +176,27 @@ struct AICoachView: View {
         withAnimation(.xomChill) {
             proxy.scrollTo(last.id, anchor: .bottom)
         }
+    }
+
+    // MARK: - Tool actions
+
+    private func handleSave(payload: WorkoutBuildPayload) {
+        Haptics.medium()
+        if let template = viewModel.saveTemplate(from: payload) {
+            savedToast = Toast(style: .success, message: "Saved \"\(template.name)\" to templates")
+        }
+    }
+
+    private func handleStart(payload: WorkoutBuildPayload) {
+        guard
+            let workoutSession,
+            let userId = authService?.currentUser?.id.uuidString.lowercased(),
+            !userId.isEmpty,
+            let template = viewModel.buildTemplate(from: payload)
+        else { return }
+        Haptics.medium()
+        workoutSession.startFromTemplate(template, userId: userId)
+        workoutSession.isPresented = true
     }
 
     // MARK: - Error banner
@@ -293,6 +347,143 @@ private struct AICoachMessageBubble: View {
                     "\(message.role == .user ? "You" : "Coach") said: \(message.text)"
                 )
         }
+    }
+}
+
+// MARK: - Workout build card
+
+/// Inline card under an assistant message that called the `build_workout`
+/// tool. Lists the exercises and offers Save / Start actions.
+private struct WorkoutBuildCard: View {
+    let payload: WorkoutBuildPayload
+    let canStart: Bool
+    let onSave: () -> Void
+    let onStart: () -> Void
+
+    /// Resolved exercises from the catalog, in payload order. Items whose
+    /// `exerciseId` isn't in `ExerciseDatabase.all` are dropped — same skip
+    /// behaviour as `AICoachViewModel.buildTemplate`.
+    private var resolved: [(item: WorkoutBuildPayload.Exercise, exercise: Exercise)] {
+        payload.exercises.compactMap { item in
+            guard let ex = ExerciseDatabase.all.first(where: { $0.id == item.exerciseId }) else {
+                return nil
+            }
+            return (item, ex)
+        }
+    }
+
+    /// Number of exercises the model returned that we couldn't map. Surfaced
+    /// in the footer so users know why the saved template might be shorter.
+    private var skippedCount: Int { payload.exercises.count - resolved.count }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+            header
+
+            Divider().background(Theme.hairline)
+
+            VStack(alignment: .leading, spacing: 6) {
+                ForEach(Array(resolved.enumerated()), id: \.offset) { _, row in
+                    exerciseRow(item: row.item, exercise: row.exercise)
+                }
+                if resolved.isEmpty {
+                    Text("No matching exercises in your catalog yet.")
+                        .font(Theme.fontCaption)
+                        .foregroundStyle(Theme.textSecondary)
+                }
+                if skippedCount > 0 && !resolved.isEmpty {
+                    Text("\(skippedCount) exercise\(skippedCount == 1 ? "" : "s") skipped (unknown id)")
+                        .font(Theme.fontCaption)
+                        .foregroundStyle(Theme.textTertiary)
+                }
+            }
+
+            HStack(spacing: Theme.Spacing.sm) {
+                Button {
+                    onSave()
+                } label: {
+                    HStack(spacing: 6) {
+                        Image(systemName: "bookmark.fill")
+                        Text("Save as Template")
+                    }
+                    .frame(maxWidth: .infinity, minHeight: 44)
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(Theme.surfaceElevated)
+                .foregroundStyle(Theme.textPrimary)
+                .disabled(resolved.isEmpty)
+
+                Button {
+                    onStart()
+                } label: {
+                    HStack(spacing: 6) {
+                        Image(systemName: "play.fill")
+                        Text("Start Now")
+                    }
+                    .frame(maxWidth: .infinity, minHeight: 44)
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(Theme.accent)
+                .foregroundStyle(.black)
+                .disabled(resolved.isEmpty || !canStart)
+            }
+        }
+        .padding(Theme.Spacing.md)
+        .background(
+            RoundedRectangle(cornerRadius: Theme.Radius.md)
+                .fill(Theme.surface)
+                .overlay(
+                    RoundedRectangle(cornerRadius: Theme.Radius.md)
+                        .strokeBorder(Theme.accent.opacity(0.4), lineWidth: 0.5)
+                )
+        )
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Suggested workout: \(payload.name), \(resolved.count) exercises")
+    }
+
+    private var header: some View {
+        HStack(spacing: Theme.Spacing.sm) {
+            Image(systemName: "dumbbell.fill")
+                .foregroundStyle(Theme.accent)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(payload.name)
+                    .font(Theme.fontBody.weight(.semibold))
+                    .foregroundStyle(Theme.textPrimary)
+                if let mins = payload.estimatedDurationMinutes, mins > 0 {
+                    Text("~\(mins) min · \(resolved.count) exercise\(resolved.count == 1 ? "" : "s")")
+                        .font(Theme.fontCaption)
+                        .foregroundStyle(Theme.textSecondary)
+                } else {
+                    Text("\(resolved.count) exercise\(resolved.count == 1 ? "" : "s")")
+                        .font(Theme.fontCaption)
+                        .foregroundStyle(Theme.textSecondary)
+                }
+            }
+            Spacer(minLength: 0)
+        }
+    }
+
+    private func exerciseRow(item: WorkoutBuildPayload.Exercise, exercise: Exercise) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: Theme.Spacing.sm) {
+            Text(exercise.name)
+                .font(Theme.fontCaption.weight(.medium))
+                .foregroundStyle(Theme.textPrimary)
+                .lineLimit(1)
+            Spacer(minLength: 0)
+            Text(targetLine(item: item))
+                .font(Theme.fontCaption)
+                .foregroundStyle(Theme.textSecondary)
+                .monospacedDigit()
+        }
+    }
+
+    private func targetLine(item: WorkoutBuildPayload.Exercise) -> String {
+        var parts = ["\(item.sets)x\(item.targetReps)"]
+        if let w = item.targetWeight, w > 0 {
+            let weightStr: String = (w.rounded() == w) ? String(Int(w)) : String(format: "%.1f", w)
+            parts.append("@ \(weightStr) lb")
+        }
+        return parts.joined(separator: " ")
     }
 }
 


### PR DESCRIPTION
Closes #252

Builds on the first slice (PR #271 + #278 hotfix). Adds:

## What's new
1. **Streaming** — SSE via `URLSession.bytes(for:)` in `AICoachService.sendMessageStream`. Token-by-token bubble updates via the streaming placeholder.
2. **Persistence** — full message list to `UserDefaults` under `aiCoach.conversation` (capped at last 50). Restore on init, clear via toolbar trash icon (confirm dialog).
3. **Tool use: `build_workout`** — model can return a structured workout. Renders an inline 'Save as Template' / 'Start Now' card under the assistant message. Save → `TemplateService.shared.saveCustomTemplate`. Start → `WorkoutLoggerViewModel.startFromTemplate`. Unknown exercise ids are skipped with a footer note.
4. **Catalog hint** — system prompt appends a compressed list of `ExerciseDatabase.all` (id/name/equipment) so the model knows valid exerciseIds. Truncated at ~3000 chars.

## Files
- `Models/AICoachMessage.swift` — Codable + optional `workoutPayload`, new `WorkoutBuildPayload` struct
- `Services/AICoachService.swift` — streaming, tool definition, catalog hint
- `ViewModels/AICoachViewModel.swift` — stream consumer, persistence, save/start mappers
- `Views/AICoach/AICoachView.swift` — clear-conversation toolbar, `WorkoutBuildCard`

## Notable
- Clear conversation has a confirm dialog (destructive action)
- `targetWeight` from the tool is appended as a TemplateExercise note (no native target-weight field today)

## Test plan
- [ ] Set Anthropic key in Settings → AI Coach
- [ ] Send 'build me a push day' → bubble streams in token-by-token
- [ ] Tool card renders with Save/Start
- [ ] Save → template appears under My Templates
- [ ] Start → workout starts with the prefilled exercises
- [ ] Restart app → conversation history restored
- [ ] Trash icon → confirm → conversation cleared