### PR TITLE
#295 #296 warmup preview + details everywhere

### DIFF
--- a/Xomfit/Views/Workout/ExerciseDetailSheet.swift
+++ b/Xomfit/Views/Workout/ExerciseDetailSheet.swift
@@ -16,6 +16,7 @@ struct ExerciseDetailSheet: View {
                     VStack(alignment: .leading, spacing: Theme.Spacing.lg) {
                         header
                         muscleAndEquipment
+                        variationsSection
                         howToSection
                         if !exercise.tips.isEmpty {
                             tipsSection
@@ -91,6 +92,70 @@ struct ExerciseDetailSheet: View {
             }
             Spacer()
         }
+    }
+
+    /// Optional grips / attachments / positions chip rows when the exercise supports variations.
+    @ViewBuilder
+    private var variationsSection: some View {
+        let grips = exercise.supportedGrips ?? []
+        let attachments = exercise.supportedAttachments ?? []
+        let positions = exercise.supportedPositions ?? []
+
+        if !grips.isEmpty || !attachments.isEmpty || !positions.isEmpty {
+            VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+                Text("Variations")
+                    .font(Theme.fontHeadline)
+                    .foregroundStyle(Theme.textPrimary)
+
+                if !grips.isEmpty {
+                    chipRow(
+                        label: "Grips",
+                        icon: "hand.raised.fill",
+                        chips: grips.map(\.displayName)
+                    )
+                }
+                if !attachments.isEmpty {
+                    chipRow(
+                        label: "Attachments",
+                        icon: "link",
+                        chips: attachments.map(\.displayName)
+                    )
+                }
+                if !positions.isEmpty {
+                    chipRow(
+                        label: "Positions",
+                        icon: "figure.strengthtraining.traditional",
+                        chips: positions.map(\.displayName)
+                    )
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(Theme.Spacing.md)
+            .background(Theme.surface)
+            .clipShape(.rect(cornerRadius: Theme.cornerRadius))
+        }
+    }
+
+    private func chipRow(label: String, icon: String, chips: [String]) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 6) {
+                Image(systemName: icon)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(Theme.accent)
+                Text(label)
+                    .font(Theme.fontSmall)
+                    .foregroundStyle(Theme.textSecondary)
+            }
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 6) {
+                    ForEach(chips, id: \.self) { chip in
+                        XomBadge(chip, variant: .secondary)
+                    }
+                }
+            }
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(label): \(chips.joined(separator: ", "))")
     }
 
     private var howToSection: some View {

--- a/Xomfit/Views/Workout/StretchDetailSheet.swift
+++ b/Xomfit/Views/Workout/StretchDetailSheet.swift
@@ -1,0 +1,146 @@
+import SwiftUI
+
+/// Read-only sheet showing how to perform a warmup stretch: description,
+/// hold time, and the muscle groups it loosens up. Mirrors `ExerciseDetailSheet`
+/// so users can tap a stretch in the warmup preview to see what they're about to do.
+struct StretchDetailSheet: View {
+    let stretch: Stretch
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Theme.background.ignoresSafeArea()
+
+                ScrollView {
+                    VStack(alignment: .leading, spacing: Theme.Spacing.lg) {
+                        header
+                        metaSection
+                        muscleSection
+                        howToSection
+                    }
+                    .padding(.horizontal, Theme.Spacing.md)
+                    .padding(.vertical, Theme.Spacing.md)
+                }
+            }
+            .navigationTitle(stretch.name)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbarColorScheme(.dark, for: .navigationBar)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { dismiss() }
+                        .foregroundStyle(Theme.accent)
+                }
+            }
+        }
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack(spacing: Theme.Spacing.md) {
+            Image(systemName: stretch.icon)
+                .font(.system(size: 32))
+                .foregroundStyle(Theme.accent)
+                .frame(width: 64, height: 64)
+                .background(Theme.accentMuted)
+                .clipShape(.rect(cornerRadius: Theme.cornerRadius))
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(stretch.name)
+                    .font(Theme.fontTitle2)
+                    .foregroundStyle(Theme.textPrimary)
+                Text("Warmup stretch")
+                    .font(Theme.fontCaption)
+                    .foregroundStyle(Theme.textSecondary)
+            }
+            Spacer()
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityAddTraits(.isHeader)
+    }
+
+    // MARK: - Meta (hold time)
+
+    private var metaSection: some View {
+        HStack(spacing: Theme.Spacing.sm) {
+            Image(systemName: "timer")
+                .font(.subheadline)
+                .foregroundStyle(Theme.accent)
+                .frame(width: 24)
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Hold Time")
+                    .font(Theme.fontSmall)
+                    .foregroundStyle(Theme.textSecondary)
+                Text(formatDuration(stretch.durationSeconds))
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(Theme.textPrimary)
+            }
+            Spacer()
+        }
+        .padding(Theme.Spacing.md)
+        .background(Theme.surface)
+        .clipShape(.rect(cornerRadius: Theme.cornerRadius))
+    }
+
+    // MARK: - Targeted muscles
+
+    @ViewBuilder
+    private var muscleSection: some View {
+        if !stretch.targetMuscleGroups.isEmpty {
+            VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+                Text(stretch.targetMuscleGroups.count > 1 ? "Targets" : "Target")
+                    .font(Theme.fontHeadline)
+                    .foregroundStyle(Theme.textPrimary)
+
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 6) {
+                        ForEach(stretch.targetMuscleGroups, id: \.self) { mg in
+                            XomBadge(mg.displayName, icon: mg.icon, color: Theme.accent, variant: .display)
+                        }
+                    }
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(Theme.Spacing.md)
+            .background(Theme.surface)
+            .clipShape(.rect(cornerRadius: Theme.cornerRadius))
+        }
+    }
+
+    // MARK: - How to
+
+    private var howToSection: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+            Text("How To")
+                .font(Theme.fontHeadline)
+                .foregroundStyle(Theme.textPrimary)
+            Text(stretch.description)
+                .font(Theme.fontBody)
+                .foregroundStyle(Theme.textPrimary.opacity(0.9))
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(Theme.Spacing.md)
+        .background(Theme.surface)
+        .clipShape(.rect(cornerRadius: Theme.cornerRadius))
+    }
+
+    // MARK: - Helpers
+
+    private func formatDuration(_ seconds: Int) -> String {
+        let s = max(seconds, 0)
+        if s >= 60 {
+            let mins = s / 60
+            let secs = s % 60
+            if secs == 0 { return "\(mins) min" }
+            return "\(mins)m \(secs)s"
+        }
+        return "\(s) sec"
+    }
+}
+
+#Preview {
+    StretchDetailSheet(stretch: StretchDatabase.all[0])
+        .preferredColorScheme(.dark)
+}

--- a/Xomfit/Views/Workout/TemplateDetailView.swift
+++ b/Xomfit/Views/Workout/TemplateDetailView.swift
@@ -205,6 +205,10 @@ struct TemplateDetailView: View {
                 }
             }
 
+            if !targetMuscleGroups.isEmpty {
+                targetsRow
+            }
+
             HStack(spacing: Theme.Spacing.lg) {
                 statPill(icon: "dumbbell.fill", label: "Exercises", value: "\(draft.exercises.count)")
                 statPill(icon: "clock.fill", label: "Duration", value: "~\(estimatedDuration)m")
@@ -216,6 +220,38 @@ struct TemplateDetailView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(Theme.surface)
         .clipShape(.rect(cornerRadius: Theme.cornerRadius))
+    }
+
+    /// Union of muscle groups hit by every exercise in the template, in source order
+    /// (de-duplicated). Used by the "Targets" chip row.
+    private var targetMuscleGroups: [MuscleGroup] {
+        var seen = Set<MuscleGroup>()
+        var ordered: [MuscleGroup] = []
+        for tex in draft.exercises {
+            for mg in tex.exercise.muscleGroups where !seen.contains(mg) {
+                seen.insert(mg)
+                ordered.append(mg)
+            }
+        }
+        return ordered
+    }
+
+    private var targetsRow: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Targets")
+                .font(Theme.fontSmall)
+                .foregroundStyle(Theme.textSecondary)
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 6) {
+                    ForEach(targetMuscleGroups, id: \.self) { mg in
+                        XomBadge(mg.displayName, icon: mg.icon, color: Theme.accent, variant: .display)
+                    }
+                }
+            }
+        }
+        .padding(.top, Theme.Spacing.xs)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Targets: \(targetMuscleGroups.map(\.displayName).joined(separator: ", "))")
     }
 
     private var totalSets: Int {
@@ -597,6 +633,7 @@ private struct EditableExerciseRow: View {
 
     @State private var repsText: String = ""
     @State private var weightText: String = ""
+    @State private var showDetails: Bool = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
@@ -624,6 +661,19 @@ private struct EditableExerciseRow: View {
                 }
 
                 Spacer()
+
+                Button {
+                    Haptics.selection()
+                    showDetails = true
+                } label: {
+                    Image(systemName: "info.circle")
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(Theme.textSecondary)
+                        .frame(width: 32, height: 32)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Show details for \(exercise.exercise.name)")
 
                 Button {
                     Haptics.light()
@@ -725,6 +775,9 @@ private struct EditableExerciseRow: View {
         .padding(Theme.Spacing.md)
         .background(Theme.surface)
         .clipShape(.rect(cornerRadius: Theme.cornerRadius))
+        .sheet(isPresented: $showDetails) {
+            ExerciseDetailSheet(exercise: exercise.exercise)
+        }
         .onAppear {
             repsText = exercise.targetReps
             if targetWeight > 0 {

--- a/Xomfit/Views/Workout/WarmupView.swift
+++ b/Xomfit/Views/Workout/WarmupView.swift
@@ -2,9 +2,14 @@ import SwiftUI
 
 /// Pre-workout stretch flow.
 ///
-/// Shows a total countdown at the top and walks the user through ~5-7 stretches,
-/// auto-advancing as each per-stretch sub-timer hits zero. Users can skip the
-/// remaining time at any point and jump straight into the workout.
+/// Two phases:
+/// 1. Preview — vertical list of suggested stretches with names, durations, and
+///    target-muscle captions. User can tap a row for the full stretch detail,
+///    hit "Start Warmup" to begin the timer, or "Skip" to jump straight to the
+///    workout.
+/// 2. Timer — total countdown at the top, walks the user through each stretch
+///    with a per-stretch sub-timer. Auto-advances; user can skip remaining time
+///    at any point.
 struct WarmupView: View {
     let stretches: [Stretch]
     /// Total warmup duration in seconds (default 6 minutes).
@@ -20,6 +25,8 @@ struct WarmupView: View {
     @State private var currentIndex: Int = 0
     @State private var timer: Timer?
     @State private var isFinished: Bool = false
+    @State private var hasStarted: Bool = false
+    @State private var stretchForDetail: Stretch?
 
     init(stretches: [Stretch], totalDuration: Int = 360, onFinish: @escaping () -> Void) {
         self.stretches = stretches
@@ -44,25 +51,21 @@ struct WarmupView: View {
         return 1 - (Double(stretchRemaining) / Double(stretch.durationSeconds))
     }
 
+    /// Sum of per-stretch hold times (clamped to the warmup budget).
+    private var estimatedTotalDuration: Int {
+        let summed = stretches.reduce(0) { $0 + $1.durationSeconds }
+        return min(summed, max(totalDuration, summed))
+    }
+
     var body: some View {
         NavigationStack {
             ZStack {
                 Theme.background.ignoresSafeArea()
 
-                ScrollView {
-                    VStack(spacing: Theme.Spacing.lg) {
-                        header
-                        totalTimerCard
-                        currentStretchCard
-                        upcomingList
-                    }
-                    .padding(Theme.Spacing.md)
-                    .padding(.bottom, 100)
-                }
-
-                VStack {
-                    Spacer()
-                    skipButton
+                if hasStarted {
+                    timerContent
+                } else {
+                    previewContent
                 }
             }
             .navigationTitle("Warmup")
@@ -78,18 +81,168 @@ struct WarmupView: View {
                     .foregroundStyle(Theme.textSecondary)
                 }
             }
-            .onAppear {
-                startTimer()
-            }
             .onDisappear {
                 stopTimer()
+            }
+            .sheet(item: $stretchForDetail) { stretch in
+                StretchDetailSheet(stretch: stretch)
             }
         }
     }
 
-    // MARK: - Header
+    // MARK: - Preview
 
-    private var header: some View {
+    private var previewContent: some View {
+        VStack(spacing: 0) {
+            ScrollView {
+                VStack(alignment: .leading, spacing: Theme.Spacing.lg) {
+                    previewHeader
+                    previewList
+                }
+                .padding(Theme.Spacing.md)
+                .padding(.bottom, 120)
+            }
+
+            VStack(spacing: Theme.Spacing.sm) {
+                Button {
+                    Haptics.medium()
+                    beginTimer()
+                } label: {
+                    HStack(spacing: 10) {
+                        Image(systemName: "play.fill")
+                        Text("Start Warmup")
+                    }
+                }
+                .buttonStyle(AccentButtonStyle())
+                .accessibilityLabel("Start warmup timer")
+
+                Button {
+                    Haptics.light()
+                    finish()
+                } label: {
+                    HStack(spacing: 10) {
+                        Image(systemName: "forward.fill")
+                        Text("Skip")
+                    }
+                }
+                .buttonStyle(GhostButtonStyle())
+                .accessibilityLabel("Skip warmup and start workout")
+            }
+            .padding(.horizontal, Theme.Spacing.md)
+            .padding(.bottom, Theme.Spacing.md)
+            .background(
+                LinearGradient(
+                    colors: [Theme.background.opacity(0), Theme.background],
+                    startPoint: .top,
+                    endPoint: .bottom
+                )
+                .frame(height: 180)
+                .allowsHitTesting(false),
+                alignment: .bottom
+            )
+        }
+    }
+
+    private var previewHeader: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Warmup")
+                .font(Theme.fontTitle2)
+                .foregroundStyle(Theme.textPrimary)
+            HStack(spacing: 6) {
+                Image(systemName: "clock.fill")
+                    .font(.caption)
+                    .foregroundStyle(Theme.accent)
+                Text("\(stretches.count) stretches · \(formatTime(estimatedTotalDuration))")
+                    .font(Theme.fontSubheadline)
+                    .foregroundStyle(Theme.textSecondary)
+            }
+            Text("Tap a stretch to see how it's done.")
+                .font(Theme.fontCaption)
+                .foregroundStyle(Theme.textSecondary.opacity(0.8))
+                .padding(.top, 2)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .accessibilityElement(children: .combine)
+        .accessibilityAddTraits(.isHeader)
+    }
+
+    private var previewList: some View {
+        VStack(spacing: Theme.Spacing.sm) {
+            ForEach(Array(stretches.enumerated()), id: \.element.id) { index, stretch in
+                Button {
+                    Haptics.selection()
+                    stretchForDetail = stretch
+                } label: {
+                    previewRow(index: index, stretch: stretch)
+                }
+                .buttonStyle(PressableCardStyle())
+                .accessibilityLabel("\(stretch.name), \(stretch.durationSeconds) seconds, \(muscleGroupSummary(stretch.targetMuscleGroups))")
+                .accessibilityHint("Opens stretch details")
+            }
+        }
+    }
+
+    private func previewRow(index: Int, stretch: Stretch) -> some View {
+        HStack(alignment: .top, spacing: Theme.Spacing.md) {
+            Text("\(index + 1)")
+                .font(.caption.weight(.bold).monospaced())
+                .foregroundStyle(Theme.accent)
+                .frame(width: 28, height: 28)
+                .background(Theme.accent.opacity(0.15))
+                .clipShape(.rect(cornerRadius: Theme.Radius.xs))
+
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(alignment: .firstTextBaseline) {
+                    Text(stretch.name)
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(Theme.textPrimary)
+                    Spacer()
+                    Text("\(stretch.durationSeconds)s")
+                        .font(.caption.weight(.semibold).monospacedDigit())
+                        .foregroundStyle(Theme.textSecondary)
+                }
+                Text(muscleGroupSummary(stretch.targetMuscleGroups))
+                    .font(Theme.fontCaption)
+                    .foregroundStyle(Theme.textSecondary)
+                    .lineLimit(2)
+                    .multilineTextAlignment(.leading)
+            }
+
+            Image(systemName: "chevron.right")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(Theme.textSecondary.opacity(0.6))
+                .padding(.top, 4)
+        }
+        .padding(Theme.Spacing.md)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Theme.surface)
+        .clipShape(.rect(cornerRadius: Theme.cornerRadius))
+        .contentShape(Rectangle())
+    }
+
+    // MARK: - Timer
+
+    private var timerContent: some View {
+        ZStack {
+            ScrollView {
+                VStack(spacing: Theme.Spacing.lg) {
+                    timerHeader
+                    totalTimerCard
+                    currentStretchCard
+                    upcomingList
+                }
+                .padding(Theme.Spacing.md)
+                .padding(.bottom, 100)
+            }
+
+            VStack {
+                Spacer()
+                skipButton
+            }
+        }
+    }
+
+    private var timerHeader: some View {
         VStack(spacing: 4) {
             Text("Loosen up first")
                 .font(Theme.fontTitle2)
@@ -103,8 +256,6 @@ struct WarmupView: View {
         .accessibilityElement(children: .combine)
         .accessibilityAddTraits(.isHeader)
     }
-
-    // MARK: - Total timer
 
     private var totalTimerCard: some View {
         VStack(spacing: Theme.Spacing.sm) {
@@ -126,8 +277,6 @@ struct WarmupView: View {
         .background(Theme.surface)
         .clipShape(.rect(cornerRadius: Theme.cornerRadius))
     }
-
-    // MARK: - Current stretch
 
     @ViewBuilder
     private var currentStretchCard: some View {
@@ -171,6 +320,24 @@ struct WarmupView: View {
 
                 HStack(spacing: Theme.Spacing.sm) {
                     Button {
+                        Haptics.selection()
+                        stretchForDetail = stretch
+                    } label: {
+                        HStack(spacing: 6) {
+                            Image(systemName: "info.circle")
+                            Text("Details")
+                        }
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(Theme.textSecondary)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 8)
+                        .background(Theme.surfaceElevated)
+                        .clipShape(.rect(cornerRadius: Theme.Radius.sm))
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Show stretch details")
+
+                    Button {
                         Haptics.light()
                         advanceToNextStretch()
                     } label: {
@@ -190,8 +357,6 @@ struct WarmupView: View {
             EmptyView()
         }
     }
-
-    // MARK: - Upcoming
 
     @ViewBuilder
     private var upcomingList: some View {
@@ -237,8 +402,6 @@ struct WarmupView: View {
         .accessibilityLabel("Up next: \(stretch.name), \(stretch.durationSeconds) seconds")
     }
 
-    // MARK: - Skip button
-
     private var skipButton: some View {
         Button {
             Haptics.medium()
@@ -255,7 +418,13 @@ struct WarmupView: View {
         .accessibilityLabel("Skip remaining warmup and start workout")
     }
 
-    // MARK: - Timer
+    // MARK: - Timer control
+
+    private func beginTimer() {
+        guard !hasStarted else { return }
+        hasStarted = true
+        startTimer()
+    }
 
     private func startTimer() {
         // Bail early if there are no stretches at all.
@@ -265,7 +434,9 @@ struct WarmupView: View {
         }
         stopTimer()
         timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { _ in
-            tick()
+            Task { @MainActor in
+                tick()
+            }
         }
     }
 
@@ -274,6 +445,7 @@ struct WarmupView: View {
         timer = nil
     }
 
+    @MainActor
     private func tick() {
         guard !isFinished else { return }
 


### PR DESCRIPTION
Closes #295, #296.

#295: WarmupView now has a preview phase (gated by hasStarted) showing the suggested stretch list with total duration + per-row tap to open StretchDetailSheet. Existing timer flow kicks in via 'Start Warmup'. Confirmed selection logic in StretchDatabase.suggestedStretches(forMuscleGroups:target:) is already smart (frequency-weighted, capped at 7, defaults to balanced routine on no data) — only shipped the preview UI.

#296:
- TemplateDetailView gets a Targets row (union of muscle groups across all exercises) + per-row info button → ExerciseDetailSheet
- ExerciseDetailSheet now shows Grips / Attachments / Positions chip rows when supported
- New StretchDetailSheet mirrors the exercise sheet pattern