### PR TITLE
#291 #292 workouts tab: tappable rows + builder save flow

### DIFF
--- a/Xomfit/ViewModels/WorkoutBuilderViewModel.swift
+++ b/Xomfit/ViewModels/WorkoutBuilderViewModel.swift
@@ -52,8 +52,11 @@ final class WorkoutBuilderViewModel {
         exercises[index].notes = notes
     }
 
-    func save() {
-        let template = WorkoutTemplate(
+    /// Builds a `WorkoutTemplate` from the current builder state without persisting.
+    /// Use this when you want the template to drive an immediate workout (e.g.
+    /// "Start Now") without committing it to saved templates.
+    func buildTemplate() -> WorkoutTemplate {
+        WorkoutTemplate(
             id: UUID().uuidString,
             name: name.trimmingCharacters(in: .whitespaces),
             description: "\(exercises.count) exercises, ~\(estimatedDuration)min",
@@ -62,7 +65,15 @@ final class WorkoutBuilderViewModel {
             category: category,
             isCustom: true
         )
+    }
+
+    /// Builds a template AND persists it via `TemplateService`. Returns the saved
+    /// template so the caller can chain into Start Now if desired.
+    @discardableResult
+    func save() -> WorkoutTemplate {
+        let template = buildTemplate()
         TemplateService.shared.saveCustomTemplate(template)
+        return template
     }
 
     func loadTemplate(_ template: WorkoutTemplate) {

--- a/Xomfit/Views/Workout/RecentWorkoutCard.swift
+++ b/Xomfit/Views/Workout/RecentWorkoutCard.swift
@@ -12,22 +12,44 @@ enum RecentWorkoutCardStyle {
 struct RecentWorkoutCard: View {
     let workout: Workout
     var style: RecentWorkoutCardStyle = .compact
-    let onSelect: () -> Void
+
+    /// Tap handler. When `nil`, the card renders as plain visual content with no
+    /// embedded Button -- intended for cases where the parent wraps this view in
+    /// a `NavigationLink` (or similar) and needs the inner content to NOT consume
+    /// taps.
+    let onSelect: (() -> Void)?
+
+    init(workout: Workout, style: RecentWorkoutCardStyle = .compact, onSelect: (() -> Void)? = nil) {
+        self.workout = workout
+        self.style = style
+        self.onSelect = onSelect
+    }
 
     var body: some View {
-        Button(action: {
-            Haptics.light()
-            onSelect()
-        }) {
-            if style == .row {
-                rowBody
-            } else {
-                compactBody
+        if let onSelect {
+            Button(action: {
+                Haptics.light()
+                onSelect()
+            }) {
+                cardContent
             }
+            .buttonStyle(PressableCardStyle())
+            .accessibilityLabel("\(workout.name), \(workout.startTime.timeAgo), \(workout.exercises.count) exercises, \(workout.durationString)")
+            .accessibilityAddTraits(.isButton)
+        } else {
+            cardContent
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel("\(workout.name), \(workout.startTime.timeAgo), \(workout.exercises.count) exercises, \(workout.durationString)")
         }
-        .buttonStyle(PressableCardStyle())
-        .accessibilityLabel("\(workout.name), \(workout.startTime.timeAgo), \(workout.exercises.count) exercises, \(workout.durationString)")
-        .accessibilityAddTraits(.isButton)
+    }
+
+    @ViewBuilder
+    private var cardContent: some View {
+        if style == .row {
+            rowBody
+        } else {
+            compactBody
+        }
     }
 
     private var compactBody: some View {
@@ -113,5 +135,6 @@ struct RecentWorkoutCard: View {
             RoundedRectangle(cornerRadius: Theme.cornerRadius)
                 .strokeBorder(Theme.hairline, lineWidth: 0.5)
         )
+        .contentShape(Rectangle())
     }
 }

--- a/Xomfit/Views/Workout/TemplateCardView.swift
+++ b/Xomfit/Views/Workout/TemplateCardView.swift
@@ -12,63 +12,85 @@ enum TemplateCardStyle {
 struct TemplateCardView: View {
     let template: WorkoutTemplate
     var style: TemplateCardStyle = .compact
-    let onSelect: () -> Void
+
+    /// Tap handler. When `nil`, the card renders as plain visual content with no
+    /// embedded Button -- intended for cases where the parent wraps this view in
+    /// a `NavigationLink` (or similar) and needs the inner content to NOT consume
+    /// taps.
+    let onSelect: (() -> Void)?
+
+    init(template: WorkoutTemplate, style: TemplateCardStyle = .compact, onSelect: (() -> Void)? = nil) {
+        self.template = template
+        self.style = style
+        self.onSelect = onSelect
+    }
 
     var body: some View {
-        Button(action: {
-            Haptics.light()
-            onSelect()
-        }) {
-            HStack(spacing: 10) {
-                // Category icon
-                Image(systemName: template.category.icon)
-                    .font(.headline)
-                    .foregroundStyle(Theme.accent)
-                    .frame(width: 32, height: 32)
-                    .background(Theme.accent.opacity(0.15))
-                    .clipShape(.rect(cornerRadius: 6))
-
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(template.name)
-                        .font(style == .row ? .subheadline.weight(.bold) : .caption.weight(.bold))
-                        .foregroundStyle(Theme.textPrimary)
-                        .lineLimit(1)
-
-                    HStack(spacing: 4) {
-                        Text("\(template.exercises.count) ex")
-                        Text("~\(template.estimatedDuration)m")
-                            .foregroundStyle(Theme.accent)
-                        if style == .row && !template.description.isEmpty {
-                            Text("•")
-                                .foregroundStyle(Theme.textTertiary)
-                            Text(template.description)
-                                .lineLimit(1)
-                        }
-                    }
-                    .font(Theme.fontSmall)
-                    .foregroundStyle(Theme.textSecondary)
-                }
-
-                if style == .row {
-                    Spacer(minLength: 0)
-                    Image(systemName: "chevron.right")
-                        .font(.caption.weight(.semibold))
-                        .foregroundStyle(Theme.textTertiary)
-                }
+        if let onSelect {
+            Button(action: {
+                Haptics.light()
+                onSelect()
+            }) {
+                cardContent
             }
-            .padding(.horizontal, 12)
-            .padding(.vertical, 10)
-            .frame(maxWidth: style == .row ? .infinity : nil, alignment: .leading)
-            .frame(width: style == .row ? nil : 160, alignment: .leading)
-            .background(Theme.surface)
-            .clipShape(.rect(cornerRadius: Theme.cornerRadius))
-            .overlay(
-                RoundedRectangle(cornerRadius: Theme.cornerRadius)
-                    .strokeBorder(Theme.hairline, lineWidth: 0.5)
-            )
+            .buttonStyle(PressableCardStyle())
+            .accessibilityLabel("\(template.name) template, \(template.exercises.count) exercises, about \(template.estimatedDuration) minutes")
+            .accessibilityAddTraits(.isButton)
+        } else {
+            cardContent
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel("\(template.name) template, \(template.exercises.count) exercises, about \(template.estimatedDuration) minutes")
         }
-        .buttonStyle(PressableCardStyle())
-        .accessibilityLabel("\(template.name) template, \(template.exercises.count) exercises, about \(template.estimatedDuration) minutes")
-        .accessibilityAddTraits(.isButton)
+    }
+
+    private var cardContent: some View {
+        HStack(spacing: 10) {
+            // Category icon
+            Image(systemName: template.category.icon)
+                .font(.headline)
+                .foregroundStyle(Theme.accent)
+                .frame(width: 32, height: 32)
+                .background(Theme.accent.opacity(0.15))
+                .clipShape(.rect(cornerRadius: 6))
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(template.name)
+                    .font(style == .row ? .subheadline.weight(.bold) : .caption.weight(.bold))
+                    .foregroundStyle(Theme.textPrimary)
+                    .lineLimit(1)
+
+                HStack(spacing: 4) {
+                    Text("\(template.exercises.count) ex")
+                    Text("~\(template.estimatedDuration)m")
+                        .foregroundStyle(Theme.accent)
+                    if style == .row && !template.description.isEmpty {
+                        Text("•")
+                            .foregroundStyle(Theme.textTertiary)
+                        Text(template.description)
+                            .lineLimit(1)
+                    }
+                }
+                .font(Theme.fontSmall)
+                .foregroundStyle(Theme.textSecondary)
+            }
+
+            if style == .row {
+                Spacer(minLength: 0)
+                Image(systemName: "chevron.right")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(Theme.textTertiary)
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .frame(maxWidth: style == .row ? .infinity : nil, alignment: .leading)
+        .frame(width: style == .row ? nil : 160, alignment: .leading)
+        .background(Theme.surface)
+        .clipShape(.rect(cornerRadius: Theme.cornerRadius))
+        .overlay(
+            RoundedRectangle(cornerRadius: Theme.cornerRadius)
+                .strokeBorder(Theme.hairline, lineWidth: 0.5)
+        )
+        .contentShape(Rectangle())
     }
 }

--- a/Xomfit/Views/Workout/WorkoutBuilderView.swift
+++ b/Xomfit/Views/Workout/WorkoutBuilderView.swift
@@ -2,11 +2,31 @@ import SwiftUI
 
 struct WorkoutBuilderView: View {
     @Environment(\.dismiss) private var dismiss
+    @Environment(AuthService.self) private var authService
+    @Environment(WorkoutLoggerViewModel.self) private var workoutSession
 
     @State private var viewModel = WorkoutBuilderViewModel()
     @State private var showExercisePicker = false
 
+    /// Action sheet presented when the user taps "Save" — lets them save as
+    /// template, start immediately, do both, or cancel.
+    @State private var showSaveOptions = false
+
+    // MARK: - Warmup flow (#261)
+
+    @AppStorage("warmupOptIn") private var warmupOptIn: String = ""
+    @AppStorage("warmupMinutes") private var warmupMinutes: Int = 6
+
+    @State private var pendingStart: (() -> Void)?
+    @State private var pendingStretches: [Stretch] = []
+    @State private var showWarmupPrompt = false
+    @State private var showWarmup = false
+
     var template: WorkoutTemplate? = nil
+
+    private var userId: String {
+        authService.currentUser?.id.uuidString.lowercased() ?? ""
+    }
 
     var body: some View {
         NavigationStack {
@@ -34,9 +54,8 @@ struct WorkoutBuilderView: View {
                 }
                 ToolbarItem(placement: .confirmationAction) {
                     Button("Save") {
-                        Haptics.success()
-                        viewModel.save()
-                        dismiss()
+                        Haptics.light()
+                        showSaveOptions = true
                     }
                     .fontWeight(.bold)
                     .foregroundStyle(viewModel.isValid ? Theme.accent : Theme.textSecondary)
@@ -53,6 +72,60 @@ struct WorkoutBuilderView: View {
         .sheet(isPresented: $showExercisePicker) {
             ExercisePickerView { exercise in
                 viewModel.addExercise(exercise)
+            }
+        }
+        .confirmationDialog(
+            "What do you want to do with this workout?",
+            isPresented: $showSaveOptions,
+            titleVisibility: .visible
+        ) {
+            Button("Save as Template") {
+                Haptics.success()
+                viewModel.save()
+                dismiss()
+            }
+            Button("Start Now") {
+                Haptics.medium()
+                let template = viewModel.buildTemplate()
+                startTemplateWithWarmupGate(template)
+            }
+            Button("Save AND Start") {
+                Haptics.success()
+                let saved = viewModel.save()
+                startTemplateWithWarmupGate(saved)
+            }
+            Button("Discard", role: .destructive) {
+                dismiss()
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("You can save it for later, jump in now, or both.")
+        }
+        .confirmationDialog(
+            "Warm up first?",
+            isPresented: $showWarmupPrompt,
+            titleVisibility: .visible
+        ) {
+            Button("Yes, \(warmupMinutes) min") {
+                warmupOptIn = "yes"
+                showWarmup = true
+            }
+            Button("No, skip") {
+                warmupOptIn = "no"
+                runPendingStartImmediately()
+            }
+            Button("Just this once", role: .cancel) {
+                runPendingStartImmediately()
+            }
+        } message: {
+            Text("A 5-10 minute stretch routine helps loosen up before lifting.")
+        }
+        .fullScreenCover(isPresented: $showWarmup) {
+            WarmupView(
+                stretches: pendingStretches.isEmpty ? StretchDatabase.defaultRoutine() : pendingStretches,
+                totalDuration: warmupMinutes * 60
+            ) {
+                runPendingStartImmediately()
             }
         }
     }
@@ -162,6 +235,60 @@ struct WorkoutBuilderView: View {
             )
         }
         .accessibilityLabel("Add exercise to workout")
+    }
+
+    // MARK: - Start flow
+
+    /// Dismisses the builder sheet, then runs the warmup gate before kicking off
+    /// the live workout. The dismiss-first ordering ensures the active workout
+    /// cover doesn't get presented on top of the builder.
+    private func startTemplateWithWarmupGate(_ template: WorkoutTemplate) {
+        let captured = template
+        let startAction: () -> Void = {
+            workoutSession.startFromTemplate(captured, userId: userId)
+            workoutSession.isPresented = true
+        }
+        let stretches = StretchDatabase.suggestedStretches(
+            for: captured,
+            target: TimeInterval(warmupMinutes * 60)
+        )
+
+        // Dismiss first so the builder sheet animates away cleanly. Then gate.
+        dismiss()
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
+            requestStart(stretches: stretches, action: startAction)
+        }
+    }
+
+    /// Mirrors `WorkoutView.requestStart` -- either prompts about warming up,
+    /// presents the warmup sheet, or runs the start action directly, depending
+    /// on the user's saved preference.
+    private func requestStart(stretches: [Stretch], action: @escaping () -> Void) {
+        pendingStart = action
+        pendingStretches = stretches
+
+        switch warmupOptIn {
+        case "yes":
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                showWarmup = true
+            }
+        case "no":
+            runPendingStartImmediately()
+        default:
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                showWarmupPrompt = true
+            }
+        }
+    }
+
+    private func runPendingStartImmediately() {
+        let action = pendingStart
+        pendingStart = nil
+        pendingStretches = []
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+            action?()
+        }
     }
 }
 

--- a/Xomfit/Views/Workout/WorkoutCategoryPage.swift
+++ b/Xomfit/Views/Workout/WorkoutCategoryPage.swift
@@ -170,10 +170,9 @@ struct WorkoutCategoryPage: View {
                 NavigationLink {
                     WorkoutDetailView(workout: workout)
                 } label: {
-                    RecentWorkoutCard(workout: workout, style: .row) { /* tap handled by NavigationLink */ }
-                        .allowsHitTesting(false)
+                    RecentWorkoutCard(workout: workout, style: .row)
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(PressableCardStyle())
                 .accessibilityLabel("\(workout.name), \(workout.startTime.timeAgo)")
             }
         }
@@ -224,10 +223,9 @@ struct WorkoutCategoryPage: View {
                     NavigationLink {
                         WorkoutDetailView(workout: workout)
                     } label: {
-                        RecentWorkoutCard(workout: workout, style: .row) { /* tap handled by NavigationLink */ }
-                            .allowsHitTesting(false)
+                        RecentWorkoutCard(workout: workout, style: .row)
                     }
-                    .buttonStyle(.plain)
+                    .buttonStyle(PressableCardStyle())
                     .accessibilityLabel("Friend workout: \(workout.name)")
                 }
             }

--- a/Xomfit/Views/Workout/WorkoutView.swift
+++ b/Xomfit/Views/Workout/WorkoutView.swift
@@ -275,10 +275,9 @@ struct WorkoutView: View {
                         NavigationLink {
                             WorkoutDetailView(workout: workout)
                         } label: {
-                            RecentWorkoutCard(workout: workout, style: .row) { /* handled by link */ }
-                                .allowsHitTesting(false)
+                            RecentWorkoutCard(workout: workout, style: .row)
                         }
-                        .buttonStyle(.plain)
+                        .buttonStyle(PressableCardStyle())
                         .accessibilityLabel("\(workout.name), \(workout.startTime.timeAgo)")
                     }
                 }
@@ -333,10 +332,9 @@ struct WorkoutView: View {
                         NavigationLink {
                             WorkoutDetailView(workout: workout)
                         } label: {
-                            RecentWorkoutCard(workout: workout, style: .row) { /* handled by link */ }
-                                .allowsHitTesting(false)
+                            RecentWorkoutCard(workout: workout, style: .row)
                         }
-                        .buttonStyle(.plain)
+                        .buttonStyle(PressableCardStyle())
                         .accessibilityLabel("Friend workout: \(workout.name)")
                     }
                 }


### PR DESCRIPTION
Closes #291, #292.

#291: RecentWorkoutCard / TemplateCardView take an optional onSelect. nil = plain visual content (no inner Button), parent wraps in NavigationLink or Button. Fixes the iOS 17 'inner-Button-inside-NavigationLink swallows taps' issue. All preview rows + See All rows now open WorkoutDetailView (recents/friends) or TemplateDetailView (templates).

#292: Builder Save button opens a confirmationDialog with Save as Template / Start Now / Save AND Start / Discard. Start paths run through the warmup gate. Builder hosts its own warmup gate (mirrors WorkoutView) so dismissing it doesn't strand the active-workout cover.