### PR TITLE
#315 add plate calculator + 1RM estimator tools

### DIFF
--- a/Xomfit/Views/Profile/PRListView.swift
+++ b/Xomfit/Views/Profile/PRListView.swift
@@ -6,6 +6,8 @@ struct PRListView: View {
     @State private var prs: [PersonalRecord] = []
     @State private var isLoading = false
     @State private var errorMessage: String?
+    /// PR currently picked for the 1RM estimator sheet. nil = sheet hidden.
+    @State private var oneRMSeed: PersonalRecord?
 
     // Group PRs by exercise name, each group sorted by date desc
     private var grouped: [(String, [PersonalRecord])] {
@@ -31,6 +33,14 @@ struct PRListView: View {
                                 PRRow(pr: pr, rank: index + 1)
                                     .listRowBackground(Theme.surface)
                                     .listRowInsets(EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: Theme.Spacing.md))
+                                    .contextMenu {
+                                        Button {
+                                            Haptics.selection()
+                                            oneRMSeed = pr
+                                        } label: {
+                                            Label("1RM Estimate", systemImage: "function")
+                                        }
+                                    }
                             }
                         } header: {
                             Text(exerciseName)
@@ -49,6 +59,10 @@ struct PRListView: View {
         .toolbarColorScheme(.dark, for: .navigationBar)
         .onAppear { loadPRs() }
         .refreshable { loadPRs() }
+        .sheet(item: $oneRMSeed) { pr in
+            OneRMEstimatorView(initialWeight: pr.weight, initialReps: pr.reps)
+                .presentationDetents([.large])
+        }
     }
 
     private var emptyState: some View {

--- a/Xomfit/Views/Profile/SettingsView.swift
+++ b/Xomfit/Views/Profile/SettingsView.swift
@@ -3,6 +3,9 @@ import SwiftUI
 struct SettingsView: View {
     @Environment(AuthService.self) private var authService
     @State private var showSignOutConfirm = false
+    /// Tools section sheet toggles — both stateless utilities live in modal sheets.
+    @State private var showPlateCalculator = false
+    @State private var showOneRMEstimator = false
 
     /// Anthropic API key override (per-user). v1: stored via @AppStorage —
     /// not secure. TODO: migrate to Keychain.
@@ -142,6 +145,28 @@ struct SettingsView: View {
                 .listRowSeparatorTint(Theme.hairline)
 
                 Section {
+                    Button {
+                        Haptics.selection()
+                        showPlateCalculator = true
+                    } label: {
+                        toolRow(icon: "circle.hexagongrid.fill", label: "Plate Calculator")
+                    }
+                    .buttonStyle(.plain)
+
+                    Button {
+                        Haptics.selection()
+                        showOneRMEstimator = true
+                    } label: {
+                        toolRow(icon: "function", label: "1RM Estimator")
+                    }
+                    .buttonStyle(.plain)
+                } header: {
+                    XomMetricLabel("Tools")
+                }
+                .listRowBackground(Theme.surface)
+                .listRowSeparatorTint(Theme.hairline)
+
+                Section {
                     settingsRow(icon: "info.circle.fill", iconColor: Theme.accent, label: "Version", value: appVersion)
                     settingsRow(icon: "building.2.fill", iconColor: Theme.accent, label: "App", value: Config.appName)
                 } header: {
@@ -180,6 +205,29 @@ struct SettingsView: View {
         } message: {
             Text("You will be returned to the login screen.")
         }
+        .sheet(isPresented: $showPlateCalculator) {
+            PlateCalculatorView()
+                .presentationDetents([.large])
+        }
+        .sheet(isPresented: $showOneRMEstimator) {
+            OneRMEstimatorView()
+                .presentationDetents([.large])
+        }
+    }
+
+    private func toolRow(icon: String, label: String) -> some View {
+        HStack(spacing: Theme.Spacing.md) {
+            Image(systemName: icon)
+                .frame(width: 24)
+                .foregroundStyle(Theme.accent)
+            Text(label)
+                .foregroundStyle(Theme.textPrimary)
+            Spacer()
+            Image(systemName: "chevron.right")
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(Theme.textTertiary)
+        }
+        .contentShape(Rectangle())
     }
 
     private func settingsRow(icon: String, iconColor: Color, label: String, value: String) -> some View {

--- a/Xomfit/Views/Tools/OneRMEstimatorView.swift
+++ b/Xomfit/Views/Tools/OneRMEstimatorView.swift
@@ -1,0 +1,239 @@
+import SwiftUI
+
+/// Pure-Swift one-rep-max estimator. Takes a weight × reps lift and returns
+/// estimates from three common formulas. Stateless — no services.
+struct OneRMEstimatorView: View {
+    /// Optional pre-fill from a PR row or set selection.
+    let initialWeight: Double?
+    let initialReps: Int?
+
+    init(initialWeight: Double? = nil, initialReps: Int? = nil) {
+        self.initialWeight = initialWeight
+        self.initialReps = initialReps
+        _weightText = State(initialValue: initialWeight.map { $0.formattedWeight } ?? "")
+        _repsText   = State(initialValue: initialReps.map { "\($0)" } ?? "")
+    }
+
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var weightText: String
+    @State private var repsText: String
+
+    private var weight: Double { Double(weightText) ?? 0 }
+    private var reps: Int { Int(repsText) ?? 0 }
+
+    /// 1RM is undefined for 0 reps, and 1-rep entries already are the 1RM.
+    /// Brzycki blows up at 37 reps; we cap at 12 (where formulas stay sensible).
+    private var validInput: Bool {
+        weight > 0 && reps >= 1 && reps <= 12
+    }
+
+    private var estimates: OneRMEstimator.Result {
+        OneRMEstimator.estimate(weight: weight, reps: reps)
+    }
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Theme.background.ignoresSafeArea()
+
+                ScrollView {
+                    VStack(alignment: .leading, spacing: Theme.Spacing.lg) {
+                        inputSection
+                        if validInput {
+                            recommendationSection
+                            secondOpinionSection
+                            disclaimer
+                        } else {
+                            placeholder
+                        }
+                    }
+                    .padding(.horizontal, Theme.Spacing.md)
+                    .padding(.vertical, Theme.Spacing.md)
+                }
+            }
+            .navigationTitle("1RM Estimator")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbarColorScheme(.dark, for: .navigationBar)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { dismiss() }
+                        .foregroundStyle(Theme.accent)
+                }
+            }
+        }
+    }
+
+    // MARK: - Sections
+
+    private var inputSection: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.md) {
+            sectionHeader("Lift")
+            HStack(spacing: Theme.Spacing.md) {
+                inputField(label: "Weight (lbs)", text: $weightText, keyboard: .decimalPad)
+                    .accessibilityLabel("Weight in pounds")
+                inputField(label: "Reps", text: $repsText, keyboard: .numberPad)
+                    .accessibilityLabel("Repetitions")
+            }
+            if reps > 12 {
+                HStack(spacing: 6) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundStyle(Theme.alert)
+                    Text("Estimates are unreliable above 12 reps. Use a heavier set.")
+                        .font(Theme.fontCaption)
+                        .foregroundStyle(Theme.textSecondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+        }
+        .padding(Theme.Spacing.md)
+        .background(Theme.surface)
+        .clipShape(.rect(cornerRadius: Theme.cornerRadius))
+    }
+
+    private var recommendationSection: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+            HStack(spacing: 6) {
+                Image(systemName: "trophy.fill")
+                    .foregroundStyle(Theme.prGold)
+                Text("Recommended (Epley)")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(Theme.prGold)
+            }
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel("Recommended estimate, Epley")
+            .accessibilityAddTraits(.isHeader)
+
+            Text("\(estimates.epley.formattedWeight) lbs")
+                .font(Theme.fontDisplay)
+                .foregroundStyle(Theme.textPrimary)
+                .accessibilityLabel("\(estimates.epley.formattedWeight) pounds")
+
+            Text("Epley is the most common gym estimator. Treat it as a ceiling, not a guarantee.")
+                .font(Theme.fontCaption)
+                .foregroundStyle(Theme.textTertiary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(Theme.Spacing.md)
+        .background(Theme.surface)
+        .overlay(
+            RoundedRectangle(cornerRadius: Theme.cornerRadius)
+                .strokeBorder(Theme.prGold.opacity(0.4), lineWidth: 1)
+        )
+        .clipShape(.rect(cornerRadius: Theme.cornerRadius))
+    }
+
+    private var secondOpinionSection: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+            sectionHeader("Second Opinion")
+            estimateRow(name: "Brzycki", value: estimates.brzycki, note: "Conservative, breaks down past ~10 reps")
+            estimateRow(name: "Lombardi", value: estimates.lombardi, note: "Aggressive, useful for low-rep sets")
+        }
+        .padding(Theme.Spacing.md)
+        .background(Theme.surface)
+        .clipShape(.rect(cornerRadius: Theme.cornerRadius))
+    }
+
+    private func estimateRow(name: String, value: Double, note: String) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: Theme.Spacing.md) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(name)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(Theme.textPrimary)
+                Text(note)
+                    .font(Theme.fontCaption)
+                    .foregroundStyle(Theme.textTertiary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            Spacer(minLength: 0)
+            Text("\(value.formattedWeight) lbs")
+                .font(Theme.fontNumberMedium)
+                .foregroundStyle(Theme.accent)
+        }
+        .padding(.vertical, 6)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(name) estimate: \(value.formattedWeight) pounds. \(note)")
+    }
+
+    private var disclaimer: some View {
+        HStack(alignment: .top, spacing: Theme.Spacing.sm) {
+            Image(systemName: "info.circle.fill")
+                .foregroundStyle(Theme.accent)
+            Text("Estimates extrapolate from your set. Always work up gradually with a spotter before testing a true 1RM.")
+                .font(Theme.fontCaption)
+                .foregroundStyle(Theme.textSecondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(Theme.Spacing.md)
+        .background(Theme.accentMuted)
+        .clipShape(.rect(cornerRadius: Theme.cornerRadius))
+    }
+
+    private var placeholder: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+            Text("Enter a weight and a rep count between 1 and 12 to see estimates.")
+                .font(Theme.fontCaption)
+                .foregroundStyle(Theme.textTertiary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(Theme.Spacing.md)
+        .background(Theme.surface)
+        .clipShape(.rect(cornerRadius: Theme.cornerRadius))
+    }
+
+    // MARK: - Helpers
+
+    private func inputField(label: String, text: Binding<String>, keyboard: UIKeyboardType) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(label.uppercased())
+                .font(.caption2.weight(.semibold))
+                .foregroundStyle(Theme.textTertiary)
+            TextField("0", text: text)
+                .keyboardType(keyboard)
+                .font(Theme.fontNumberLarge)
+                .foregroundStyle(Theme.textPrimary)
+                .padding(.vertical, Theme.Spacing.sm)
+                .padding(.horizontal, Theme.Spacing.md)
+                .background(Theme.surfaceElevated)
+                .clipShape(.rect(cornerRadius: Theme.cornerRadiusSmall))
+        }
+    }
+
+    private func sectionHeader(_ title: String) -> some View {
+        Text(title.uppercased())
+            .font(.caption.weight(.semibold))
+            .foregroundStyle(Theme.accent)
+            .accessibilityAddTraits(.isHeader)
+    }
+}
+
+// MARK: - Estimator engine
+
+enum OneRMEstimator {
+    struct Result: Equatable {
+        var epley: Double
+        var brzycki: Double
+        var lombardi: Double
+    }
+
+    /// Returns 1RM estimates from the three formulas. For reps == 1, all three
+    /// degenerate to the input weight.
+    static func estimate(weight: Double, reps: Int) -> Result {
+        guard weight > 0, reps >= 1 else {
+            return Result(epley: 0, brzycki: 0, lombardi: 0)
+        }
+        let r = Double(reps)
+        let epley = weight * (1.0 + r / 30.0)
+        let brzyckiDenom = 37.0 - r
+        let brzycki = brzyckiDenom > 0 ? weight * 36.0 / brzyckiDenom : 0
+        let lombardi = weight * pow(r, 0.10)
+        return Result(epley: epley, brzycki: brzycki, lombardi: lombardi)
+    }
+}
+
+#Preview {
+    OneRMEstimatorView(initialWeight: 225, initialReps: 5)
+        .preferredColorScheme(.dark)
+}

--- a/Xomfit/Views/Tools/PlateCalculatorView.swift
+++ b/Xomfit/Views/Tools/PlateCalculatorView.swift
@@ -1,0 +1,423 @@
+import SwiftUI
+
+/// Pure-Swift plate stack calculator. Given a target weight and bar weight,
+/// greedily computes which plates to load on each side using the available
+/// plate set. Stateless — no services, no persistence.
+struct PlateCalculatorView: View {
+    /// Optional pre-fill from the active set row's weight TextField.
+    let initialTargetWeight: Double?
+
+    init(initialTargetWeight: Double? = nil) {
+        self.initialTargetWeight = initialTargetWeight
+        _targetWeightText = State(initialValue: initialTargetWeight.map { $0.formattedWeight } ?? "")
+    }
+
+    @Environment(\.dismiss) private var dismiss
+
+    // MARK: - Inputs
+
+    @State private var targetWeightText: String
+    @State private var barWeight: Double = 45
+    /// Available plate set (lbs). Greedy descending order.
+    @State private var availablePlates: [Double] = [45, 35, 25, 10, 5, 2.5]
+
+    private static let standardBarWeights: [Double] = [45, 35, 25]
+    @State private var customBarText: String = ""
+    @State private var useCustomBar: Bool = false
+
+    // MARK: - Derived
+
+    private var targetWeight: Double {
+        Double(targetWeightText) ?? 0
+    }
+
+    /// Per-side plate stack using a greedy algorithm. Returns plates heaviest
+    /// first; `remainder` is what couldn't be loaded with the available set.
+    private var stack: PlateStack {
+        PlateCalculator.compute(
+            target: targetWeight,
+            bar: barWeight,
+            plates: availablePlates
+        )
+    }
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Theme.background.ignoresSafeArea()
+
+                ScrollView {
+                    VStack(alignment: .leading, spacing: Theme.Spacing.lg) {
+                        targetSection
+                        barSection
+                        platesSection
+                        resultSection
+                    }
+                    .padding(.horizontal, Theme.Spacing.md)
+                    .padding(.vertical, Theme.Spacing.md)
+                }
+            }
+            .navigationTitle("Plate Calculator")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbarColorScheme(.dark, for: .navigationBar)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { dismiss() }
+                        .foregroundStyle(Theme.accent)
+                }
+            }
+        }
+    }
+
+    // MARK: - Sections
+
+    private var targetSection: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+            sectionHeader("Target Weight")
+            HStack(spacing: Theme.Spacing.sm) {
+                TextField("0", text: $targetWeightText)
+                    .keyboardType(.decimalPad)
+                    .font(Theme.fontNumberLarge)
+                    .foregroundStyle(Theme.textPrimary)
+                    .multilineTextAlignment(.leading)
+                    .padding(.vertical, Theme.Spacing.sm)
+                    .padding(.horizontal, Theme.Spacing.md)
+                    .background(Theme.surfaceElevated)
+                    .clipShape(.rect(cornerRadius: Theme.cornerRadiusSmall))
+                    .accessibilityLabel("Target weight in pounds")
+                Text("lbs")
+                    .font(Theme.fontHeadline)
+                    .foregroundStyle(Theme.textSecondary)
+            }
+        }
+        .padding(Theme.Spacing.md)
+        .background(Theme.surface)
+        .clipShape(.rect(cornerRadius: Theme.cornerRadius))
+    }
+
+    private var barSection: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+            sectionHeader("Bar Weight")
+            HStack(spacing: Theme.Spacing.sm) {
+                ForEach(Self.standardBarWeights, id: \.self) { w in
+                    Button {
+                        Haptics.selection()
+                        useCustomBar = false
+                        barWeight = w
+                    } label: {
+                        Text("\(w.formattedWeight)")
+                            .font(.subheadline.weight(.semibold).monospacedDigit())
+                            .foregroundStyle(barWeight == w && !useCustomBar ? .black : Theme.textPrimary)
+                            .padding(.vertical, 8)
+                            .frame(maxWidth: .infinity)
+                            .background(barWeight == w && !useCustomBar ? Theme.accent : Theme.surfaceElevated)
+                            .clipShape(.rect(cornerRadius: Theme.cornerRadiusSmall))
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("\(w.formattedWeight) pound bar")
+                }
+                Button {
+                    Haptics.selection()
+                    useCustomBar = true
+                    if let v = Double(customBarText), v >= 0 { barWeight = v }
+                } label: {
+                    Text("Custom")
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(useCustomBar ? .black : Theme.textPrimary)
+                        .padding(.vertical, 8)
+                        .frame(maxWidth: .infinity)
+                        .background(useCustomBar ? Theme.accent : Theme.surfaceElevated)
+                        .clipShape(.rect(cornerRadius: Theme.cornerRadiusSmall))
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Use custom bar weight")
+            }
+
+            if useCustomBar {
+                HStack(spacing: Theme.Spacing.sm) {
+                    TextField("e.g. 15", text: $customBarText)
+                        .keyboardType(.decimalPad)
+                        .font(Theme.fontNumberMedium)
+                        .foregroundStyle(Theme.textPrimary)
+                        .padding(.vertical, Theme.Spacing.sm)
+                        .padding(.horizontal, Theme.Spacing.md)
+                        .background(Theme.surfaceElevated)
+                        .clipShape(.rect(cornerRadius: Theme.cornerRadiusSmall))
+                        .onChange(of: customBarText) { _, newValue in
+                            if let v = Double(newValue), v >= 0 { barWeight = v }
+                        }
+                        .accessibilityLabel("Custom bar weight in pounds")
+                    Text("lbs")
+                        .font(Theme.fontCaption)
+                        .foregroundStyle(Theme.textSecondary)
+                }
+            }
+        }
+        .padding(Theme.Spacing.md)
+        .background(Theme.surface)
+        .clipShape(.rect(cornerRadius: Theme.cornerRadius))
+    }
+
+    private var platesSection: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+            sectionHeader("Available Plates (lbs)")
+            // Toggle chips for the standard plate set.
+            FlowChipRow(items: Self.defaultPlates, selected: Set(availablePlates)) { plate in
+                Haptics.selection()
+                if availablePlates.contains(plate) {
+                    availablePlates.removeAll { $0 == plate }
+                } else {
+                    availablePlates.append(plate)
+                    availablePlates.sort(by: >)
+                }
+            }
+            Text("Tap to toggle which plates you have on hand.")
+                .font(Theme.fontCaption)
+                .foregroundStyle(Theme.textTertiary)
+        }
+        .padding(Theme.Spacing.md)
+        .background(Theme.surface)
+        .clipShape(.rect(cornerRadius: Theme.cornerRadius))
+    }
+
+    private var resultSection: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.md) {
+            sectionHeader("Per Side")
+            if targetWeight <= 0 {
+                Text("Enter a target weight to see the plate stack.")
+                    .font(Theme.fontCaption)
+                    .foregroundStyle(Theme.textTertiary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            } else if targetWeight < barWeight {
+                HStack(spacing: Theme.Spacing.sm) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundStyle(Theme.alert)
+                    Text("Target is lighter than the bar (\(barWeight.formattedWeight) lbs).")
+                        .font(Theme.fontCaption)
+                        .foregroundStyle(Theme.textSecondary)
+                }
+            } else {
+                plateStackVisualization
+                summaryRow
+                if stack.remainder > 0.0001 {
+                    HStack(spacing: Theme.Spacing.sm) {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .foregroundStyle(Theme.alert)
+                        Text("Couldn't load exactly. \(stack.remainder.formattedWeight) lbs short per side with selected plates.")
+                            .font(Theme.fontCaption)
+                            .foregroundStyle(Theme.textSecondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+            }
+        }
+        .padding(Theme.Spacing.md)
+        .background(Theme.surface)
+        .clipShape(.rect(cornerRadius: Theme.cornerRadius))
+    }
+
+    // MARK: - Plate visualization
+
+    private var plateStackVisualization: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(alignment: .center, spacing: 4) {
+                // Bar nub
+                Rectangle()
+                    .fill(Theme.textTertiary)
+                    .frame(width: 18, height: 8)
+                    .accessibilityHidden(true)
+
+                ForEach(Array(stack.plates.enumerated()), id: \.offset) { _, plate in
+                    plateView(weight: plate)
+                }
+
+                if stack.plates.isEmpty {
+                    Text("Just the bar")
+                        .font(Theme.fontCaption)
+                        .foregroundStyle(Theme.textTertiary)
+                        .padding(.leading, Theme.Spacing.sm)
+                }
+            }
+            .padding(.vertical, Theme.Spacing.sm)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(stack.accessibilityDescription)
+    }
+
+    private func plateView(weight: Double) -> some View {
+        let height: CGFloat = plateHeight(for: weight)
+        let width: CGFloat = plateWidth(for: weight)
+        return RoundedRectangle(cornerRadius: 4)
+            .fill(plateColor(for: weight))
+            .frame(width: width, height: height)
+            .overlay(
+                Text(weight.formattedWeight)
+                    .font(.system(size: 11, weight: .heavy, design: .rounded).monospacedDigit())
+                    .foregroundStyle(.white)
+                    .rotationEffect(.degrees(-90))
+            )
+            .accessibilityHidden(true)
+    }
+
+    private func plateHeight(for weight: Double) -> CGFloat {
+        switch weight {
+        case 45...: return 90
+        case 35..<45: return 78
+        case 25..<35: return 66
+        case 10..<25: return 54
+        case 5..<10: return 42
+        default: return 32
+        }
+    }
+
+    private func plateWidth(for weight: Double) -> CGFloat {
+        switch weight {
+        case 45...: return 22
+        case 25..<45: return 18
+        case 10..<25: return 16
+        default: return 12
+        }
+    }
+
+    private func plateColor(for weight: Double) -> Color {
+        switch weight {
+        case 45...: return Color(hex: "1B4DCB") // blue 45
+        case 35..<45: return Color(hex: "F5C84B") // gold 35
+        case 25..<35: return Color(hex: "2E7D32") // green 25
+        case 10..<25: return Color(hex: "B0B0B5") // chrome 10
+        case 5..<10: return Color(hex: "1F1F26") // black 5
+        default: return Color(hex: "8A6C2F") // bronze 2.5
+        }
+    }
+
+    private var summaryRow: some View {
+        HStack(spacing: Theme.Spacing.lg) {
+            summaryStat(label: "Per Side", value: "\(stack.perSide.formattedWeight) lbs")
+            summaryStat(label: "Bar", value: "\(barWeight.formattedWeight) lbs")
+            summaryStat(label: "Total", value: "\(stack.total.formattedWeight) lbs")
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func summaryStat(label: String, value: String) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(label.uppercased())
+                .font(.caption2.weight(.semibold))
+                .foregroundStyle(Theme.textTertiary)
+            Text(value)
+                .font(Theme.fontNumberMedium)
+                .foregroundStyle(Theme.textPrimary)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(label) \(value)")
+    }
+
+    private func sectionHeader(_ title: String) -> some View {
+        Text(title.uppercased())
+            .font(.caption.weight(.semibold))
+            .foregroundStyle(Theme.accent)
+            .accessibilityAddTraits(.isHeader)
+    }
+
+    // MARK: - Defaults
+
+    static let defaultPlates: [Double] = [45, 35, 25, 10, 5, 2.5]
+}
+
+// MARK: - Plate Calculator engine
+
+struct PlateStack: Equatable {
+    /// Per-side plate sequence, heaviest first.
+    var plates: [Double]
+    /// Total per side (sum of `plates`).
+    var perSide: Double
+    /// Total loaded weight (bar + 2 × perSide).
+    var total: Double
+    /// Per-side weight that couldn't be matched with the available plate set.
+    var remainder: Double
+
+    var accessibilityDescription: String {
+        if plates.isEmpty { return "Just the bar." }
+        let counts = Dictionary(grouping: plates, by: { $0 })
+            .map { (weight: $0.key, count: $0.value.count) }
+            .sorted { $0.weight > $1.weight }
+        let parts = counts.map { "\($0.count) at \($0.weight.formattedWeight)" }
+        return "Per side: " + parts.joined(separator: ", ")
+    }
+}
+
+enum PlateCalculator {
+    /// Greedy plate calculator. Subtracts the heaviest plate that fits from the
+    /// remaining per-side weight until either nothing fits or the target is
+    /// satisfied. Plates may be reused (gym has many of each size).
+    static func compute(target: Double, bar: Double, plates: [Double]) -> PlateStack {
+        guard target > 0, bar >= 0 else {
+            return PlateStack(plates: [], perSide: 0, total: bar, remainder: 0)
+        }
+        guard target >= bar else {
+            return PlateStack(plates: [], perSide: 0, total: bar, remainder: 0)
+        }
+        var remaining = (target - bar) / 2.0
+        // Tolerate floating-point noise (1g ≈ 0.0022 lbs).
+        let epsilon = 0.001
+        let sorted = plates.sorted(by: >)
+        var picked: [Double] = []
+
+        for plate in sorted {
+            while remaining + epsilon >= plate {
+                picked.append(plate)
+                remaining -= plate
+            }
+        }
+
+        let perSide = picked.reduce(0, +)
+        let total = bar + perSide * 2
+        let leftover = max(0, remaining)
+        return PlateStack(
+            plates: picked,
+            perSide: perSide,
+            total: total,
+            remainder: leftover < epsilon ? 0 : leftover
+        )
+    }
+}
+
+// MARK: - Helper chip row
+
+private struct FlowChipRow: View {
+    let items: [Double]
+    let selected: Set<Double>
+    let onTap: (Double) -> Void
+
+    var body: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 6) {
+                ForEach(items, id: \.self) { item in
+                    let isSelected = selected.contains(item)
+                    Button {
+                        onTap(item)
+                    } label: {
+                        Text(item.formattedWeight)
+                            .font(.caption.weight(.semibold).monospacedDigit())
+                            .foregroundStyle(isSelected ? .black : Theme.textPrimary)
+                            .padding(.horizontal, Theme.Spacing.md)
+                            .padding(.vertical, 8)
+                            .background(isSelected ? Theme.accent : Theme.surfaceElevated)
+                            .clipShape(.capsule)
+                            .overlay(
+                                Capsule().strokeBorder(isSelected ? Color.clear : Theme.hairline, lineWidth: 0.5)
+                            )
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("\(item.formattedWeight) pound plate")
+                    .accessibilityAddTraits(isSelected ? [.isSelected] : [])
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    PlateCalculatorView(initialTargetWeight: 225)
+        .preferredColorScheme(.dark)
+}

--- a/Xomfit/Views/Workout/ExerciseDetailSheet.swift
+++ b/Xomfit/Views/Workout/ExerciseDetailSheet.swift
@@ -6,6 +6,8 @@ import SwiftUI
 struct ExerciseDetailSheet: View {
     let exercise: Exercise
     @Environment(\.dismiss) private var dismiss
+    /// Toggles the 1RM estimator sheet from the meta row link.
+    @State private var showOneRM: Bool = false
 
     var body: some View {
         NavigationStack {
@@ -70,10 +72,32 @@ struct ExerciseDetailSheet: View {
                 value: exercise.muscleGroups.map(\.displayName).joined(separator: ", "),
                 icon: exercise.muscleGroups.first?.icon ?? "figure.strengthtraining.traditional"
             )
+
+            // Tools link — opens the 1RM estimator inline (no pre-fill; user types).
+            Button {
+                Haptics.selection()
+                showOneRM = true
+            } label: {
+                HStack(spacing: 6) {
+                    Image(systemName: "function")
+                        .font(.caption.weight(.semibold))
+                    Text("Estimate 1RM")
+                        .font(.caption.weight(.semibold))
+                }
+                .foregroundStyle(Theme.accent)
+                .padding(.top, 2)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Estimate one rep max")
+            .accessibilityHint("Opens the 1RM estimator")
         }
         .padding(Theme.Spacing.md)
         .background(Theme.surface)
         .clipShape(.rect(cornerRadius: Theme.cornerRadius))
+        .sheet(isPresented: $showOneRM) {
+            OneRMEstimatorView()
+                .presentationDetents([.large])
+        }
     }
 
     private func metaRow(label: String, value: String, icon: String) -> some View {

--- a/Xomfit/Views/Workout/SetRowView.swift
+++ b/Xomfit/Views/Workout/SetRowView.swift
@@ -21,6 +21,10 @@ struct SetRowView: View {
     @State private var repsText: String
     @FocusState private var isWeightFocused: Bool
     @FocusState private var isRepsFocused: Bool
+    /// Confirmation dialog presented after long-pressing the weight field.
+    @State private var showWeightActions: Bool = false
+    /// Plate calculator sheet, opened from the weight field action sheet.
+    @State private var showPlateCalculator: Bool = false
 
     private var isCompleted: Bool {
         workoutSet.completedAt != Date.distantPast
@@ -104,6 +108,16 @@ struct SetRowView: View {
             let formatted = newReps > 0 ? "\(newReps)" : ""
             if repsText != formatted { repsText = formatted }
         }
+        .confirmationDialog("Weight", isPresented: $showWeightActions, titleVisibility: .hidden) {
+            Button("Plate Calculator") {
+                showPlateCalculator = true
+            }
+            Button("Cancel", role: .cancel) {}
+        }
+        .sheet(isPresented: $showPlateCalculator) {
+            PlateCalculatorView(initialTargetWeight: Double(weightText))
+                .presentationDetents([.large])
+        }
     }
 
     // MARK: - Main row (weight / reps / complete)
@@ -170,6 +184,18 @@ struct SetRowView: View {
                         if let w = Double(newValue) {
                             onWeightChange(w)
                         }
+                    }
+                    // Long-press surfaces the plate calculator without breaking text input.
+                    .simultaneousGesture(
+                        LongPressGesture(minimumDuration: 0.45)
+                            .onEnded { _ in
+                                Haptics.medium()
+                                isWeightFocused = false
+                                showWeightActions = true
+                            }
+                    )
+                    .accessibilityAction(named: Text("Plate Calculator")) {
+                        showWeightActions = true
                     }
 
                 Button(action: onToggleWeightMode) {


### PR DESCRIPTION
Closes #315. Plate calculator (greedy per-side w/ bar selector + plate set toggles) + 1RM estimator (Epley/Brzycki/Lombardi). Reachable via long-press on weight TextField → confirmation dialog, PR row context menu, ExerciseDetailSheet 'Estimate 1RM' link, and Settings → Tools.