### PR TITLE
#310 first-run polish: tutorial overlays + persistent welcome card

### DIFF
--- a/Xomfit/Views/Workout/ActiveWorkoutView.swift
+++ b/Xomfit/Views/Workout/ActiveWorkoutView.swift
@@ -23,6 +23,17 @@ struct ActiveWorkoutView: View {
     /// to scroll to the picked card, then cleared.
     @State private var pendingScrollIndex: Int?
 
+    // First-run polish (#310)
+    /// Persisted flag — once dismissed, the active-workout tutorial overlay never re-shows.
+    @AppStorage("xomfit_first_workout_tutorial_seen") private var firstTutorialSeen = false
+    /// Persisted flag — first-ever rest timer toast across the user's history.
+    @AppStorage("xomfit_first_rest_timer_seen") private var firstRestTimerSeen = false
+    /// Drives the tutorial overlay. Lifted to local state so we can animate it
+    /// in/out independently of the AppStorage write.
+    @State private var showFirstTutorial = false
+    /// Single-shot rest timer onboarding toast.
+    @State private var restTimerToast: Toast?
+
     var body: some View {
         @Bindable var viewModel = viewModel
 
@@ -132,6 +143,19 @@ struct ActiveWorkoutView: View {
                     }
                 }
 
+                // First-run tutorial overlay (#310). Sits above the rest of
+                // the workout UI so it's the first thing the user sees on
+                // their first active workout. Persisted by AppStorage so it
+                // never re-shows after dismissal.
+                if showFirstTutorial {
+                    FirstWorkoutTutorial {
+                        withAnimation(.xomConfident) {
+                            showFirstTutorial = false
+                        }
+                        firstTutorialSeen = true
+                    }
+                }
+
                 // Exercise Transition Overlay
                 if viewModel.showExerciseTransition {
                     Color.black.opacity(0.4)
@@ -189,6 +213,16 @@ struct ActiveWorkoutView: View {
         .onChange(of: viewModel.isRestTimerActive) { _, isActive in
             if isActive {
                 restTimerHapticFired = false
+                // First-time rest timer toast (#310). Surface a small explainer
+                // the very first time the rest timer fires, then never again.
+                if !firstRestTimerSeen {
+                    firstRestTimerSeen = true
+                    restTimerToast = Toast(
+                        style: .info,
+                        message: "Rest timer running. +30s adds time, Skip ends it, tap to minimize.",
+                        duration: 5.0
+                    )
+                }
             }
         }
         .onChange(of: scenePhase) { _, newPhase in
@@ -274,6 +308,24 @@ struct ActiveWorkoutView: View {
                 }
             }
             .presentationDetents([.medium])
+        }
+        // First-run rest timer toast (#310). Uses the existing toast pattern
+        // shared with launch streak/PR badges in MainTabView.
+        .toast($restTimerToast)
+        .onAppear {
+            // Show the active-workout tutorial overlay only on the user's
+            // very first active workout. Defer slightly so it lands after
+            // the cover's mount animation finishes (#310).
+            if !firstTutorialSeen && !showFirstTutorial {
+                Task { @MainActor in
+                    try? await Task.sleep(for: .milliseconds(450))
+                    if !firstTutorialSeen {
+                        withAnimation(.xomConfident) {
+                            showFirstTutorial = true
+                        }
+                    }
+                }
+            }
         }
     }
 

--- a/Xomfit/Views/Workout/FirstWorkoutTutorial.swift
+++ b/Xomfit/Views/Workout/FirstWorkoutTutorial.swift
@@ -1,0 +1,150 @@
+import SwiftUI
+
+// MARK: - FirstWorkoutTutorial (#310)
+
+/// One-shot dimmed overlay that introduces the three core controls of the
+/// active workout screen (set row entry, completion checkmark, focus toggle).
+/// Dismissal is persisted by the caller via
+/// `@AppStorage("xomfit_first_workout_tutorial_seen")` so it never re-shows.
+struct FirstWorkoutTutorial: View {
+    /// Called when the user dismisses the overlay (either via button or backdrop tap).
+    let onDismiss: () -> Void
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    /// The three callouts surfaced on the overlay. Capped at three by design —
+    /// any more than that is information overload for a first-run tip sheet.
+    private let callouts: [Callout] = [
+        Callout(
+            icon: "rectangle.and.pencil.and.ellipsis",
+            title: "Tap a row to log",
+            body: "Tap any set row to type in your weight and reps."
+        ),
+        Callout(
+            icon: "checkmark.circle.fill",
+            title: "Tap the check to complete",
+            body: "Hit the checkmark when you finish a set. The rest timer kicks off automatically."
+        ),
+        Callout(
+            icon: "eye",
+            title: "Try Focus mode",
+            body: "Tap the eye icon up top for a zoomed-in, one-set-at-a-time view."
+        ),
+    ]
+
+    var body: some View {
+        ZStack {
+            // Backdrop — tap to dismiss
+            Color.black.opacity(0.55)
+                .ignoresSafeArea()
+                .contentShape(Rectangle())
+                .onTapGesture {
+                    Haptics.light()
+                    onDismiss()
+                }
+                .accessibilityLabel("Dismiss tutorial")
+                .accessibilityAddTraits(.isButton)
+
+            // Card
+            VStack(spacing: Theme.Spacing.md) {
+                // Header
+                VStack(spacing: Theme.Spacing.xs) {
+                    Image(systemName: "sparkles")
+                        .font(.title2)
+                        .foregroundStyle(Theme.accent)
+                        .accessibilityHidden(true)
+
+                    Text("Quick tour")
+                        .font(.title3.weight(.bold))
+                        .foregroundStyle(Theme.textPrimary)
+
+                    Text("Three things to know before your first set.")
+                        .font(Theme.fontCaption)
+                        .foregroundStyle(Theme.textSecondary)
+                        .multilineTextAlignment(.center)
+                }
+                .padding(.top, Theme.Spacing.sm)
+
+                // Callouts
+                VStack(spacing: Theme.Spacing.sm) {
+                    ForEach(callouts) { callout in
+                        CalloutRow(callout: callout)
+                    }
+                }
+
+                // Got it
+                Button {
+                    Haptics.success()
+                    onDismiss()
+                } label: {
+                    Text("Got it")
+                        .font(.body.weight(.bold))
+                        .foregroundStyle(.black)
+                        .frame(maxWidth: .infinity)
+                        .frame(minHeight: 44)
+                        .background(Theme.accent)
+                        .clipShape(.rect(cornerRadius: Theme.cornerRadiusSmall))
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Dismiss tutorial")
+                .accessibilityHint("Closes the quick tour. It won't show again.")
+            }
+            .padding(Theme.Spacing.lg)
+            .background(Theme.surface)
+            .clipShape(.rect(cornerRadius: Theme.cornerRadius))
+            .overlay(
+                RoundedRectangle(cornerRadius: Theme.cornerRadius)
+                    .stroke(Theme.accent.opacity(0.25), lineWidth: 1)
+            )
+            .shadow(color: .black.opacity(0.4), radius: 24, x: 0, y: 8)
+            .padding(.horizontal, Theme.Spacing.lg)
+            .frame(maxWidth: 520)
+        }
+        .transition(reduceMotion
+            ? .opacity
+            : .opacity.combined(with: .scale(scale: 0.96)))
+        .zIndex(200)
+    }
+}
+
+// MARK: - Callout
+
+private struct Callout: Identifiable {
+    let id = UUID()
+    let icon: String
+    let title: String
+    let body: String
+}
+
+private struct CalloutRow: View {
+    let callout: Callout
+
+    var body: some View {
+        HStack(alignment: .top, spacing: Theme.Spacing.md) {
+            Image(systemName: callout.icon)
+                .font(.title3.weight(.semibold))
+                .foregroundStyle(Theme.accent)
+                .frame(width: 32, height: 32)
+                .background(Theme.accent.opacity(0.15))
+                .clipShape(Circle())
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(callout.title)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(Theme.textPrimary)
+                Text(callout.body)
+                    .font(Theme.fontCaption)
+                    .foregroundStyle(Theme.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer(minLength: 0)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(Theme.Spacing.sm)
+        .background(Theme.surface.opacity(0.6))
+        .clipShape(.rect(cornerRadius: Theme.cornerRadiusSmall))
+        .accessibilityElement(children: .combine)
+    }
+}

--- a/Xomfit/Views/Workout/WorkoutView.swift
+++ b/Xomfit/Views/Workout/WorkoutView.swift
@@ -102,8 +102,14 @@ struct WorkoutView: View {
                             }
                             .padding(.horizontal, Theme.Spacing.md)
 
-                            // First workout guide for new users
-                            if viewModel.recent.isEmpty && !hasStartedFirstWorkout {
+                            // First workout guide for new users (#310).
+                            // Persist this card even after recents arrive — gate
+                            // only on whether the user has built/saved their own
+                            // template (myTemplates + savedTemplates), plus the
+                            // manual "Skip" escape hatch.
+                            if viewModel.myTemplates.isEmpty
+                                && viewModel.savedTemplates.isEmpty
+                                && !hasStartedFirstWorkout {
                                 firstWorkoutCard
                             }
 


### PR DESCRIPTION
Closes #310. New FirstWorkoutTutorial overlay (3 callouts) on first ActiveWorkoutView, one-time Toast on first rest timer, welcome card persists until user has saved/built a template.