### PR TITLE
#321 perf: ExerciseDatabase index, LazyVStack audit, memoize profile filters, slim feed payload

### DIFF
--- a/Xomfit/Models/ExerciseDatabase.swift
+++ b/Xomfit/Models/ExerciseDatabase.swift
@@ -4,6 +4,14 @@ import Foundation
 /// Organized by muscle group with form tips
 struct ExerciseDatabase {
     static let all: [Exercise] = chest + back + shoulders + legs + arms + core + unilateral + machineAndCableExtras + bodyweightExtras + mobility
+
+    /// O(1) lookup by exercise id. Replaces `all.first(where: { $0.id == ... })` callsites
+    /// which were O(n) per lookup and frequently used inside view-rendered loops (#321).
+    static let byId: [String: Exercise] = Dictionary(uniqueKeysWithValues: all.map { ($0.id, $0) })
+
+    /// O(1) lookup by exercise name. Replaces `all.first(where: { $0.name == ... })` callsites,
+    /// notably in feed muscle-group filters that ran for every visible feed item (#321).
+    static let byName: [String: Exercise] = Dictionary(uniqueKeysWithValues: all.map { ($0.name, $0) })
     
     // MARK: - Chest
     static let chest: [Exercise] = [

--- a/Xomfit/Models/WorkoutTemplate.swift
+++ b/Xomfit/Models/WorkoutTemplate.swift
@@ -63,7 +63,7 @@ struct WorkoutTemplate: Codable, Identifiable {
 extension WorkoutTemplate {
     // Force unwrap is intentional — these are compile-time constants referencing known IDs
     private static func ex(_ id: String) -> Exercise {
-        ExerciseDatabase.all.first(where: { $0.id == id })!
+        ExerciseDatabase.byId[id]!
     }
 
     static let builtIn: [WorkoutTemplate] = [

--- a/Xomfit/Services/FeedService.swift
+++ b/Xomfit/Services/FeedService.swift
@@ -149,7 +149,23 @@ final class FeedService {
 
     // MARK: - Post Workout to Feed
 
-    func postWorkoutToFeed(workout: Workout, userId: String, caption: String? = nil, photoURLs: [String]? = nil) async throws {
+    /// Posts a workout to the social feed.
+    ///
+    /// `compact` controls whether the per-set details (`ExerciseSummary.sets`) are
+    /// encoded into the payload (#321). Feed cards only render summaries
+    /// (`bestWeight`, `bestReps`, `setCount`, `isPR`), and `FeedDetailView` fetches
+    /// the full workout via `WorkoutService.fetchWorkout`, so the per-set array
+    /// is dead weight in the payload that bloats the row and the wire response.
+    /// Defaults to `true` to avoid posting the bloat going forward; pass `false`
+    /// only if a caller specifically needs the snapshot to round-trip through
+    /// the feed payload (no current callers do).
+    func postWorkoutToFeed(
+        workout: Workout,
+        userId: String,
+        caption: String? = nil,
+        photoURLs: [String]? = nil,
+        compact: Bool = true
+    ) async throws {
         let exercises = workout.exercises.map { ex in
             WorkoutActivity.ExerciseSummary(
                 id: ex.id,
@@ -158,7 +174,7 @@ final class FeedService {
                 bestReps: ex.bestSet?.reps ?? 0,
                 isPR: ex.sets.contains { $0.isPersonalRecord },
                 setCount: ex.sets.count,
-                sets: ex.sets.enumerated().map { index, set in
+                sets: compact ? nil : ex.sets.enumerated().map { index, set in
                     WorkoutActivity.ExerciseSummary.SetDetail(
                         setNumber: index + 1,
                         weight: set.weight,

--- a/Xomfit/Services/LeaderboardService.swift
+++ b/Xomfit/Services/LeaderboardService.swift
@@ -64,7 +64,7 @@ final class LeaderboardService {
             // Muscle group filter
             if let filter = muscleGroupFilter {
                 let exerciseGroups = activity.exercises.flatMap { ex in
-                    ExerciseDatabase.all.first(where: { $0.name == ex.name })?.muscleGroups ?? []
+                    ExerciseDatabase.byName[ex.name]?.muscleGroups ?? []
                 }
                 guard exerciseGroups.contains(filter) else { continue }
             }

--- a/Xomfit/Services/WorkoutService.swift
+++ b/Xomfit/Services/WorkoutService.swift
@@ -363,7 +363,7 @@ final class WorkoutService {
         let exercises = row.workoutExercises
             .sorted { $0.sortOrder < $1.sortOrder }
             .map { exRow in
-                let exercise = ExerciseDatabase.all.first(where: { $0.id == exRow.exerciseId })
+                let exercise = ExerciseDatabase.byId[exRow.exerciseId]
                     ?? Exercise(
                         id: exRow.exerciseId,
                         name: exRow.exerciseName,

--- a/Xomfit/ViewModels/AICoachViewModel.swift
+++ b/Xomfit/ViewModels/AICoachViewModel.swift
@@ -134,7 +134,7 @@ final class AICoachViewModel {
     /// exercises survive the filter.
     func buildTemplate(from payload: WorkoutBuildPayload) -> WorkoutTemplate? {
         let templateExercises: [WorkoutTemplate.TemplateExercise] = payload.exercises.compactMap { item in
-            guard let exercise = ExerciseDatabase.all.first(where: { $0.id == item.exerciseId }) else {
+            guard let exercise = ExerciseDatabase.byId[item.exerciseId] else {
                 return nil
             }
             let notes: String?

--- a/Xomfit/ViewModels/FeedViewModel.swift
+++ b/Xomfit/ViewModels/FeedViewModel.swift
@@ -22,7 +22,7 @@ final class FeedViewModel {
             if !selectedMuscleGroups.isEmpty {
                 guard let exercises = item.workoutActivity?.exercises else { return false }
                 let itemGroups = exercises.flatMap { ex in
-                    ExerciseDatabase.all.first(where: { $0.name == ex.name })?.muscleGroups ?? []
+                    ExerciseDatabase.byName[ex.name]?.muscleGroups ?? []
                 }
                 if selectedMuscleGroups.isDisjoint(with: itemGroups) { return false }
             }

--- a/Xomfit/ViewModels/ProfileViewModel.swift
+++ b/Xomfit/ViewModels/ProfileViewModel.swift
@@ -95,33 +95,51 @@ final class ProfileViewModel {
     var selectedTab: ProfileTab = .feed
 
     // MARK: - Feed
-    var feedItems: [SocialFeedItem] = []
-    var feedDateRange: FeedDateRange = .all
-    var feedMuscleGroups: Set<MuscleGroup> = []
+    var feedItems: [SocialFeedItem] = [] {
+        didSet { recomputeFilters() }
+    }
+    var feedDateRange: FeedDateRange = .all {
+        didSet { recomputeFilters() }
+    }
+    var feedMuscleGroups: Set<MuscleGroup> = [] {
+        didSet { recomputeFilters() }
+    }
 
-    var filteredFeedItems: [SocialFeedItem] {
-        feedItems.filter { item in
+    /// Cached result of the feed filter (#321). Recomputed only when `feedItems`
+    /// or filter state change, instead of running on every body render.
+    private var _filteredFeedItems: [SocialFeedItem] = []
+    var filteredFeedItems: [SocialFeedItem] { _filteredFeedItems }
+
+    var isFeedFiltered: Bool { feedDateRange != .all || !feedMuscleGroups.isEmpty }
+
+    // MARK: - Workouts (profile history)
+    var workouts: [Workout] = [] {
+        didSet { recomputeFilters() }
+    }
+
+    /// Cached result of the workouts filter (#321).
+    private var _filteredWorkouts: [Workout] = []
+    var filteredWorkouts: [Workout] { _filteredWorkouts }
+
+    /// Recomputes both filtered collections. Call from view `.onChange` of the
+    /// filter state, or after assigning `feedItems`/`workouts`. Cheap when the
+    /// filter is empty (just an array copy).
+    func recomputeFilters() {
+        _filteredFeedItems = feedItems.filter { item in
             if let start = feedDateRange.startDate, item.createdAt < start {
                 return false
             }
             if !feedMuscleGroups.isEmpty {
                 guard let exercises = item.workoutActivity?.exercises else { return false }
                 let itemGroups = exercises.flatMap { ex in
-                    ExerciseDatabase.all.first(where: { $0.name == ex.name })?.muscleGroups ?? []
+                    ExerciseDatabase.byName[ex.name]?.muscleGroups ?? []
                 }
                 if feedMuscleGroups.isDisjoint(with: itemGroups) { return false }
             }
             return true
         }
-    }
 
-    var isFeedFiltered: Bool { feedDateRange != .all || !feedMuscleGroups.isEmpty }
-
-    // MARK: - Workouts (profile history)
-    var workouts: [Workout] = []
-
-    var filteredWorkouts: [Workout] {
-        workouts.filter { workout in
+        _filteredWorkouts = workouts.filter { workout in
             if let start = feedDateRange.startDate, workout.startTime < start {
                 return false
             }

--- a/Xomfit/Views/AICoach/AICoachView.swift
+++ b/Xomfit/Views/AICoach/AICoachView.swift
@@ -365,7 +365,7 @@ private struct WorkoutBuildCard: View {
     /// behaviour as `AICoachViewModel.buildTemplate`.
     private var resolved: [(item: WorkoutBuildPayload.Exercise, exercise: Exercise)] {
         payload.exercises.compactMap { item in
-            guard let ex = ExerciseDatabase.all.first(where: { $0.id == item.exerciseId }) else {
+            guard let ex = ExerciseDatabase.byId[item.exerciseId] else {
                 return nil
             }
             return (item, ex)

--- a/Xomfit/Views/Feed/FeedView.swift
+++ b/Xomfit/Views/Feed/FeedView.swift
@@ -194,7 +194,7 @@ struct FeedView: View {
         let templateExercises = activity.exercises.map { ex in
             WorkoutTemplate.TemplateExercise(
                 id: UUID().uuidString,
-                exercise: ExerciseDatabase.all.first(where: { $0.name == ex.name })
+                exercise: ExerciseDatabase.byName[ex.name]
                     ?? Exercise(
                         id: ex.id,
                         name: ex.name,

--- a/Xomfit/Views/Workout/ExercisePickerView.swift
+++ b/Xomfit/Views/Workout/ExercisePickerView.swift
@@ -12,7 +12,7 @@ struct ExercisePickerView: View {
 
     private var recentExercises: [Exercise] {
         let ids = UserDefaults.standard.stringArray(forKey: Self.recentKey) ?? []
-        return ids.compactMap { id in ExerciseDatabase.all.first(where: { $0.id == id }) }
+        return ids.compactMap { id in ExerciseDatabase.byId[id] }
     }
 
     private static func recordRecent(_ exercise: Exercise) {


### PR DESCRIPTION
Closes #321. byId/byName dicts on ExerciseDatabase, replaced 9 .first(where:) callsites with O(1) lookups. ProfileViewModel filters memoized. FeedService.postWorkoutToFeed defaults to compact (omits per-set details, kept summaries). LazyVStack audit found everything already lazy where needed.