### PR TITLE
#288 fix: prevent active-workout cover stuck half-dismissed state

### DIFF
--- a/Xomfit/Views/MainTabView.swift
+++ b/Xomfit/Views/MainTabView.swift
@@ -67,6 +67,10 @@ struct MainTabView: View {
             ActiveWorkoutView()
                 .environment(authService)
                 .environment(workoutSession)
+                // #288: prevent accidental swipe-dismiss leaving the cover stuck
+                // in a half-dismissed state (only the workout header bar visible).
+                // The user must explicitly Discard or Finish to leave the workout.
+                .interactiveDismissDisabled(workoutSession.isActive)
         }
         .toast($launchBadgeToast)
         .task {


### PR DESCRIPTION
Closes #288. Adds .interactiveDismissDisabled(workoutSession.isActive) to the .fullScreenCover so the user can't accidentally swipe-leak through nested sheets and orphan the header. Discard / Finish remain the only paths out.