### PR TITLE
#318 add per-exercise notes + rest override

### DIFF
--- a/Xomfit/Models/Workout.swift
+++ b/Xomfit/Models/Workout.swift
@@ -127,6 +127,9 @@ struct WorkoutExercise: Codable, Identifiable {
     /// When non-nil, this exercise is part of a superset group.
     /// All exercises sharing the same UUID are performed back-to-back (1 set of A → 1 set of B → rest → ...).
     var supersetGroupId: UUID? = nil
+    /// Per-exercise rest override in seconds. When nil, the global `defaultRestDuration` is used.
+    /// Backwards-compatible: pre-existing workouts decode this as nil.
+    var restSeconds: Int? = nil
 
     var bestSet: WorkoutSet? {
         sets.max(by: { $0.volume < $1.volume })

--- a/Xomfit/Models/WorkoutTemplate.swift
+++ b/Xomfit/Models/WorkoutTemplate.swift
@@ -15,6 +15,9 @@ struct WorkoutTemplate: Codable, Identifiable {
         var targetSets: Int
         var targetReps: String // "5" or "8-12"
         var notes: String?
+        /// Per-exercise rest override in seconds. nil = use the workout's global default.
+        /// Optional + default keeps existing templates decodable as-is.
+        var restSeconds: Int? = nil
     }
 
     enum TemplateCategory: String, Codable, CaseIterable {

--- a/Xomfit/ViewModels/WorkoutBuilderViewModel.swift
+++ b/Xomfit/ViewModels/WorkoutBuilderViewModel.swift
@@ -49,7 +49,14 @@ final class WorkoutBuilderViewModel {
 
     func updateNotes(at index: Int, notes: String?) {
         guard exercises.indices.contains(index) else { return }
-        exercises[index].notes = notes
+        let trimmed = notes?.trimmingCharacters(in: .whitespacesAndNewlines)
+        exercises[index].notes = (trimmed?.isEmpty == false) ? trimmed : nil
+    }
+
+    /// Per-exercise rest override. Pass nil to fall back to the workout's global default.
+    func updateRestSeconds(at index: Int, seconds: Int?) {
+        guard exercises.indices.contains(index) else { return }
+        exercises[index].restSeconds = seconds
     }
 
     /// Builds a `WorkoutTemplate` from the current builder state without persisting.

--- a/Xomfit/ViewModels/WorkoutLoggerViewModel.swift
+++ b/Xomfit/ViewModels/WorkoutLoggerViewModel.swift
@@ -222,6 +222,7 @@ final class WorkoutLoggerViewModel {
                 notes: templateExercise.notes
             )
             we.selectedLaterality = templateExercise.exercise.defaultLaterality
+            we.restSeconds = templateExercise.restSeconds
             builtExercises.append(we)
         }
         exercises = builtExercises
@@ -327,6 +328,19 @@ final class WorkoutLoggerViewModel {
         exercises[exerciseIndex].selectedLaterality = laterality
     }
 
+    /// Update or clear the per-exercise note. Trims whitespace; treats empty strings as nil.
+    func setNotes(exerciseIndex: Int, notes: String?) {
+        guard exercises.indices.contains(exerciseIndex) else { return }
+        let trimmed = notes?.trimmingCharacters(in: .whitespacesAndNewlines)
+        exercises[exerciseIndex].notes = (trimmed?.isEmpty == false) ? trimmed : nil
+    }
+
+    /// Set or clear the per-exercise rest override. Pass nil to fall back to the global default.
+    func setRestSeconds(exerciseIndex: Int, seconds: Int?) {
+        guard exercises.indices.contains(exerciseIndex) else { return }
+        exercises[exerciseIndex].restSeconds = seconds
+    }
+
     // MARK: - Set Management
 
     func addSet(to exerciseIndex: Int) {
@@ -381,8 +395,7 @@ final class WorkoutLoggerViewModel {
 
             let shouldStartRest = !nextSetIsDropSet && !inSupersetRound
             if shouldStartRest {
-                let exerciseCategory = exercises[exerciseIndex].exercise.category
-                startRestTimer(for: exerciseCategory)
+                startRestTimer(for: exerciseIndex)
             }
 
             // Auto-advance focus for supersets — jump to the sibling exercise's matching set
@@ -703,10 +716,17 @@ final class WorkoutLoggerViewModel {
     /// Timestamp when the rest timer was started — used to survive background suspension.
     private var restTimerStartDate: Date?
 
-    func startRestTimer(for category: ExerciseCategory) {
-        guard defaultRestDuration > 0 else { return }
-        restDuration = defaultRestDuration
-        restTimeRemaining = defaultRestDuration
+    /// Starts the rest timer using the per-exercise override when set, otherwise falls
+    /// back to the global default. Reading the override at fire-time means edits to
+    /// a pill mid-workout take effect on the very next set.
+    func startRestTimer(for exerciseIndex: Int) {
+        let override = exercises.indices.contains(exerciseIndex)
+            ? exercises[exerciseIndex].restSeconds
+            : nil
+        let duration = Double(override ?? Int(defaultRestDuration))
+        guard duration > 0 else { return }
+        restDuration = duration
+        restTimeRemaining = duration
         isRestTimerActive = true
         restTimerStartDate = Date()
         updateLiveActivity()
@@ -920,7 +940,7 @@ final class WorkoutLoggerViewModel {
         let completedExercises: [WorkoutExercise] = exercises.compactMap { ex in
             let doneSets = ex.sets.filter { $0.completedAt != Date.distantPast }
             guard !doneSets.isEmpty else { return nil }
-            return WorkoutExercise(
+            var copy = WorkoutExercise(
                 id: ex.id,
                 exercise: ex.exercise,
                 sets: doneSets,
@@ -930,6 +950,9 @@ final class WorkoutLoggerViewModel {
                 selectedPosition: ex.selectedPosition,
                 selectedLaterality: ex.selectedLaterality
             )
+            copy.supersetGroupId = ex.supersetGroupId
+            copy.restSeconds = ex.restSeconds
+            return copy
         }
 
         let trimmedNotes = notes?.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Xomfit/Views/Workout/ActiveWorkoutView.swift
+++ b/Xomfit/Views/Workout/ActiveWorkoutView.swift
@@ -571,7 +571,8 @@ struct ActiveWorkoutView: View {
                     exercise: ex.exercise,
                     targetSets: ex.sets.count,
                     targetReps: ex.bestSet.map { "\($0.reps)" } ?? "8",
-                    notes: ex.notes
+                    notes: ex.notes,
+                    restSeconds: ex.restSeconds
                 )
             }
             let template = WorkoutTemplate(
@@ -795,19 +796,19 @@ private struct ExerciseCard: View {
                 }
             }
 
-            // Variant config (grip, attachment, position, laterality)
-            if exercise.exercise.supportedGrips != nil ||
-               exercise.exercise.supportedAttachments != nil ||
-               exercise.exercise.supportedPositions != nil ||
-               exercise.exercise.supportsUnilateral {
-                ExerciseConfigRow(
-                    exercise: exercise,
-                    onGripChanged: { grip in viewModel.setGrip(exerciseIndex: exerciseIndex, grip: grip) },
-                    onAttachmentChanged: { att in viewModel.setAttachment(exerciseIndex: exerciseIndex, attachment: att) },
-                    onPositionChanged: { pos in viewModel.setPosition(exerciseIndex: exerciseIndex, position: pos) },
-                    onLateralityChanged: { lat in viewModel.setLaterality(exerciseIndex: exerciseIndex, laterality: lat) }
-                )
-            }
+            // Variant config (grip, attachment, position, laterality) + per-session extras
+            // (notes pill, rest override). The extras pills always render so the user can
+            // edit notes / rest even on exercises without grip/attachment/position variants.
+            ExerciseConfigRow(
+                exercise: exercise,
+                onGripChanged: { grip in viewModel.setGrip(exerciseIndex: exerciseIndex, grip: grip) },
+                onAttachmentChanged: { att in viewModel.setAttachment(exerciseIndex: exerciseIndex, attachment: att) },
+                onPositionChanged: { pos in viewModel.setPosition(exerciseIndex: exerciseIndex, position: pos) },
+                onLateralityChanged: { lat in viewModel.setLaterality(exerciseIndex: exerciseIndex, laterality: lat) },
+                onNotesChanged: { notes in viewModel.setNotes(exerciseIndex: exerciseIndex, notes: notes) },
+                onRestSecondsChanged: { secs in viewModel.setRestSeconds(exerciseIndex: exerciseIndex, seconds: secs) },
+                defaultRestSeconds: Int(viewModel.defaultRestDuration)
+            )
 
             // Laterality badge
             if exercise.exercise.supportsUnilateral && exercise.selectedLaterality != .bilateral {

--- a/Xomfit/Views/Workout/ExerciseConfigRow.swift
+++ b/Xomfit/Views/Workout/ExerciseConfigRow.swift
@@ -8,6 +8,17 @@ struct ExerciseConfigRow: View {
     let onAttachmentChanged: (CableAttachment) -> Void
     let onPositionChanged: (ExercisePosition) -> Void
     var onLateralityChanged: ((Laterality) -> Void)? = nil
+    /// Optional notes handler. Pass nil/empty to clear. When omitted, the notes pill is hidden.
+    var onNotesChanged: ((String?) -> Void)? = nil
+    /// Optional per-exercise rest override handler. Pass nil to clear (use global). When omitted,
+    /// the rest pill is hidden.
+    var onRestSecondsChanged: ((Int?) -> Void)? = nil
+    /// Global default surfaced inside the rest sheet so the user can compare/reset.
+    /// Defaults to 90s — the same fallback used by `WorkoutLoggerViewModel`.
+    var defaultRestSeconds: Int = 90
+
+    @State private var showNotesSheet = false
+    @State private var showRestSheet = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
@@ -51,8 +62,120 @@ struct ExerciseConfigRow: View {
                     }
                 }
             }
+
+            // Notes + rest extras row — only rendered when at least one handler is wired up.
+            if onNotesChanged != nil || onRestSecondsChanged != nil {
+                extrasRow
+            }
+        }
+        .sheet(isPresented: $showNotesSheet) {
+            if let onNotesChanged {
+                ExerciseNotesSheet(
+                    exerciseName: exercise.exercise.name,
+                    initialNotes: exercise.notes ?? "",
+                    onSave: { onNotesChanged($0) }
+                )
+                .presentationDetents([.medium, .large])
+            }
+        }
+        .sheet(isPresented: $showRestSheet) {
+            if let onRestSecondsChanged {
+                ExerciseRestSheet(
+                    exerciseName: exercise.exercise.name,
+                    initialRestSeconds: exercise.restSeconds ?? defaultRestSeconds,
+                    isCustomized: exercise.restSeconds != nil,
+                    defaultRestSeconds: defaultRestSeconds,
+                    onSave: { onRestSecondsChanged($0) }
+                )
+                .presentationDetents([.medium])
+            }
         }
     }
+
+    // MARK: - Extras Row (Notes + Rest)
+
+    private var extrasRow: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 6) {
+                if onNotesChanged != nil {
+                    notesPill
+                }
+                if onRestSecondsChanged != nil {
+                    restPill
+                }
+            }
+        }
+    }
+
+    private var notesPill: some View {
+        let hasNote = (exercise.notes?.isEmpty == false)
+        return Button {
+            Haptics.selection()
+            showNotesSheet = true
+        } label: {
+            HStack(spacing: 4) {
+                Image(systemName: hasNote ? "note.text" : "plus")
+                    .font(.caption2.weight(.semibold))
+                if hasNote, let preview = notePreview(exercise.notes) {
+                    Text(preview)
+                        .font(.caption2.weight(.semibold))
+                        .lineLimit(1)
+                } else {
+                    Text("Add note")
+                        .font(.caption2.weight(.semibold))
+                }
+            }
+            .foregroundStyle(hasNote ? .black : Theme.textSecondary)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(hasNote ? Theme.accent : Theme.surfaceSecondary)
+            .clipShape(.capsule)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(hasNote ? "Edit note: \(exercise.notes ?? "")" : "Add note")
+    }
+
+    private var restPill: some View {
+        let isCustom = exercise.restSeconds != nil
+        let seconds = exercise.restSeconds ?? defaultRestSeconds
+        return Button {
+            Haptics.selection()
+            showRestSheet = true
+        } label: {
+            HStack(spacing: 4) {
+                Image(systemName: "timer")
+                    .font(.caption2.weight(.semibold))
+                Text("Rest: \(formatRest(seconds))")
+                    .font(.caption2.weight(.semibold))
+            }
+            .foregroundStyle(isCustom ? .black : Theme.textSecondary)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(isCustom ? Theme.accent : Theme.surfaceSecondary)
+            .clipShape(.capsule)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Rest \(formatRest(seconds))\(isCustom ? ", custom" : ", default")")
+    }
+
+    private func notePreview(_ notes: String?) -> String? {
+        guard let notes else { return nil }
+        let single = notes.replacingOccurrences(of: "\n", with: " ")
+        let trimmed = single.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        if trimmed.count > 24 { return String(trimmed.prefix(24)) + "…" }
+        return trimmed
+    }
+
+    private func formatRest(_ seconds: Int) -> String {
+        if seconds >= 60 && seconds % 60 == 0 { return "\(seconds / 60)m" }
+        if seconds < 60 { return "\(seconds)s" }
+        let m = seconds / 60
+        let s = seconds % 60
+        return "\(m)m \(s)s"
+    }
+
+    // MARK: - Section / Pill helpers
 
     private func configSection<Content: View>(label: String, @ViewBuilder content: () -> Content) -> some View {
         ScrollView(.horizontal, showsIndicators: false) {
@@ -78,5 +201,214 @@ struct ExerciseConfigRow: View {
         }
         .buttonStyle(.plain)
         .accessibilityLabel("\(label)\(isSelected ? ", selected" : "")")
+    }
+}
+
+// MARK: - Notes Sheet
+
+/// Sheet with a TextEditor for editing per-exercise notes.
+/// Caps input at 500 characters and shows a live counter.
+struct ExerciseNotesSheet: View {
+    let exerciseName: String
+    let initialNotes: String
+    let onSave: (String?) -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var text: String = ""
+    @FocusState private var editorFocused: Bool
+
+    private static let maxLength = 500
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Theme.background.ignoresSafeArea()
+
+                VStack(alignment: .leading, spacing: Theme.Spacing.md) {
+                    Text("Notes for this exercise stay with the workout — perfect for form cues, weight setups, or how it felt.")
+                        .font(Theme.fontCaption)
+                        .foregroundStyle(Theme.textSecondary)
+
+                    TextEditor(text: $text)
+                        .font(Theme.fontBody)
+                        .foregroundStyle(Theme.textPrimary)
+                        .scrollContentBackground(.hidden)
+                        .padding(Theme.Spacing.sm)
+                        .frame(minHeight: 140, maxHeight: 240)
+                        .background(Theme.surface)
+                        .clipShape(.rect(cornerRadius: Theme.cornerRadiusSmall))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: Theme.cornerRadiusSmall)
+                                .stroke(Theme.textSecondary.opacity(0.2), lineWidth: 1)
+                        )
+                        .focused($editorFocused)
+                        .onChange(of: text) { _, newValue in
+                            if newValue.count > Self.maxLength {
+                                text = String(newValue.prefix(Self.maxLength))
+                            }
+                        }
+
+                    HStack {
+                        Spacer()
+                        Text("\(text.count) / \(Self.maxLength)")
+                            .font(.caption2.monospacedDigit())
+                            .foregroundStyle(text.count >= Self.maxLength ? Theme.destructive : Theme.textSecondary)
+                            .accessibilityLabel("\(text.count) of \(Self.maxLength) characters used")
+                    }
+
+                    Spacer()
+                }
+                .padding(Theme.Spacing.md)
+            }
+            .navigationTitle(exerciseName)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbarColorScheme(.dark, for: .navigationBar)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                        .foregroundStyle(Theme.accent)
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") {
+                        Haptics.success()
+                        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+                        onSave(trimmed.isEmpty ? nil : trimmed)
+                        dismiss()
+                    }
+                    .fontWeight(.bold)
+                    .foregroundStyle(Theme.accent)
+                }
+            }
+        }
+        .onAppear {
+            text = initialNotes
+            // Defer focus a tick so the sheet can settle before the keyboard slides up.
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+                editorFocused = true
+            }
+        }
+    }
+}
+
+// MARK: - Rest Sheet
+
+/// Sheet with a slider for picking a per-exercise rest override (60-600s in 30s steps).
+struct ExerciseRestSheet: View {
+    let exerciseName: String
+    let initialRestSeconds: Int
+    let isCustomized: Bool
+    let defaultRestSeconds: Int
+    let onSave: (Int?) -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var seconds: Double = 90
+
+    private static let minSeconds: Double = 60
+    private static let maxSeconds: Double = 600
+    private static let step: Double = 30
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Theme.background.ignoresSafeArea()
+
+                VStack(alignment: .leading, spacing: Theme.Spacing.lg) {
+                    Text("Override the workout's default rest just for this exercise. Range: 1m–10m in 30s steps.")
+                        .font(Theme.fontCaption)
+                        .foregroundStyle(Theme.textSecondary)
+
+                    VStack(spacing: Theme.Spacing.sm) {
+                        Text(formatRest(Int(seconds)))
+                            .font(.system(size: 48, weight: .bold, design: .monospaced))
+                            .foregroundStyle(Theme.accent)
+                            .accessibilityLabel("Rest \(formatRest(Int(seconds)))")
+
+                        Slider(
+                            value: $seconds,
+                            in: Self.minSeconds...Self.maxSeconds,
+                            step: Self.step
+                        ) {
+                            Text("Rest seconds")
+                        }
+                        .tint(Theme.accent)
+                        .onChange(of: seconds) { _, _ in
+                            Haptics.selection()
+                        }
+
+                        HStack {
+                            Text(formatRest(Int(Self.minSeconds)))
+                            Spacer()
+                            Text(formatRest(Int(Self.maxSeconds)))
+                        }
+                        .font(.caption2.monospaced())
+                        .foregroundStyle(Theme.textSecondary)
+                    }
+                    .padding(Theme.Spacing.md)
+                    .frame(maxWidth: .infinity)
+                    .background(Theme.surface)
+                    .clipShape(.rect(cornerRadius: Theme.cornerRadius))
+
+                    if isCustomized {
+                        Button {
+                            Haptics.medium()
+                            onSave(nil)
+                            dismiss()
+                        } label: {
+                            HStack {
+                                Image(systemName: "arrow.uturn.backward")
+                                Text("Reset to default (\(formatRest(defaultRestSeconds)))")
+                                    .font(.subheadline.weight(.semibold))
+                            }
+                            .foregroundStyle(Theme.destructive)
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 12)
+                            .background(Theme.destructive.opacity(0.1))
+                            .clipShape(.rect(cornerRadius: Theme.cornerRadiusSmall))
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityLabel("Reset rest to default \(formatRest(defaultRestSeconds))")
+                    } else {
+                        Text("Default: \(formatRest(defaultRestSeconds))")
+                            .font(Theme.fontCaption)
+                            .foregroundStyle(Theme.textSecondary)
+                            .frame(maxWidth: .infinity, alignment: .center)
+                    }
+
+                    Spacer()
+                }
+                .padding(Theme.Spacing.md)
+            }
+            .navigationTitle(exerciseName)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbarColorScheme(.dark, for: .navigationBar)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                        .foregroundStyle(Theme.accent)
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Save") {
+                        Haptics.success()
+                        onSave(Int(seconds))
+                        dismiss()
+                    }
+                    .fontWeight(.bold)
+                    .foregroundStyle(Theme.accent)
+                }
+            }
+        }
+        .onAppear {
+            // Snap initial value onto the slider step grid.
+            let snapped = (Double(initialRestSeconds) / Self.step).rounded() * Self.step
+            seconds = min(max(snapped, Self.minSeconds), Self.maxSeconds)
+        }
+    }
+
+    private func formatRest(_ seconds: Int) -> String {
+        if seconds >= 60 && seconds % 60 == 0 { return "\(seconds / 60)m" }
+        if seconds < 60 { return "\(seconds)s" }
+        let m = seconds / 60
+        let s = seconds % 60
+        return "\(m)m \(s)s"
     }
 }

--- a/Xomfit/Views/Workout/WorkoutBuilderView.swift
+++ b/Xomfit/Views/Workout/WorkoutBuilderView.swift
@@ -182,6 +182,8 @@ struct WorkoutBuilderView: View {
                             exercise: exercise,
                             onUpdateSets: { viewModel.updateSets(at: index, sets: $0) },
                             onUpdateReps: { viewModel.updateReps(at: index, reps: $0) },
+                            onUpdateNotes: { viewModel.updateNotes(at: index, notes: $0) },
+                            onUpdateRestSeconds: { viewModel.updateRestSeconds(at: index, seconds: $0) },
                             onDelete: { viewModel.removeExercise(at: index) }
                         )
                     }
@@ -298,9 +300,22 @@ private struct BuilderExerciseRow: View {
     let exercise: WorkoutTemplate.TemplateExercise
     let onUpdateSets: (Int) -> Void
     let onUpdateReps: (String) -> Void
+    let onUpdateNotes: (String?) -> Void
+    let onUpdateRestSeconds: (Int?) -> Void
     let onDelete: () -> Void
 
+    /// Pulled from the same UserDefaults key the rest of the app reads. Lets the
+    /// rest pill show the live default when the template doesn't override.
+    @AppStorage("restDuration") private var defaultRestStored: Double = 90
+
     @State private var repsText: String = ""
+    @State private var showNotesSheet = false
+    @State private var showRestSheet = false
+
+    private var defaultRestSeconds: Int {
+        let v = defaultRestStored > 0 ? defaultRestStored : 90
+        return Int(v)
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
@@ -390,9 +405,105 @@ private struct BuilderExerciseRow: View {
                         }
                 }
             }
+
+            // Notes + per-exercise rest override (#318) — reuses the same sheets the
+            // live workout uses so the look-and-feel matches the template builder.
+            HStack(spacing: 6) {
+                notesPill
+                restPill
+                Spacer()
+            }
         }
         .padding(Theme.Spacing.md)
         .background(Theme.surface)
         .clipShape(.rect(cornerRadius: Theme.cornerRadius))
+        .sheet(isPresented: $showNotesSheet) {
+            ExerciseNotesSheet(
+                exerciseName: exercise.exercise.name,
+                initialNotes: exercise.notes ?? "",
+                onSave: { onUpdateNotes($0) }
+            )
+            .presentationDetents([.medium, .large])
+        }
+        .sheet(isPresented: $showRestSheet) {
+            ExerciseRestSheet(
+                exerciseName: exercise.exercise.name,
+                initialRestSeconds: exercise.restSeconds ?? defaultRestSeconds,
+                isCustomized: exercise.restSeconds != nil,
+                defaultRestSeconds: defaultRestSeconds,
+                onSave: { onUpdateRestSeconds($0) }
+            )
+            .presentationDetents([.medium])
+        }
+    }
+
+    // MARK: - Pills
+
+    private var notesPill: some View {
+        let hasNote = (exercise.notes?.isEmpty == false)
+        return Button {
+            Haptics.selection()
+            showNotesSheet = true
+        } label: {
+            HStack(spacing: 4) {
+                Image(systemName: hasNote ? "note.text" : "plus")
+                    .font(.caption2.weight(.semibold))
+                if hasNote, let preview = previewText(exercise.notes) {
+                    Text(preview)
+                        .font(.caption2.weight(.semibold))
+                        .lineLimit(1)
+                } else {
+                    Text("Add note")
+                        .font(.caption2.weight(.semibold))
+                }
+            }
+            .foregroundStyle(hasNote ? .black : Theme.textSecondary)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(hasNote ? Theme.accent : Theme.surfaceSecondary)
+            .clipShape(.capsule)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(hasNote ? "Edit note: \(exercise.notes ?? "")" : "Add note")
+    }
+
+    private var restPill: some View {
+        let isCustom = exercise.restSeconds != nil
+        let seconds = exercise.restSeconds ?? defaultRestSeconds
+        return Button {
+            Haptics.selection()
+            showRestSheet = true
+        } label: {
+            HStack(spacing: 4) {
+                Image(systemName: "timer")
+                    .font(.caption2.weight(.semibold))
+                Text("Rest: \(formatRest(seconds))")
+                    .font(.caption2.weight(.semibold))
+            }
+            .foregroundStyle(isCustom ? .black : Theme.textSecondary)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(isCustom ? Theme.accent : Theme.surfaceSecondary)
+            .clipShape(.capsule)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Rest \(formatRest(seconds))\(isCustom ? ", custom" : ", default")")
+    }
+
+    private func previewText(_ notes: String?) -> String? {
+        guard let notes else { return nil }
+        let single = notes.replacingOccurrences(of: "\n", with: " ")
+        let trimmed = single.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        if trimmed.count > 24 { return String(trimmed.prefix(24)) + "…" }
+        return trimmed
+    }
+
+    private func formatRest(_ seconds: Int) -> String {
+        if seconds >= 60 && seconds % 60 == 0 { return "\(seconds / 60)m" }
+        if seconds < 60 { return "\(seconds)s" }
+        let m = seconds / 60
+        let s = seconds % 60
+        return "\(m)m \(s)s"
     }
 }

--- a/Xomfit/Views/Workout/WorkoutDetailView.swift
+++ b/Xomfit/Views/Workout/WorkoutDetailView.swift
@@ -141,42 +141,56 @@ struct WorkoutDetailView: View {
                     ForEach(Array(exercise.sets.enumerated()), id: \.element.id) { setIndex, workoutSet in
                         setRow(set: workoutSet, number: setIndex + 1)
                     }
-
-                    // Exercise notes
-                    if let notes = exercise.notes, !notes.isEmpty {
-                        Text(notes)
-                            .font(Theme.fontSmall)
-                            .foregroundStyle(Theme.textSecondary)
-                            .padding(.top, 4)
-                    }
                 }
             } label: {
-                HStack(spacing: Theme.Spacing.sm) {
-                    Text("\(index)")
-                        .font(.caption.weight(.bold).monospaced())
-                        .foregroundStyle(Theme.accent)
-                        .frame(width: 24, height: 24)
-                        .background(Theme.accent.opacity(0.12))
-                        .clipShape(.rect(cornerRadius: 6))
+                VStack(alignment: .leading, spacing: 4) {
+                    HStack(spacing: Theme.Spacing.sm) {
+                        Text("\(index)")
+                            .font(.caption.weight(.bold).monospaced())
+                            .foregroundStyle(Theme.accent)
+                            .frame(width: 24, height: 24)
+                            .background(Theme.accent.opacity(0.12))
+                            .clipShape(.rect(cornerRadius: 6))
 
-                    Text(exercise.exercise.name)
-                        .font(.subheadline.weight(.bold))
-                        .foregroundStyle(Theme.textPrimary)
+                        Text(exercise.exercise.name)
+                            .font(.subheadline.weight(.bold))
+                            .foregroundStyle(Theme.textPrimary)
 
-                    Spacer()
+                        Spacer()
 
-                    Text("\(exercise.sets.count) sets")
-                        .font(Theme.fontCaption)
-                        .foregroundStyle(Theme.textSecondary)
+                        Text("\(exercise.sets.count) sets")
+                            .font(Theme.fontCaption)
+                            .foregroundStyle(Theme.textSecondary)
 
-                    if exercise.sets.contains(where: { $0.isPersonalRecord }) {
-                        HStack(spacing: 3) {
-                            Image(systemName: "trophy.fill")
-                                .font(.caption2)
-                            Text("PR")
-                                .font(.caption2.weight(.bold))
+                        if exercise.sets.contains(where: { $0.isPersonalRecord }) {
+                            HStack(spacing: 3) {
+                                Image(systemName: "trophy.fill")
+                                    .font(.caption2)
+                                Text("PR")
+                                    .font(.caption2.weight(.bold))
+                            }
+                            .foregroundStyle(Theme.prGold)
                         }
-                        .foregroundStyle(Theme.prGold)
+                    }
+
+                    // Quoted note preview — surfaces the per-exercise note inline so the
+                    // user sees their context without expanding the disclosure.
+                    if let notes = exercise.notes, !notes.isEmpty {
+                        HStack(alignment: .top, spacing: 6) {
+                            // Indent to roughly align with the exercise name (past the index badge).
+                            Spacer().frame(width: 24 + Theme.Spacing.sm)
+                            Rectangle()
+                                .fill(Theme.accent.opacity(0.6))
+                                .frame(width: 2)
+                            Text(notes)
+                                .font(Theme.fontSmall)
+                                .italic()
+                                .foregroundStyle(Theme.textSecondary)
+                                .lineLimit(2)
+                                .multilineTextAlignment(.leading)
+                            Spacer(minLength: 0)
+                        }
+                        .accessibilityLabel("Note: \(notes)")
                     }
                 }
             }

--- a/Xomfit/Views/Workout/WorkoutFocusView.swift
+++ b/Xomfit/Views/Workout/WorkoutFocusView.swift
@@ -30,19 +30,19 @@ struct WorkoutFocusView: View {
                     VStack(spacing: Theme.Spacing.lg) {
                         exerciseHeader(exercise: exercise)
 
-                        // Variant config (grip, attachment, position, laterality) — shown when available
-                        if exercise.exercise.supportedGrips != nil ||
-                           exercise.exercise.supportedAttachments != nil ||
-                           exercise.exercise.supportedPositions != nil ||
-                           exercise.exercise.supportsUnilateral {
-                            ExerciseConfigRow(
-                                exercise: exercise,
-                                onGripChanged: { grip in viewModel.setGrip(exerciseIndex: viewModel.focusExerciseIndex, grip: grip) },
-                                onAttachmentChanged: { att in viewModel.setAttachment(exerciseIndex: viewModel.focusExerciseIndex, attachment: att) },
-                                onPositionChanged: { pos in viewModel.setPosition(exerciseIndex: viewModel.focusExerciseIndex, position: pos) },
-                                onLateralityChanged: { lat in viewModel.setLaterality(exerciseIndex: viewModel.focusExerciseIndex, laterality: lat) }
-                            )
-                        }
+                        // Variant config (grip, attachment, position, laterality) + per-session extras
+                        // (notes / rest override). Shown unconditionally so the extras pills are
+                        // always reachable from focus mode.
+                        ExerciseConfigRow(
+                            exercise: exercise,
+                            onGripChanged: { grip in viewModel.setGrip(exerciseIndex: viewModel.focusExerciseIndex, grip: grip) },
+                            onAttachmentChanged: { att in viewModel.setAttachment(exerciseIndex: viewModel.focusExerciseIndex, attachment: att) },
+                            onPositionChanged: { pos in viewModel.setPosition(exerciseIndex: viewModel.focusExerciseIndex, position: pos) },
+                            onLateralityChanged: { lat in viewModel.setLaterality(exerciseIndex: viewModel.focusExerciseIndex, laterality: lat) },
+                            onNotesChanged: { notes in viewModel.setNotes(exerciseIndex: viewModel.focusExerciseIndex, notes: notes) },
+                            onRestSecondsChanged: { secs in viewModel.setRestSeconds(exerciseIndex: viewModel.focusExerciseIndex, seconds: secs) },
+                            defaultRestSeconds: Int(viewModel.defaultRestDuration)
+                        )
 
                         setIndicator(exercise: exercise)
 


### PR DESCRIPTION
Closes #318. WorkoutExercise + TemplateExercise gain restSeconds: Int? (nil = use global). VM startRestTimer now reads per-exercise override. New ExerciseNotesSheet (TextEditor + 500-char counter) and ExerciseRestSheet (60-600s slider). Pills surfaced in ExerciseConfigRow + BuilderExerciseRow. Notes render as quoted line in WorkoutDetailView.