### PR TITLE
#317 add body measurements tracking (charts + per-kind detail)

### DIFF
--- a/Xomfit/Models/BodyComposition.swift
+++ b/Xomfit/Models/BodyComposition.swift
@@ -92,8 +92,10 @@ struct BodyCompositionEntry: Identifiable, Codable {
     }
 }
 
-// MARK: - Measurement Metric
-enum BodyMeasurement: String, CaseIterable, Identifiable {
+// MARK: - Measurement Metric (legacy — kept for BodyCompositionEntry compatibility).
+// New measurement tracking uses `BodyMeasurement` struct + `MeasurementKind` enum
+// in `Models/BodyMeasurement.swift` (#317).
+enum LegacyBodyMeasurement: String, CaseIterable, Identifiable {
     case weight = "Weight"
     case chest = "Chest"
     case waist = "Waist"

--- a/Xomfit/Models/BodyMeasurement.swift
+++ b/Xomfit/Models/BodyMeasurement.swift
@@ -1,0 +1,120 @@
+import Foundation
+import SwiftUI
+
+// MARK: - BodyMeasurement (#317)
+//
+// Single-metric measurement entry. One row per (kind, recordedAt) so the
+// time series for any kind can be plotted independently. Photos are intentionally
+// out of scope here — they ship in a follow-up PR.
+//
+// Storage assumption: weights in lbs, lengths in inches, body-fat in %.
+// Conversion to metric is a display-time concern.
+//
+struct BodyMeasurement: Codable, Identifiable, Hashable {
+    let id: String
+    let userId: String
+    let kind: MeasurementKind
+    let value: Double
+    let recordedAt: Date
+    let notes: String?
+
+    init(
+        id: String = UUID().uuidString,
+        userId: String,
+        kind: MeasurementKind,
+        value: Double,
+        recordedAt: Date = Date(),
+        notes: String? = nil
+    ) {
+        self.id = id
+        self.userId = userId
+        self.kind = kind
+        self.value = value
+        self.recordedAt = recordedAt
+        self.notes = notes
+    }
+}
+
+// MARK: - MeasurementKind
+
+enum MeasurementKind: String, Codable, CaseIterable, Identifiable, Hashable {
+    case weight
+    case bodyFatPercent = "body_fat_percent"
+    case chest
+    case waist
+    case arm
+    case thigh
+    case calf
+    case neck
+    case shoulders
+    case custom
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .weight:          return "Weight"
+        case .bodyFatPercent:  return "Body Fat"
+        case .chest:           return "Chest"
+        case .waist:           return "Waist"
+        case .arm:             return "Arm"
+        case .thigh:           return "Thigh"
+        case .calf:            return "Calf"
+        case .neck:            return "Neck"
+        case .shoulders:       return "Shoulders"
+        case .custom:          return "Custom"
+        }
+    }
+
+    /// Display unit. Lengths use inches; weight uses lbs; body fat uses percent.
+    var unit: String {
+        switch self {
+        case .weight:         return "lbs"
+        case .bodyFatPercent: return "%"
+        default:              return "in"
+        }
+    }
+
+    /// SF Symbol used on the measurements list / detail header.
+    var systemImage: String {
+        switch self {
+        case .weight:          return "scalemass.fill"
+        case .bodyFatPercent:  return "percent"
+        case .chest:           return "figure.arms.open"
+        case .waist:           return "figure.stand"
+        case .arm:             return "figure.strengthtraining.traditional"
+        case .thigh:           return "figure.walk"
+        case .calf:            return "figure.walk"
+        case .neck:            return "figure.stand"
+        case .shoulders:       return "figure.arms.open"
+        case .custom:          return "ruler"
+        }
+    }
+
+    /// Sensible numeric step for the log-entry stepper / number pad.
+    var step: Double {
+        switch self {
+        case .weight:         return 0.5
+        case .bodyFatPercent: return 0.1
+        default:              return 0.25
+        }
+    }
+
+    /// Reasonable input bounds (used to gate validation, not as a hard cap on history).
+    var inputRange: ClosedRange<Double> {
+        switch self {
+        case .weight:         return 30...700
+        case .bodyFatPercent: return 1...75
+        default:              return 1...100
+        }
+    }
+
+    /// Format a stored value for display (no unit suffix). Two-decimal max, trims trailing zeros.
+    func format(_ value: Double) -> String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.minimumFractionDigits = 0
+        formatter.maximumFractionDigits = 2
+        return formatter.string(from: NSNumber(value: value)) ?? String(value)
+    }
+}

--- a/Xomfit/Services/MeasurementsService.swift
+++ b/Xomfit/Services/MeasurementsService.swift
@@ -1,0 +1,151 @@
+import Foundation
+import Supabase
+
+// MARK: - Supabase migration (#317)
+//
+// Body measurements are stored in `body_measurements`. If this table does not
+// yet exist in the project, running the service is safe: every call catches
+// errors and returns an empty / no-op result so the UI degrades to its empty
+// state. Apply the following SQL in Supabase to enable persistence:
+//
+// ```sql
+// create table if not exists public.body_measurements (
+//     id uuid primary key default gen_random_uuid(),
+//     user_id uuid not null references auth.users(id) on delete cascade,
+//     kind text not null,
+//     value double precision not null,
+//     recorded_at timestamptz not null default now(),
+//     notes text
+// );
+//
+// create index if not exists body_measurements_user_kind_idx
+//     on public.body_measurements (user_id, kind, recorded_at desc);
+//
+// alter table public.body_measurements enable row level security;
+//
+// create policy "Users manage their own measurements"
+//     on public.body_measurements
+//     for all
+//     using (auth.uid() = user_id)
+//     with check (auth.uid() = user_id);
+// ```
+
+// MARK: - DB row
+
+private struct BodyMeasurementRow: Codable {
+    let id: String
+    let userId: String
+    let kind: String
+    let value: Double
+    let recordedAt: String  // ISO8601 from Supabase
+    let notes: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case userId = "user_id"
+        case kind
+        case value
+        case recordedAt = "recorded_at"
+        case notes
+    }
+}
+
+private struct BodyMeasurementInsertPayload: Encodable {
+    let id: String
+    let user_id: String
+    let kind: String
+    let value: Double
+    let recorded_at: String
+    let notes: String?
+}
+
+// MARK: - MeasurementsService
+
+@MainActor
+final class MeasurementsService {
+    static let shared = MeasurementsService()
+
+    private static let tableName = "body_measurements"
+
+    private let iso8601: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return f
+    }()
+
+    private init() {}
+
+    /// Fetch every measurement for `userId`, newest first. Returns `[]` on any failure
+    /// (table missing, offline, RLS rejection) so the UI can render an empty state.
+    func fetchAll(userId: String) async -> [BodyMeasurement] {
+        do {
+            let rows: [BodyMeasurementRow] = try await supabase
+                .from(Self.tableName)
+                .select()
+                .eq("user_id", value: userId)
+                .order("recorded_at", ascending: false)
+                .execute()
+                .value
+
+            return rows.compactMap(decode)
+        } catch {
+            // Graceful degradation — table may not exist yet, or the user may be offline.
+            return []
+        }
+    }
+
+    /// Insert a new measurement. Returns the persisted row on success, or `nil` on failure
+    /// (caller should surface a generic error rather than crashing).
+    @discardableResult
+    func insert(_ measurement: BodyMeasurement) async -> BodyMeasurement? {
+        let payload = BodyMeasurementInsertPayload(
+            id: measurement.id,
+            user_id: measurement.userId,
+            kind: measurement.kind.rawValue,
+            value: measurement.value,
+            recorded_at: iso8601.string(from: measurement.recordedAt),
+            notes: measurement.notes
+        )
+
+        do {
+            try await supabase
+                .from(Self.tableName)
+                .insert(payload)
+                .execute()
+            return measurement
+        } catch {
+            return nil
+        }
+    }
+
+    /// Delete a measurement by id. Returns `true` on success, `false` otherwise.
+    @discardableResult
+    func delete(id: String, userId: String) async -> Bool {
+        do {
+            try await supabase
+                .from(Self.tableName)
+                .delete()
+                .eq("id", value: id)
+                .eq("user_id", value: userId)
+                .execute()
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    // MARK: - Decoding
+
+    private func decode(_ row: BodyMeasurementRow) -> BodyMeasurement? {
+        guard let kind = MeasurementKind(rawValue: row.kind) else { return nil }
+        let date = iso8601.date(from: row.recordedAt) ?? Date()
+        return BodyMeasurement(
+            id: row.id,
+            userId: row.userId,
+            kind: kind,
+            value: row.value,
+            recordedAt: date,
+            notes: row.notes
+        )
+    }
+}

--- a/Xomfit/ViewModels/MeasurementsViewModel.swift
+++ b/Xomfit/ViewModels/MeasurementsViewModel.swift
@@ -1,0 +1,114 @@
+import Foundation
+
+// MARK: - MeasurementsViewModel (#317)
+
+@MainActor
+@Observable
+final class MeasurementsViewModel {
+    // MARK: - State
+
+    var measurements: [BodyMeasurement] = []
+    var isLoading: Bool = false
+    var errorMessage: String?
+
+    /// Set during load so writes can be attributed to the right user.
+    private(set) var userId: String = ""
+
+    // MARK: - Derived
+
+    /// Measurements grouped by kind, each list newest-first (matches `fetchAll`).
+    var byKind: [MeasurementKind: [BodyMeasurement]] {
+        var result: [MeasurementKind: [BodyMeasurement]] = [:]
+        for measurement in measurements {
+            result[measurement.kind, default: []].append(measurement)
+        }
+        // Already newest-first from the service, but defensively re-sort to keep the
+        // grouping stable if a callsite ever appends in another order.
+        for (kind, list) in result {
+            result[kind] = list.sorted { $0.recordedAt > $1.recordedAt }
+        }
+        return result
+    }
+
+    // MARK: - Loading
+
+    func loadAll(userId: String) async {
+        self.userId = userId
+        isLoading = true
+        errorMessage = nil
+        measurements = await MeasurementsService.shared.fetchAll(userId: userId)
+        isLoading = false
+    }
+
+    // MARK: - Mutations
+
+    /// Add a new measurement. Optimistically prepends on success; surfaces an
+    /// error if the insert fails so the UI can show feedback.
+    func add(
+        kind: MeasurementKind,
+        value: Double,
+        recordedAt: Date = Date(),
+        notes: String? = nil
+    ) async {
+        guard !userId.isEmpty else {
+            errorMessage = "Sign in required to log measurements."
+            return
+        }
+
+        let measurement = BodyMeasurement(
+            userId: userId,
+            kind: kind,
+            value: value,
+            recordedAt: recordedAt,
+            notes: notes?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+        )
+
+        if let saved = await MeasurementsService.shared.insert(measurement) {
+            measurements.insert(saved, at: 0)
+        } else {
+            errorMessage = "Couldn't save measurement. Try again."
+        }
+    }
+
+    /// Remove a measurement. Optimistically drops it from local state on success.
+    func remove(_ measurement: BodyMeasurement) async {
+        let success = await MeasurementsService.shared.delete(id: measurement.id, userId: measurement.userId)
+        if success {
+            measurements.removeAll { $0.id == measurement.id }
+        } else {
+            errorMessage = "Couldn't delete measurement."
+        }
+    }
+
+    // MARK: - Convenience accessors
+
+    /// Most recent measurement for the given kind, or nil.
+    func latest(of kind: MeasurementKind) -> BodyMeasurement? {
+        byKind[kind]?.first
+    }
+
+    /// Change in value over the last `days` days for `kind`. nil when fewer than two
+    /// data points exist within the window or no prior data is available.
+    func delta(for kind: MeasurementKind, days: Int = 30) -> Double? {
+        let series = byKind[kind] ?? []
+        guard let latest = series.first else { return nil }
+
+        let cutoff = Calendar.current.date(byAdding: .day, value: -days, to: latest.recordedAt) ?? .distantPast
+        // Pick the oldest point at or after the cutoff (so a 30-day delta uses the
+        // first reading inside the window, not the latest one).
+        let baseline = series
+            .dropFirst() // exclude latest
+            .filter { $0.recordedAt >= cutoff }
+            .last
+            ?? series.dropFirst().first
+
+        guard let baseline else { return nil }
+        return latest.value - baseline.value
+    }
+}
+
+// MARK: - String helper
+
+private extension String {
+    var nilIfEmpty: String? { isEmpty ? nil : self }
+}

--- a/Xomfit/Views/Profile/MeasurementKindDetailView.swift
+++ b/Xomfit/Views/Profile/MeasurementKindDetailView.swift
@@ -1,0 +1,405 @@
+import Charts
+import SwiftUI
+
+// MARK: - MeasurementKindDetailView (#317)
+//
+// Time-series chart for one `MeasurementKind` plus an inline form to log a new
+// entry. The view binds to the parent `MeasurementsViewModel` so writes update
+// every kind's series consistently.
+//
+struct MeasurementKindDetailView: View {
+    let kind: MeasurementKind
+
+    @Bindable var viewModel: MeasurementsViewModel
+
+    @State private var range: TimeRange = .threeMonths
+    @State private var valueText: String = ""
+    @State private var notesText: String = ""
+    @State private var entryDate: Date = Date()
+    @State private var isSaving: Bool = false
+    @State private var pendingDelete: BodyMeasurement?
+    @State private var isDeleteAlertPresented: Bool = false
+
+    @FocusState private var valueFocused: Bool
+
+    enum TimeRange: String, CaseIterable, Identifiable {
+        case oneMonth = "1M"
+        case threeMonths = "3M"
+        case sixMonths = "6M"
+        case year = "1Y"
+        case all = "All"
+
+        var id: String { rawValue }
+
+        var days: Int? {
+            switch self {
+            case .oneMonth:    return 30
+            case .threeMonths: return 90
+            case .sixMonths:   return 180
+            case .year:        return 365
+            case .all:         return nil
+            }
+        }
+    }
+
+    private var allEntries: [BodyMeasurement] {
+        viewModel.byKind[kind] ?? []
+    }
+
+    private var rangedEntries: [BodyMeasurement] {
+        guard let days = range.days else { return allEntries }
+        let cutoff = Calendar.current.date(byAdding: .day, value: -days, to: Date()) ?? .distantPast
+        return allEntries.filter { $0.recordedAt >= cutoff }
+    }
+
+    /// Chart data is oldest-first so the line reads left to right.
+    private var chartPoints: [BodyMeasurement] {
+        rangedEntries.sorted { $0.recordedAt < $1.recordedAt }
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: Theme.Spacing.md) {
+                summaryCard
+                rangePicker
+                chartCard
+                logEntryCard
+                historySection
+            }
+            .padding(.horizontal, Theme.Spacing.md)
+            .padding(.vertical, Theme.Spacing.md)
+            .padding(.bottom, 100)
+        }
+        .background(Theme.background.ignoresSafeArea())
+        .navigationTitle(kind.displayName)
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbarColorScheme(.dark, for: .navigationBar)
+        .scrollDismissesKeyboard(.interactively)
+        .alert(
+            "Delete measurement?",
+            isPresented: $isDeleteAlertPresented,
+            presenting: pendingDelete
+        ) { entry in
+            Button("Delete", role: .destructive) {
+                Task { await viewModel.remove(entry) }
+                pendingDelete = nil
+            }
+            Button("Cancel", role: .cancel) {
+                pendingDelete = nil
+            }
+        } message: { entry in
+            Text("This will remove the \(kind.format(entry.value)) \(kind.unit) entry from \(entry.recordedAt.formatted(date: .abbreviated, time: .omitted)).")
+        }
+    }
+
+    // MARK: - Summary
+
+    private var summaryCard: some View {
+        XomCard(variant: .elevated) {
+            HStack(spacing: Theme.Spacing.md) {
+                Image(systemName: kind.systemImage)
+                    .font(.title2)
+                    .foregroundStyle(Theme.accent)
+                    .frame(width: 44, height: 44)
+                    .background(Theme.accentMuted)
+                    .clipShape(Circle())
+
+                VStack(alignment: .leading, spacing: 4) {
+                    if let latest = viewModel.latest(of: kind) {
+                        Text("\(kind.format(latest.value)) \(kind.unit)")
+                            .font(Theme.fontNumberLarge)
+                            .foregroundStyle(Theme.textPrimary)
+                        Text("Last logged \(latest.recordedAt.formatted(date: .abbreviated, time: .omitted))")
+                            .font(Theme.fontSmall)
+                            .foregroundStyle(Theme.textSecondary)
+                    } else {
+                        Text("Not logged yet")
+                            .font(Theme.fontHeadline)
+                            .foregroundStyle(Theme.textPrimary)
+                        Text("Add your first entry below")
+                            .font(Theme.fontSmall)
+                            .foregroundStyle(Theme.textSecondary)
+                    }
+                }
+
+                Spacer()
+
+                deltaPill
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var deltaPill: some View {
+        if let delta = viewModel.delta(for: kind, days: 30) {
+            let lowerIsBetter = (kind == .waist || kind == .bodyFatPercent)
+            let isPositive = lowerIsBetter ? delta < 0 : delta > 0
+            let bg: Color = abs(delta) < 0.05
+                ? Theme.surface
+                : (isPositive ? Theme.accentMuted : Theme.destructive.opacity(0.15))
+            let fg: Color = abs(delta) < 0.05
+                ? Theme.textSecondary
+                : (isPositive ? Theme.accent : Theme.destructive)
+            let prefix = delta > 0 ? "+" : ""
+            VStack(alignment: .trailing, spacing: 2) {
+                Text("\(prefix)\(kind.format(delta))")
+                    .font(Theme.fontNumberMedium)
+                    .foregroundStyle(fg)
+                Text("30d")
+                    .font(Theme.fontSmall)
+                    .foregroundStyle(Theme.textTertiary)
+            }
+            .padding(.horizontal, Theme.Spacing.sm)
+            .padding(.vertical, Theme.Spacing.xs)
+            .background(bg)
+            .clipShape(RoundedRectangle(cornerRadius: Theme.Radius.sm))
+        }
+    }
+
+    // MARK: - Range picker
+
+    private var rangePicker: some View {
+        Picker("Range", selection: $range) {
+            ForEach(TimeRange.allCases) { range in
+                Text(range.rawValue).tag(range)
+            }
+        }
+        .pickerStyle(.segmented)
+    }
+
+    // MARK: - Chart
+
+    @ViewBuilder
+    private var chartCard: some View {
+        XomCard {
+            VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+                Text("Trend")
+                    .font(Theme.fontSubheadline.weight(.semibold))
+                    .foregroundStyle(Theme.textPrimary)
+
+                if chartPoints.count >= 2 {
+                    chart
+                        .frame(height: 180)
+                } else if chartPoints.count == 1 {
+                    Text("Add another entry to see a trend")
+                        .font(Theme.fontSmall)
+                        .foregroundStyle(Theme.textSecondary)
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 180)
+                } else {
+                    Text("No data in this range")
+                        .font(Theme.fontSmall)
+                        .foregroundStyle(Theme.textSecondary)
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 180)
+                }
+            }
+        }
+    }
+
+    private var chart: some View {
+        Chart(chartPoints) { point in
+            LineMark(
+                x: .value("Date", point.recordedAt),
+                y: .value(kind.displayName, point.value)
+            )
+            .foregroundStyle(Theme.accent)
+            .interpolationMethod(.monotone)
+            .lineStyle(StrokeStyle(lineWidth: 2))
+
+            PointMark(
+                x: .value("Date", point.recordedAt),
+                y: .value(kind.displayName, point.value)
+            )
+            .foregroundStyle(Theme.accent)
+            .symbolSize(40)
+        }
+        .chartYAxis {
+            AxisMarks(position: .leading) { value in
+                AxisGridLine().foregroundStyle(Theme.hairline)
+                AxisValueLabel {
+                    if let v = value.as(Double.self) {
+                        Text(kind.format(v))
+                            .font(.caption2)
+                            .foregroundStyle(Theme.textTertiary)
+                    }
+                }
+            }
+        }
+        .chartXAxis {
+            AxisMarks { _ in
+                AxisGridLine().foregroundStyle(Theme.hairline)
+                AxisValueLabel()
+                    .font(.caption2)
+                    .foregroundStyle(Theme.textTertiary)
+            }
+        }
+    }
+
+    // MARK: - Log entry form
+
+    private var logEntryCard: some View {
+        XomCard(variant: .elevated) {
+            VStack(alignment: .leading, spacing: Theme.Spacing.md) {
+                Text("Log new entry")
+                    .font(Theme.fontSubheadline.weight(.semibold))
+                    .foregroundStyle(Theme.textPrimary)
+
+                HStack(spacing: Theme.Spacing.sm) {
+                    TextField("Value", text: $valueText)
+                        .keyboardType(.decimalPad)
+                        .focused($valueFocused)
+                        .font(Theme.fontNumberMedium)
+                        .foregroundStyle(Theme.textPrimary)
+                        .padding(Theme.Spacing.sm)
+                        .background(Theme.surface)
+                        .clipShape(RoundedRectangle(cornerRadius: Theme.Radius.sm))
+                        .accessibilityLabel("Measurement value in \(kind.unit)")
+
+                    Text(kind.unit)
+                        .font(Theme.fontBody)
+                        .foregroundStyle(Theme.textSecondary)
+                        .frame(minWidth: 36, alignment: .leading)
+                }
+
+                DatePicker(
+                    "Date",
+                    selection: $entryDate,
+                    in: ...Date(),
+                    displayedComponents: .date
+                )
+                .datePickerStyle(.compact)
+                .tint(Theme.accent)
+                .foregroundStyle(Theme.textPrimary)
+
+                TextField("Notes (optional)", text: $notesText, axis: .vertical)
+                    .lineLimit(1...3)
+                    .padding(Theme.Spacing.sm)
+                    .background(Theme.surface)
+                    .clipShape(RoundedRectangle(cornerRadius: Theme.Radius.sm))
+                    .accessibilityLabel("Notes")
+
+                XomButton(
+                    "Save Entry",
+                    icon: "checkmark.circle.fill",
+                    isLoading: isSaving,
+                    action: saveEntry
+                )
+                .disabled(!isValueValid || isSaving)
+                .opacity(isValueValid ? 1 : 0.5)
+
+                if let errorMessage = viewModel.errorMessage {
+                    Text(errorMessage)
+                        .font(Theme.fontSmall)
+                        .foregroundStyle(Theme.destructive)
+                }
+            }
+        }
+    }
+
+    // MARK: - History
+
+    @ViewBuilder
+    private var historySection: some View {
+        if !allEntries.isEmpty {
+            VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+                Text("History")
+                    .font(Theme.fontSubheadline.weight(.semibold))
+                    .foregroundStyle(Theme.textPrimary)
+                    .padding(.horizontal, Theme.Spacing.xs)
+
+                VStack(spacing: Theme.Spacing.xs) {
+                    ForEach(allEntries) { entry in
+                        historyRow(entry)
+                    }
+                }
+            }
+        }
+    }
+
+    private func historyRow(_ entry: BodyMeasurement) -> some View {
+        XomCard(padding: Theme.Spacing.sm) {
+            HStack(spacing: Theme.Spacing.md) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("\(kind.format(entry.value)) \(kind.unit)")
+                        .font(Theme.fontNumberMedium)
+                        .foregroundStyle(Theme.textPrimary)
+                    Text(entry.recordedAt, style: .date)
+                        .font(Theme.fontSmall)
+                        .foregroundStyle(Theme.textSecondary)
+                    if let notes = entry.notes, !notes.isEmpty {
+                        Text(notes)
+                            .font(Theme.fontSmall)
+                            .foregroundStyle(Theme.textTertiary)
+                            .lineLimit(2)
+                    }
+                }
+
+                Spacer()
+
+                Button {
+                    Haptics.light()
+                    pendingDelete = entry
+                    isDeleteAlertPresented = true
+                } label: {
+                    Image(systemName: "trash")
+                        .font(.subheadline)
+                        .foregroundStyle(Theme.textSecondary)
+                        .frame(width: 44, height: 44)
+                }
+                .accessibilityLabel("Delete entry")
+            }
+        }
+    }
+
+    // MARK: - Actions
+
+    private var parsedValue: Double? {
+        let normalized = valueText.replacingOccurrences(of: ",", with: ".")
+        return Double(normalized)
+    }
+
+    private var isValueValid: Bool {
+        guard let value = parsedValue else { return false }
+        return kind.inputRange.contains(value)
+    }
+
+    private func saveEntry() {
+        guard let value = parsedValue, !isSaving else { return }
+        isSaving = true
+        valueFocused = false
+        Haptics.light()
+
+        Task {
+            await viewModel.add(
+                kind: kind,
+                value: value,
+                recordedAt: entryDate,
+                notes: notesText
+            )
+            isSaving = false
+            if viewModel.errorMessage == nil {
+                Haptics.success()
+                resetForm()
+            }
+        }
+    }
+
+    private func resetForm() {
+        valueText = ""
+        notesText = ""
+        entryDate = Date()
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    NavigationStack {
+        MeasurementKindDetailView(
+            kind: .weight,
+            viewModel: MeasurementsViewModel()
+        )
+    }
+    .background(Theme.background)
+}

--- a/Xomfit/Views/Profile/MeasurementsView.swift
+++ b/Xomfit/Views/Profile/MeasurementsView.swift
@@ -1,0 +1,229 @@
+import SwiftUI
+
+// MARK: - MeasurementsView (#317)
+//
+// One row per `MeasurementKind`, showing the latest value and 30-day delta.
+// Tapping a row drills into `MeasurementKindDetailView` for the chart + log form.
+//
+// TODO(#317-photos): Progress photos ship in a follow-up PR. When they land,
+// surface a thumbnail strip / "Photos" entry above the kinds list.
+//
+struct MeasurementsView: View {
+    let userId: String
+
+    @State private var viewModel = MeasurementsViewModel()
+
+    var body: some View {
+        ZStack {
+            Theme.background.ignoresSafeArea()
+
+            if viewModel.isLoading && viewModel.measurements.isEmpty {
+                loadingState
+            } else if viewModel.measurements.isEmpty {
+                emptyState
+            } else {
+                measurementsList
+            }
+        }
+        .navigationTitle("Body")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbarColorScheme(.dark, for: .navigationBar)
+        .task {
+            await viewModel.loadAll(userId: userId)
+        }
+        .refreshable {
+            await viewModel.loadAll(userId: userId)
+        }
+    }
+
+    // MARK: - Loading
+
+    private var loadingState: some View {
+        VStack(spacing: Theme.Spacing.md) {
+            ForEach(0..<5, id: \.self) { index in
+                SkeletonCard(height: 64)
+                    .staggeredAppear(index: index)
+            }
+        }
+        .padding(.horizontal, Theme.Spacing.md)
+        .padding(.top, Theme.Spacing.md)
+    }
+
+    // MARK: - Empty state
+
+    private var emptyState: some View {
+        ScrollView {
+            VStack(spacing: Theme.Spacing.lg) {
+                XomEmptyState(
+                    icon: "ruler",
+                    title: "No measurements yet",
+                    subtitle: "Track your weight, body fat, and circumference measurements over time.",
+                    floatingLoop: true
+                )
+
+                quickStartGrid
+                    .padding(.horizontal, Theme.Spacing.md)
+            }
+            .padding(.top, Theme.Spacing.xl)
+        }
+    }
+
+    /// Grid of all kinds even when empty — invites the user to start logging.
+    private var quickStartGrid: some View {
+        LazyVGrid(
+            columns: [
+                GridItem(.flexible(), spacing: Theme.Spacing.sm),
+                GridItem(.flexible(), spacing: Theme.Spacing.sm)
+            ],
+            spacing: Theme.Spacing.sm
+        ) {
+            ForEach(MeasurementKind.allCases) { kind in
+                NavigationLink {
+                    MeasurementKindDetailView(kind: kind, viewModel: viewModel)
+                        .hideTabBar()
+                } label: {
+                    quickStartCard(for: kind)
+                }
+                .buttonStyle(PressableCardStyle())
+                .accessibilityLabel("Log \(kind.displayName)")
+            }
+        }
+    }
+
+    private func quickStartCard(for kind: MeasurementKind) -> some View {
+        XomCard(padding: Theme.Spacing.sm) {
+            VStack(spacing: Theme.Spacing.xs) {
+                Image(systemName: kind.systemImage)
+                    .font(.title3)
+                    .foregroundStyle(Theme.accent)
+                    .frame(height: 24)
+
+                Text(kind.displayName)
+                    .font(Theme.fontSubheadline.weight(.semibold))
+                    .foregroundStyle(Theme.textPrimary)
+
+                Text("Tap to log")
+                    .font(Theme.fontSmall)
+                    .foregroundStyle(Theme.textSecondary)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, Theme.Spacing.xs)
+        }
+    }
+
+    // MARK: - Populated list
+
+    private var measurementsList: some View {
+        ScrollView {
+            VStack(spacing: Theme.Spacing.sm) {
+                ForEach(MeasurementKind.allCases) { kind in
+                    NavigationLink {
+                        MeasurementKindDetailView(kind: kind, viewModel: viewModel)
+                            .hideTabBar()
+                    } label: {
+                        MeasurementKindRow(
+                            kind: kind,
+                            latest: viewModel.latest(of: kind),
+                            delta: viewModel.delta(for: kind, days: 30)
+                        )
+                    }
+                    .buttonStyle(PressableCardStyle())
+                    .accessibilityHint("Opens chart and log entry form")
+                }
+            }
+            .padding(.horizontal, Theme.Spacing.md)
+            .padding(.vertical, Theme.Spacing.md)
+            .padding(.bottom, 100)
+        }
+    }
+}
+
+// MARK: - Row
+
+private struct MeasurementKindRow: View {
+    let kind: MeasurementKind
+    let latest: BodyMeasurement?
+    let delta: Double?
+
+    var body: some View {
+        XomCard {
+            HStack(spacing: Theme.Spacing.md) {
+                Image(systemName: kind.systemImage)
+                    .font(.title3)
+                    .foregroundStyle(Theme.accent)
+                    .frame(width: 32, height: 32)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(kind.displayName)
+                        .font(Theme.fontSubheadline.weight(.semibold))
+                        .foregroundStyle(Theme.textPrimary)
+                    deltaCaption
+                }
+
+                Spacer()
+
+                latestValue
+            }
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(accessibilitySummary)
+    }
+
+    @ViewBuilder
+    private var latestValue: some View {
+        if let latest {
+            VStack(alignment: .trailing, spacing: 2) {
+                Text("\(kind.format(latest.value)) \(kind.unit)")
+                    .font(Theme.fontNumberMedium)
+                    .foregroundStyle(Theme.textPrimary)
+                Text(latest.recordedAt, style: .date)
+                    .font(Theme.fontSmall)
+                    .foregroundStyle(Theme.textTertiary)
+            }
+        } else {
+            Text("Tap to log")
+                .font(Theme.fontSmall)
+                .foregroundStyle(Theme.textSecondary)
+        }
+    }
+
+    @ViewBuilder
+    private var deltaCaption: some View {
+        if let delta {
+            let lowerIsBetter = (kind == .waist || kind == .bodyFatPercent)
+            let isPositiveChange = lowerIsBetter ? delta < 0 : delta > 0
+            let color: Color = abs(delta) < 0.05
+                ? Theme.textSecondary
+                : (isPositiveChange ? Theme.accent : Theme.destructive)
+            let prefix = delta > 0 ? "+" : ""
+            Text("\(prefix)\(kind.format(delta)) \(kind.unit) · 30d")
+                .font(Theme.fontSmall)
+                .foregroundStyle(color)
+        } else {
+            Text("No trend yet")
+                .font(Theme.fontSmall)
+                .foregroundStyle(Theme.textSecondary)
+        }
+    }
+
+    private var accessibilitySummary: String {
+        var parts: [String] = [kind.displayName]
+        if let latest {
+            parts.append("\(kind.format(latest.value)) \(kind.unit)")
+        }
+        if let delta {
+            let direction = delta > 0 ? "up" : "down"
+            parts.append("\(direction) \(kind.format(abs(delta))) \(kind.unit) over 30 days")
+        }
+        return parts.joined(separator: ", ")
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    NavigationStack {
+        MeasurementsView(userId: "preview-user")
+    }
+    .background(Theme.background)
+}

--- a/Xomfit/Views/Profile/ProfileStatsView.swift
+++ b/Xomfit/Views/Profile/ProfileStatsView.swift
@@ -16,6 +16,8 @@ struct ProfileStatsView: View {
     var currentStreak: Int = 0
     /// Longest streak across history (#250).
     var longestStreak: Int = 0
+    /// Profile owner — used by the Body measurements link (#317). nil = link hidden.
+    var userId: String? = nil
 
     @State private var heatmapFilter: HeatmapTimeFilter = .week
 
@@ -30,6 +32,7 @@ struct ProfileStatsView: View {
         VStack(spacing: Theme.Spacing.sm) {
             StreakCard(currentStreak: currentStreak, longestStreak: longestStreak)
             statsCards
+            bodyLink
             volumeTrendSection
             consistencySection
             topExercisesSection
@@ -37,6 +40,47 @@ struct ProfileStatsView: View {
             prSection
         }
         .padding(.horizontal, Theme.Spacing.md)
+    }
+
+    // MARK: - Body Measurements Link (#317)
+
+    @ViewBuilder
+    private var bodyLink: some View {
+        if let userId, !userId.isEmpty {
+            NavigationLink {
+                MeasurementsView(userId: userId)
+                    .hideTabBar()
+            } label: {
+                XomCard {
+                    HStack(spacing: Theme.Spacing.md) {
+                        Image(systemName: "ruler")
+                            .font(.title3)
+                            .foregroundStyle(Theme.accent)
+                            .frame(width: 32, height: 32)
+                            .background(Theme.accentMuted)
+                            .clipShape(Circle())
+
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Body")
+                                .font(Theme.fontSubheadline.weight(.semibold))
+                                .foregroundStyle(Theme.textPrimary)
+                            Text("Track weight, body fat, and measurements")
+                                .font(Theme.fontSmall)
+                                .foregroundStyle(Theme.textSecondary)
+                        }
+
+                        Spacer()
+
+                        Image(systemName: "chevron.right")
+                            .font(.subheadline.weight(.semibold))
+                            .foregroundStyle(Theme.textTertiary)
+                    }
+                }
+            }
+            .buttonStyle(PressableCardStyle())
+            .accessibilityLabel("Body measurements")
+            .accessibilityHint("Opens weight, body fat, and circumference tracker")
+        }
     }
 
     // MARK: - Stats Cards

--- a/Xomfit/Views/Profile/ProfileView.swift
+++ b/Xomfit/Views/Profile/ProfileView.swift
@@ -194,7 +194,9 @@ struct ProfileView: View {
                 topExercises: viewModel.topExercisesByVolume,
                 prOfTheMonth: viewModel.prOfTheMonth,
                 currentStreak: viewModel.currentStreak,
-                longestStreak: viewModel.longestStreak
+                longestStreak: viewModel.longestStreak,
+                // Only own profile gets the Body link — measurements are private to the user.
+                userId: viewModel.isOwnProfile ? resolvedUserId : nil
             )
         }
     }


### PR DESCRIPTION
Closes #317 (measurements only; photos deferred). Codable BodyMeasurement model + 10-kind enum, Supabase service that no-ops on missing table, @Observable VM, MeasurementsView (kinds list + 30d delta + empty-state quick-start), MeasurementKindDetailView (Charts line + log form). Body link on own profile only.