### PR TITLE
#312 settings: units, default rest, theme, week start, export, support

### DIFF
--- a/Xomfit/Models/WeightUnit.swift
+++ b/Xomfit/Models/WeightUnit.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+/// User-selectable weight unit. Persisted via `@AppStorage("weightUnit")`.
+/// Storage is always lbs internally; this enum drives display-only conversion.
+/// Conversion uses 1 lb = 0.4536 kg (display only -- never round-trip stored data).
+enum WeightUnit: String, CaseIterable, Identifiable {
+    case lbs
+    case kg
+
+    var id: String { rawValue }
+
+    /// User-facing label (e.g. "lbs", "kg").
+    var displayName: String {
+        switch self {
+        case .lbs: return "lbs"
+        case .kg:  return "kg"
+        }
+    }
+
+    /// Long form for accessibility / VoiceOver.
+    var accessibilityName: String {
+        switch self {
+        case .lbs: return "pounds"
+        case .kg:  return "kilograms"
+        }
+    }
+
+    /// Multiplier from internally-stored lbs to this display unit.
+    var multiplierFromLbs: Double {
+        switch self {
+        case .lbs: return 1.0
+        case .kg:  return 0.4536
+        }
+    }
+}

--- a/Xomfit/Services/AuthService.swift
+++ b/Xomfit/Services/AuthService.swift
@@ -171,6 +171,26 @@ final class AuthService {
         }
     }
 
+    // MARK: - Delete Account
+
+    /// Permanently deletes the user's account. Calls a Supabase RPC named
+    /// `delete_my_account` that is expected to handle row deletion + auth
+    /// user removal server-side. Signs the user out locally on success.
+    ///
+    /// TODO: Confirm the `delete_my_account` Postgres function exists and
+    /// is granted to `authenticated`. If it doesn't, surface the error to
+    /// the user (we never silently no-op an account deletion).
+    func deleteAccount() async throws {
+        errorMessage = nil
+        do {
+            try await supabase.rpc("delete_my_account").execute()
+        } catch {
+            errorMessage = "Could not delete account: \(error.localizedDescription)"
+            throw error
+        }
+        await signOut()
+    }
+
     // MARK: - Sign Out
 
     func signOut() async {

--- a/Xomfit/Utils/CSVExporter.swift
+++ b/Xomfit/Utils/CSVExporter.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+/// Workout -> CSV. Used by Settings "Export workouts" (#312).
+///
+/// Output columns: id, date, exercise, set, weight, reps.
+/// `weight` is emitted in the user's chosen display unit; the column header
+/// reflects the unit so the export is self-describing.
+enum CSVExporter {
+
+    /// One row per set across all workouts. Newest workouts first (caller's order is preserved).
+    static func csv(for workouts: [Workout], unit: WeightUnit = .lbs) -> String {
+        var lines: [String] = []
+        lines.append("id,date,exercise,set,weight_\(unit.rawValue),reps")
+
+        let isoFormatter: ISO8601DateFormatter = {
+            let f = ISO8601DateFormatter()
+            f.formatOptions = [.withInternetDateTime]
+            return f
+        }()
+
+        for workout in workouts {
+            let dateString = isoFormatter.string(from: workout.startTime)
+            for exercise in workout.exercises {
+                for (index, set) in exercise.sets.enumerated() {
+                    let setNumber = index + 1
+                    let weight = set.weight.formattedWeight(unit: unit)
+                    let row = [
+                        escape(workout.id),
+                        escape(dateString),
+                        escape(exercise.exercise.name),
+                        "\(setNumber)",
+                        weight,
+                        "\(set.reps)"
+                    ].joined(separator: ",")
+                    lines.append(row)
+                }
+            }
+        }
+
+        return lines.joined(separator: "\n")
+    }
+
+    /// Writes the CSV to a temporary file and returns the URL.
+    /// Caller is responsible for handing the URL to a share sheet.
+    static func writeToTempFile(csv: String, filename: String = "xomfit_workouts.csv") throws -> URL {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent(filename)
+        try csv.write(to: url, atomically: true, encoding: .utf8)
+        return url
+    }
+
+    // MARK: - Private
+
+    /// Escapes a CSV field per RFC 4180: wraps in quotes when it contains a
+    /// comma, double-quote, or newline; doubles any embedded quotes.
+    private static func escape(_ value: String) -> String {
+        let needsQuoting = value.contains(",") || value.contains("\"") || value.contains("\n") || value.contains("\r")
+        guard needsQuoting else { return value }
+        let escaped = value.replacingOccurrences(of: "\"", with: "\"\"")
+        return "\"\(escaped)\""
+    }
+}

--- a/Xomfit/Utils/Formatters.swift
+++ b/Xomfit/Utils/Formatters.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+// MARK: - Weight Formatting
+
+extension Double {
+    /// Formats a weight value (stored internally in lbs) for display in the
+    /// given unit. Values are converted display-only -- the underlying
+    /// stored value is never mutated.
+    ///
+    /// - Parameters:
+    ///   - unit: target display unit. Pass the user's `weightUnit` AppStorage value.
+    ///   - includeUnit: when true, appends " lbs" or " kg" after the number.
+    /// - Returns: a string like "135" / "61.2" / "135 lbs" / "61.2 kg".
+    func formattedWeight(unit: WeightUnit, includeUnit: Bool = false) -> String {
+        let converted = self * unit.multiplierFromLbs
+        let body: String = converted.truncatingRemainder(dividingBy: 1) == 0
+            ? String(format: "%.0f", converted)
+            : String(format: "%.1f", converted)
+        return includeUnit ? "\(body) \(unit.displayName)" : body
+    }
+}
+
+// MARK: - AppStorage helpers
+
+/// Reads the user's saved weight unit from UserDefaults. Falls back to `.lbs`
+/// when unset or invalid. Keep this in lockstep with `@AppStorage("weightUnit")`.
+func currentWeightUnit() -> WeightUnit {
+    let raw = UserDefaults.standard.string(forKey: "weightUnit") ?? WeightUnit.lbs.rawValue
+    return WeightUnit(rawValue: raw) ?? .lbs
+}

--- a/Xomfit/Utils/WorkoutInsights.swift
+++ b/Xomfit/Utils/WorkoutInsights.swift
@@ -9,6 +9,16 @@ import Foundation
 /// so they're trivially testable and safe to call repeatedly from views.
 enum WorkoutInsights {
 
+    /// Returns a `Calendar` configured to respect the user's
+    /// "Week starts on" preference (`@AppStorage("weekStartDay")`).
+    /// 0 = Sunday (default), 1 = Monday.
+    static func userCalendar() -> Calendar {
+        var cal = Calendar.current
+        let weekStartDay = UserDefaults.standard.integer(forKey: "weekStartDay")
+        cal.firstWeekday = weekStartDay == 1 ? 2 : 1
+        return cal
+    }
+
     // MARK: - Streaks
 
     /// Current consecutive-day streak ending today (or yesterday).

--- a/Xomfit/Views/Feed/FeedItemCard.swift
+++ b/Xomfit/Views/Feed/FeedItemCard.swift
@@ -389,25 +389,29 @@ private struct WorkoutActivityContent: View {
 private struct PRActivityContent: View {
     let activity: PRActivity
 
+    /// Display unit for weight values. Stored values stay lbs.
+    @AppStorage("weightUnit") private var weightUnitRaw: String = WeightUnit.lbs.rawValue
+    private var weightUnit: WeightUnit { WeightUnit(rawValue: weightUnitRaw) ?? .lbs }
+
     var body: some View {
         ActivityStripeCard(stripeColor: Theme.prGold, icon: "trophy.fill", title: activity.exerciseName) {
             Text(activity.exerciseName)
                 .font(.subheadline.weight(.semibold))
                 .foregroundStyle(Theme.textPrimary)
 
-            Text("\(activity.weight.formattedWeight) lbs × \(activity.reps) reps")
+            Text("\(activity.weight.formattedWeight(unit: weightUnit)) \(weightUnit.displayName) × \(activity.reps) reps")
                 .font(Theme.fontDisplay)
                 .foregroundStyle(Theme.prGold)
-                .accessibilityLabel("\(activity.weight.formattedWeight) pounds, \(activity.reps) reps")
+                .accessibilityLabel("\(activity.weight.formattedWeight(unit: weightUnit)) \(weightUnit.accessibilityName), \(activity.reps) reps")
 
             if let prev = activity.previousBest {
-                Text("Previous best: \(prev.formattedWeight) lbs")
+                Text("Previous best: \(prev.formattedWeight(unit: weightUnit)) \(weightUnit.displayName)")
                     .font(Theme.fontCaption)
                     .foregroundStyle(Theme.textTertiary)
             }
 
             if let imp = activity.improvement, imp > 0 {
-                XomBadge("+\(imp.formattedWeight) lbs", color: Theme.accent, variant: .display)
+                XomBadge("+\(imp.formattedWeight(unit: weightUnit)) \(weightUnit.displayName)", color: Theme.accent, variant: .display)
             }
         }
     }

--- a/Xomfit/Views/MainTabView.swift
+++ b/Xomfit/Views/MainTabView.swift
@@ -10,6 +10,18 @@ struct MainTabView: View {
     /// App-open streak / new-PR celebration toast (#250). Cleared after auto-dismiss.
     @State private var launchBadgeToast: Toast?
 
+    /// Theme override from Settings (#312). Empty string = follow system.
+    @AppStorage("colorScheme") private var preferredColorSchemeRaw: String = ""
+
+    /// Maps the stored value to a `ColorScheme?`. nil => follow system.
+    private var resolvedColorScheme: ColorScheme? {
+        switch preferredColorSchemeRaw {
+        case "light": return .light
+        case "dark":  return .dark
+        default:      return nil
+        }
+    }
+
     private let resumeTimer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
 
     var body: some View {
@@ -89,6 +101,7 @@ struct MainTabView: View {
             launchBadgeToast = Toast(style: .success, message: badge.message)
         }
         .environment(\.tabBarVisible, $tabBarVisible)
+        .preferredColorScheme(resolvedColorScheme)
     }
 }
 

--- a/Xomfit/Views/Profile/ProfileCalendarView.swift
+++ b/Xomfit/Views/Profile/ProfileCalendarView.swift
@@ -7,8 +7,24 @@ struct ProfileCalendarView: View {
     @State private var displayedMonth: Date = Date()
     @State private var selectedDate: IdentifiableDate? = nil
 
-    private let calendar = Calendar.current
-    private let dayOfWeekHeaders = ["S", "M", "T", "W", "T", "F", "S"]
+    /// 0 = Sunday, 1 = Monday. Drives the firstWeekday + header order.
+    @AppStorage("weekStartDay") private var weekStartDay: Int = 0
+
+    /// Calendar configured to honor the user's "Week starts on" preference.
+    private var calendar: Calendar {
+        var cal = Calendar.current
+        // Calendar.firstWeekday: 1 = Sunday, 2 = Monday.
+        cal.firstWeekday = weekStartDay == 1 ? 2 : 1
+        return cal
+    }
+
+    /// Header order rotates so the leading column matches `firstWeekday`.
+    private var dayOfWeekHeaders: [String] {
+        weekStartDay == 1
+            ? ["M", "T", "W", "T", "F", "S", "S"]
+            : ["S", "M", "T", "W", "T", "F", "S"]
+    }
+
     private let columns = Array(repeating: GridItem(.flexible(), spacing: 6), count: 7)
 
     /// Normalize workoutDays keys to startOfDay for reliable matching.

--- a/Xomfit/Views/Profile/ProfileStatsView.swift
+++ b/Xomfit/Views/Profile/ProfileStatsView.swift
@@ -19,6 +19,10 @@ struct ProfileStatsView: View {
 
     @State private var heatmapFilter: HeatmapTimeFilter = .week
 
+    /// Display unit for weight values. Stored values stay lbs.
+    @AppStorage("weightUnit") private var weightUnitRaw: String = WeightUnit.lbs.rawValue
+    private var weightUnit: WeightUnit { WeightUnit(rawValue: weightUnitRaw) ?? .lbs }
+
     private var activeMuscleGroupSets: [String: Int] {
         switch heatmapFilter {
         case .week: return muscleGroupSetsThisWeek
@@ -251,7 +255,7 @@ struct ProfileStatsView: View {
                 }
             }
 
-            Text("\(pr.weight.formattedWeight) lbs \u{00D7} \(pr.reps)")
+            Text("\(pr.weight.formattedWeight(unit: weightUnit)) \(weightUnit.displayName) \u{00D7} \(pr.reps)")
                 .font(Theme.fontNumberMedium)
                 .foregroundStyle(Theme.textPrimary)
         }
@@ -270,7 +274,7 @@ struct ProfileStatsView: View {
     }
 
     private func prOfTheMonthAccessibility(pr: PersonalRecord, pctText: String?) -> String {
-        var parts = ["PR of the month: \(pr.exerciseName), \(pr.weight.formattedWeight) pounds for \(pr.reps) reps"]
+        var parts = ["PR of the month: \(pr.exerciseName), \(pr.weight.formattedWeight(unit: weightUnit)) \(weightUnit.accessibilityName) for \(pr.reps) reps"]
         if let pctText {
             parts.append("\(pctText) improvement")
         }

--- a/Xomfit/Views/Profile/SettingsView.swift
+++ b/Xomfit/Views/Profile/SettingsView.swift
@@ -1,17 +1,51 @@
+import StoreKit
 import SwiftUI
+import UIKit
 
 struct SettingsView: View {
     @Environment(AuthService.self) private var authService
     @State private var showSignOutConfirm = false
+    @State private var showDeleteAccountConfirm = false
+    @State private var deleteAccountError: String? = nil
+    @State private var isExporting = false
+    @State private var exportError: String? = nil
 
-    /// Anthropic API key override (per-user). v1: stored via @AppStorage —
+    /// Anthropic API key override (per-user). v1: stored via @AppStorage --
     /// not secure. TODO: migrate to Keychain.
     @AppStorage("aiCoach.anthropicAPIKey") private var anthropicAPIKey: String = ""
+
+    // MARK: - App Preferences (#312)
+
+    @AppStorage("weightUnit") private var weightUnitRaw: String = WeightUnit.lbs.rawValue
+    @AppStorage("restDuration") private var restDurationSeconds: Double = 90
+    /// 0 = Sunday, 1 = Monday.
+    @AppStorage("weekStartDay") private var weekStartDay: Int = 0
+    /// "" = system, "light", "dark".
+    @AppStorage("colorScheme") private var preferredColorSchemeRaw: String = ""
+
+    // MARK: - Notifications top-level toggle (#312)
+
+    @AppStorage("workoutRemindersEnabled") private var workoutRemindersEnabled: Bool = false
+    @State private var notificationsAuthorized: Bool = false
+
+    private var weightUnit: WeightUnit {
+        WeightUnit(rawValue: weightUnitRaw) ?? .lbs
+    }
+
+    // MARK: - Computed
 
     private var appVersion: String {
         let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0"
         let build = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "1"
         return "\(version) (\(build))"
+    }
+
+    private var versionShort: String {
+        Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0"
+    }
+
+    private var buildNumber: String {
+        Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "1"
     }
 
     /// Short summary of the current fitness questionnaire state for the row trailing label.
@@ -28,143 +62,15 @@ struct SettingsView: View {
             Theme.background.ignoresSafeArea()
 
             List {
-                Section {
-                    if let email = authService.currentUser?.email {
-                        settingsRow(icon: "envelope.fill", iconColor: Theme.accent, label: "Email", value: email)
-                    }
-                } header: {
-                    XomMetricLabel("Account")
-                }
-                .listRowBackground(Theme.surface)
-                .listRowSeparatorTint(Theme.hairline)
-
-                Section {
-                    NavigationLink {
-                        NotificationPreferencesView()
-                    } label: {
-                        HStack(spacing: Theme.Spacing.md) {
-                            Image(systemName: "bell.fill")
-                                .frame(width: 24)
-                                .foregroundStyle(Theme.accent)
-                            Text("Notification Settings")
-                                .foregroundStyle(Theme.textPrimary)
-                        }
-                    }
-                    .tint(Theme.textTertiary)
-                } header: {
-                    XomMetricLabel("Notifications")
-                }
-                .listRowBackground(Theme.surface)
-                .listRowSeparatorTint(Theme.hairline)
-
-                Section {
-                    NavigationLink {
-                        FitnessQuestionnaireView(mode: .edit)
-                            .navigationTitle("Fitness Goals")
-                            .navigationBarTitleDisplayMode(.inline)
-                            .hideTabBar()
-                    } label: {
-                        HStack(spacing: Theme.Spacing.md) {
-                            Image(systemName: "target")
-                                .frame(width: 24)
-                                .foregroundStyle(Theme.accent)
-                            Text("Fitness Goals")
-                                .foregroundStyle(Theme.textPrimary)
-                            Spacer()
-                            Text(fitnessGoalsSummary)
-                                .font(Theme.fontCaption)
-                                .foregroundStyle(Theme.textTertiary)
-                                .lineLimit(1)
-                        }
-                    }
-                    .tint(Theme.textTertiary)
-                } header: {
-                    XomMetricLabel("Training")
-                }
-                .listRowBackground(Theme.surface)
-                .listRowSeparatorTint(Theme.hairline)
-
-                Section {
-                    NavigationLink {
-                        ReportsListView()
-                            .hideTabBar()
-                    } label: {
-                        HStack(spacing: Theme.Spacing.md) {
-                            Image(systemName: "doc.text.magnifyingglass")
-                                .frame(width: 24)
-                                .foregroundStyle(Theme.accent)
-                            Text("Reports")
-                                .foregroundStyle(Theme.textPrimary)
-                        }
-                    }
-                    .tint(Theme.textTertiary)
-                } header: {
-                    XomMetricLabel("Reports")
-                }
-                .listRowBackground(Theme.surface)
-                .listRowSeparatorTint(Theme.hairline)
-
-                Section {
-                    NavigationLink {
-                        AICoachView()
-                            .hideTabBar()
-                    } label: {
-                        HStack(spacing: Theme.Spacing.md) {
-                            Image(systemName: "sparkles")
-                                .frame(width: 24)
-                                .foregroundStyle(Theme.accent)
-                            Text("AI Coach")
-                                .foregroundStyle(Theme.textPrimary)
-                        }
-                    }
-                    .tint(Theme.textTertiary)
-
-                    HStack(spacing: Theme.Spacing.md) {
-                        Image(systemName: "key.fill")
-                            .frame(width: 24)
-                            .foregroundStyle(Theme.accent)
-                        SecureField("Anthropic API Key", text: $anthropicAPIKey)
-                            .foregroundStyle(Theme.textPrimary)
-                            .font(Theme.fontBody)
-                            .textInputAutocapitalization(.never)
-                            .autocorrectionDisabled()
-                            .accessibilityLabel("Anthropic API Key")
-                            .accessibilityHint("Stored on this device only")
-                    }
-                } header: {
-                    XomMetricLabel("AI Coach")
-                } footer: {
-                    Text("Stored on this device only. Get a key at console.anthropic.com.")
-                        .font(Theme.fontCaption)
-                        .foregroundStyle(Theme.textTertiary)
-                }
-                .listRowBackground(Theme.surface)
-                .listRowSeparatorTint(Theme.hairline)
-
-                Section {
-                    settingsRow(icon: "info.circle.fill", iconColor: Theme.accent, label: "Version", value: appVersion)
-                    settingsRow(icon: "building.2.fill", iconColor: Theme.accent, label: "App", value: Config.appName)
-                } header: {
-                    XomMetricLabel("About")
-                }
-                .listRowBackground(Theme.surface)
-                .listRowSeparatorTint(Theme.hairline)
-
-                Section {
-                    Button(role: .destructive) {
-                        showSignOutConfirm = true
-                    } label: {
-                        HStack(spacing: Theme.Spacing.md) {
-                            Image(systemName: "rectangle.portrait.and.arrow.right")
-                                .frame(width: 24)
-                                .foregroundStyle(Theme.destructive)
-                            Text("Sign Out")
-                                .foregroundStyle(Theme.destructive)
-                        }
-                    }
-                    .listRowBackground(Theme.surface)
-                    .listRowSeparatorTint(Theme.hairline)
-                }
+                accountSection
+                notificationsSection
+                appPreferencesSection
+                trainingSection
+                aiCoachSection
+                dataPrivacySection
+                supportSection
+                aboutSection
+                signOutSection
             }
             .listStyle(.insetGrouped)
             .scrollContentBackground(.hidden)
@@ -172,6 +78,7 @@ struct SettingsView: View {
         .navigationTitle("Settings")
         .navigationBarTitleDisplayMode(.large)
         .toolbarColorScheme(.dark, for: .navigationBar)
+        .task { await refreshNotificationStatus() }
         .alert("Sign Out?", isPresented: $showSignOutConfirm) {
             Button("Sign Out", role: .destructive) {
                 Task { await authService.signOut() }
@@ -180,6 +87,402 @@ struct SettingsView: View {
         } message: {
             Text("You will be returned to the login screen.")
         }
+        .alert("Delete Account?", isPresented: $showDeleteAccountConfirm) {
+            Button("Delete", role: .destructive) {
+                Task { await deleteAccount() }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("This permanently removes your account and workouts. This cannot be undone.")
+        }
+        .alert("Couldn't delete account", isPresented: Binding(
+            get: { deleteAccountError != nil },
+            set: { if !$0 { deleteAccountError = nil } }
+        )) {
+            Button("OK", role: .cancel) { deleteAccountError = nil }
+        } message: {
+            Text(deleteAccountError ?? "")
+        }
+        .alert("Couldn't export workouts", isPresented: Binding(
+            get: { exportError != nil },
+            set: { if !$0 { exportError = nil } }
+        )) {
+            Button("OK", role: .cancel) { exportError = nil }
+        } message: {
+            Text(exportError ?? "")
+        }
+    }
+
+    // MARK: - Sections
+
+    private var accountSection: some View {
+        Section {
+            if let email = authService.currentUser?.email {
+                settingsRow(icon: "envelope.fill", iconColor: Theme.accent, label: "Email", value: email)
+            }
+        } header: {
+            XomMetricLabel("Account")
+        }
+        .listRowBackground(Theme.surface)
+        .listRowSeparatorTint(Theme.hairline)
+    }
+
+    private var notificationsSection: some View {
+        Section {
+            Toggle(isOn: workoutRemindersBinding) {
+                HStack(spacing: Theme.Spacing.md) {
+                    Image(systemName: "alarm.fill")
+                        .frame(width: 24)
+                        .foregroundStyle(Theme.accent)
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Workout reminders")
+                            .foregroundStyle(Theme.textPrimary)
+                        if !notificationsAuthorized {
+                            Text("Push permission required")
+                                .font(Theme.fontCaption)
+                                .foregroundStyle(Theme.textTertiary)
+                        }
+                    }
+                }
+            }
+            .tint(Theme.accent)
+            .accessibilityHint("Master switch for workout reminder push notifications")
+
+            NavigationLink {
+                NotificationPreferencesView()
+            } label: {
+                HStack(spacing: Theme.Spacing.md) {
+                    Image(systemName: "bell.fill")
+                        .frame(width: 24)
+                        .foregroundStyle(Theme.accent)
+                    Text("Notification Settings")
+                        .foregroundStyle(Theme.textPrimary)
+                }
+            }
+            .tint(Theme.textTertiary)
+        } header: {
+            XomMetricLabel("Notifications")
+        }
+        .listRowBackground(Theme.surface)
+        .listRowSeparatorTint(Theme.hairline)
+    }
+
+    private var appPreferencesSection: some View {
+        Section {
+            // Weight unit
+            HStack(spacing: Theme.Spacing.md) {
+                Image(systemName: "scalemass.fill")
+                    .frame(width: 24)
+                    .foregroundStyle(Theme.accent)
+                Text("Weight unit")
+                    .foregroundStyle(Theme.textPrimary)
+                Spacer()
+                Picker("Weight unit", selection: $weightUnitRaw) {
+                    Text("lbs").tag(WeightUnit.lbs.rawValue)
+                    Text("kg").tag(WeightUnit.kg.rawValue)
+                }
+                .pickerStyle(.segmented)
+                .frame(width: 130)
+                .accessibilityLabel("Weight unit")
+            }
+
+            // Default rest duration (seconds)
+            HStack(spacing: Theme.Spacing.md) {
+                Image(systemName: "timer")
+                    .frame(width: 24)
+                    .foregroundStyle(Theme.accent)
+                Stepper(value: $restDurationSeconds, in: 30...600, step: 15) {
+                    HStack {
+                        Text("Default rest")
+                            .foregroundStyle(Theme.textPrimary)
+                        Spacer()
+                        Text(formatRest(restDurationSeconds))
+                            .font(Theme.fontCaption)
+                            .foregroundStyle(Theme.textTertiary)
+                            .monospacedDigit()
+                    }
+                }
+                .accessibilityLabel("Default rest duration")
+                .accessibilityValue(formatRest(restDurationSeconds))
+            }
+
+            // Week start day
+            HStack(spacing: Theme.Spacing.md) {
+                Image(systemName: "calendar")
+                    .frame(width: 24)
+                    .foregroundStyle(Theme.accent)
+                Text("Week starts on")
+                    .foregroundStyle(Theme.textPrimary)
+                Spacer()
+                Picker("Week starts on", selection: $weekStartDay) {
+                    Text("Sun").tag(0)
+                    Text("Mon").tag(1)
+                }
+                .pickerStyle(.segmented)
+                .frame(width: 130)
+                .accessibilityLabel("Week starts on")
+            }
+
+            // Theme
+            HStack(spacing: Theme.Spacing.md) {
+                Image(systemName: "paintbrush.fill")
+                    .frame(width: 24)
+                    .foregroundStyle(Theme.accent)
+                Text("Theme")
+                    .foregroundStyle(Theme.textPrimary)
+                Spacer()
+                Picker("Theme", selection: $preferredColorSchemeRaw) {
+                    Text("System").tag("")
+                    Text("Light").tag("light")
+                    Text("Dark").tag("dark")
+                }
+                .pickerStyle(.menu)
+                .tint(Theme.accent)
+                .accessibilityLabel("Theme")
+            }
+        } header: {
+            XomMetricLabel("App Preferences")
+        }
+        .listRowBackground(Theme.surface)
+        .listRowSeparatorTint(Theme.hairline)
+    }
+
+    private var trainingSection: some View {
+        Section {
+            NavigationLink {
+                FitnessQuestionnaireView(mode: .edit)
+                    .navigationTitle("Fitness Goals")
+                    .navigationBarTitleDisplayMode(.inline)
+                    .hideTabBar()
+            } label: {
+                HStack(spacing: Theme.Spacing.md) {
+                    Image(systemName: "target")
+                        .frame(width: 24)
+                        .foregroundStyle(Theme.accent)
+                    Text("Fitness Goals")
+                        .foregroundStyle(Theme.textPrimary)
+                    Spacer()
+                    Text(fitnessGoalsSummary)
+                        .font(Theme.fontCaption)
+                        .foregroundStyle(Theme.textTertiary)
+                        .lineLimit(1)
+                }
+            }
+            .tint(Theme.textTertiary)
+
+            NavigationLink {
+                ReportsListView()
+                    .hideTabBar()
+            } label: {
+                HStack(spacing: Theme.Spacing.md) {
+                    Image(systemName: "doc.text.magnifyingglass")
+                        .frame(width: 24)
+                        .foregroundStyle(Theme.accent)
+                    Text("Reports")
+                        .foregroundStyle(Theme.textPrimary)
+                }
+            }
+            .tint(Theme.textTertiary)
+        } header: {
+            XomMetricLabel("Training")
+        }
+        .listRowBackground(Theme.surface)
+        .listRowSeparatorTint(Theme.hairline)
+    }
+
+    private var aiCoachSection: some View {
+        Section {
+            NavigationLink {
+                AICoachView()
+                    .hideTabBar()
+            } label: {
+                HStack(spacing: Theme.Spacing.md) {
+                    Image(systemName: "sparkles")
+                        .frame(width: 24)
+                        .foregroundStyle(Theme.accent)
+                    Text("AI Coach")
+                        .foregroundStyle(Theme.textPrimary)
+                }
+            }
+            .tint(Theme.textTertiary)
+
+            HStack(spacing: Theme.Spacing.md) {
+                Image(systemName: "key.fill")
+                    .frame(width: 24)
+                    .foregroundStyle(Theme.accent)
+                SecureField("Anthropic API Key", text: $anthropicAPIKey)
+                    .foregroundStyle(Theme.textPrimary)
+                    .font(Theme.fontBody)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+                    .accessibilityLabel("Anthropic API Key")
+                    .accessibilityHint("Stored on this device only")
+            }
+        } header: {
+            XomMetricLabel("AI Coach")
+        } footer: {
+            Text("Stored on this device only. Get a key at console.anthropic.com.")
+                .font(Theme.fontCaption)
+                .foregroundStyle(Theme.textTertiary)
+        }
+        .listRowBackground(Theme.surface)
+        .listRowSeparatorTint(Theme.hairline)
+    }
+
+    private var dataPrivacySection: some View {
+        Section {
+            Button {
+                Task { await exportWorkouts() }
+            } label: {
+                HStack(spacing: Theme.Spacing.md) {
+                    Image(systemName: "square.and.arrow.up")
+                        .frame(width: 24)
+                        .foregroundStyle(Theme.accent)
+                    Text("Export workouts")
+                        .foregroundStyle(Theme.textPrimary)
+                    Spacer()
+                    if isExporting {
+                        ProgressView().tint(Theme.accent)
+                    }
+                }
+            }
+            .disabled(isExporting)
+            .accessibilityLabel("Export workouts")
+            .accessibilityHint("Builds a CSV of your sets and opens the share sheet")
+
+            Button(role: .destructive) {
+                showDeleteAccountConfirm = true
+            } label: {
+                HStack(spacing: Theme.Spacing.md) {
+                    Image(systemName: "trash.fill")
+                        .frame(width: 24)
+                        .foregroundStyle(Theme.destructive)
+                    Text("Delete account")
+                        .foregroundStyle(Theme.destructive)
+                }
+            }
+        } header: {
+            XomMetricLabel("Data & Privacy")
+        }
+        .listRowBackground(Theme.surface)
+        .listRowSeparatorTint(Theme.hairline)
+    }
+
+    private var supportSection: some View {
+        Section {
+            Button {
+                openFeedbackMail()
+            } label: {
+                HStack(spacing: Theme.Spacing.md) {
+                    Image(systemName: "envelope.open.fill")
+                        .frame(width: 24)
+                        .foregroundStyle(Theme.accent)
+                    Text("Send feedback")
+                        .foregroundStyle(Theme.textPrimary)
+                }
+            }
+            .accessibilityHint("Opens Mail with a prefilled feedback message")
+
+            Button {
+                requestAppReview()
+            } label: {
+                HStack(spacing: Theme.Spacing.md) {
+                    Image(systemName: "star.fill")
+                        .frame(width: 24)
+                        .foregroundStyle(Theme.prGold)
+                    Text("Rate XomFit")
+                        .foregroundStyle(Theme.textPrimary)
+                }
+            }
+            .accessibilityHint("Prompts the App Store rating sheet")
+
+            Link(destination: URL(string: "https://xomware.com/privacy")!) {
+                HStack(spacing: Theme.Spacing.md) {
+                    Image(systemName: "lock.shield.fill")
+                        .frame(width: 24)
+                        .foregroundStyle(Theme.accent)
+                    Text("Privacy Policy")
+                        .foregroundStyle(Theme.textPrimary)
+                    Spacer()
+                    Image(systemName: "arrow.up.right.square")
+                        .font(.caption)
+                        .foregroundStyle(Theme.textTertiary)
+                }
+            }
+            .accessibilityHint("Opens xomware.com/privacy in your browser")
+        } header: {
+            XomMetricLabel("Support")
+        }
+        .listRowBackground(Theme.surface)
+        .listRowSeparatorTint(Theme.hairline)
+    }
+
+    private var aboutSection: some View {
+        Section {
+            settingsRow(icon: "info.circle.fill", iconColor: Theme.accent, label: "Version", value: appVersion)
+            settingsRow(icon: "building.2.fill", iconColor: Theme.accent, label: "App", value: Config.appName)
+        } header: {
+            XomMetricLabel("About")
+        }
+        .listRowBackground(Theme.surface)
+        .listRowSeparatorTint(Theme.hairline)
+    }
+
+    private var signOutSection: some View {
+        Section {
+            Button(role: .destructive) {
+                showSignOutConfirm = true
+            } label: {
+                HStack(spacing: Theme.Spacing.md) {
+                    Image(systemName: "rectangle.portrait.and.arrow.right")
+                        .frame(width: 24)
+                        .foregroundStyle(Theme.destructive)
+                    Text("Sign Out")
+                        .foregroundStyle(Theme.destructive)
+                }
+            }
+            .listRowBackground(Theme.surface)
+            .listRowSeparatorTint(Theme.hairline)
+        }
+    }
+
+    // MARK: - Bindings
+
+    /// Custom binding so flipping the master toggle on triggers a permission
+    /// prompt when the system has not yet authorized push.
+    private var workoutRemindersBinding: Binding<Bool> {
+        Binding(
+            get: { workoutRemindersEnabled && notificationsAuthorized },
+            set: { newValue in
+                workoutRemindersEnabled = newValue
+                if newValue && !notificationsAuthorized {
+                    Task {
+                        await NotificationService.shared.requestPermission()
+                        await refreshNotificationStatus()
+                        // If the system denied, drop the master switch back to off.
+                        if !notificationsAuthorized {
+                            workoutRemindersEnabled = false
+                        }
+                    }
+                }
+            }
+        )
+    }
+
+    // MARK: - Helpers
+
+    private func formatRest(_ seconds: Double) -> String {
+        let total = Int(seconds.rounded())
+        let m = total / 60
+        let s = total % 60
+        if m == 0 { return "\(s)s" }
+        if s == 0 { return "\(m)m" }
+        return "\(m)m \(s)s"
+    }
+
+    private func refreshNotificationStatus() async {
+        await NotificationService.shared.checkPermission()
+        notificationsAuthorized = NotificationService.shared.isPermissionGranted
     }
 
     private func settingsRow(icon: String, iconColor: Color, label: String, value: String) -> some View {
@@ -194,5 +497,98 @@ struct SettingsView: View {
                 .foregroundStyle(Theme.textTertiary)
                 .font(Theme.fontCaption)
         }
+    }
+
+    // MARK: - Actions
+
+    private func exportWorkouts() async {
+        guard let userId = authService.currentUser?.id.uuidString.lowercased() else {
+            exportError = "Sign in required"
+            return
+        }
+        isExporting = true
+        defer { isExporting = false }
+
+        let workouts = WorkoutService.shared.fetchWorkoutsFromCache(userId: userId)
+        guard !workouts.isEmpty else {
+            exportError = "No workouts to export yet."
+            return
+        }
+
+        let csv = CSVExporter.csv(for: workouts, unit: weightUnit)
+        do {
+            let url = try CSVExporter.writeToTempFile(csv: csv)
+            presentShareSheet(items: [url])
+        } catch {
+            exportError = error.localizedDescription
+        }
+    }
+
+    private func deleteAccount() async {
+        do {
+            try await authService.deleteAccount()
+        } catch {
+            deleteAccountError = error.localizedDescription
+        }
+    }
+
+    private func openFeedbackMail() {
+        let version = versionShort
+        let build = buildNumber
+        let iosVersion = UIDevice.current.systemVersion
+        let device = UIDevice.current.model
+        let body = """
+
+
+        ---
+        App version: \(version) (\(build))
+        iOS: \(iosVersion)
+        Device: \(device)
+        """
+        var components = URLComponents()
+        components.scheme = "mailto"
+        components.path = "dominickj.giordano@gmail.com"
+        components.queryItems = [
+            URLQueryItem(name: "subject", value: "XomFit Feedback"),
+            URLQueryItem(name: "body", value: body)
+        ]
+        guard let url = components.url else { return }
+        UIApplication.shared.open(url)
+    }
+
+    private func requestAppReview() {
+        guard let scene = UIApplication.shared.connectedScenes
+            .compactMap({ $0 as? UIWindowScene })
+            .first else { return }
+        if #available(iOS 18.0, *) {
+            AppStore.requestReview(in: scene)
+        } else {
+            SKStoreReviewController.requestReview(in: scene)
+        }
+    }
+
+    private func presentShareSheet(items: [Any]) {
+        let controller = UIActivityViewController(activityItems: items, applicationActivities: nil)
+        guard let scene = UIApplication.shared.connectedScenes
+            .compactMap({ $0 as? UIWindowScene })
+            .first,
+              let root = scene.keyWindow?.rootViewController else { return }
+        // Walk to the topmost presented controller so the share sheet sits above any modal.
+        var top: UIViewController = root
+        while let presented = top.presentedViewController {
+            top = presented
+        }
+        // iPad popover anchor.
+        if let pop = controller.popoverPresentationController {
+            pop.sourceView = top.view
+            pop.sourceRect = CGRect(
+                x: top.view.bounds.midX,
+                y: top.view.bounds.midY,
+                width: 0,
+                height: 0
+            )
+            pop.permittedArrowDirections = []
+        }
+        top.present(controller, animated: true)
     }
 }

--- a/Xomfit/Views/Profile/VolumeTrendChart.swift
+++ b/Xomfit/Views/Profile/VolumeTrendChart.swift
@@ -6,6 +6,10 @@ import SwiftUI
 struct VolumeTrendChart: View {
     let buckets: [ProfileViewModel.VolumeBucket]
 
+    /// Display unit for axis + accessibility labels. Stored values stay lbs.
+    @AppStorage("weightUnit") private var weightUnitRaw: String = WeightUnit.lbs.rawValue
+    private var weightUnit: WeightUnit { WeightUnit(rawValue: weightUnitRaw) ?? .lbs }
+
     private static let dayMonthFormatter: DateFormatter = {
         let f = DateFormatter()
         f.dateFormat = "M/d"
@@ -43,14 +47,15 @@ struct VolumeTrendChart: View {
             }
 
             Chart(buckets) { bucket in
+                let displayVolume = bucket.volume * weightUnit.multiplierFromLbs
                 BarMark(
                     x: .value("Week", Self.dayMonthFormatter.string(from: bucket.weekStart)),
-                    y: .value("Volume", bucket.volume)
+                    y: .value("Volume", displayVolume)
                 )
                 .foregroundStyle(barColor(for: bucket))
                 .cornerRadius(4)
                 .accessibilityLabel(Self.dayMonthFormatter.string(from: bucket.weekStart))
-                .accessibilityValue("\(formattedVolume(bucket.volume)) pounds")
+                .accessibilityValue("\(formattedVolume(displayVolume)) \(weightUnit.accessibilityName)")
             }
             .chartYAxis {
                 AxisMarks(position: .leading) { value in

--- a/Xomfit/Views/Workout/SetRowView.swift
+++ b/Xomfit/Views/Workout/SetRowView.swift
@@ -22,6 +22,10 @@ struct SetRowView: View {
     @FocusState private var isWeightFocused: Bool
     @FocusState private var isRepsFocused: Bool
 
+    /// Display-only weight unit. Edits stay in lbs internally regardless.
+    @AppStorage("weightUnit") private var weightUnitRaw: String = WeightUnit.lbs.rawValue
+    private var weightUnit: WeightUnit { WeightUnit(rawValue: weightUnitRaw) ?? .lbs }
+
     private var isCompleted: Bool {
         workoutSet.completedAt != Date.distantPast
     }
@@ -173,7 +177,7 @@ struct SetRowView: View {
                     }
 
                 Button(action: onToggleWeightMode) {
-                    Text(workoutSet.weightMode == .perSide ? "lbs ×2  ×" : "lbs  ×")
+                    Text(workoutSet.weightMode == .perSide ? "\(weightUnit.displayName) ×2  ×" : "\(weightUnit.displayName)  ×")
                         .font(Theme.fontCaption)
                         .foregroundStyle(workoutSet.weightMode == .perSide ? Theme.accent : Theme.textSecondary)
                 }
@@ -248,7 +252,7 @@ struct SetRowView: View {
             if let last = lastSet, last.weight > 0, last.reps > 0 {
                 hintChip(
                     label: "Last",
-                    value: "\(last.weight.formattedWeight)×\(last.reps)",
+                    value: "\(last.weight.formattedWeight(unit: weightUnit))×\(last.reps)",
                     color: Theme.textSecondary
                 )
             }
@@ -256,7 +260,7 @@ struct SetRowView: View {
             if let pr = personalRecord, pr.weight > 0, pr.reps > 0 {
                 hintChip(
                     label: "PR",
-                    value: "\(pr.weight.formattedWeight)×\(pr.reps)",
+                    value: "\(pr.weight.formattedWeight(unit: weightUnit))×\(pr.reps)",
                     color: Theme.prGold
                 )
             }


### PR DESCRIPTION
Closes #312. Full SettingsView rebuild: weight unit (lbs/kg), default rest stepper, week start day, theme picker, export workouts (CSV via share sheet), delete account (Supabase RPC), feedback mailto, App Store review, privacy link. Unit + week-start propagate via @AppStorage to SetRowView, ProfileStatsView, VolumeTrendChart, FeedItemCard, ProfileCalendarView, WorkoutInsights.