### PR TITLE
#311 states pass: empty/loading/error coverage across profile, feed, reports, AI coach

### DIFF
--- a/Xomfit/ViewModels/AICoachViewModel.swift
+++ b/Xomfit/ViewModels/AICoachViewModel.swift
@@ -105,13 +105,62 @@ final class AICoachViewModel {
             // still flip off the streaming flag.
             finishStreaming(id: placeholderId)
         } catch {
-            // Drop the placeholder and surface the error.
+            // Drop the placeholder and surface a user-friendly error.
             messages.removeAll { $0.id == placeholderId }
-            errorMessage = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+            errorMessage = Self.userFacingMessage(for: error)
             persist()
         }
 
         isSending = false
+    }
+
+    // MARK: - Error mapping (#311)
+
+    /// Maps service / transport errors to copy that tells the user what to do
+    /// next. Falls back to `localizedDescription` for the long tail.
+    static func userFacingMessage(for error: Error) -> String {
+        if let serviceError = error as? AICoachServiceError {
+            switch serviceError {
+            case .missingAPIKey:
+                return "Your API key is invalid. Update it in Settings → AI Coach."
+            case .http(let status, _):
+                switch status {
+                case 401, 403:
+                    return "Your API key is invalid. Update it in Settings → AI Coach."
+                case 429:
+                    return "Rate limited. Try again in a minute."
+                default:
+                    return serviceError.errorDescription ?? error.localizedDescription
+                }
+            case .transport(let underlying):
+                if let urlError = underlying as? URLError, Self.isOfflineURLError(urlError) {
+                    return "You're offline. Check your connection."
+                }
+                return underlying.localizedDescription
+            case .invalidResponse, .decoding:
+                return serviceError.errorDescription ?? error.localizedDescription
+            }
+        }
+        if let urlError = error as? URLError, Self.isOfflineURLError(urlError) {
+            return "You're offline. Check your connection."
+        }
+        return (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+    }
+
+    private static func isOfflineURLError(_ error: URLError) -> Bool {
+        switch error.code {
+        case .notConnectedToInternet,
+             .networkConnectionLost,
+             .dataNotAllowed,
+             .internationalRoamingOff,
+             .timedOut,
+             .cannotConnectToHost,
+             .cannotFindHost,
+             .dnsLookupFailed:
+            return true
+        default:
+            return false
+        }
     }
 
     /// Clear the conversation, wipe the persisted blob, and reset transient state.

--- a/Xomfit/ViewModels/FeedViewModel.swift
+++ b/Xomfit/ViewModels/FeedViewModel.swift
@@ -7,6 +7,12 @@ final class FeedViewModel {
     var isLoading: Bool = false
     var isRefreshing: Bool = false
     var errorMessage: String? = nil
+    /// #311: true while a filter change is being applied; FeedView renders a
+    /// brief skeleton overlay so the list doesn't pop instantly.
+    var isFiltering: Bool = false
+    /// #311: distinguish a load-more failure from "truly exhausted". When set,
+    /// FeedView shows a retry banner at the bottom of the list.
+    var loadMoreError: String? = nil
 
     // Filters
     var dateRange: FeedDateRange = .all
@@ -42,6 +48,7 @@ final class FeedViewModel {
     func loadFeed(userId: String) async {
         isLoading = true
         errorMessage = nil
+        loadMoreError = nil
         offset = 0
         hasMore = true
 
@@ -67,8 +74,18 @@ final class FeedViewModel {
         isRefreshing = false
     }
 
+    /// #311: re-applies the current filters without re-fetching, but flips
+    /// `isFiltering` for a short window so the list shows a skeleton rather
+    /// than instantly snapping to a different result set. Pure UI flag.
+    func applyFilterChange() async {
+        isFiltering = true
+        try? await Task.sleep(nanoseconds: 250_000_000) // 0.25s
+        isFiltering = false
+    }
+
     func loadMore(userId: String) async {
         guard hasMore, !isLoading else { return }
+        loadMoreError = nil
         do {
             let items = try await FeedService.shared.fetchFeed(
                 userId: userId,
@@ -79,8 +96,10 @@ final class FeedViewModel {
             offset += items.count
             hasMore = items.count == pageSize
         } catch {
-            // Non-fatal — just stop paginating
-            hasMore = false
+            // #311: keep `hasMore` true so the user can retry, and surface
+            // a retry banner at the bottom of the feed instead of silently
+            // exhausting pagination.
+            loadMoreError = error.localizedDescription
         }
     }
 

--- a/Xomfit/Views/Feed/FeedView.swift
+++ b/Xomfit/Views/Feed/FeedView.swift
@@ -38,8 +38,28 @@ struct FeedView: View {
                             )
                             Spacer()
                         } else {
-                            feedList
+                            ZStack {
+                                feedList
+                                // #311: brief skeleton overlay while a refresh
+                                // or filter change is in flight so the list
+                                // doesn't pop without feedback.
+                                if viewModel.isRefreshing || viewModel.isFiltering {
+                                    feedSkeleton
+                                        .background(Theme.background)
+                                        .transition(.opacity)
+                                }
+                            }
+                            .animation(.easeInOut(duration: 0.2), value: viewModel.isRefreshing)
+                            .animation(.easeInOut(duration: 0.2), value: viewModel.isFiltering)
                         }
+                    }
+                    // #311: trip the filtering flag whenever the date range or
+                    // muscle-group selection changes so the skeleton flashes.
+                    .onChange(of: viewModel.dateRange) { _, _ in
+                        Task { await viewModel.applyFilterChange() }
+                    }
+                    .onChange(of: viewModel.selectedMuscleGroups) { _, _ in
+                        Task { await viewModel.applyFilterChange() }
                     }
                 }
             }
@@ -142,7 +162,11 @@ struct FeedView: View {
                     }
                 }
 
-                if !viewModel.hasMore && !viewModel.filteredFeedItems.isEmpty {
+                // #311: surface load-more failures with a retry banner so the
+                // user knows pagination didn't silently exhaust.
+                if let loadMoreError = viewModel.loadMoreError {
+                    loadMoreRetryBanner(message: loadMoreError)
+                } else if !viewModel.hasMore && !viewModel.filteredFeedItems.isEmpty {
                     Text("You're all caught up!")
                         .font(Theme.fontCaption)
                         .foregroundStyle(Theme.textSecondary)
@@ -156,6 +180,50 @@ struct FeedView: View {
         .refreshable {
             await viewModel.refreshFeed(userId: userId)
         }
+    }
+
+    // MARK: - Load-More Retry Banner (#311)
+
+    private func loadMoreRetryBanner(message: String) -> some View {
+        VStack(spacing: Theme.Spacing.xs) {
+            HStack(spacing: Theme.Spacing.sm) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundStyle(Theme.alert)
+                Text("Couldn't load more posts")
+                    .font(Theme.fontCaption.weight(.semibold))
+                    .foregroundStyle(Theme.textPrimary)
+            }
+            Text(message)
+                .font(Theme.fontCaption)
+                .foregroundStyle(Theme.textSecondary)
+                .multilineTextAlignment(.center)
+            Button {
+                Haptics.light()
+                Task { await viewModel.loadMore(userId: userId) }
+            } label: {
+                Text("Retry")
+                    .font(Theme.fontCaption.weight(.semibold))
+                    .foregroundStyle(Theme.accent)
+                    .padding(.horizontal, Theme.Spacing.md)
+                    .padding(.vertical, 8)
+                    .frame(minHeight: 36)
+                    .background(
+                        Capsule().fill(Theme.accent.opacity(0.15))
+                    )
+            }
+            .accessibilityLabel("Retry loading more posts")
+        }
+        .frame(maxWidth: .infinity)
+        .padding(Theme.Spacing.md)
+        .background(
+            RoundedRectangle(cornerRadius: Theme.Radius.md)
+                .fill(Theme.alert.opacity(0.10))
+                .overlay(
+                    RoundedRectangle(cornerRadius: Theme.Radius.md)
+                        .strokeBorder(Theme.alert.opacity(0.4), lineWidth: 0.5)
+                )
+        )
+        .padding(.vertical, Theme.Spacing.sm)
     }
 
     // MARK: - Empty State
@@ -225,12 +293,10 @@ struct FeedView: View {
     // MARK: - Error View
 
     private func errorView(message: String) -> some View {
-        XomEmptyState(
-            icon: "exclamationmark.triangle",
+        XomErrorState(
             title: "Failed to load feed",
-            subtitle: message,
-            ctaLabel: "Try Again",
-            ctaAction: { Task { await viewModel.loadFeed(userId: userId) } }
+            message: message,
+            retryAction: { Task { await viewModel.loadFeed(userId: userId) } }
         )
     }
 }

--- a/Xomfit/Views/Profile/ProfileStatsView.swift
+++ b/Xomfit/Views/Profile/ProfileStatsView.swift
@@ -18,6 +18,9 @@ struct ProfileStatsView: View {
     var longestStreak: Int = 0
     /// Profile owner — used by the Body measurements link (#317). nil = link hidden.
     var userId: String? = nil
+    /// Optional CTA fired from the "log your first workout" empty state (#311).
+    /// When nil, the empty-state card hides its action button.
+    var onStartWorkout: (() -> Void)? = nil
 
     @State private var heatmapFilter: HeatmapTimeFilter = .week
 
@@ -34,6 +37,12 @@ struct ProfileStatsView: View {
 
     var body: some View {
         VStack(spacing: Theme.Spacing.sm) {
+            // #311: when there are no workouts yet, surface a friendly empty
+            // state above the (all-zero) cards so the screen doesn't feel
+            // broken. Stats stay rendered below for context.
+            if totalWorkouts == 0 {
+                firstWorkoutEmptyState
+            }
             StreakCard(currentStreak: currentStreak, longestStreak: longestStreak)
             statsCards
             bodyLink
@@ -44,6 +53,24 @@ struct ProfileStatsView: View {
             prSection
         }
         .padding(.horizontal, Theme.Spacing.md)
+    }
+
+    // MARK: - First-Workout Empty State (#311)
+
+    private var firstWorkoutEmptyState: some View {
+        VStack(spacing: Theme.Spacing.sm) {
+            XomEmptyState(
+                icon: "dumbbell.fill",
+                title: "No stats yet",
+                subtitle: "Log your first workout to unlock stats.",
+                ctaLabel: onStartWorkout != nil ? "Start Workout" : nil,
+                ctaAction: onStartWorkout
+            )
+        }
+        .frame(maxWidth: .infinity)
+        .cardStyle()
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("No stats yet. Log your first workout to unlock stats.")
     }
 
     // MARK: - Body Measurements Link (#317)

--- a/Xomfit/Views/Profile/ProfileView.swift
+++ b/Xomfit/Views/Profile/ProfileView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct ProfileView: View {
     @Environment(AuthService.self) private var authService
+    @Environment(WorkoutLoggerViewModel.self) private var workoutSession
     @State private var viewModel = ProfileViewModel()
     @State private var showEditSheet = false
 
@@ -35,7 +36,23 @@ struct ProfileView: View {
         ZStack {
             Theme.background.ignoresSafeArea()
 
-            if viewModel.isLoading {
+            if let error = viewModel.errorMessage, !viewModel.isLoading {
+                // #311: surface the failure with a retry CTA instead of an
+                // indefinite skeleton. Loading state takes precedence so the
+                // skeleton still shows during the actual fetch.
+                XomErrorState(
+                    title: "Couldn't load profile",
+                    message: error,
+                    retryAction: {
+                        Task {
+                            await viewModel.loadAll(
+                                userId: resolvedUserId,
+                                currentUserId: currentUserId
+                            )
+                        }
+                    }
+                )
+            } else if viewModel.isLoading {
                 profileSkeleton
             } else if !viewModel.isOwnProfile && viewModel.isPrivate && !viewModel.isFriendsRelation {
                 PrivateProfileView(
@@ -200,9 +217,27 @@ struct ProfileView: View {
                 currentStreak: viewModel.currentStreak,
                 longestStreak: viewModel.longestStreak,
                 // Only own profile gets the Body link — measurements are private to the user.
-                userId: viewModel.isOwnProfile ? resolvedUserId : nil
+                userId: viewModel.isOwnProfile ? resolvedUserId : nil,
+                onStartWorkout: statsEmptyStateAction
             )
         }
+    }
+
+    // MARK: - Quick Start Workout (#311 stats empty-state CTA)
+
+    /// Returns the start-workout closure when viewing your own profile, nil
+    /// otherwise. Pulled out so the call site is explicitly typed (the inline
+    /// ternary trips Swift's type-checker complexity budget in `tabContent`).
+    private var statsEmptyStateAction: (() -> Void)? {
+        guard viewModel.isOwnProfile else { return nil }
+        return { startEmptyWorkout() }
+    }
+
+    private func startEmptyWorkout() {
+        Haptics.medium()
+        let userId = authService.currentUser?.id.uuidString.lowercased() ?? ""
+        workoutSession.startWorkout(name: "Workout", userId: userId)
+        workoutSession.isPresented = true
     }
 
     // MARK: - Toolbar

--- a/Xomfit/Views/Reports/ReportsListView.swift
+++ b/Xomfit/Views/Reports/ReportsListView.swift
@@ -69,10 +69,12 @@ struct ReportsListView: View {
     // MARK: - Empty
 
     private var emptyState: some View {
+        // #311: longer empty-state copy that explains the cadence so users
+        // don't read "no reports" as broken.
         XomEmptyState(
             icon: "doc.text.magnifyingglass",
             title: "No reports yet",
-            subtitle: "Your first weekly summary will arrive Monday morning."
+            subtitle: "Reports are auto-generated. Complete your first workout this week and we'll send your first weekly summary on Monday."
         )
     }
 


### PR DESCRIPTION
Closes #311. ProfileStatsView empty card with Start CTA, ProfileView XomErrorState retry on load fail, ReportsListView clearer copy, FeedView skeleton during refresh/filter + load-more retry banner, AICoachViewModel maps 401/429/offline to specific user-facing copy.