### PR TITLE
#302 add Now Playing capture for active workouts (Apple Music v1)

### DIFF
--- a/Xomfit.xcodeproj/project.pbxproj
+++ b/Xomfit.xcodeproj/project.pbxproj
@@ -710,6 +710,7 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
+				INFOPLIST_KEY_NSAppleMusicUsageDescription = "XomFit captures the songs that played during your workout so you can see your soundtrack later.";
 				INFOPLIST_KEY_NSSupportsLiveActivities = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -746,6 +747,7 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
+				INFOPLIST_KEY_NSAppleMusicUsageDescription = "XomFit captures the songs that played during your workout so you can see your soundtrack later.";
 				INFOPLIST_KEY_NSSupportsLiveActivities = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;

--- a/Xomfit/Models/SocialFeedItem.swift
+++ b/Xomfit/Models/SocialFeedItem.swift
@@ -60,6 +60,10 @@ struct WorkoutActivity: Codable {
     var location: String?
     var rating: Int?
     var photoURLs: [String]?
+    /// One-line teaser surfaced on the feed card (#302). Apple Music capture only.
+    /// `trackCount` is 0 and `firstTrackTitle` is nil when the workout had no captured tracks.
+    var trackCount: Int?
+    var firstTrackTitle: String?
 
     struct ExerciseSummary: Codable, Identifiable {
         let id: String

--- a/Xomfit/Models/Workout.swift
+++ b/Xomfit/Models/Workout.swift
@@ -10,8 +10,58 @@ struct Workout: Codable, Identifiable {
     var notes: String?
     var location: String?
     var rating: Int?
-    
+    /// Songs captured passively during this workout via `NowPlayingService` (#302).
+    /// Apple Music only — see `WorkoutTrack` for the iOS platform restriction.
+    /// Defaulted so older cached / decoded payloads stay backward-compatible.
+    var tracks: [WorkoutTrack] = []
+
     var startDate: Date { startTime }
+
+    // MARK: - Codable
+    //
+    // Custom decoder so older cached `Workout` payloads (no `tracks` key) keep decoding.
+    // Encoding stays synthesized.
+    enum CodingKeys: String, CodingKey {
+        case id, userId, name, exercises, startTime, endTime, notes, location, rating, tracks
+    }
+
+    init(
+        id: String,
+        userId: String,
+        name: String,
+        exercises: [WorkoutExercise],
+        startTime: Date,
+        endTime: Date? = nil,
+        notes: String? = nil,
+        location: String? = nil,
+        rating: Int? = nil,
+        tracks: [WorkoutTrack] = []
+    ) {
+        self.id = id
+        self.userId = userId
+        self.name = name
+        self.exercises = exercises
+        self.startTime = startTime
+        self.endTime = endTime
+        self.notes = notes
+        self.location = location
+        self.rating = rating
+        self.tracks = tracks
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(String.self, forKey: .id)
+        userId = try container.decode(String.self, forKey: .userId)
+        name = try container.decode(String.self, forKey: .name)
+        exercises = try container.decode([WorkoutExercise].self, forKey: .exercises)
+        startTime = try container.decode(Date.self, forKey: .startTime)
+        endTime = try container.decodeIfPresent(Date.self, forKey: .endTime)
+        notes = try container.decodeIfPresent(String.self, forKey: .notes)
+        location = try container.decodeIfPresent(String.self, forKey: .location)
+        rating = try container.decodeIfPresent(Int.self, forKey: .rating)
+        tracks = try container.decodeIfPresent([WorkoutTrack].self, forKey: .tracks) ?? []
+    }
 
     var duration: TimeInterval {
         (endTime ?? Date()).timeIntervalSince(startTime)

--- a/Xomfit/Models/WorkoutTrack.swift
+++ b/Xomfit/Models/WorkoutTrack.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+/// A single audio track captured during an active workout via Now Playing polling.
+///
+/// Platform limitation: iOS does NOT expose other apps' Now Playing metadata to third-party
+/// apps. `MPNowPlayingInfoCenter.default()` is only readable by the OWNING audio app, and
+/// `MPMusicPlayerController.systemMusicPlayer` only reflects Apple Music / iTunes Match content.
+/// As a result, Spotify / Xomify / podcast players will NOT appear in this list — that's a
+/// hard iOS restriction with no public API workaround.
+struct WorkoutTrack: Codable, Hashable, Identifiable {
+    var id: UUID = UUID()
+    var title: String
+    var artist: String?
+    var album: String?
+    var capturedAt: Date
+    /// Source application that surfaced the track (e.g. "Apple Music"). Hard-coded for v1
+    /// because Apple Music is the only legal capture target.
+    var sourceApp: String
+}

--- a/Xomfit/Services/FeedService.swift
+++ b/Xomfit/Services/FeedService.swift
@@ -168,6 +168,11 @@ final class FeedService {
             )
         }
 
+        // Now Playing capture teaser (#302). Skip when no tracks were captured so we
+        // don't bloat the payload with empty fields for Spotify-only workouts.
+        let trackCount: Int? = workout.tracks.isEmpty ? nil : workout.tracks.count
+        let firstTrackTitle: String? = workout.tracks.first?.title
+
         let activity = WorkoutActivity(
             workoutId: workout.id,
             workoutName: workout.name,
@@ -179,7 +184,9 @@ final class FeedService {
             exercises: exercises,
             location: workout.location,
             rating: workout.rating,
-            photoURLs: photoURLs
+            photoURLs: photoURLs,
+            trackCount: trackCount,
+            firstTrackTitle: firstTrackTitle
         )
 
         let payloadData = try jsonEncoder.encode(activity)

--- a/Xomfit/Services/NowPlayingService.swift
+++ b/Xomfit/Services/NowPlayingService.swift
@@ -1,0 +1,123 @@
+import Foundation
+import MediaPlayer
+
+/// Polls `MPMusicPlayerController.systemMusicPlayer` during an active workout to capture
+/// the songs the user listens to and attaches them to the saved `Workout`.
+///
+/// ## iOS platform limitation (read this before extending)
+///
+/// iOS does NOT expose other apps' Now Playing metadata to third-party apps:
+/// - `MPNowPlayingInfoCenter.default()` is only readable by the OWNING audio app.
+/// - `MPRemoteCommandCenter` notifications carry no cross-app metadata.
+/// - `MPMusicPlayerController.systemMusicPlayer` only reflects Apple Music / iTunes Match.
+///
+/// The only legal capture target is therefore Apple Music. Spotify, Xomify, podcast apps,
+/// and YouTube Music will NOT appear in captured tracks. That's a hard iOS restriction —
+/// the only workarounds are (a) being the audio app yourself, or (b) private API
+/// (rejected at App Review). v1 ships the Apple Music capture only.
+@MainActor
+final class NowPlayingService {
+    static let shared = NowPlayingService()
+
+    /// 30s polling cadence — frequent enough to catch song changes, cheap enough to avoid wakelock pressure.
+    private let pollInterval: TimeInterval = 30
+
+    /// Accumulated tracks for the current capture session, deduped by `dedupeKey`.
+    private var captured: [WorkoutTrack] = []
+    private var seenKeys: Set<String> = []
+    private var pollTask: Task<Void, Never>?
+    private var isAuthorized: Bool = false
+
+    private init() {}
+
+    // MARK: - Authorization
+
+    /// Triggers the system Apple Music auth prompt the first time. Subsequent calls
+    /// are cheap — they just refresh the cached `isAuthorized` flag.
+    func ensureAuthorization() async {
+        let status = MPMediaLibrary.authorizationStatus()
+        switch status {
+        case .authorized:
+            isAuthorized = true
+        case .notDetermined:
+            let result = await withCheckedContinuation { (continuation: CheckedContinuation<MPMediaLibraryAuthorizationStatus, Never>) in
+                MPMediaLibrary.requestAuthorization { status in
+                    continuation.resume(returning: status)
+                }
+            }
+            isAuthorized = (result == .authorized)
+        case .denied, .restricted:
+            isAuthorized = false
+        @unknown default:
+            isAuthorized = false
+        }
+    }
+
+    // MARK: - Capture Lifecycle
+
+    /// Begins polling. Idempotent — safe to call repeatedly. If auth was denied, this is a no-op.
+    func startCapture() {
+        // Reset session state up-front so a back-to-back start clears prior captures
+        captured.removeAll()
+        seenKeys.removeAll()
+        pollTask?.cancel()
+
+        // Kick off auth check + first poll. If auth lands on denied, the polling loop
+        // will simply observe the auth flag and exit — no nag, no UI.
+        pollTask = Task { [weak self] in
+            guard let self else { return }
+            await self.ensureAuthorization()
+            // Capture immediately so a song already playing at workout start is recorded.
+            self.captureCurrentTrack()
+
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: UInt64(self.pollInterval * 1_000_000_000))
+                if Task.isCancelled { return }
+                self.captureCurrentTrack()
+            }
+        }
+    }
+
+    /// Stops polling and returns the captured list. Clears internal state so the next
+    /// `startCapture()` begins fresh.
+    @discardableResult
+    func stopCapture() -> [WorkoutTrack] {
+        pollTask?.cancel()
+        pollTask = nil
+        let result = captured
+        captured.removeAll()
+        seenKeys.removeAll()
+        return result
+    }
+
+    // MARK: - Polling
+
+    /// Reads `systemMusicPlayer.nowPlayingItem` once. No-op when:
+    ///   - Apple Music auth is denied
+    ///   - Nothing is playing via Apple Music (Spotify/podcasts/etc. won't surface here)
+    ///   - The current track was already captured (deduped by title+artist+persistentID)
+    private func captureCurrentTrack() {
+        guard isAuthorized else { return }
+        guard let item = MPMusicPlayerController.systemMusicPlayer.nowPlayingItem else { return }
+        guard let title = item.title, !title.isEmpty else { return }
+
+        let key = dedupeKey(title: title, artist: item.artist, persistentID: item.persistentID)
+        guard !seenKeys.contains(key) else { return }
+        seenKeys.insert(key)
+
+        let track = WorkoutTrack(
+            title: title,
+            artist: item.artist,
+            album: item.albumTitle,
+            capturedAt: Date(),
+            sourceApp: "Apple Music"
+        )
+        captured.append(track)
+    }
+
+    private func dedupeKey(title: String, artist: String?, persistentID: MPMediaEntityPersistentID) -> String {
+        // persistentID == 0 for some streamed / radio items — fall back to title+artist alone in that case.
+        let pid = persistentID == 0 ? "" : String(persistentID)
+        return "\(title.lowercased())|\(artist?.lowercased() ?? "")|\(pid)"
+    }
+}

--- a/Xomfit/ViewModels/WorkoutLoggerViewModel.swift
+++ b/Xomfit/ViewModels/WorkoutLoggerViewModel.swift
@@ -159,6 +159,10 @@ final class WorkoutLoggerViewModel {
         totalPausedDuration = 0
         skipRestTimer()
         startLiveActivity()
+
+        // Begin Now Playing capture — Apple Music only (see NowPlayingService docs).
+        // Silent no-op when the user denied Apple Music access.
+        NowPlayingService.shared.startCapture()
     }
 
     func discardWorkout() {
@@ -184,6 +188,9 @@ final class WorkoutLoggerViewModel {
         location = ""
         rating = 0
         skipRestTimer()
+
+        // Drop any captured Now Playing tracks — discarding the workout discards the soundtrack.
+        _ = NowPlayingService.shared.stopCapture()
     }
 
     func startFromTemplate(_ template: WorkoutTemplate, userId: String) {
@@ -927,6 +934,11 @@ final class WorkoutLoggerViewModel {
 
         let trimmedNotes = notes?.trimmingCharacters(in: .whitespacesAndNewlines)
         let trimmedLocation = location.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        // Pull the Now Playing capture and attach it to the saved workout.
+        // Empty list when the user denied Apple Music access or only used non-Apple Music sources.
+        let capturedTracks = NowPlayingService.shared.stopCapture()
+
         let workout = Workout(
             id: UUID().uuidString,
             userId: userId,
@@ -936,7 +948,8 @@ final class WorkoutLoggerViewModel {
             endTime: Date(),
             notes: trimmedNotes?.isEmpty == false ? trimmedNotes : nil,
             location: trimmedLocation.isEmpty ? nil : trimmedLocation,
-            rating: rating > 0 ? rating : nil
+            rating: rating > 0 ? rating : nil,
+            tracks: capturedTracks
         )
 
         do {

--- a/Xomfit/Views/Workout/WorkoutDetailView.swift
+++ b/Xomfit/Views/Workout/WorkoutDetailView.swift
@@ -11,6 +11,7 @@ struct WorkoutDetailView: View {
                 VStack(spacing: Theme.Spacing.md) {
                     summaryCard
                     exerciseList
+                    soundtrackSection
                 }
                 .padding(.horizontal, Theme.Spacing.md)
                 .padding(.vertical, Theme.Spacing.sm)
@@ -214,6 +215,85 @@ struct WorkoutDetailView: View {
         .font(.subheadline.weight(.medium).monospaced())
         .padding(.vertical, 4)
         .accessibilityLabel("Set \(number): \(formatWeight(set.weight)) lbs for \(set.reps) reps\(set.isPersonalRecord ? ", personal record" : "")")
+    }
+
+    // MARK: - Soundtrack
+
+    /// Apple Music-only Now Playing capture (#302). See `NowPlayingService` for the iOS
+    /// platform restriction explaining why Spotify / Xomify won't ever appear here.
+    @ViewBuilder
+    private var soundtrackSection: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+            HStack(spacing: 6) {
+                Image(systemName: "music.note")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(Theme.accent)
+                Text("Soundtrack")
+                    .font(.subheadline.weight(.bold))
+                    .foregroundStyle(Theme.textPrimary)
+                Spacer()
+                if !workout.tracks.isEmpty {
+                    Text("\(workout.tracks.count)")
+                        .font(.caption.weight(.semibold).monospaced())
+                        .foregroundStyle(Theme.textSecondary)
+                }
+            }
+
+            if workout.tracks.isEmpty {
+                Text("No tracks captured. Tip: Now Playing capture works with Apple Music.")
+                    .font(Theme.fontSmall)
+                    .foregroundStyle(Theme.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .accessibilityLabel("No tracks captured during this workout")
+            } else {
+                VStack(spacing: 0) {
+                    ForEach(Array(workout.tracks.enumerated()), id: \.element.id) { index, track in
+                        soundtrackRow(track: track)
+                        if index < workout.tracks.count - 1 {
+                            Divider()
+                                .background(Theme.textSecondary.opacity(0.15))
+                        }
+                    }
+                }
+            }
+        }
+        .padding(Theme.Spacing.md)
+        .background(Theme.surface)
+        .clipShape(.rect(cornerRadius: Theme.cornerRadius))
+    }
+
+    private func soundtrackRow(track: WorkoutTrack) -> some View {
+        HStack(spacing: Theme.Spacing.sm) {
+            Image(systemName: "music.note")
+                .font(.caption)
+                .foregroundStyle(Theme.textSecondary)
+                .frame(width: 20)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(track.title)
+                    .font(.subheadline.weight(.medium))
+                    .foregroundStyle(Theme.textPrimary)
+                    .lineLimit(1)
+                if let artist = track.artist, !artist.isEmpty {
+                    Text(artist)
+                        .font(Theme.fontSmall)
+                        .foregroundStyle(Theme.textSecondary)
+                        .lineLimit(1)
+                }
+            }
+
+            Spacer()
+        }
+        .padding(.vertical, 8)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(accessibilityLabel(for: track))
+    }
+
+    private func accessibilityLabel(for track: WorkoutTrack) -> String {
+        if let artist = track.artist, !artist.isEmpty {
+            return "\(track.title) by \(artist)"
+        }
+        return track.title
     }
 
     // MARK: - Helpers


### PR DESCRIPTION
Closes #302 (scope A — passive Apple Music capture).

While a workout is active, polls MPMusicPlayerController.systemMusicPlayer.nowPlayingItem every 30s and dedupes by (title, artist, persistentID). Captured tracks attach to the saved Workout via a new tracks: [WorkoutTrack] = [] field (backward-compatible decoding for older cached rows). Soundtrack section renders on WorkoutDetailView; feed post payload gains optional trackCount + firstTrackTitle for a one-line teaser.

## Platform limitation
iOS does not expose other apps' Now Playing metadata to third parties on any public API. **Spotify, Xomify, podcast apps, and YouTube Music will not appear** in captured tracks. Documented in code + WorkoutDetailView empty-state caption.

## Permission
Added INFOPLIST_KEY_NSAppleMusicUsageDescription to both Debug + Release configs. NowPlayingService silently no-ops if user denies auth.

## Files
- new: Models/WorkoutTrack.swift, Services/NowPlayingService.swift
- modified: Models/Workout.swift (+tracks field), ViewModels/WorkoutLoggerViewModel.swift (start/stop hooks), Views/Workout/WorkoutDetailView.swift (Soundtrack section), Models/SocialFeedItem.swift + Services/FeedService.swift (feed payload teaser), pbxproj (Info.plist key)

Scope B (Xomify pick-a-song) is the follow-up.