### PR TITLE
#320 social: comment threading + activity badges + workout share-as-image

### DIFF
--- a/Xomfit/Models/BadgeCatalog.swift
+++ b/Xomfit/Models/BadgeCatalog.swift
@@ -1,0 +1,110 @@
+import Foundation
+
+// MARK: - ActivityBadge
+//
+// NOTE (#320): we use `ActivityBadge` rather than `Badge` to avoid colliding with
+// the existing `Badge` type defined in `Challenge.swift`, which is the
+// challenge-leaderboard award system. This file describes the *static catalog*
+// of progression badges (first workout, streaks, volume thresholds, etc.).
+
+/// A single static catalog entry describing a progression milestone.
+struct ActivityBadge: Codable, Identifiable, Hashable {
+    let id: String
+    let title: String
+    let description: String
+    let iconSystemName: String
+    let unlockCriteria: BadgeCriteria
+}
+
+/// Criteria for unlocking an `ActivityBadge`. Evaluated by `BadgeEvaluator`.
+enum BadgeCriteria: Codable, Hashable {
+    /// Logged a first workout.
+    case firstWorkout
+    /// Achieved a consecutive-day workout streak >= the given length.
+    case streakDays(Int)
+    /// Logged at least N total workouts.
+    case totalWorkouts(Int)
+    /// Lifetime training volume (in lbs) >= the given threshold.
+    case totalVolumeLbs(Double)
+    /// Set their first PR.
+    case firstPR
+}
+
+// MARK: - BadgeCatalog
+
+/// Static catalog of all progression badges in the app.
+/// Order here is the order shown in the UI grid.
+enum BadgeCatalog {
+    static let all: [ActivityBadge] = [
+        ActivityBadge(
+            id: "first-workout",
+            title: "First Steps",
+            description: "Logged your first workout.",
+            iconSystemName: "figure.walk",
+            unlockCriteria: .firstWorkout
+        ),
+        ActivityBadge(
+            id: "streak-7",
+            title: "7-Day Streak",
+            description: "Worked out 7 days in a row.",
+            iconSystemName: "flame.fill",
+            unlockCriteria: .streakDays(7)
+        ),
+        ActivityBadge(
+            id: "streak-30",
+            title: "30-Day Streak",
+            description: "Worked out 30 days in a row.",
+            iconSystemName: "flame.circle.fill",
+            unlockCriteria: .streakDays(30)
+        ),
+        ActivityBadge(
+            id: "first-pr",
+            title: "First PR",
+            description: "Set your first personal record.",
+            iconSystemName: "trophy.fill",
+            unlockCriteria: .firstPR
+        ),
+        ActivityBadge(
+            id: "workouts-10",
+            title: "Getting Going",
+            description: "Logged 10 total workouts.",
+            iconSystemName: "10.circle.fill",
+            unlockCriteria: .totalWorkouts(10)
+        ),
+        ActivityBadge(
+            id: "workouts-50",
+            title: "Half-Century",
+            description: "Logged 50 total workouts.",
+            iconSystemName: "50.circle.fill",
+            unlockCriteria: .totalWorkouts(50)
+        ),
+        ActivityBadge(
+            id: "workouts-100",
+            title: "Century Club",
+            description: "Logged 100 total workouts.",
+            iconSystemName: "100.circle.fill",
+            unlockCriteria: .totalWorkouts(100)
+        ),
+        ActivityBadge(
+            id: "volume-10k",
+            title: "10k Lifter",
+            description: "Lifted 10,000 lbs total.",
+            iconSystemName: "scalemass.fill",
+            unlockCriteria: .totalVolumeLbs(10_000)
+        ),
+        ActivityBadge(
+            id: "volume-50k",
+            title: "50k Lifter",
+            description: "Lifted 50,000 lbs total.",
+            iconSystemName: "dumbbell.fill",
+            unlockCriteria: .totalVolumeLbs(50_000)
+        ),
+        ActivityBadge(
+            id: "volume-100k",
+            title: "100k Lifter",
+            description: "Lifted 100,000 lbs total.",
+            iconSystemName: "bolt.fill",
+            unlockCriteria: .totalVolumeLbs(100_000)
+        )
+    ]
+}

--- a/Xomfit/Models/SocialFeedItem.swift
+++ b/Xomfit/Models/SocialFeedItem.swift
@@ -122,6 +122,9 @@ struct FeedComment: Codable, Identifiable {
     var user: AppUser?
     var text: String
     var createdAt: Date
+    /// Optional parent comment id — when set, this is a reply to that comment.
+    /// Backwards-compatible: existing rows decode this as nil. (#320)
+    var parentCommentId: String? = nil
 }
 
 // MARK: - Mock Data

--- a/Xomfit/Services/FeedService.swift
+++ b/Xomfit/Services/FeedService.swift
@@ -41,6 +41,10 @@ struct FeedCommentRow: Codable {
     let userId: String
     let text: String
     let createdAt: String
+    /// Optional reply parent — present when the row is a reply to another comment.
+    /// MIGRATION TODO (#320): add `parent_comment_id uuid null references feed_comments(id)`
+    /// to the `feed_comments` table when threading is rolled out server-side.
+    let parentCommentId: String?
 
     enum CodingKeys: String, CodingKey {
         case id
@@ -48,6 +52,7 @@ struct FeedCommentRow: Codable {
         case userId = "user_id"
         case text
         case createdAt = "created_at"
+        case parentCommentId = "parent_comment_id"
     }
 }
 
@@ -73,6 +78,9 @@ private struct FeedCommentInsert: Encodable {
     let feed_item_id: String
     let user_id: String
     let text: String
+    /// MIGRATION TODO (#320): backend column `parent_comment_id` must exist.
+    /// When nil this is a top-level comment; otherwise it is a reply.
+    let parent_comment_id: String?
 }
 
 // MARK: - FeedService
@@ -300,17 +308,25 @@ final class FeedService {
                 userId: row.userId,
                 user: nil,
                 text: row.text,
-                createdAt: date
+                createdAt: date,
+                parentCommentId: row.parentCommentId
             )
         }
     }
 
-    func postComment(feedItemId: String, userId: String, text: String) async throws {
+    /// Post a comment. When `parentCommentId` is non-nil this is a threaded reply (#320).
+    func postComment(
+        feedItemId: String,
+        userId: String,
+        text: String,
+        parentCommentId: String? = nil
+    ) async throws {
         let insert = FeedCommentInsert(
             id: UUID().uuidString,
             feed_item_id: feedItemId,
             user_id: userId,
-            text: text
+            text: text,
+            parent_comment_id: parentCommentId
         )
         do {
             try await supabase

--- a/Xomfit/Utils/BadgeEvaluator.swift
+++ b/Xomfit/Utils/BadgeEvaluator.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// Pure evaluator that decides which `ActivityBadge` entries from `BadgeCatalog`
+/// a user has unlocked given their workout history and first-PR date (#320).
+///
+/// Like `WorkoutInsights`, this is intentionally pure — no service calls,
+/// no side effects — so it's trivially testable and safe to re-run from views.
+enum BadgeEvaluator {
+    /// Returns the badges currently unlocked for this user, in catalog order.
+    /// - Parameters:
+    ///   - workouts: all workouts the user has logged.
+    ///   - firstPRDate: date of the user's first ever PR, if any.
+    static func unlocked(for workouts: [Workout], firstPRDate: Date?) -> [ActivityBadge] {
+        let totalWorkouts = workouts.count
+        let totalVolume = workouts.reduce(0.0) { $0 + $1.totalVolume }
+        let longestStreak = WorkoutInsights.longestStreak(workouts: workouts)
+
+        return BadgeCatalog.all.filter { badge in
+            switch badge.unlockCriteria {
+            case .firstWorkout:
+                return totalWorkouts >= 1
+            case .streakDays(let days):
+                return longestStreak >= days
+            case .totalWorkouts(let n):
+                return totalWorkouts >= n
+            case .totalVolumeLbs(let lbs):
+                return totalVolume >= lbs
+            case .firstPR:
+                return firstPRDate != nil
+            }
+        }
+    }
+}

--- a/Xomfit/Utils/WorkoutImageRenderer.swift
+++ b/Xomfit/Utils/WorkoutImageRenderer.swift
@@ -1,0 +1,202 @@
+import SwiftUI
+import UIKit
+
+/// Renders a branded workout summary card to a `UIImage` for sharing (#320).
+/// Uses iOS 17 `ImageRenderer`. The card layout intentionally lives inside this
+/// file so the share output is stable and doesn't drift with `WorkoutDetailView`.
+@MainActor
+enum WorkoutImageRenderer {
+    /// Renders a workout card and returns the rendered image, or nil if rendering fails.
+    static func render(workout: Workout, scale: CGFloat = 3.0) -> UIImage? {
+        let card = WorkoutShareCard(workout: workout)
+            .frame(width: 1080)
+            .background(Theme.background)
+
+        let renderer = ImageRenderer(content: card)
+        renderer.scale = scale
+        // Force the renderer into dark mode so brand colours stay correct
+        // even when the user's OS is in light mode.
+        renderer.proposedSize = ProposedViewSize(width: 1080, height: nil)
+        return renderer.uiImage
+    }
+}
+
+// MARK: - Share Card
+
+/// Internal layout used only for image rendering. Sized for a 1080-wide card.
+private struct WorkoutShareCard: View {
+    let workout: Workout
+
+    private var formattedVolume: String {
+        if workout.totalVolume >= 1000 {
+            return String(format: "%.1fk", workout.totalVolume / 1000)
+        }
+        return "\(Int(workout.totalVolume))"
+    }
+
+    private var dateString: String {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        return formatter.string(from: workout.startTime)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 32) {
+            header
+            statsRow
+            exerciseList
+            footer
+        }
+        .padding(48)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Theme.background)
+        .environment(\.colorScheme, .dark)
+    }
+
+    private var header: some View {
+        HStack(alignment: .firstTextBaseline) {
+            VStack(alignment: .leading, spacing: 8) {
+                Text(dateString)
+                    .font(.system(size: 22, weight: .medium))
+                    .foregroundStyle(Theme.accent)
+                Text(workout.name)
+                    .font(.system(size: 56, weight: .heavy))
+                    .foregroundStyle(Theme.textPrimary)
+                    .lineLimit(2)
+                    .multilineTextAlignment(.leading)
+            }
+            Spacer()
+        }
+    }
+
+    private var statsRow: some View {
+        HStack(spacing: 16) {
+            statCard(value: "\(workout.exercises.count)", label: "EXERCISES")
+            statCard(value: "\(workout.totalSets)", label: "SETS")
+            statCard(value: "\(formattedVolume) lbs", label: "VOLUME", highlight: true)
+            if workout.totalPRs > 0 {
+                statCard(value: "\(workout.totalPRs)", label: "PRs", color: Theme.prGold)
+            }
+        }
+    }
+
+    private func statCard(
+        value: String,
+        label: String,
+        highlight: Bool = false,
+        color: Color = Theme.textPrimary
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(value)
+                .font(.system(size: 40, weight: .heavy, design: .rounded).monospacedDigit())
+                .foregroundStyle(highlight ? Theme.accent : color)
+            Text(label)
+                .font(.system(size: 14, weight: .semibold))
+                .tracking(1.0)
+                .foregroundStyle(Theme.textSecondary)
+        }
+        .padding(20)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Theme.surface)
+        .clipShape(RoundedRectangle(cornerRadius: 20))
+        .overlay(
+            RoundedRectangle(cornerRadius: 20)
+                .strokeBorder(Theme.hairline, lineWidth: 1)
+        )
+    }
+
+    private var exerciseList: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text("EXERCISES")
+                .font(.system(size: 14, weight: .semibold))
+                .tracking(1.0)
+                .foregroundStyle(Theme.textSecondary)
+
+            VStack(spacing: 12) {
+                ForEach(Array(workout.exercises.prefix(6).enumerated()), id: \.element.id) { index, exercise in
+                    exerciseRow(index: index + 1, exercise: exercise)
+                }
+                if workout.exercises.count > 6 {
+                    Text("+ \(workout.exercises.count - 6) more")
+                        .font(.system(size: 18, weight: .medium))
+                        .foregroundStyle(Theme.textSecondary)
+                        .padding(.top, 4)
+                }
+            }
+        }
+    }
+
+    private func exerciseRow(index: Int, exercise: WorkoutExercise) -> some View {
+        let hasPR = exercise.sets.contains(where: { $0.isPersonalRecord })
+        return HStack(spacing: 16) {
+            Text("\(index)")
+                .font(.system(size: 20, weight: .bold, design: .rounded).monospacedDigit())
+                .foregroundStyle(Theme.accent)
+                .frame(width: 40, height: 40)
+                .background(Theme.accent.opacity(0.15))
+                .clipShape(RoundedRectangle(cornerRadius: 10))
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(exercise.exercise.name)
+                    .font(.system(size: 24, weight: .bold))
+                    .foregroundStyle(Theme.textPrimary)
+                    .lineLimit(1)
+                Text("\(exercise.sets.count) sets")
+                    .font(.system(size: 16, weight: .medium))
+                    .foregroundStyle(Theme.textSecondary)
+            }
+
+            Spacer()
+
+            if hasPR {
+                HStack(spacing: 6) {
+                    Image(systemName: "trophy.fill")
+                    Text("PR")
+                        .font(.system(size: 16, weight: .bold))
+                }
+                .foregroundStyle(Theme.prGold)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 6)
+                .background(Theme.prGold.opacity(0.15))
+                .clipShape(Capsule())
+            }
+        }
+        .padding(16)
+        .background(Theme.surface)
+        .clipShape(RoundedRectangle(cornerRadius: 16))
+    }
+
+    private var footer: some View {
+        HStack {
+            Image("XomFitLogo")
+                .resizable()
+                .scaledToFit()
+                .frame(width: 48, height: 48)
+            Text("XomFit")
+                .font(.system(size: 24, weight: .heavy))
+                .foregroundStyle(Theme.textPrimary)
+            Spacer()
+            Text(workout.durationString)
+                .font(.system(size: 22, weight: .bold).monospacedDigit())
+                .foregroundStyle(Theme.accent)
+                .padding(.horizontal, 16)
+                .padding(.vertical, 8)
+                .background(Theme.accent.opacity(0.15))
+                .clipShape(Capsule())
+        }
+        .padding(.top, 8)
+    }
+}
+
+// MARK: - UIActivityViewController helper
+
+/// SwiftUI wrapper presenting `UIActivityViewController` with the rendered image (#320).
+struct WorkoutShareSheet: UIViewControllerRepresentable {
+    let image: UIImage
+
+    func makeUIViewController(context: Context) -> UIActivityViewController {
+        UIActivityViewController(activityItems: [image], applicationActivities: nil)
+    }
+
+    func updateUIViewController(_ uiViewController: UIActivityViewController, context: Context) {}
+}

--- a/Xomfit/Views/Feed/FeedCommentsView.swift
+++ b/Xomfit/Views/Feed/FeedCommentsView.swift
@@ -1,5 +1,8 @@
 import SwiftUI
 
+/// Threaded comments view (#320).
+/// Renders top-level comments + nested replies indented 24pt with a 'Reply' affordance.
+/// Reply mode pins an "@username" prefix above the composer; an X clears it.
 struct FeedCommentsView: View {
     let feedItemId: String
     let userId: String
@@ -8,6 +11,24 @@ struct FeedCommentsView: View {
     @State private var newCommentText = ""
     @State private var isLoading = false
     @State private var isPosting = false
+    /// When non-nil, the next post is a reply to this comment.
+    @State private var replyingTo: FeedComment? = nil
+
+    @FocusState private var composerFocused: Bool
+
+    /// Indent applied to nested replies.
+    private static let replyIndent: CGFloat = 24
+
+    /// Top-level comments only — replies are rendered nested under their parent.
+    private var topLevelComments: [FeedComment] {
+        comments.filter { $0.parentCommentId == nil }
+    }
+
+    /// Map of parent comment id -> ordered replies (oldest first).
+    private var repliesByParent: [String: [FeedComment]] {
+        Dictionary(grouping: comments.filter { $0.parentCommentId != nil }) { $0.parentCommentId ?? "" }
+            .mapValues { $0.sorted { $0.createdAt < $1.createdAt } }
+    }
 
     var body: some View {
         ZStack {
@@ -40,8 +61,8 @@ struct FeedCommentsView: View {
                 } else {
                     ScrollView {
                         LazyVStack(spacing: 0) {
-                            ForEach(comments) { comment in
-                                CommentRow(comment: comment)
+                            ForEach(topLevelComments) { comment in
+                                threadView(for: comment)
                                     .padding(.horizontal, Theme.Spacing.md)
                                     .padding(.vertical, 6)
                             }
@@ -50,6 +71,7 @@ struct FeedCommentsView: View {
                     }
                 }
 
+                replyContextBar
                 commentComposer
             }
         }
@@ -59,17 +81,70 @@ struct FeedCommentsView: View {
         .task { await loadComments() }
     }
 
+    // MARK: - Thread Renderer
+
+    @ViewBuilder
+    private func threadView(for parent: FeedComment) -> some View {
+        VStack(spacing: 0) {
+            CommentRow(comment: parent, onReply: { startReply(to: parent) })
+
+            // Replies — indented 24pt left of the parent.
+            if let replies = repliesByParent[parent.id], !replies.isEmpty {
+                VStack(spacing: 0) {
+                    ForEach(replies) { reply in
+                        CommentRow(comment: reply, onReply: { startReply(to: parent) })
+                    }
+                }
+                .padding(.leading, Self.replyIndent)
+            }
+        }
+    }
+
+    // MARK: - Reply Context Bar
+
+    @ViewBuilder
+    private var replyContextBar: some View {
+        if let replyingTo {
+            HStack(spacing: Theme.Spacing.xs) {
+                Text("Replying to ")
+                    .font(Theme.fontSmall)
+                    .foregroundStyle(Theme.textSecondary)
+                + Text("@\(displayHandle(for: replyingTo))")
+                    .font(Theme.fontSmall.weight(.semibold))
+                    .foregroundStyle(Theme.accent)
+
+                Spacer()
+
+                Button {
+                    Haptics.light()
+                    cancelReply()
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.body)
+                        .foregroundStyle(Theme.textSecondary)
+                        .frame(width: 44, height: 44)
+                }
+                .accessibilityLabel("Cancel reply")
+            }
+            .padding(.horizontal, Theme.Spacing.md)
+            .padding(.vertical, 4)
+            .background(Theme.surface)
+            .overlay(alignment: .top) { XomDivider() }
+        }
+    }
+
     // MARK: - Comment Composer
 
     private var commentComposer: some View {
         HStack(spacing: Theme.Spacing.sm) {
-            TextField("Add a comment...", text: $newCommentText)
+            TextField(replyingTo == nil ? "Add a comment..." : "Add a reply...", text: $newCommentText)
                 .font(Theme.fontBody)
                 .foregroundStyle(Theme.textPrimary)
                 .padding(.horizontal, Theme.Spacing.md)
                 .padding(.vertical, 10)
                 .background(Theme.surface)
                 .clipShape(.rect(cornerRadius: Theme.cornerRadiusSmall))
+                .focused($composerFocused)
 
             Button {
                 Haptics.light()
@@ -86,6 +161,7 @@ struct FeedCommentsView: View {
                 }
             }
             .disabled(newCommentText.trimmingCharacters(in: .whitespaces).isEmpty || isPosting)
+            .accessibilityLabel(replyingTo == nil ? "Post comment" : "Post reply")
         }
         .padding(.horizontal, Theme.Spacing.md)
         .padding(.vertical, Theme.Spacing.sm)
@@ -93,6 +169,26 @@ struct FeedCommentsView: View {
     }
 
     // MARK: - Actions
+
+    /// Resolves a user-facing handle for the reply context bar.
+    /// Falls back to displayName when the username is empty (placeholder profile rows
+    /// from `FeedService.buildSocialFeedItem` may be empty).
+    private func displayHandle(for comment: FeedComment) -> String {
+        if let username = comment.user?.username, !username.isEmpty {
+            return username
+        }
+        return comment.user?.displayName ?? "user"
+    }
+
+    private func startReply(to comment: FeedComment) {
+        Haptics.selection()
+        replyingTo = comment
+        composerFocused = true
+    }
+
+    private func cancelReply() {
+        replyingTo = nil
+    }
 
     private func loadComments() async {
         isLoading = true
@@ -112,9 +208,11 @@ struct FeedCommentsView: View {
             try await FeedService.shared.postComment(
                 feedItemId: feedItemId,
                 userId: userId,
-                text: text
+                text: text,
+                parentCommentId: replyingTo?.id
             )
             newCommentText = ""
+            replyingTo = nil
             comments = try await FeedService.shared.fetchComments(feedItemId: feedItemId)
         } catch {
             // Non-fatal
@@ -127,6 +225,8 @@ struct FeedCommentsView: View {
 
 private struct CommentRow: View {
     let comment: FeedComment
+    /// Tapped when the user taps the Reply button on this row.
+    let onReply: () -> Void
 
     var body: some View {
         VStack(spacing: 0) {
@@ -148,12 +248,22 @@ private struct CommentRow: View {
                     Text(comment.text)
                         .font(Theme.fontBody)
                         .foregroundStyle(Theme.textPrimary)
+
+                    Button(action: onReply) {
+                        Text("Reply")
+                            .font(Theme.fontSmall.weight(.semibold))
+                            .foregroundStyle(Theme.textSecondary)
+                            .padding(.vertical, 6)
+                            .padding(.trailing, 12)
+                            .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Reply to \(comment.user?.displayName ?? "user")")
                 }
 
                 Spacer()
             }
             .padding(.vertical, 10)
-            .accessibilityElement(children: .combine)
 
             XomDivider()
         }

--- a/Xomfit/Views/Profile/BadgesSection.swift
+++ b/Xomfit/Views/Profile/BadgesSection.swift
@@ -1,0 +1,195 @@
+import SwiftUI
+
+/// Profile section showing progression badges from `BadgeCatalog` (#320).
+/// Renders a pill grid of all catalog entries; locked entries dim and show a
+/// padlock overlay. Tapping a pill opens a detail sheet with the unlock criteria.
+struct BadgesSection: View {
+    let workouts: [Workout]
+    let firstPRDate: Date?
+
+    @State private var selectedBadge: ActivityBadge?
+
+    private var unlockedIds: Set<String> {
+        Set(BadgeEvaluator.unlocked(for: workouts, firstPRDate: firstPRDate).map(\.id))
+    }
+
+    private let columns: [GridItem] = [
+        GridItem(.adaptive(minimum: 96), spacing: Theme.Spacing.sm)
+    ]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+            HStack {
+                Text("Badges")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(Theme.textSecondary)
+                Spacer()
+                Text("\(unlockedIds.count) / \(BadgeCatalog.all.count)")
+                    .font(Theme.fontSmall)
+                    .foregroundStyle(Theme.textSecondary)
+                    .monospacedDigit()
+            }
+            .padding(.horizontal, Theme.Spacing.sm)
+
+            LazyVGrid(columns: columns, spacing: Theme.Spacing.sm) {
+                ForEach(BadgeCatalog.all) { badge in
+                    BadgePill(
+                        badge: badge,
+                        isUnlocked: unlockedIds.contains(badge.id)
+                    ) {
+                        Haptics.selection()
+                        selectedBadge = badge
+                    }
+                }
+            }
+            .padding(.horizontal, Theme.Spacing.sm)
+        }
+        .cardStyle()
+        .sheet(item: $selectedBadge) { badge in
+            BadgeDetailSheet(
+                badge: badge,
+                isUnlocked: unlockedIds.contains(badge.id)
+            )
+        }
+    }
+}
+
+// MARK: - Badge Pill
+
+private struct BadgePill: View {
+    let badge: ActivityBadge
+    let isUnlocked: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            VStack(spacing: 6) {
+                ZStack {
+                    Circle()
+                        .fill(isUnlocked ? Theme.accent.opacity(0.18) : Theme.surfaceElevated)
+                        .frame(width: 44, height: 44)
+                    Image(systemName: badge.iconSystemName)
+                        .font(.title3)
+                        .foregroundStyle(isUnlocked ? Theme.accent : Theme.textTertiary)
+                    if !isUnlocked {
+                        Image(systemName: "lock.fill")
+                            .font(.caption2.weight(.bold))
+                            .foregroundStyle(Theme.textSecondary)
+                            .padding(4)
+                            .background(Circle().fill(Theme.background))
+                            .offset(x: 16, y: 16)
+                    }
+                }
+
+                Text(badge.title)
+                    .font(Theme.fontSmall)
+                    .foregroundStyle(isUnlocked ? Theme.textPrimary : Theme.textSecondary)
+                    .lineLimit(2)
+                    .multilineTextAlignment(.center)
+                    .frame(maxWidth: .infinity)
+            }
+            .padding(.vertical, Theme.Spacing.xs)
+            .frame(minHeight: 96)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(PressableCardStyle())
+        .accessibilityLabel(isUnlocked
+            ? "\(badge.title), unlocked. \(badge.description)"
+            : "\(badge.title), locked. \(badge.description)"
+        )
+    }
+}
+
+// MARK: - Badge Detail Sheet
+
+private struct BadgeDetailSheet: View {
+    let badge: ActivityBadge
+    let isUnlocked: Bool
+
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Theme.background.ignoresSafeArea()
+
+                VStack(spacing: Theme.Spacing.lg) {
+                    ZStack {
+                        Circle()
+                            .fill(isUnlocked ? Theme.accent.opacity(0.18) : Theme.surfaceElevated)
+                            .frame(width: 120, height: 120)
+                        Image(systemName: badge.iconSystemName)
+                            .font(.system(size: 56))
+                            .foregroundStyle(isUnlocked ? Theme.accent : Theme.textTertiary)
+                    }
+                    .padding(.top, Theme.Spacing.xl)
+
+                    VStack(spacing: Theme.Spacing.sm) {
+                        Text(badge.title)
+                            .font(Theme.fontTitle)
+                            .foregroundStyle(Theme.textPrimary)
+                            .multilineTextAlignment(.center)
+
+                        Text(badge.description)
+                            .font(Theme.fontBody)
+                            .foregroundStyle(Theme.textSecondary)
+                            .multilineTextAlignment(.center)
+                            .padding(.horizontal, Theme.Spacing.lg)
+                    }
+
+                    XomCard(padding: Theme.Spacing.md, variant: .elevated) {
+                        VStack(alignment: .leading, spacing: Theme.Spacing.xs) {
+                            XomMetricLabel("Unlock criteria")
+                            Text(criteriaDescription)
+                                .font(Theme.fontBody)
+                                .foregroundStyle(Theme.textPrimary)
+
+                            HStack(spacing: 6) {
+                                Image(systemName: isUnlocked ? "checkmark.seal.fill" : "lock.fill")
+                                    .foregroundStyle(isUnlocked ? Theme.accent : Theme.textSecondary)
+                                Text(isUnlocked ? "Unlocked" : "Locked")
+                                    .font(Theme.fontSmall.weight(.semibold))
+                                    .foregroundStyle(isUnlocked ? Theme.accent : Theme.textSecondary)
+                            }
+                            .padding(.top, Theme.Spacing.xs)
+                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                    .padding(.horizontal, Theme.Spacing.md)
+
+                    Spacer()
+                }
+            }
+            .navigationTitle("Badge")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbarColorScheme(.dark, for: .navigationBar)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Done") { dismiss() }
+                        .foregroundStyle(Theme.accent)
+                }
+            }
+        }
+    }
+
+    private var criteriaDescription: String {
+        switch badge.unlockCriteria {
+        case .firstWorkout:
+            return "Log your first workout."
+        case .streakDays(let days):
+            return "Reach a \(days)-day workout streak."
+        case .totalWorkouts(let n):
+            return "Log \(n) total workouts."
+        case .totalVolumeLbs(let lbs):
+            let formatted: String
+            if lbs >= 1000 {
+                formatted = String(format: "%.0fk", lbs / 1000)
+            } else {
+                formatted = String(format: "%.0f", lbs)
+            }
+            return "Lift \(formatted) lbs total."
+        case .firstPR:
+            return "Set your first personal record."
+        }
+    }
+}

--- a/Xomfit/Views/Profile/ProfileStatsView.swift
+++ b/Xomfit/Views/Profile/ProfileStatsView.swift
@@ -18,6 +18,10 @@ struct ProfileStatsView: View {
     var longestStreak: Int = 0
     /// Profile owner — used by the Body measurements link (#317). nil = link hidden.
     var userId: String? = nil
+    /// Workout history used by `BadgesSection` for badge evaluation (#320).
+    var workouts: [Workout] = []
+    /// Date of the user's first PR (oldest), used by `BadgesSection` (#320).
+    var firstPRDate: Date? = nil
 
     @State private var heatmapFilter: HeatmapTimeFilter = .week
 
@@ -35,6 +39,7 @@ struct ProfileStatsView: View {
     var body: some View {
         VStack(spacing: Theme.Spacing.sm) {
             StreakCard(currentStreak: currentStreak, longestStreak: longestStreak)
+            BadgesSection(workouts: workouts, firstPRDate: firstPRDate)
             statsCards
             bodyLink
             volumeTrendSection

--- a/Xomfit/Views/Profile/ProfileView.swift
+++ b/Xomfit/Views/Profile/ProfileView.swift
@@ -200,7 +200,9 @@ struct ProfileView: View {
                 currentStreak: viewModel.currentStreak,
                 longestStreak: viewModel.longestStreak,
                 // Only own profile gets the Body link — measurements are private to the user.
-                userId: viewModel.isOwnProfile ? resolvedUserId : nil
+                userId: viewModel.isOwnProfile ? resolvedUserId : nil,
+                workouts: viewModel.workouts,
+                firstPRDate: viewModel.allPRs.map(\.date).min()
             )
         }
     }

--- a/Xomfit/Views/Workout/WorkoutDetailView.swift
+++ b/Xomfit/Views/Workout/WorkoutDetailView.swift
@@ -3,6 +3,10 @@ import SwiftUI
 struct WorkoutDetailView: View {
     let workout: Workout
 
+    /// Image rendered for sharing (#320). Held while the share sheet is presented
+    /// so `UIActivityViewController` doesn't see a stale image.
+    @State private var shareImage: UIImage?
+
     var body: some View {
         ZStack {
             Theme.background.ignoresSafeArea()
@@ -21,6 +25,25 @@ struct WorkoutDetailView: View {
         .navigationBarTitleDisplayMode(.inline)
         .toolbarColorScheme(.dark, for: .navigationBar)
         .hideTabBar()
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button {
+                    Haptics.light()
+                    shareImage = WorkoutImageRenderer.render(workout: workout)
+                } label: {
+                    Image(systemName: "square.and.arrow.up")
+                        .foregroundStyle(Theme.accent)
+                }
+                .accessibilityLabel("Share workout as image")
+            }
+        }
+        .sheet(item: Binding(
+            get: { shareImage.map { ShareImageWrapper(image: $0) } },
+            set: { shareImage = $0?.image }
+        )) { wrapper in
+            WorkoutShareSheet(image: wrapper.image)
+                .presentationDetents([.medium, .large])
+        }
     }
 
     // MARK: - Summary Card
@@ -327,4 +350,12 @@ struct WorkoutDetailView: View {
         formatter.dateFormat = "h:mm a"
         return "\(formatter.string(from: start)) - \(formatter.string(from: end))"
     }
+}
+
+// MARK: - Share Image Wrapper (#320)
+
+/// `Identifiable` wrapper so we can drive `.sheet(item:)` off the rendered image.
+private struct ShareImageWrapper: Identifiable {
+    let id = UUID()
+    let image: UIImage
 }


### PR DESCRIPTION
Closes #320. FeedComment.parentCommentId for nested replies (FeedService writes parent_comment_id - migration TODO). FeedCommentsView re-rendered hierarchically with Reply affordance. New BadgeCatalog (10 progression badges) + BadgeEvaluator + BadgesSection on Profile. WorkoutImageRenderer (iOS 17 ImageRenderer) + Share toolbar button on WorkoutDetailView.