### PR TITLE
#260 add Reports list + detail UI (backend-ready, fails gracefully when endpoints absent)

### DIFF
--- a/Xomfit/Models/UserReport.swift
+++ b/Xomfit/Models/UserReport.swift
@@ -1,0 +1,83 @@
+import Foundation
+
+// MARK: - UserReport
+//
+// Wire shape (snake_case) is decoded via `convertFromSnakeCase` on the
+// shared `JSONDecoder` configured in `ReportsService`. Backend payload:
+//
+//   {
+//     id, kind, period_start, period_end,
+//     stats_json: { total_volume, session_count, avg_session_minutes,
+//                   top_exercises: [{name, volume, sets}],
+//                   new_prs: [{exercise, weight, reps}] },
+//     recommendation_text, created_at,
+//     read_at, feedback_rating, feedback_text
+//   }
+//
+// `stats_json` decodes to `stats` because we apply `convertFromSnakeCase`
+// at decode time *and* declare it as `stats` here — matched via
+// `CodingKeys` overrides below.
+
+struct UserReport: Codable, Identifiable, Hashable {
+    let id: String
+    let kind: ReportKind
+    let periodStart: Date
+    let periodEnd: Date
+    let stats: Stats
+    let recommendationText: String
+    let createdAt: Date
+    let readAt: Date?
+    let feedbackRating: Int?
+    let feedbackText: String?
+
+    enum ReportKind: String, Codable, Hashable {
+        case weekly
+        case monthly
+    }
+
+    struct Stats: Codable, Hashable {
+        let totalVolume: Double
+        let sessionCount: Int
+        let avgSessionMinutes: Double
+        let topExercises: [TopExercise]
+        let newPRs: [NewPR]
+
+        // `new_prs` -> `newPrs` under default snake-case decoding,
+        // so we explicitly remap to `newPRs` for readable Swift naming.
+        enum CodingKeys: String, CodingKey {
+            case totalVolume
+            case sessionCount
+            case avgSessionMinutes
+            case topExercises
+            case newPRs = "newPrs"
+        }
+    }
+
+    struct TopExercise: Codable, Hashable {
+        let name: String
+        let volume: Double
+        let sets: Int
+    }
+
+    struct NewPR: Codable, Hashable {
+        let exercise: String
+        let weight: Double
+        let reps: Int
+    }
+
+    // The backend names the stats field `stats_json`; with
+    // `convertFromSnakeCase` that becomes `statsJson`, so map it
+    // back to our `stats` property.
+    enum CodingKeys: String, CodingKey {
+        case id
+        case kind
+        case periodStart
+        case periodEnd
+        case stats = "statsJson"
+        case recommendationText
+        case createdAt
+        case readAt
+        case feedbackRating
+        case feedbackText
+    }
+}

--- a/Xomfit/Services/ReportsService.swift
+++ b/Xomfit/Services/ReportsService.swift
@@ -1,0 +1,217 @@
+import Foundation
+import Supabase
+
+// MARK: - ReportsService
+//
+// Thin REST client for the Reports API (#260). The backend is being built
+// in parallel under `xomfit-backend` and lives behind the Supabase
+// project's Functions endpoint:
+//
+//     <supabaseURL>/functions/v1/api/reports
+//
+// Auth: forwards the current Supabase session JWT as a Bearer token, plus
+// the Supabase anon key as `apikey` (Edge Functions still require it).
+//
+// Resilience: until the backend ships, every endpoint returns "not found"
+// and the service silently no-ops instead of surfacing errors to the UI.
+// Network failures are also swallowed so the Reports tab loads to an
+// empty state offline rather than a red error wall.
+
+@MainActor
+final class ReportsService {
+    static let shared = ReportsService()
+
+    private let session: URLSession
+    private let decoder: JSONDecoder
+    private let encoder: JSONEncoder
+
+    private init(session: URLSession = .shared) {
+        self.session = session
+
+        let dec = JSONDecoder()
+        dec.keyDecodingStrategy = .convertFromSnakeCase
+        // Backend emits ISO-8601 with optional fractional seconds. Use
+        // the value-typed `Date.ISO8601FormatStyle` parsers so the
+        // strategy closure stays Sendable under strict concurrency.
+        dec.dateDecodingStrategy = .custom { decoder in
+            let container = try decoder.singleValueContainer()
+            let raw = try container.decode(String.self)
+            if let date = try? Date(raw, strategy: .iso8601) { return date }
+            if let date = try? Date(
+                raw,
+                strategy: .iso8601.year().month().day()
+                    .dateTimeSeparator(.standard)
+                    .time(includingFractionalSeconds: true)
+            ) { return date }
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "Unrecognized ISO-8601 date: \(raw)"
+            )
+        }
+        self.decoder = dec
+
+        let enc = JSONEncoder()
+        enc.keyEncodingStrategy = .convertToSnakeCase
+        self.encoder = enc
+    }
+
+    // MARK: - Public API
+
+    /// Fetches reports for the signed-in user.
+    /// Returns `[]` when the backend isn't deployed yet (404), the user
+    /// is signed out, or the request fails for any reason.
+    func fetchReports(kind: UserReport.ReportKind?) async throws -> [UserReport] {
+        var query: [URLQueryItem] = []
+        if let kind {
+            query.append(URLQueryItem(name: "kind", value: kind.rawValue))
+        }
+
+        do {
+            let data = try await request(
+                method: "GET",
+                path: "/reports",
+                query: query,
+                body: Optional<EmptyBody>.none
+            )
+            return try decoder.decode([UserReport].self, from: data)
+        } catch ReportsServiceError.notFound {
+            // Backend hasn't shipped — degrade silently with an empty list.
+            print("[ReportsService] /reports returned 404 — backend not deployed yet, returning [].")
+            return []
+        } catch ReportsServiceError.notAuthenticated {
+            print("[ReportsService] No active session, returning [].")
+            return []
+        } catch {
+            print("[ReportsService] fetchReports failed: \(error.localizedDescription)")
+            return []
+        }
+    }
+
+    /// Marks a report as read. Silently no-ops on 404 (backend missing).
+    func markRead(reportId: String) async throws {
+        do {
+            _ = try await request(
+                method: "POST",
+                path: "/reports/\(reportId)/read",
+                query: [],
+                body: Optional<EmptyBody>.none
+            )
+        } catch ReportsServiceError.notFound {
+            print("[ReportsService] markRead 404 — no-op until backend ships.")
+        } catch ReportsServiceError.notAuthenticated {
+            print("[ReportsService] markRead skipped: not authenticated.")
+        }
+    }
+
+    /// Submits feedback for a report. Silently no-ops on 404.
+    func submitFeedback(reportId: String, rating: Int, text: String?) async throws {
+        let payload = FeedbackPayload(rating: rating, text: text)
+        do {
+            _ = try await request(
+                method: "POST",
+                path: "/reports/\(reportId)/feedback",
+                query: [],
+                body: payload
+            )
+        } catch ReportsServiceError.notFound {
+            print("[ReportsService] submitFeedback 404 — no-op until backend ships.")
+        } catch ReportsServiceError.notAuthenticated {
+            print("[ReportsService] submitFeedback skipped: not authenticated.")
+        }
+    }
+
+    // MARK: - Private
+
+    /// Resolves the backend base URL. Lives at the Supabase functions
+    /// endpoint (e.g. `https://<ref>.supabase.co/functions/v1/api`).
+    private func baseURL() throws -> URL {
+        guard let supaURL = URL(string: Config.supabaseURL),
+              let host = supaURL.host else {
+            throw ReportsServiceError.invalidConfig
+        }
+        var components = URLComponents()
+        components.scheme = supaURL.scheme ?? "https"
+        components.host = host
+        if let port = supaURL.port { components.port = port }
+        components.path = "/functions/v1/api"
+        guard let url = components.url else {
+            throw ReportsServiceError.invalidConfig
+        }
+        return url
+    }
+
+    private func request<Body: Encodable>(
+        method: String,
+        path: String,
+        query: [URLQueryItem],
+        body: Body?
+    ) async throws -> Data {
+        let session = try await supabase.auth.session
+        let token = session.accessToken
+        guard !token.isEmpty else { throw ReportsServiceError.notAuthenticated }
+
+        let base = try baseURL()
+        guard var components = URLComponents(url: base, resolvingAgainstBaseURL: false) else {
+            throw ReportsServiceError.invalidConfig
+        }
+        components.path += path
+        if !query.isEmpty { components.queryItems = query }
+        guard let url = components.url else { throw ReportsServiceError.invalidConfig }
+
+        var req = URLRequest(url: url)
+        req.httpMethod = method
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        req.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        req.setValue(Config.supabaseAnonKey, forHTTPHeaderField: "apikey")
+
+        if let body {
+            req.httpBody = try encoder.encode(body)
+        }
+
+        let (data, response) = try await self.session.data(for: req)
+        guard let http = response as? HTTPURLResponse else {
+            throw ReportsServiceError.invalidResponse
+        }
+
+        switch http.statusCode {
+        case 200..<300:
+            return data
+        case 404:
+            throw ReportsServiceError.notFound
+        case 401, 403:
+            throw ReportsServiceError.notAuthenticated
+        default:
+            throw ReportsServiceError.http(status: http.statusCode)
+        }
+    }
+
+}
+
+// MARK: - Errors
+
+enum ReportsServiceError: LocalizedError {
+    case invalidConfig
+    case invalidResponse
+    case notFound
+    case notAuthenticated
+    case http(status: Int)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidConfig:     "Reports backend isn't configured."
+        case .invalidResponse:   "Unexpected response from reports backend."
+        case .notFound:          "Reports backend not deployed."
+        case .notAuthenticated:  "Sign in to view reports."
+        case .http(let status):  "Reports backend error (HTTP \(status))."
+        }
+    }
+}
+
+// MARK: - Wire Types
+
+private struct FeedbackPayload: Encodable {
+    let rating: Int
+    let text: String?
+}
+
+private struct EmptyBody: Encodable {}

--- a/Xomfit/ViewModels/ReportsViewModel.swift
+++ b/Xomfit/ViewModels/ReportsViewModel.swift
@@ -1,0 +1,122 @@
+import Foundation
+
+// MARK: - ReportsViewModel
+//
+// Drives `ReportsListView` + `ReportDetailView` for the Weekly Cron /
+// Monthly Reports feature (#260). The service is intentionally
+// fault-tolerant — when the backend hasn't shipped yet, `loadAll`
+// returns no items and `errorMessage` stays nil so the empty state shows.
+
+@MainActor
+@Observable
+final class ReportsViewModel {
+    var reports: [UserReport] = []
+    var isLoading: Bool = false
+    var errorMessage: String? = nil
+
+    /// Reports grouped by kind for sectioned display, newest first.
+    /// Weekly first, monthly second — matches the typical cadence.
+    var weeklyReports: [UserReport] {
+        reports
+            .filter { $0.kind == .weekly }
+            .sorted { $0.periodEnd > $1.periodEnd }
+    }
+
+    var monthlyReports: [UserReport] {
+        reports
+            .filter { $0.kind == .monthly }
+            .sorted { $0.periodEnd > $1.periodEnd }
+    }
+
+    var isEmpty: Bool { reports.isEmpty && !isLoading }
+
+    // MARK: - Load
+
+    func loadAll() async {
+        isLoading = true
+        errorMessage = nil
+
+        do {
+            // Single fetch with no kind filter — backend returns both.
+            let all = try await ReportsService.shared.fetchReports(kind: nil)
+            // Defensive sort: newest period_end first.
+            self.reports = all.sorted { $0.periodEnd > $1.periodEnd }
+        } catch {
+            // Service swallows most errors and returns []. Anything that
+            // does propagate here is a hard failure worth surfacing.
+            errorMessage = error.localizedDescription
+        }
+
+        isLoading = false
+    }
+
+    // MARK: - Mark Read
+
+    /// Marks the given report as read. Optimistically updates local state
+    /// regardless of backend status so the unread dot disappears
+    /// immediately when the user taps in.
+    func markRead(_ report: UserReport) async {
+        guard report.readAt == nil else { return }
+
+        // Optimistic local update.
+        if let index = reports.firstIndex(where: { $0.id == report.id }) {
+            let original = reports[index]
+            reports[index] = UserReport(
+                id: original.id,
+                kind: original.kind,
+                periodStart: original.periodStart,
+                periodEnd: original.periodEnd,
+                stats: original.stats,
+                recommendationText: original.recommendationText,
+                createdAt: original.createdAt,
+                readAt: Date(),
+                feedbackRating: original.feedbackRating,
+                feedbackText: original.feedbackText
+            )
+        }
+
+        do {
+            try await ReportsService.shared.markRead(reportId: report.id)
+        } catch {
+            // Service already swallowed 404 / auth. Anything else is a
+            // soft failure — keep the optimistic update; the next reload
+            // from the backend will reconcile.
+            print("[ReportsViewModel] markRead failed: \(error.localizedDescription)")
+        }
+    }
+
+    // MARK: - Submit Feedback
+
+    func submitFeedback(report: UserReport, rating: Int, text: String?) async {
+        // Trim text to nil so empty strings don't ship as feedback.
+        let trimmed = text?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let normalizedText = (trimmed?.isEmpty ?? true) ? nil : trimmed
+
+        // Optimistic local update.
+        if let index = reports.firstIndex(where: { $0.id == report.id }) {
+            let original = reports[index]
+            reports[index] = UserReport(
+                id: original.id,
+                kind: original.kind,
+                periodStart: original.periodStart,
+                periodEnd: original.periodEnd,
+                stats: original.stats,
+                recommendationText: original.recommendationText,
+                createdAt: original.createdAt,
+                readAt: original.readAt ?? Date(),
+                feedbackRating: rating,
+                feedbackText: normalizedText
+            )
+        }
+
+        do {
+            try await ReportsService.shared.submitFeedback(
+                reportId: report.id,
+                rating: rating,
+                text: normalizedText
+            )
+        } catch {
+            print("[ReportsViewModel] submitFeedback failed: \(error.localizedDescription)")
+        }
+    }
+}

--- a/Xomfit/Views/Profile/SettingsView.swift
+++ b/Xomfit/Views/Profile/SettingsView.swift
@@ -86,6 +86,26 @@ struct SettingsView: View {
 
                 Section {
                     NavigationLink {
+                        ReportsListView()
+                            .hideTabBar()
+                    } label: {
+                        HStack(spacing: Theme.Spacing.md) {
+                            Image(systemName: "doc.text.magnifyingglass")
+                                .frame(width: 24)
+                                .foregroundStyle(Theme.accent)
+                            Text("Reports")
+                                .foregroundStyle(Theme.textPrimary)
+                        }
+                    }
+                    .tint(Theme.textTertiary)
+                } header: {
+                    XomMetricLabel("Reports")
+                }
+                .listRowBackground(Theme.surface)
+                .listRowSeparatorTint(Theme.hairline)
+
+                Section {
+                    NavigationLink {
                         AICoachView()
                             .hideTabBar()
                     } label: {

--- a/Xomfit/Views/Reports/ReportDetailView.swift
+++ b/Xomfit/Views/Reports/ReportDetailView.swift
@@ -1,0 +1,365 @@
+import SwiftUI
+
+// MARK: - ReportDetailView
+//
+// Detail surface for a single weekly / monthly report (#260). Presents
+// the period header, three stat cards (volume / sessions / avg
+// duration), top exercises, new PRs (if any), the recommendation prose,
+// and a thumbs-up / thumbs-down feedback row at the bottom.
+//
+// On appear: marks the report as read via the view model. On feedback
+// submit: writes through the view model and dismisses the view.
+
+struct ReportDetailView: View {
+    let report: UserReport
+    /// Shared view model passed down from `ReportsListView` so that
+    /// optimistic mutations (read state, feedback) reflect back into the
+    /// list when the user pops.
+    var viewModel: ReportsViewModel
+
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var feedbackRating: Int? = nil
+    @State private var feedbackText: String = ""
+    @State private var isSubmitting: Bool = false
+    @State private var showFeedbackForm: Bool = false
+
+    /// Look up the latest version of this report from the view model so
+    /// optimistic updates show up here too (e.g. immediately after
+    /// submitting feedback).
+    private var current: UserReport {
+        viewModel.reports.first(where: { $0.id == report.id }) ?? report
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: Theme.Spacing.lg) {
+                header
+                statsRow
+                if !current.stats.topExercises.isEmpty {
+                    topExercisesSection
+                }
+                if !current.stats.newPRs.isEmpty {
+                    newPRsSection
+                }
+                recommendationSection
+                feedbackSection
+            }
+            .padding(.horizontal, Theme.Spacing.md)
+            .padding(.top, Theme.Spacing.md)
+            .padding(.bottom, Theme.Spacing.xxl)
+        }
+        .background(Theme.background.ignoresSafeArea())
+        .navigationTitle(navTitle)
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbarColorScheme(.dark, for: .navigationBar)
+        .task {
+            // Mark read when the user actually opens the detail view.
+            await viewModel.markRead(report)
+            // Pre-seed the feedback UI from any prior submission.
+            feedbackRating = current.feedbackRating
+            feedbackText = current.feedbackText ?? ""
+            showFeedbackForm = current.feedbackRating != nil
+        }
+    }
+
+    private var navTitle: String {
+        switch current.kind {
+        case .weekly:  "Weekly Report"
+        case .monthly: "Monthly Report"
+        }
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.xs) {
+            HStack(spacing: Theme.Spacing.sm) {
+                Image(systemName: current.kind == .weekly ? "calendar.badge.clock" : "calendar")
+                    .font(.title3.weight(.semibold))
+                    .foregroundStyle(Theme.accent)
+                Text(current.kind.rawValue.capitalized)
+                    .font(Theme.fontHeadline)
+                    .foregroundStyle(Theme.textPrimary)
+            }
+            Text(periodString)
+                .font(Theme.fontTitle2)
+                .foregroundStyle(Theme.textPrimary)
+            Text("Generated \(relativeCreatedAt)")
+                .font(Theme.fontCaption)
+                .foregroundStyle(Theme.textTertiary)
+        }
+    }
+
+    private var periodString: String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMM d, yyyy"
+        let start = formatter.string(from: current.periodStart)
+        let end = formatter.string(from: current.periodEnd)
+        return "\(start) – \(end)"
+    }
+
+    private var relativeCreatedAt: String {
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .abbreviated
+        return formatter.localizedString(for: current.createdAt, relativeTo: Date())
+    }
+
+    // MARK: - Stats Row
+
+    private var statsRow: some View {
+        HStack(spacing: Theme.Spacing.sm) {
+            statCard(
+                label: "Volume",
+                value: formattedVolume(current.stats.totalVolume),
+                icon: "chart.bar.fill"
+            )
+            statCard(
+                label: "Sessions",
+                value: "\(current.stats.sessionCount)",
+                icon: "figure.strengthtraining.traditional"
+            )
+            statCard(
+                label: "Avg Min",
+                value: avgMinutesString,
+                icon: "clock"
+            )
+        }
+    }
+
+    private var avgMinutesString: String {
+        let value = current.stats.avgSessionMinutes
+        if value <= 0 { return "0" }
+        if value >= 100 { return String(Int(value.rounded())) }
+        return String(format: "%.1f", value)
+    }
+
+    private func statCard(label: String, value: String, icon: String) -> some View {
+        XomCard(padding: Theme.Spacing.md, variant: .elevated) {
+            VStack(alignment: .leading, spacing: Theme.Spacing.xs) {
+                HStack {
+                    Image(systemName: icon)
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(Theme.accent)
+                    Spacer()
+                }
+                Text(value)
+                    .font(Theme.fontNumberLarge)
+                    .foregroundStyle(Theme.textPrimary)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.6)
+                XomMetricLabel(label)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    // MARK: - Top Exercises
+
+    private var topExercisesSection: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+            XomMetricLabel("Top Exercises")
+            XomCard(padding: 0) {
+                VStack(spacing: 0) {
+                    ForEach(Array(current.stats.topExercises.enumerated()), id: \.offset) { index, exercise in
+                        topExerciseRow(rank: index + 1, exercise: exercise)
+                        if index < current.stats.topExercises.count - 1 {
+                            Divider().background(Theme.hairline)
+                        }
+                    }
+                }
+                .padding(.vertical, Theme.Spacing.sm)
+            }
+        }
+    }
+
+    private func topExerciseRow(rank: Int, exercise: UserReport.TopExercise) -> some View {
+        HStack(spacing: Theme.Spacing.md) {
+            Text("\(rank)")
+                .font(.subheadline.weight(.bold).monospacedDigit())
+                .foregroundStyle(Theme.accent)
+                .frame(width: 24)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(exercise.name)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(Theme.textPrimary)
+                Text("\(exercise.sets) set\(exercise.sets == 1 ? "" : "s")")
+                    .font(.caption)
+                    .foregroundStyle(Theme.textTertiary)
+            }
+
+            Spacer(minLength: 0)
+
+            Text(formattedVolume(exercise.volume))
+                .font(.subheadline.weight(.semibold).monospacedDigit())
+                .foregroundStyle(Theme.textPrimary)
+        }
+        .padding(.horizontal, Theme.Spacing.md)
+        .padding(.vertical, Theme.Spacing.sm)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Rank \(rank), \(exercise.name), \(exercise.sets) sets, volume \(formattedVolume(exercise.volume))")
+    }
+
+    // MARK: - New PRs
+
+    private var newPRsSection: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+            XomMetricLabel("New PRs")
+            XomCard(padding: 0) {
+                VStack(spacing: 0) {
+                    ForEach(Array(current.stats.newPRs.enumerated()), id: \.offset) { index, pr in
+                        newPRRow(pr)
+                        if index < current.stats.newPRs.count - 1 {
+                            Divider().background(Theme.hairline)
+                        }
+                    }
+                }
+                .padding(.vertical, Theme.Spacing.sm)
+            }
+        }
+    }
+
+    private func newPRRow(_ pr: UserReport.NewPR) -> some View {
+        HStack(spacing: Theme.Spacing.md) {
+            Image(systemName: "trophy.fill")
+                .font(.body.weight(.semibold))
+                .foregroundStyle(Theme.prGold)
+                .frame(width: 24)
+
+            Text(pr.exercise)
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(Theme.textPrimary)
+
+            Spacer(minLength: 0)
+
+            Text("\(formattedWeight(pr.weight)) × \(pr.reps)")
+                .font(.subheadline.weight(.semibold).monospacedDigit())
+                .foregroundStyle(Theme.textPrimary)
+        }
+        .padding(.horizontal, Theme.Spacing.md)
+        .padding(.vertical, Theme.Spacing.sm)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("New PR \(pr.exercise), \(formattedWeight(pr.weight)) for \(pr.reps) reps")
+    }
+
+    // MARK: - Recommendation
+
+    private var recommendationSection: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+            XomMetricLabel("Recommendation")
+            XomCard(variant: .base) {
+                Text(current.recommendationText.isEmpty
+                     ? "No recommendation available for this period."
+                     : current.recommendationText)
+                    .font(Theme.fontBody)
+                    .foregroundStyle(Theme.textPrimary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
+    // MARK: - Feedback
+
+    private var feedbackSection: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+            XomMetricLabel("Was this helpful?")
+
+            XomCard(variant: .base) {
+                VStack(alignment: .leading, spacing: Theme.Spacing.md) {
+                    HStack(spacing: Theme.Spacing.md) {
+                        feedbackButton(rating: 1, icon: "hand.thumbsup.fill", label: "Yes")
+                        feedbackButton(rating: -1, icon: "hand.thumbsdown.fill", label: "No")
+                        Spacer()
+                        if isSubmitting {
+                            ProgressView().tint(Theme.accent)
+                        }
+                    }
+
+                    if showFeedbackForm {
+                        VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+                            TextField(
+                                "Optional comment (what worked, what didn't)",
+                                text: $feedbackText,
+                                axis: .vertical
+                            )
+                            .lineLimit(2...5)
+                            .font(Theme.fontBody)
+                            .foregroundStyle(Theme.textPrimary)
+                            .padding(Theme.Spacing.md)
+                            .background(Theme.surfaceElevated)
+                            .clipShape(RoundedRectangle(cornerRadius: Theme.Radius.sm))
+                            .overlay(
+                                RoundedRectangle(cornerRadius: Theme.Radius.sm)
+                                    .strokeBorder(Theme.hairline, lineWidth: 0.5)
+                            )
+
+                            XomButton("Send Feedback", variant: .primary, isLoading: isSubmitting) {
+                                Task { await submitFeedback() }
+                            }
+                            .disabled(feedbackRating == nil || isSubmitting)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func feedbackButton(rating: Int, icon: String, label: String) -> some View {
+        let isSelected = feedbackRating == rating
+        Button {
+            Haptics.light()
+            feedbackRating = rating
+            showFeedbackForm = true
+        } label: {
+            HStack(spacing: Theme.Spacing.xs) {
+                Image(systemName: icon)
+                Text(label)
+                    .font(.subheadline.weight(.semibold))
+            }
+            .foregroundStyle(isSelected ? .black : Theme.textPrimary)
+            .padding(.horizontal, Theme.Spacing.md)
+            .padding(.vertical, Theme.Spacing.sm)
+            .background(isSelected ? Theme.accent : Theme.surfaceElevated)
+            .clipShape(Capsule())
+            .overlay(
+                Capsule()
+                    .strokeBorder(isSelected ? Color.clear : Theme.hairline, lineWidth: 0.5)
+            )
+        }
+        .buttonStyle(PressableCardStyle())
+        .accessibilityLabel("\(label) feedback")
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+    }
+
+    private func submitFeedback() async {
+        guard let rating = feedbackRating, !isSubmitting else { return }
+        isSubmitting = true
+        await viewModel.submitFeedback(report: current, rating: rating, text: feedbackText)
+        Haptics.success()
+        isSubmitting = false
+        dismiss()
+    }
+
+    // MARK: - Formatting Helpers
+
+    private func formattedVolume(_ value: Double) -> String {
+        if value >= 1_000_000 {
+            return String(format: "%.1fM", value / 1_000_000)
+        }
+        if value >= 1_000 {
+            return String(format: "%.1fk", value / 1_000)
+        }
+        return String(Int(value.rounded()))
+    }
+
+    private func formattedWeight(_ value: Double) -> String {
+        // Match plate-loaded display: drop the trailing .0 when whole.
+        if value.truncatingRemainder(dividingBy: 1) == 0 {
+            return "\(Int(value)) lb"
+        }
+        return String(format: "%.1f lb", value)
+    }
+}

--- a/Xomfit/Views/Reports/ReportsListView.swift
+++ b/Xomfit/Views/Reports/ReportsListView.swift
@@ -1,0 +1,204 @@
+import SwiftUI
+
+// MARK: - ReportsListView
+//
+// Top-level Reports surface (#260). Lists weekly and monthly reports
+// (newest first within each section) with an unread dot for any report
+// where `readAt == nil`. Empty state covers the common "first week, no
+// data yet" case.
+//
+// Deep-linked from `xomfit://report/<id>` via `XomfitApp.onOpenURL`,
+// which programmatically pushes a `ReportDetailView` onto this screen's
+// `NavigationStack`.
+
+struct ReportsListView: View {
+    @State private var viewModel = ReportsViewModel()
+
+    /// Optional id captured from a `xomfit://report/<id>` deep-link.
+    /// When the matching report shows up in `viewModel.reports`, we push
+    /// the detail view automatically.
+    var deepLinkReportId: String? = nil
+
+    @State private var deepLinkedReport: UserReport? = nil
+
+    var body: some View {
+        ZStack {
+            Theme.background.ignoresSafeArea()
+
+            if viewModel.isLoading && viewModel.reports.isEmpty {
+                loadingState
+            } else if viewModel.isEmpty {
+                emptyState
+            } else {
+                listContent
+            }
+        }
+        .navigationTitle("Reports")
+        .navigationBarTitleDisplayMode(.large)
+        .toolbarColorScheme(.dark, for: .navigationBar)
+        .task {
+            await viewModel.loadAll()
+            resolveDeepLinkIfPossible()
+        }
+        .refreshable {
+            await viewModel.loadAll()
+            resolveDeepLinkIfPossible()
+        }
+        // Programmatic push for deep-link arrivals. We use an
+        // `item`-based navigation destination so dismissing the detail
+        // view cleans up the binding for free.
+        .navigationDestination(item: $deepLinkedReport) { report in
+            ReportDetailView(report: report, viewModel: viewModel)
+        }
+    }
+
+    // MARK: - Loading
+
+    private var loadingState: some View {
+        VStack(spacing: Theme.Spacing.md) {
+            ForEach(0..<3, id: \.self) { index in
+                SkeletonCard(height: 92)
+                    .staggeredAppear(index: index)
+            }
+            Spacer()
+        }
+        .padding(.horizontal, Theme.Spacing.md)
+        .padding(.top, Theme.Spacing.md)
+    }
+
+    // MARK: - Empty
+
+    private var emptyState: some View {
+        XomEmptyState(
+            icon: "doc.text.magnifyingglass",
+            title: "No reports yet",
+            subtitle: "Your first weekly summary will arrive Monday morning."
+        )
+    }
+
+    // MARK: - List
+
+    private var listContent: some View {
+        List {
+            if !viewModel.weeklyReports.isEmpty {
+                Section {
+                    ForEach(viewModel.weeklyReports) { report in
+                        NavigationLink {
+                            ReportDetailView(report: report, viewModel: viewModel)
+                        } label: {
+                            ReportRow(report: report)
+                        }
+                        .listRowBackground(Theme.surface)
+                        .listRowSeparatorTint(Theme.hairline)
+                    }
+                } header: {
+                    XomMetricLabel("Weekly")
+                }
+            }
+
+            if !viewModel.monthlyReports.isEmpty {
+                Section {
+                    ForEach(viewModel.monthlyReports) { report in
+                        NavigationLink {
+                            ReportDetailView(report: report, viewModel: viewModel)
+                        } label: {
+                            ReportRow(report: report)
+                        }
+                        .listRowBackground(Theme.surface)
+                        .listRowSeparatorTint(Theme.hairline)
+                    }
+                } header: {
+                    XomMetricLabel("Monthly")
+                }
+            }
+        }
+        .listStyle(.insetGrouped)
+        .scrollContentBackground(.hidden)
+    }
+
+    // MARK: - Deep Link Resolution
+
+    private func resolveDeepLinkIfPossible() {
+        guard let id = deepLinkReportId else { return }
+        guard deepLinkedReport == nil else { return }
+        if let match = viewModel.reports.first(where: { $0.id == id }) {
+            deepLinkedReport = match
+        }
+        // If no match, fall back gracefully: the user lands on the list
+        // and can pick a report manually. No alert / error toast — the
+        // backend may simply not have ingested that id yet.
+    }
+}
+
+// MARK: - ReportRow
+
+private struct ReportRow: View {
+    let report: UserReport
+
+    private var isUnread: Bool { report.readAt == nil }
+
+    private var iconName: String {
+        switch report.kind {
+        case .weekly:  "calendar.badge.clock"
+        case .monthly: "calendar"
+        }
+    }
+
+    private var dateRangeText: String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMM d"
+        let start = formatter.string(from: report.periodStart)
+        let end = formatter.string(from: report.periodEnd)
+        return "\(start) – \(end)"
+    }
+
+    private var excerpt: String {
+        // Trim newlines for compact list rendering.
+        let single = report.recommendationText
+            .replacingOccurrences(of: "\n", with: " ")
+            .trimmingCharacters(in: .whitespaces)
+        return single.isEmpty
+            ? "Tap to view your summary and recommendation."
+            : single
+    }
+
+    var body: some View {
+        HStack(alignment: .top, spacing: Theme.Spacing.md) {
+            ZStack {
+                Circle()
+                    .fill(Theme.accentMuted)
+                    .frame(width: 36, height: 36)
+                Image(systemName: iconName)
+                    .font(.body.weight(.semibold))
+                    .foregroundStyle(Theme.accent)
+            }
+
+            VStack(alignment: .leading, spacing: Theme.Spacing.xs) {
+                HStack(spacing: Theme.Spacing.sm) {
+                    Text(dateRangeText)
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(Theme.textPrimary)
+                    if isUnread {
+                        Circle()
+                            .fill(Theme.accent)
+                            .frame(width: 8, height: 8)
+                            .accessibilityLabel("Unread")
+                    }
+                }
+
+                Text(excerpt)
+                    .font(.footnote)
+                    .foregroundStyle(Theme.textSecondary)
+                    .lineLimit(2)
+                    .multilineTextAlignment(.leading)
+            }
+
+            Spacer(minLength: 0)
+        }
+        .padding(.vertical, 4)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(
+            "\(report.kind.rawValue.capitalized) report, \(dateRangeText)\(isUnread ? ", unread" : "")"
+        )
+    }
+}

--- a/Xomfit/XomfitApp.swift
+++ b/Xomfit/XomfitApp.swift
@@ -11,6 +11,13 @@ struct XomFitApp: App {
     @State private var showFitnessQuestionnaire = false
     @AppStorage("onboardingSkipped") private var onboardingSkipped = false
 
+    /// Deep-link target for `xomfit://report/<id>` (#260). When set, we
+    /// present the Reports list as a sheet pre-seeded with this id, so
+    /// the matching detail view auto-pushes once data loads. Reset to nil
+    /// when the sheet dismisses.
+    @State private var pendingReportId: String? = nil
+    @State private var showReportsSheet = false
+
     var body: some Scene {
         WindowGroup {
             Group {
@@ -51,6 +58,12 @@ struct XomFitApp: App {
                             }
                             .interactiveDismissDisabled()
                         }
+                        .sheet(isPresented: $showReportsSheet, onDismiss: { pendingReportId = nil }) {
+                            NavigationStack {
+                                ReportsListView(deepLinkReportId: pendingReportId)
+                            }
+                            .preferredColorScheme(.dark)
+                        }
                 } else {
                     LoginView()
                         .environment(authService)
@@ -61,6 +74,22 @@ struct XomFitApp: App {
                 if url.scheme == "xomfit", url.host == "workout" {
                     if workoutSession.isActive {
                         workoutSession.isPresented = true
+                    }
+                    return
+                }
+                if url.scheme == "xomfit", url.host == "report" {
+                    // `xomfit://report/<id>` — first path component is the id.
+                    let id = url.pathComponents
+                        .filter { $0 != "/" }
+                        .first?
+                        .trimmingCharacters(in: .whitespacesAndNewlines)
+                    if let id, !id.isEmpty {
+                        pendingReportId = id
+                    } else {
+                        pendingReportId = nil
+                    }
+                    if authService.isAuthenticated {
+                        showReportsSheet = true
                     }
                     return
                 }


### PR DESCRIPTION
Closes #260 (iOS half).

## What ships
- `Models/UserReport.swift` — Codable + nested `Stats`/`TopExercise`/`NewPR`
- `Services/ReportsService.swift` — REST client; swallows 404/auth/network errors so UI degrades cleanly until the backend is deployed
- `ViewModels/ReportsViewModel.swift` — @Observable VM with optimistic markRead + submitFeedback
- `Views/Reports/ReportsListView.swift` — sectioned (Weekly / Monthly), unread dot, loading skeleton, empty state
- `Views/Reports/ReportDetailView.swift` — period header, 3 stat cards, top exercises, new PRs, recommendation prose, thumbs up/down + comment
- `SettingsView.swift` — Reports section row → list view
- `XomfitApp.swift` — `xomfit://report/<id>` deep link → opens Reports sheet pre-seeded with the id

## Coordinated with backend (Xomware/xomfit-backend#6)
The backend ships endpoints `GET /reports`, `POST /reports/{id}/read`, `POST /reports/{id}/feedback` on AWS API Gateway + Lambda + DynamoDB.

## Known follow-up: endpoint URL
The agent built the service against `<supabaseURL>/functions/v1/api/reports` (Supabase Edge Functions convention). The actual backend deploys to API Gateway, so the base URL needs adjusting once the Terraform contract lands. Until then, the UI shows the empty state cleanly. This is a 1-line change in `ReportsService.swift`.

## Test plan
- [ ] Build clean
- [ ] Settings → Reports row appears
- [ ] Open Reports list → empty state ('No reports yet — your first weekly summary will arrive Monday morning')
- [ ] After backend + URL update, real reports list and details render
- [ ] `xomfit://report/<id>` deep link opens the reports sheet