### PR TITLE
#314 design system: spacing/color/font/icon tokens consistently across 78 files

### DIFF
--- a/Xomfit/Utils/Theme.swift
+++ b/Xomfit/Utils/Theme.swift
@@ -55,6 +55,8 @@ enum Theme {
 
     enum Spacing {
         static let hairline: CGFloat = 0.5
+        static let tighter: CGFloat = 2
+        static let tight:   CGFloat = 4
         static let xs:  CGFloat = 4
         static let sm:  CGFloat = 8
         static let md:  CGFloat = 16
@@ -96,10 +98,15 @@ enum Theme {
     static let fontLargeTitle: Font  = .largeTitle.weight(.bold)
     static let fontTitle: Font       = .title.weight(.bold)
     static let fontTitle2: Font      = .title2.weight(.semibold)
+    static let fontTitle3: Font      = .title3
     static let fontHeadline: Font    = .title3.weight(.semibold)
     static let fontBody: Font        = .body
+    static let fontBodyEmphasized: Font = .body.weight(.semibold)
+    static let fontCallout: Font     = .callout
+    static let fontFootnote: Font    = .footnote
     static let fontSubheadline: Font = .subheadline
     static let fontCaption: Font     = .caption
+    static let fontCaption2: Font    = .caption2
     static let fontSmall: Font       = .caption2.weight(.medium)
 
     /// Uppercase + 0.5 kerning metric label. Apply via XomMetricLabel or .metricLabel() modifier.

--- a/Xomfit/Views/AICoach/AICoachView.swift
+++ b/Xomfit/Views/AICoach/AICoachView.swift
@@ -315,7 +315,7 @@ private struct AICoachMessageBubble: View {
         Image(systemName: "sparkles")
             .font(.subheadline.weight(.bold))
             .foregroundStyle(Theme.accent)
-            .frame(width: 32, height: 32)
+            .frame(width: Theme.Spacing.xl, height: Theme.Spacing.xl)
             .background(Theme.accent.opacity(0.18))
             .clipShape(Circle())
             .accessibilityHidden(true)
@@ -445,7 +445,7 @@ private struct WorkoutBuildCard: View {
         HStack(spacing: Theme.Spacing.sm) {
             Image(systemName: "dumbbell.fill")
                 .foregroundStyle(Theme.accent)
-            VStack(alignment: .leading, spacing: 2) {
+            VStack(alignment: .leading, spacing: Theme.Spacing.tighter) {
                 Text(payload.name)
                     .font(Theme.fontBody.weight(.semibold))
                     .foregroundStyle(Theme.textPrimary)
@@ -493,7 +493,7 @@ private struct TypingDots: View {
     @State private var phase: Int = 0
 
     var body: some View {
-        HStack(spacing: 4) {
+        HStack(spacing: Theme.Spacing.tight) {
             ForEach(0..<3, id: \.self) { index in
                 Circle()
                     .fill(Theme.textSecondary)

--- a/Xomfit/Views/Auth/LoginView.swift
+++ b/Xomfit/Views/Auth/LoginView.swift
@@ -65,11 +65,11 @@ struct LoginView: View {
                                     }
                                 }
                             } label: {
-                                HStack(spacing: 8) {
+                                HStack(spacing: Theme.Spacing.sm) {
                                     Image(systemName: "g.circle.fill")
-                                        .font(.title3)
+                                        .font(Theme.fontTitle3)
                                     Text("Sign in with Google")
-                                        .font(.body.weight(.semibold))
+                                        .font(Theme.fontBodyEmphasized)
                                 }
                                 .foregroundStyle(.black)
                                 .frame(maxWidth: .infinity)
@@ -142,7 +142,7 @@ struct LoginView: View {
                         .padding(.horizontal, Theme.Spacing.lg)
 
                         // Sign up link
-                        HStack(spacing: 4) {
+                        HStack(spacing: Theme.Spacing.tight) {
                             Text("Don't have an account?")
                                 .foregroundStyle(Theme.textSecondary)
                                 .font(Theme.fontCaption)

--- a/Xomfit/Views/Auth/ProfileCompletionView.swift
+++ b/Xomfit/Views/Auth/ProfileCompletionView.swift
@@ -58,7 +58,7 @@ struct ProfileCompletionView: View {
 
     private var usernameSection: some View {
         Section {
-            HStack(spacing: 4) {
+            HStack(spacing: Theme.Spacing.tight) {
                 Text("@")
                     .foregroundStyle(Theme.textSecondary)
                 TextField("username", text: $username)
@@ -115,7 +115,7 @@ struct ProfileCompletionView: View {
                             .tint(.black)
                     } else {
                         Text("Continue")
-                            .font(.body.weight(.semibold))
+                            .font(Theme.fontBodyEmphasized)
                     }
                     Spacer()
                 }

--- a/Xomfit/Views/Auth/SignUpView.swift
+++ b/Xomfit/Views/Auth/SignUpView.swift
@@ -32,7 +32,7 @@ struct SignUpView: View {
                             .font(Theme.fontCaption)
                             .foregroundStyle(Theme.textSecondary)
                     }
-                    .padding(.top, 48)
+                    .padding(.top, Theme.Spacing.xxl)
                     .padding(.bottom, Theme.Spacing.md)
 
                     // Form
@@ -93,7 +93,7 @@ struct SignUpView: View {
                     .padding(.horizontal, Theme.Spacing.lg)
 
                     // Back to login
-                    HStack(spacing: 4) {
+                    HStack(spacing: Theme.Spacing.tight) {
                         Text("Already have an account?")
                             .foregroundStyle(Theme.textSecondary)
                             .font(Theme.fontCaption)

--- a/Xomfit/Views/Common/ToastView.swift
+++ b/Xomfit/Views/Common/ToastView.swift
@@ -36,20 +36,20 @@ struct ToastView: View {
     }
 
     var body: some View {
-        HStack(spacing: 12) {
+        HStack(spacing: Theme.Spacing.sm + Theme.Spacing.tight) {
             Image(systemName: icon)
-                .font(.title3)
+                .font(Theme.fontTitle3)
                 .foregroundStyle(iconColor)
 
             Text(toast.message)
                 .font(.subheadline.weight(.medium))
-                .foregroundStyle(.white)
+                .foregroundStyle(Theme.textPrimary)
                 .lineLimit(2)
 
             Spacer()
         }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 14)
+        .padding(.horizontal, Theme.Spacing.md)
+        .padding(.vertical, Theme.Spacing.md - Theme.Spacing.tighter)
         .background(
             RoundedRectangle(cornerRadius: 14)
                 .fill(.ultraThinMaterial)
@@ -58,7 +58,7 @@ struct ToastView: View {
                         .fill(Color.black.opacity(0.5))
                 )
         )
-        .padding(.horizontal, 16)
+        .padding(.horizontal, Theme.Spacing.md)
     }
 }
 
@@ -72,7 +72,7 @@ struct ToastModifier: ViewModifier {
             .overlay(alignment: .top) {
                 if let toast = toast {
                     ToastView(toast: toast)
-                        .padding(.top, 8)
+                        .padding(.top, Theme.Spacing.sm)
                         .transition(.move(edge: .top).combined(with: .opacity))
                         .onAppear {
                             Task {

--- a/Xomfit/Views/Common/UserSearchView.swift
+++ b/Xomfit/Views/Common/UserSearchView.swift
@@ -63,7 +63,7 @@ struct UserSearchView: View {
         HStack(spacing: 10) {
             Image(systemName: "magnifyingglass")
                 .foregroundStyle(Theme.textSecondary)
-                .font(.body)
+                .font(Theme.fontBody)
 
             TextField("Search by username", text: $query)
                 .textInputAutocapitalization(.never)
@@ -123,7 +123,7 @@ struct UserSearchView: View {
             // Avatar circle with initials
             initialsAvatar(profile)
 
-            VStack(alignment: .leading, spacing: 2) {
+            VStack(alignment: .leading, spacing: Theme.Spacing.tighter) {
                 Text(profile.displayName.isEmpty ? profile.username : profile.displayName)
                     .font(.subheadline.weight(.semibold))
                     .foregroundStyle(Theme.textPrimary)
@@ -134,7 +134,7 @@ struct UserSearchView: View {
 
             Spacer()
         }
-        .padding(.vertical, 4)
+        .padding(.vertical, Theme.Spacing.tight)
         .accessibilityElement(children: .combine)
     }
 
@@ -161,7 +161,7 @@ struct UserSearchView: View {
     private var emptyState: some View {
         VStack(spacing: Theme.Spacing.sm) {
             Image(systemName: "magnifyingglass")
-                .font(.largeTitle)
+                .font(Theme.fontLargeTitle)
                 .foregroundStyle(Theme.textSecondary)
             Text("Search for users by username")
                 .font(Theme.fontBody)
@@ -172,7 +172,7 @@ struct UserSearchView: View {
     private var noResultsView: some View {
         VStack(spacing: Theme.Spacing.sm) {
             Image(systemName: "person.slash")
-                .font(.largeTitle)
+                .font(Theme.fontLargeTitle)
                 .foregroundStyle(Theme.textSecondary)
             Text("No users found")
                 .font(Theme.fontBody)

--- a/Xomfit/Views/Common/XomAvatar.swift
+++ b/Xomfit/Views/Common/XomAvatar.swift
@@ -85,7 +85,7 @@ struct XomAvatar: View {
 // MARK: - Preview
 
 #Preview {
-    HStack(spacing: 16) {
+    HStack(spacing: Theme.Spacing.md) {
         XomAvatar(name: "Dom Giordano", size: 44)
         XomAvatar(name: "Dom Giordano", size: 96, ringColor: Theme.accent)
         XomAvatar(name: "Dom Giordano", size: 48, isOnline: true)

--- a/Xomfit/Views/Common/XomBadge.swift
+++ b/Xomfit/Views/Common/XomBadge.swift
@@ -35,7 +35,7 @@ struct XomBadge: View {
     }
 
     var body: some View {
-        HStack(spacing: 4) {
+        HStack(spacing: Theme.Spacing.tight) {
             if let icon {
                 Image(systemName: icon)
                     .font(.system(size: 10, weight: .semibold))
@@ -45,8 +45,8 @@ struct XomBadge: View {
                 .font(Theme.fontSmall)
                 .foregroundStyle(labelForeground)
         }
-        .padding(.horizontal, 8)
-        .padding(.vertical, 4)
+        .padding(.horizontal, Theme.Spacing.sm)
+        .padding(.vertical, Theme.Spacing.tight)
         .background(backgroundFill)
         .clipShape(RoundedRectangle(cornerRadius: Theme.Radius.xs))
         .overlay(
@@ -93,7 +93,7 @@ struct XomBadge: View {
 // MARK: - Preview
 
 #Preview {
-    VStack(spacing: 16) {
+    VStack(spacing: Theme.Spacing.md) {
         HStack {
             XomBadge("Workout", icon: "dumbbell.fill", color: Theme.accent, variant: .display)
             XomBadge("PR", icon: "trophy.fill", color: Theme.prGold, variant: .display)

--- a/Xomfit/Views/Common/XomButton.swift
+++ b/Xomfit/Views/Common/XomButton.swift
@@ -113,7 +113,7 @@ struct XomButton: View {
 // MARK: - Preview
 
 #Preview {
-    VStack(spacing: 16) {
+    VStack(spacing: Theme.Spacing.md) {
         XomButton("Start Workout", variant: .primary) {}
         XomButton("Edit Profile", variant: .secondary) {}
         XomButton("Delete", variant: .destructive) {}

--- a/Xomfit/Views/Common/XomFitLoader.swift
+++ b/Xomfit/Views/Common/XomFitLoader.swift
@@ -112,15 +112,15 @@ struct XomFitLoaderSpin: View {
     ZStack {
         Theme.background.ignoresSafeArea()
         VStack(spacing: 40) {
-            VStack(spacing: 8) {
+            VStack(spacing: Theme.Spacing.sm) {
                 XomFitLoaderPaint(size: 80)
                 Text("Paint").font(Theme.fontCaption).foregroundStyle(Theme.textSecondary)
             }
-            VStack(spacing: 8) {
+            VStack(spacing: Theme.Spacing.sm) {
                 XomFitLoaderPulse(size: 60)
                 Text("Pulse").font(Theme.fontCaption).foregroundStyle(Theme.textSecondary)
             }
-            VStack(spacing: 8) {
+            VStack(spacing: Theme.Spacing.sm) {
                 XomFitLoaderSpin(size: 50)
                 Text("Spin").font(Theme.fontCaption).foregroundStyle(Theme.textSecondary)
             }

--- a/Xomfit/Views/Common/XomMetricLabel.swift
+++ b/Xomfit/Views/Common/XomMetricLabel.swift
@@ -39,7 +39,7 @@ extension View {
 // MARK: - Preview
 
 #Preview {
-    VStack(spacing: 8) {
+    VStack(spacing: Theme.Spacing.sm) {
         XomMetricLabel("Total Volume")
         XomMetricLabel("Weekly Workouts")
         Text("custom text").metricLabel()

--- a/Xomfit/Views/Common/XomSkeletonRow.swift
+++ b/Xomfit/Views/Common/XomSkeletonRow.swift
@@ -53,7 +53,7 @@ struct XomSkeletonRow: View {
             // Content area
             RoundedRectangle(cornerRadius: 8)
                 .fill(Theme.surfaceElevated)
-                .frame(height: 16)
+                .frame(height: Theme.Spacing.md)
             RoundedRectangle(cornerRadius: 8)
                 .fill(Theme.surfaceElevated)
                 .frame(width: 200, height: 16)

--- a/Xomfit/Views/Common/XomStat.swift
+++ b/Xomfit/Views/Common/XomStat.swift
@@ -30,14 +30,14 @@ struct XomStat: View {
     }
 
     var body: some View {
-        VStack(spacing: 2) {
+        VStack(spacing: Theme.Spacing.tighter) {
             if let icon {
                 Image(systemName: icon)
-                    .font(.caption)
+                    .font(Theme.fontCaption)
                     .foregroundStyle(iconColor)
             }
 
-            HStack(alignment: .firstTextBaseline, spacing: 2) {
+            HStack(alignment: .firstTextBaseline, spacing: Theme.Spacing.tighter) {
                 Text(value)
                     .font(Theme.fontNumberLarge)
                     .foregroundStyle(Theme.textPrimary)

--- a/Xomfit/Views/Common/XomToolbarTitle.swift
+++ b/Xomfit/Views/Common/XomToolbarTitle.swift
@@ -28,7 +28,7 @@ struct XomToolbarTitle: View {
 
             if let subtitle {
                 Text(subtitle)
-                    .font(.caption)
+                    .font(Theme.fontCaption)
                     .foregroundStyle(Theme.textSecondary)
             }
         }

--- a/Xomfit/Views/Feed/FeedCommentsView.swift
+++ b/Xomfit/Views/Feed/FeedCommentsView.swift
@@ -48,7 +48,7 @@ struct FeedCommentsView: View {
                     Spacer()
                     VStack(spacing: Theme.Spacing.sm) {
                         Image(systemName: "bubble.right")
-                            .font(.largeTitle)
+                            .font(Theme.fontLargeTitle)
                             .foregroundStyle(Theme.textSecondary)
                         Text("No comments yet")
                             .font(Theme.fontHeadline)
@@ -120,14 +120,14 @@ struct FeedCommentsView: View {
                     cancelReply()
                 } label: {
                     Image(systemName: "xmark.circle.fill")
-                        .font(.body)
+                        .font(Theme.fontBody)
                         .foregroundStyle(Theme.textSecondary)
                         .frame(width: 44, height: 44)
                 }
                 .accessibilityLabel("Cancel reply")
             }
             .padding(.horizontal, Theme.Spacing.md)
-            .padding(.vertical, 4)
+            .padding(.vertical, Theme.Spacing.tight)
             .background(Theme.surface)
             .overlay(alignment: .top) { XomDivider() }
         }
@@ -156,7 +156,7 @@ struct FeedCommentsView: View {
                         .frame(width: 44, height: 44)
                 } else {
                     Image(systemName: "arrow.up.circle.fill")
-                        .font(.largeTitle)
+                        .font(Theme.fontLargeTitle)
                         .foregroundStyle(newCommentText.isEmpty ? Theme.textSecondary : Theme.accent)
                 }
             }

--- a/Xomfit/Views/Feed/FeedDetailView.swift
+++ b/Xomfit/Views/Feed/FeedDetailView.swift
@@ -108,13 +108,13 @@ struct FeedDetailView: View {
                         .font(.title3.weight(.bold))
                         .foregroundStyle(Theme.textPrimary)
 
-                    HStack(spacing: 8) {
+                    HStack(spacing: Theme.Spacing.sm) {
                         Image(systemName: "calendar")
-                            .font(.caption)
+                            .font(Theme.fontCaption)
                         Text(localItem.createdAt.workoutDateString)
                         Text("·")
                         Image(systemName: "clock")
-                            .font(.caption)
+                            .font(Theme.fontCaption)
                         Text(formatDuration(activity.duration))
                     }
                     .font(Theme.fontCaption)
@@ -204,7 +204,7 @@ struct FeedDetailView: View {
 
                             if workoutSet.isPersonalRecord {
                                 Image(systemName: "trophy.fill")
-                                    .font(.caption2)
+                                    .font(Theme.fontCaption2)
                                     .foregroundStyle(Theme.prGold)
                             }
 
@@ -218,11 +218,11 @@ struct FeedDetailView: View {
                     Text("\(index)")
                         .font(.caption.weight(.bold).monospaced())
                         .foregroundStyle(Theme.accent)
-                        .frame(width: 24, height: 24)
+                        .frame(width: Theme.Spacing.lg, height: Theme.Spacing.lg)
                         .background(Theme.accent.opacity(0.12))
                         .clipShape(.rect(cornerRadius: 6))
 
-                    VStack(alignment: .leading, spacing: 2) {
+                    VStack(alignment: .leading, spacing: Theme.Spacing.tighter) {
                         Text(exercise.exercise.name)
                             .font(.subheadline.weight(.bold))
                             .foregroundStyle(Theme.textPrimary)
@@ -238,7 +238,7 @@ struct FeedDetailView: View {
                     if exercise.sets.contains(where: { $0.isPersonalRecord }) {
                         HStack(spacing: 3) {
                             Image(systemName: "trophy.fill")
-                                .font(.caption2)
+                                .font(Theme.fontCaption2)
                             Text("PR")
                                 .font(.caption2.weight(.bold))
                         }
@@ -257,9 +257,9 @@ struct FeedDetailView: View {
     private func fallbackExerciseRow(exercise: WorkoutActivity.ExerciseSummary) -> some View {
         HStack(spacing: 12) {
             Image(systemName: "figure.strengthtraining.traditional")
-                .font(.subheadline)
+                .font(Theme.fontSubheadline)
                 .foregroundStyle(exercise.isPR ? Theme.prGold : Theme.accent)
-                .frame(width: 32, height: 32)
+                .frame(width: Theme.Spacing.xl, height: Theme.Spacing.xl)
                 .background((exercise.isPR ? Theme.prGold : Theme.accent).opacity(0.15))
                 .clipShape(.rect(cornerRadius: 8))
 
@@ -277,7 +277,7 @@ struct FeedDetailView: View {
             if exercise.isPR {
                 HStack(spacing: 3) {
                     Image(systemName: "trophy.fill")
-                        .font(.caption2)
+                        .font(Theme.fontCaption2)
                     Text("PR")
                         .font(.caption2.weight(.bold))
                 }
@@ -298,7 +298,7 @@ struct FeedDetailView: View {
                 size: 48
             )
 
-            VStack(alignment: .leading, spacing: 2) {
+            VStack(alignment: .leading, spacing: Theme.Spacing.tighter) {
                 Text(localItem.user.displayName.isEmpty ? localItem.user.username : localItem.user.displayName)
                     .font(.subheadline.weight(.semibold))
                     .foregroundStyle(Theme.textPrimary)
@@ -330,7 +330,7 @@ struct FeedDetailView: View {
             } label: {
                 HStack(spacing: 5) {
                     Image(systemName: localItem.isLiked ? "heart.fill" : "heart")
-                        .font(.body)
+                        .font(Theme.fontBody)
                         .foregroundStyle(localItem.isLiked ? Theme.destructive : Theme.textSecondary)
                     Text("\(localItem.likes)")
                         .font(.subheadline.weight(.medium))
@@ -345,7 +345,7 @@ struct FeedDetailView: View {
             } label: {
                 HStack(spacing: 5) {
                     Image(systemName: "bubble.right")
-                        .font(.body)
+                        .font(Theme.fontBody)
                         .foregroundStyle(Theme.textSecondary)
                     Text("\(localItem.comments.count)")
                         .font(.subheadline.weight(.medium))
@@ -358,7 +358,7 @@ struct FeedDetailView: View {
                 shareFeedItem()
             } label: {
                 Image(systemName: "square.and.arrow.up")
-                    .font(.body)
+                    .font(Theme.fontBody)
                     .foregroundStyle(Theme.textSecondary)
             }
             .accessibilityLabel("Share")
@@ -370,9 +370,9 @@ struct FeedDetailView: View {
     // MARK: - Helpers
 
     private func workoutStat(value: String, label: String, icon: String, color: Color = Theme.accent) -> some View {
-        VStack(spacing: 4) {
+        VStack(spacing: Theme.Spacing.tight) {
             Image(systemName: icon)
-                .font(.subheadline)
+                .font(Theme.fontSubheadline)
                 .foregroundStyle(color)
             Text(value)
                 .font(.body.weight(.bold))

--- a/Xomfit/Views/Feed/FeedFilterBar.swift
+++ b/Xomfit/Views/Feed/FeedFilterBar.swift
@@ -28,7 +28,7 @@ struct FeedFilterBar: View {
     var body: some View {
         VStack(spacing: 0) {
             ScrollView(.horizontal, showsIndicators: false) {
-                HStack(spacing: 8) {
+                HStack(spacing: Theme.Spacing.sm) {
                     // Date range chips
                     ForEach(FeedDateRange.allCases) { range in
                         let isActive = selectedDateRange == range
@@ -66,7 +66,7 @@ struct FeedFilterBar: View {
                 }
                 .padding(.horizontal, Theme.Spacing.md)
             }
-            .padding(.vertical, 8)
+            .padding(.vertical, Theme.Spacing.sm)
 
             XomDivider()
         }

--- a/Xomfit/Views/Feed/FeedItemCard.swift
+++ b/Xomfit/Views/Feed/FeedItemCard.swift
@@ -32,7 +32,7 @@ struct FeedItemCard: View {
                     Text(caption)
                         .font(Theme.fontBody)
                         .foregroundStyle(Theme.textPrimary)
-                        .padding(.top, 2)
+                        .padding(.top, Theme.Spacing.tighter)
                 }
 
                 XomDivider()
@@ -82,7 +82,7 @@ struct FeedItemCard: View {
                 size: 48
             )
 
-            VStack(alignment: .leading, spacing: 2) {
+            VStack(alignment: .leading, spacing: Theme.Spacing.tighter) {
                 Text(item.user.displayName.isEmpty ? item.user.username : item.user.displayName)
                     .font(.subheadline.weight(.semibold))
                     .foregroundStyle(Theme.textPrimary)
@@ -118,7 +118,7 @@ struct FeedItemCard: View {
                     Image(systemName: "ellipsis")
                         .font(.system(size: 18, weight: .medium))
                         .foregroundStyle(Theme.textSecondary)
-                        .frame(width: 32, height: 32)
+                        .frame(width: Theme.Spacing.xl, height: Theme.Spacing.xl)
                         .contentShape(Rectangle())
                 }
                 .accessibilityLabel("Post options")
@@ -292,7 +292,7 @@ private struct WorkoutActivityContent: View {
                     .foregroundStyle(Theme.textPrimary)
 
                 if let rating = activity.rating, rating > 0 {
-                    HStack(spacing: 2) {
+                    HStack(spacing: Theme.Spacing.tighter) {
                         ForEach(1...5, id: \.self) { star in
                             Image(systemName: star <= rating ? "star.fill" : "star")
                                 .font(.system(size: 10))
@@ -303,7 +303,7 @@ private struct WorkoutActivityContent: View {
             }
 
             if let location = activity.location, !location.isEmpty {
-                HStack(spacing: 4) {
+                HStack(spacing: Theme.Spacing.tight) {
                     Image(systemName: "location.fill")
                         .font(.system(size: 10))
                     Text(location)

--- a/Xomfit/Views/Feed/FeedView.swift
+++ b/Xomfit/Views/Feed/FeedView.swift
@@ -77,7 +77,7 @@ struct FeedView: View {
                                 if NotificationService.shared.unreadCount > 0 {
                                     Circle()
                                         .fill(Theme.destructive)
-                                        .frame(width: 8, height: 8)
+                                        .frame(width: Theme.Spacing.sm, height: Theme.Spacing.sm)
                                         .offset(x: 3, y: -3)
                                 }
                             }
@@ -205,7 +205,7 @@ struct FeedView: View {
                     .font(Theme.fontCaption.weight(.semibold))
                     .foregroundStyle(Theme.accent)
                     .padding(.horizontal, Theme.Spacing.md)
-                    .padding(.vertical, 8)
+                    .padding(.vertical, Theme.Spacing.sm)
                     .frame(minHeight: 36)
                     .background(
                         Capsule().fill(Theme.accent.opacity(0.15))

--- a/Xomfit/Views/Feed/PhotoZoomView.swift
+++ b/Xomfit/Views/Feed/PhotoZoomView.swift
@@ -92,7 +92,7 @@ struct PhotoZoomView: View {
                         }
                 case .failure:
                     Image(systemName: "photo")
-                        .font(.largeTitle)
+                        .font(Theme.fontLargeTitle)
                         .foregroundStyle(Theme.textSecondary)
                 default:
                     ProgressView().tint(Theme.textSecondary)
@@ -107,7 +107,7 @@ struct PhotoZoomView: View {
                         dismiss()
                     } label: {
                         Image(systemName: "xmark.circle.fill")
-                            .font(.title2)
+                            .font(Theme.fontTitle2)
                             .foregroundStyle(Theme.textSecondary)
                             .background(Color.black.opacity(0.4).clipShape(Circle()))
                     }

--- a/Xomfit/Views/Friends/FriendsView.swift
+++ b/Xomfit/Views/Friends/FriendsView.swift
@@ -257,7 +257,7 @@ private struct SearchResultRow: View {
                 size: 40
             )
 
-            VStack(alignment: .leading, spacing: 2) {
+            VStack(alignment: .leading, spacing: Theme.Spacing.tighter) {
                 Text(profile.displayName)
                     .font(.subheadline.weight(.semibold))
                     .foregroundStyle(Theme.textPrimary)
@@ -270,7 +270,7 @@ private struct SearchResultRow: View {
 
             actionView
         }
-        .padding(.vertical, 4)
+        .padding(.vertical, Theme.Spacing.tight)
         .confirmationDialog(
             "Cancel friend request?",
             isPresented: $showCancelDialog,
@@ -389,7 +389,7 @@ private struct PendingRequestRow: View {
         HStack(spacing: Theme.Spacing.md) {
             XomAvatar(name: requesterName, size: 40)
 
-            VStack(alignment: .leading, spacing: 2) {
+            VStack(alignment: .leading, spacing: Theme.Spacing.tighter) {
                 Text(requesterName)
                     .font(.subheadline.weight(.semibold))
                     .foregroundStyle(Theme.textPrimary)
@@ -403,7 +403,7 @@ private struct PendingRequestRow: View {
 
             Spacer()
 
-            HStack(spacing: 8) {
+            HStack(spacing: Theme.Spacing.sm) {
                 Button("Accept") {
                     Haptics.light()
                     onAccept()
@@ -431,7 +431,7 @@ private struct PendingRequestRow: View {
                 .accessibilityLabel("Decline friend request")
             }
         }
-        .padding(.vertical, 4)
+        .padding(.vertical, Theme.Spacing.tight)
     }
 }
 
@@ -455,7 +455,7 @@ private struct OutgoingRequestRow: View {
         HStack(spacing: Theme.Spacing.md) {
             XomAvatar(name: addresseeName, size: 40)
 
-            VStack(alignment: .leading, spacing: 2) {
+            VStack(alignment: .leading, spacing: Theme.Spacing.tighter) {
                 Text(addresseeName)
                     .font(.subheadline.weight(.semibold))
                     .foregroundStyle(Theme.textPrimary)
@@ -482,7 +482,7 @@ private struct OutgoingRequestRow: View {
             .buttonStyle(.plain)
             .accessibilityLabel("Cancel outgoing friend request")
         }
-        .padding(.vertical, 4)
+        .padding(.vertical, Theme.Spacing.tight)
         .confirmationDialog(
             "Cancel friend request?",
             isPresented: $showCancelDialog,
@@ -517,7 +517,7 @@ private struct FriendListRow: View {
         HStack(spacing: Theme.Spacing.md) {
             XomAvatar(name: friendName, size: 40)
 
-            VStack(alignment: .leading, spacing: 2) {
+            VStack(alignment: .leading, spacing: Theme.Spacing.tighter) {
                 Text(friendName)
                     .font(.subheadline.weight(.semibold))
                     .foregroundStyle(Theme.textPrimary)
@@ -535,7 +535,7 @@ private struct FriendListRow: View {
 
             Spacer()
         }
-        .padding(.vertical, 4)
+        .padding(.vertical, Theme.Spacing.tight)
         .swipeActions(edge: .trailing) {
             Button("Remove", role: .destructive) {
                 onRemove()

--- a/Xomfit/Views/MainTabView.swift
+++ b/Xomfit/Views/MainTabView.swift
@@ -160,7 +160,7 @@ private struct WorkoutResumeBar: View {
                     .background(Theme.accent.opacity(0.15))
                     .clipShape(Circle())
 
-                VStack(alignment: .leading, spacing: 2) {
+                VStack(alignment: .leading, spacing: Theme.Spacing.tighter) {
                     Text(workoutName.isEmpty ? "Workout" : workoutName)
                         .font(.subheadline.weight(.semibold))
                         .foregroundStyle(Theme.textPrimary)

--- a/Xomfit/Views/Notifications/NotificationInboxView.swift
+++ b/Xomfit/Views/Notifications/NotificationInboxView.swift
@@ -74,7 +74,7 @@ private struct NotificationRow: View {
     var body: some View {
         HStack(spacing: 12) {
             Image(systemName: notification.type.icon)
-                .font(.body)
+                .font(Theme.fontBody)
                 .foregroundStyle(iconColor)
                 .frame(width: 36, height: 36)
                 .background(iconColor.opacity(0.15))
@@ -102,10 +102,10 @@ private struct NotificationRow: View {
             if !notification.isRead {
                 Circle()
                     .fill(Theme.accent)
-                    .frame(width: 8, height: 8)
+                    .frame(width: Theme.Spacing.sm, height: Theme.Spacing.sm)
             }
         }
-        .padding(.vertical, 4)
+        .padding(.vertical, Theme.Spacing.tight)
     }
 
     private var iconColor: Color {

--- a/Xomfit/Views/Notifications/NotificationPreferencesView.swift
+++ b/Xomfit/Views/Notifications/NotificationPreferencesView.swift
@@ -55,9 +55,9 @@ struct NotificationPreferencesView: View {
         Toggle(isOn: isOn) {
             HStack(spacing: 10) {
                 Image(systemName: icon)
-                    .font(.subheadline)
+                    .font(Theme.fontSubheadline)
                     .foregroundStyle(Theme.accent)
-                    .frame(width: 24)
+                    .frame(width: Theme.Spacing.lg)
                 Text(label)
                     .font(Theme.fontBody)
                     .foregroundStyle(Theme.textPrimary)

--- a/Xomfit/Views/Onboarding/FitnessQuestionnaireView.swift
+++ b/Xomfit/Views/Onboarding/FitnessQuestionnaireView.swift
@@ -152,7 +152,7 @@ struct FitnessQuestionnaireView: View {
                 ForEach(0..<totalPages, id: \.self) { index in
                     Circle()
                         .fill(index == currentPage ? Theme.accent : Theme.surfaceElevated)
-                        .frame(width: 8, height: 8)
+                        .frame(width: Theme.Spacing.sm, height: Theme.Spacing.sm)
                         .overlay(
                             Circle()
                                 .strokeBorder(
@@ -333,14 +333,14 @@ private struct ChoiceRow: View {
             HStack(spacing: Theme.Spacing.md) {
                 if let icon {
                     Image(systemName: icon)
-                        .font(.title3)
+                        .font(Theme.fontTitle3)
                         .foregroundStyle(isSelected ? Theme.accent : Theme.textSecondary)
-                        .frame(width: 32, height: 32)
+                        .frame(width: Theme.Spacing.xl, height: Theme.Spacing.xl)
                 }
 
-                VStack(alignment: .leading, spacing: 2) {
+                VStack(alignment: .leading, spacing: Theme.Spacing.tighter) {
                     Text(label)
-                        .font(.body.weight(.semibold))
+                        .font(Theme.fontBodyEmphasized)
                         .foregroundStyle(Theme.textPrimary)
 
                     if let subtitle {
@@ -353,7 +353,7 @@ private struct ChoiceRow: View {
                 Spacer()
 
                 Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
-                    .font(.title3)
+                    .font(Theme.fontTitle3)
                     .foregroundStyle(isSelected ? Theme.accent : Theme.textTertiary)
             }
             .padding(Theme.Spacing.md)
@@ -416,7 +416,7 @@ private struct ChipButton: View {
     var body: some View {
         Button(action: onTap) {
             Text(label)
-                .font(.body.weight(.semibold))
+                .font(Theme.fontBodyEmphasized)
                 .foregroundStyle(isSelected ? .black : Theme.textPrimary)
                 .frame(maxWidth: .infinity, minHeight: 56)
                 .background(

--- a/Xomfit/Views/Onboarding/OnboardingBottomBar.swift
+++ b/Xomfit/Views/Onboarding/OnboardingBottomBar.swift
@@ -19,7 +19,7 @@ struct OnboardingBottomBar: View {
                 ForEach(0..<totalPages, id: \.self) { index in
                     Circle()
                         .fill(index == currentPage ? Theme.accent : Theme.surfaceElevated)
-                        .frame(width: 8, height: 8)
+                        .frame(width: Theme.Spacing.sm, height: Theme.Spacing.sm)
                         .overlay(
                             Circle()
                                 .strokeBorder(

--- a/Xomfit/Views/Onboarding/OnboardingFriendsScreen.swift
+++ b/Xomfit/Views/Onboarding/OnboardingFriendsScreen.swift
@@ -81,7 +81,7 @@ struct OnboardingFriendsScreen: View {
                     } else if searchResults.isEmpty && searchQuery.isEmpty {
                         VStack(spacing: Theme.Spacing.sm) {
                             Image(systemName: "person.2.fill")
-                                .font(.largeTitle)
+                                .font(Theme.fontLargeTitle)
                                 .foregroundStyle(Theme.textSecondary.opacity(0.5))
                             Text("Search by username to find friends")
                                 .font(Theme.fontBody)
@@ -145,7 +145,7 @@ struct OnboardingFriendsScreen: View {
                 size: 40
             )
 
-            VStack(alignment: .leading, spacing: 2) {
+            VStack(alignment: .leading, spacing: Theme.Spacing.tighter) {
                 Text(user.displayName.isEmpty ? user.username : user.displayName)
                     .font(.subheadline.weight(.semibold))
                     .foregroundStyle(Theme.textPrimary)

--- a/Xomfit/Views/Onboarding/OnboardingGoalsScreen.swift
+++ b/Xomfit/Views/Onboarding/OnboardingGoalsScreen.swift
@@ -75,13 +75,13 @@ private struct GoalCard: View {
             VStack(spacing: Theme.Spacing.sm) {
                 ZStack(alignment: .topTrailing) {
                     Image(systemName: goal.icon)
-                        .font(.largeTitle)
+                        .font(Theme.fontLargeTitle)
                         .foregroundStyle(isSelected ? Theme.accent : Theme.textSecondary)
                         .frame(maxWidth: .infinity)
 
                     if isSelected {
                         Image(systemName: "checkmark.circle.fill")
-                            .font(.body)
+                            .font(Theme.fontBody)
                             .foregroundStyle(Theme.accent)
                             .transition(.scale.combined(with: .opacity))
                     }

--- a/Xomfit/Views/Onboarding/OnboardingPermissionsScreen.swift
+++ b/Xomfit/Views/Onboarding/OnboardingPermissionsScreen.swift
@@ -115,14 +115,14 @@ struct OnboardingPermissionsScreen: View {
         VStack(alignment: .leading, spacing: Theme.Spacing.md) {
             HStack(spacing: Theme.Spacing.md) {
                 Image(systemName: icon)
-                    .font(.title3)
+                    .font(Theme.fontTitle3)
                     .foregroundStyle(Theme.accent)
                     .frame(width: 44, height: 44)
                     .background(Theme.accent.opacity(0.12))
                     .clipShape(Circle())
                     .accessibilityHidden(true)
 
-                VStack(alignment: .leading, spacing: 2) {
+                VStack(alignment: .leading, spacing: Theme.Spacing.tighter) {
                     Text(title)
                         .font(.subheadline.weight(.semibold))
                         .foregroundStyle(Theme.textPrimary)

--- a/Xomfit/Views/Onboarding/OnboardingWelcomeScreen.swift
+++ b/Xomfit/Views/Onboarding/OnboardingWelcomeScreen.swift
@@ -49,7 +49,7 @@ struct OnboardingWelcomeScreen: View {
     private func featureRow(icon: String, text: String) -> some View {
         HStack(spacing: Theme.Spacing.md) {
             Image(systemName: icon)
-                .font(.title3)
+                .font(Theme.fontTitle3)
                 .foregroundStyle(Theme.accent)
                 .frame(width: 44, height: 44)
                 .background(Theme.accent.opacity(0.12))

--- a/Xomfit/Views/Profile/BadgesSection.swift
+++ b/Xomfit/Views/Profile/BadgesSection.swift
@@ -69,13 +69,13 @@ private struct BadgePill: View {
                         .fill(isUnlocked ? Theme.accent.opacity(0.18) : Theme.surfaceElevated)
                         .frame(width: 44, height: 44)
                     Image(systemName: badge.iconSystemName)
-                        .font(.title3)
+                        .font(Theme.fontTitle3)
                         .foregroundStyle(isUnlocked ? Theme.accent : Theme.textTertiary)
                     if !isUnlocked {
                         Image(systemName: "lock.fill")
                             .font(.caption2.weight(.bold))
                             .foregroundStyle(Theme.textSecondary)
-                            .padding(4)
+                            .padding(Theme.Spacing.tight)
                             .background(Circle().fill(Theme.background))
                             .offset(x: 16, y: 16)
                     }

--- a/Xomfit/Views/Profile/BodyHeatmapView.swift
+++ b/Xomfit/Views/Profile/BodyHeatmapView.swift
@@ -105,7 +105,7 @@ struct BodyHeatmapView: View {
     }
 
     private func legendItem(color: Color, label: String) -> some View {
-        VStack(spacing: 2) {
+        VStack(spacing: Theme.Spacing.tighter) {
             RoundedRectangle(cornerRadius: 3)
                 .fill(color)
                 .frame(width: 20, height: 12)

--- a/Xomfit/Views/Profile/MeasurementKindDetailView.swift
+++ b/Xomfit/Views/Profile/MeasurementKindDetailView.swift
@@ -98,13 +98,13 @@ struct MeasurementKindDetailView: View {
         XomCard(variant: .elevated) {
             HStack(spacing: Theme.Spacing.md) {
                 Image(systemName: kind.systemImage)
-                    .font(.title2)
+                    .font(Theme.fontTitle2)
                     .foregroundStyle(Theme.accent)
                     .frame(width: 44, height: 44)
                     .background(Theme.accentMuted)
                     .clipShape(Circle())
 
-                VStack(alignment: .leading, spacing: 4) {
+                VStack(alignment: .leading, spacing: Theme.Spacing.tight) {
                     if let latest = viewModel.latest(of: kind) {
                         Text("\(kind.format(latest.value)) \(kind.unit)")
                             .font(Theme.fontNumberLarge)
@@ -141,7 +141,7 @@ struct MeasurementKindDetailView: View {
                 ? Theme.textSecondary
                 : (isPositive ? Theme.accent : Theme.destructive)
             let prefix = delta > 0 ? "+" : ""
-            VStack(alignment: .trailing, spacing: 2) {
+            VStack(alignment: .trailing, spacing: Theme.Spacing.tighter) {
                 Text("\(prefix)\(kind.format(delta))")
                     .font(Theme.fontNumberMedium)
                     .foregroundStyle(fg)
@@ -220,7 +220,7 @@ struct MeasurementKindDetailView: View {
                 AxisValueLabel {
                     if let v = value.as(Double.self) {
                         Text(kind.format(v))
-                            .font(.caption2)
+                            .font(Theme.fontCaption2)
                             .foregroundStyle(Theme.textTertiary)
                     }
                 }
@@ -230,7 +230,7 @@ struct MeasurementKindDetailView: View {
             AxisMarks { _ in
                 AxisGridLine().foregroundStyle(Theme.hairline)
                 AxisValueLabel()
-                    .font(.caption2)
+                    .font(Theme.fontCaption2)
                     .foregroundStyle(Theme.textTertiary)
             }
         }
@@ -320,7 +320,7 @@ struct MeasurementKindDetailView: View {
     private func historyRow(_ entry: BodyMeasurement) -> some View {
         XomCard(padding: Theme.Spacing.sm) {
             HStack(spacing: Theme.Spacing.md) {
-                VStack(alignment: .leading, spacing: 2) {
+                VStack(alignment: .leading, spacing: Theme.Spacing.tighter) {
                     Text("\(kind.format(entry.value)) \(kind.unit)")
                         .font(Theme.fontNumberMedium)
                         .foregroundStyle(Theme.textPrimary)
@@ -343,8 +343,8 @@ struct MeasurementKindDetailView: View {
                     isDeleteAlertPresented = true
                 } label: {
                     Image(systemName: "trash")
-                        .font(.subheadline)
-                        .foregroundStyle(Theme.textSecondary)
+                        .font(Theme.fontSubheadline)
+                        .foregroundStyle(Theme.destructive)
                         .frame(width: 44, height: 44)
                 }
                 .accessibilityLabel("Delete entry")

--- a/Xomfit/Views/Profile/MeasurementsView.swift
+++ b/Xomfit/Views/Profile/MeasurementsView.swift
@@ -94,9 +94,9 @@ struct MeasurementsView: View {
         XomCard(padding: Theme.Spacing.sm) {
             VStack(spacing: Theme.Spacing.xs) {
                 Image(systemName: kind.systemImage)
-                    .font(.title3)
+                    .font(Theme.fontTitle3)
                     .foregroundStyle(Theme.accent)
-                    .frame(height: 24)
+                    .frame(height: Theme.Spacing.lg)
 
                 Text(kind.displayName)
                     .font(Theme.fontSubheadline.weight(.semibold))
@@ -149,11 +149,11 @@ private struct MeasurementKindRow: View {
         XomCard {
             HStack(spacing: Theme.Spacing.md) {
                 Image(systemName: kind.systemImage)
-                    .font(.title3)
+                    .font(Theme.fontTitle3)
                     .foregroundStyle(Theme.accent)
-                    .frame(width: 32, height: 32)
+                    .frame(width: Theme.Spacing.xl, height: Theme.Spacing.xl)
 
-                VStack(alignment: .leading, spacing: 2) {
+                VStack(alignment: .leading, spacing: Theme.Spacing.tighter) {
                     Text(kind.displayName)
                         .font(Theme.fontSubheadline.weight(.semibold))
                         .foregroundStyle(Theme.textPrimary)
@@ -172,7 +172,7 @@ private struct MeasurementKindRow: View {
     @ViewBuilder
     private var latestValue: some View {
         if let latest {
-            VStack(alignment: .trailing, spacing: 2) {
+            VStack(alignment: .trailing, spacing: Theme.Spacing.tighter) {
                 Text("\(kind.format(latest.value)) \(kind.unit)")
                     .font(Theme.fontNumberMedium)
                     .foregroundStyle(Theme.textPrimary)

--- a/Xomfit/Views/Profile/PRListView.swift
+++ b/Xomfit/Views/Profile/PRListView.swift
@@ -118,8 +118,8 @@ private struct PRRow: View {
             HStack(spacing: Theme.Spacing.md) {
                 Image(systemName: "trophy.fill")
                     .foregroundStyle(isTopThree ? Theme.prGold : Theme.textTertiary)
-                    .font(.subheadline)
-                    .frame(width: 24)
+                    .font(Theme.fontSubheadline)
+                    .frame(width: Theme.Spacing.lg)
 
                 VStack(alignment: .leading, spacing: 3) {
                     Text("\(pr.weight.formattedWeight) lbs \u{00D7} \(pr.reps) reps")

--- a/Xomfit/Views/Profile/PrivateProfileView.swift
+++ b/Xomfit/Views/Profile/PrivateProfileView.swift
@@ -20,7 +20,7 @@ struct PrivateProfileView: View {
             XomAvatar(name: displayName.isEmpty ? username : initials, size: 80)
 
             // Name
-            VStack(spacing: 4) {
+            VStack(spacing: Theme.Spacing.tight) {
                 if !displayName.isEmpty {
                     Text(displayName)
                         .font(Theme.fontTitle2)

--- a/Xomfit/Views/Profile/ProfileCalendarView.swift
+++ b/Xomfit/Views/Profile/ProfileCalendarView.swift
@@ -112,7 +112,7 @@ struct ProfileCalendarView: View {
                 navigateMonth(by: -1)
             } label: {
                 Image(systemName: "chevron.left")
-                    .font(.body.weight(.semibold))
+                    .font(Theme.fontBodyEmphasized)
                     .foregroundStyle(Theme.accent)
                     .frame(width: 44, height: 44)
             }
@@ -130,7 +130,7 @@ struct ProfileCalendarView: View {
                 navigateMonth(by: 1)
             } label: {
                 Image(systemName: "chevron.right")
-                    .font(.body.weight(.semibold))
+                    .font(Theme.fontBodyEmphasized)
                     .foregroundStyle(canGoForwardMonth ? Theme.accent : Theme.textSecondary.opacity(0.3))
                     .frame(width: 44, height: 44)
             }
@@ -176,7 +176,7 @@ struct ProfileCalendarView: View {
                 selectedDate = IdentifiableDate(date: normalized)
             }
         } label: {
-            VStack(spacing: 2) {
+            VStack(spacing: Theme.Spacing.tighter) {
                 Text("\(dayNumber)")
                     .font(.subheadline.weight(count > 0 ? .bold : .regular))
                     .foregroundStyle(cellForeground(count: count, isToday: isToday))
@@ -306,7 +306,7 @@ struct ProfileCalendarView: View {
     }
 
     private func recapStat(label: String, value: String) -> some View {
-        VStack(alignment: .leading, spacing: 2) {
+        VStack(alignment: .leading, spacing: Theme.Spacing.tighter) {
             Text(label.uppercased())
                 .font(Theme.fontSmall)
                 .foregroundStyle(Theme.textSecondary)
@@ -390,7 +390,7 @@ struct ProfileCalendarView: View {
                         .id(weekIdx)
                     }
                 }
-                .padding(.vertical, 2)
+                .padding(.vertical, Theme.Spacing.tighter)
             }
             .onAppear {
                 // Scroll to the latest week so today is visible by default.
@@ -665,7 +665,7 @@ private struct CalendarDayDetailSheet: View {
                 } else if loadedWorkouts.isEmpty {
                     VStack(spacing: Theme.Spacing.sm) {
                         Image(systemName: "calendar.badge.exclamationmark")
-                            .font(.largeTitle)
+                            .font(Theme.fontLargeTitle)
                             .foregroundStyle(Theme.textSecondary)
                         Text("No workouts found")
                             .font(Theme.fontBody)
@@ -683,7 +683,7 @@ private struct CalendarDayDetailSheet: View {
                             } label: {
                                 HStack(spacing: 12) {
                                     Image(systemName: "dumbbell.fill")
-                                        .font(.body)
+                                        .font(Theme.fontBody)
                                         .foregroundStyle(Theme.accent)
                                         .frame(width: 36, height: 36)
                                         .background(Theme.accent.opacity(0.15))
@@ -693,7 +693,7 @@ private struct CalendarDayDetailSheet: View {
                                         Text(workout.name)
                                             .font(.subheadline.weight(.semibold))
                                             .foregroundStyle(Theme.textPrimary)
-                                        HStack(spacing: 8) {
+                                        HStack(spacing: Theme.Spacing.sm) {
                                             Text("\(workout.exercises.count) exercises")
                                             Text(workout.durationString)
                                                 .foregroundStyle(Theme.accent)

--- a/Xomfit/Views/Profile/ProfileFeedView.swift
+++ b/Xomfit/Views/Profile/ProfileFeedView.swift
@@ -23,7 +23,7 @@ struct ProfileFeedView: View {
             } else if isFiltered && filteredItems.isEmpty {
                 VStack(spacing: Theme.Spacing.sm) {
                     Image(systemName: "line.3.horizontal.decrease")
-                        .font(.largeTitle)
+                        .font(Theme.fontLargeTitle)
                         .foregroundStyle(Theme.textSecondary)
                     Text("No matching posts")
                         .font(Theme.fontBody)

--- a/Xomfit/Views/Profile/ProfileFriendsView.swift
+++ b/Xomfit/Views/Profile/ProfileFriendsView.swift
@@ -45,7 +45,7 @@ struct ProfileFriendsView: View {
         return HStack(spacing: Theme.Spacing.md) {
             XomAvatar(name: name, size: 40)
 
-            VStack(alignment: .leading, spacing: 2) {
+            VStack(alignment: .leading, spacing: Theme.Spacing.tighter) {
                 Text(name)
                     .font(.subheadline.weight(.semibold))
                     .foregroundStyle(Theme.textPrimary)
@@ -74,7 +74,7 @@ struct ProfileFriendsView: View {
     private var emptyState: some View {
         VStack(spacing: Theme.Spacing.sm) {
             Image(systemName: "person.2")
-                .font(.largeTitle)
+                .font(Theme.fontLargeTitle)
                 .foregroundStyle(Theme.textSecondary)
             Text("No friends yet")
                 .font(Theme.fontBody)

--- a/Xomfit/Views/Profile/ProfileHeaderView.swift
+++ b/Xomfit/Views/Profile/ProfileHeaderView.swift
@@ -44,7 +44,7 @@ struct ProfileHeaderView: View {
                         )
                         .hideTabBar()
                     } label: {
-                        VStack(spacing: 2) {
+                        VStack(spacing: Theme.Spacing.tighter) {
                             Text("\(friendCount)")
                                 .font(Theme.fontNumberLarge)
                                 .foregroundStyle(Theme.textPrimary)
@@ -68,7 +68,7 @@ struct ProfileHeaderView: View {
             }
 
             // Name + username + bio
-            VStack(alignment: .leading, spacing: 4) {
+            VStack(alignment: .leading, spacing: Theme.Spacing.tight) {
                 if !displayName.isEmpty {
                     Text(displayName)
                         .font(Theme.fontTitle2)
@@ -87,12 +87,12 @@ struct ProfileHeaderView: View {
                         .foregroundStyle(Theme.textSecondary)
                         .lineLimit(4)
                         .truncationMode(.tail)
-                        .padding(.top, 2)
+                        .padding(.top, Theme.Spacing.tighter)
                 }
 
                 if isPrivate && isOwnProfile {
                     XomBadge("Private Account", icon: "lock.fill", variant: .secondary)
-                        .padding(.top, 4)
+                        .padding(.top, Theme.Spacing.tight)
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -107,7 +107,7 @@ struct ProfileHeaderView: View {
 
     private func statColumn(value: Int, label: String, action: @escaping () -> Void) -> some View {
         Button(action: action) {
-            VStack(spacing: 2) {
+            VStack(spacing: Theme.Spacing.tighter) {
                 Text("\(value)")
                     .font(Theme.fontNumberLarge)
                     .foregroundStyle(Theme.textPrimary)

--- a/Xomfit/Views/Profile/ProfileStatsView.swift
+++ b/Xomfit/Views/Profile/ProfileStatsView.swift
@@ -90,13 +90,13 @@ struct ProfileStatsView: View {
                 XomCard {
                     HStack(spacing: Theme.Spacing.md) {
                         Image(systemName: "ruler")
-                            .font(.title3)
+                            .font(Theme.fontTitle3)
                             .foregroundStyle(Theme.accent)
-                            .frame(width: 32, height: 32)
+                            .frame(width: Theme.Spacing.xl, height: Theme.Spacing.xl)
                             .background(Theme.accentMuted)
                             .clipShape(Circle())
 
-                        VStack(alignment: .leading, spacing: 2) {
+                        VStack(alignment: .leading, spacing: Theme.Spacing.tighter) {
                             Text("Body")
                                 .font(Theme.fontSubheadline.weight(.semibold))
                                 .foregroundStyle(Theme.textPrimary)
@@ -135,9 +135,9 @@ struct ProfileStatsView: View {
 
     private func countUpStatCard(icon: String, count: Int, label: String, iconColor: Color) -> some View {
         XomCard(padding: Theme.Spacing.sm) {
-            VStack(spacing: 4) {
+            VStack(spacing: Theme.Spacing.tight) {
                 Image(systemName: icon)
-                    .font(.headline)
+                    .font(Theme.fontHeadline)
                     .foregroundStyle(iconColor)
                 CountUpNumber(target: count)
                 XomMetricLabel(label)
@@ -205,7 +205,7 @@ struct ProfileStatsView: View {
     }
 
     private func consistencyBar(count: Int, maxCount: Int) -> some View {
-        VStack(spacing: 4) {
+        VStack(spacing: Theme.Spacing.tight) {
             GeometryReader { proxy in
                 VStack {
                     Spacer(minLength: 0)
@@ -360,7 +360,7 @@ struct ProfileStatsView: View {
     private var emptyState: some View {
         VStack(spacing: Theme.Spacing.sm) {
             Image(systemName: "trophy")
-                .font(.largeTitle)
+                .font(Theme.fontLargeTitle)
                 .foregroundStyle(Theme.textSecondary)
             Text("No PRs yet")
                 .font(Theme.fontBody)

--- a/Xomfit/Views/Profile/ProfileTabPicker.swift
+++ b/Xomfit/Views/Profile/ProfileTabPicker.swift
@@ -15,10 +15,10 @@ struct ProfileTabPicker: View {
                     } label: {
                         VStack(spacing: Theme.Spacing.xs) {
                             Image(systemName: tab.icon)
-                                .font(.headline)
+                                .font(Theme.fontHeadline)
                                 // Active: textPrimary. Inactive: textSecondary. Accent is reserved for the underline only.
                                 .foregroundStyle(selectedTab == tab ? Theme.textPrimary : Theme.textSecondary)
-                                .frame(height: 24)
+                                .frame(height: Theme.Spacing.lg)
 
                             Text(tab.label)
                                 .font(Theme.fontSmall)

--- a/Xomfit/Views/Profile/ProfileView.swift
+++ b/Xomfit/Views/Profile/ProfileView.swift
@@ -219,7 +219,7 @@ struct ProfileView: View {
                 // Only own profile gets the Body link — measurements are private to the user.
                 userId: viewModel.isOwnProfile ? resolvedUserId : nil,
                 workouts: viewModel.workouts,
-                firstPRDate: viewModel.allPRs.map(\.date).min()
+                firstPRDate: viewModel.allPRs.map(\.date).min(),
                 onStartWorkout: statsEmptyStateAction
             )
         }
@@ -247,7 +247,7 @@ struct ProfileView: View {
     @ToolbarContentBuilder
     private var ownProfileToolbar: some ToolbarContent {
         ToolbarItem(placement: .topBarTrailing) {
-            HStack(spacing: 16) {
+            HStack(spacing: Theme.Spacing.md) {
                 NavigationLink {
                     AICoachView()
                         .hideTabBar()

--- a/Xomfit/Views/Profile/ProfileWorkoutListView.swift
+++ b/Xomfit/Views/Profile/ProfileWorkoutListView.swift
@@ -24,7 +24,7 @@ struct ProfileWorkoutListView: View {
             } else if isFiltered && workouts.isEmpty {
                 VStack(spacing: Theme.Spacing.sm) {
                     Image(systemName: "line.3.horizontal.decrease")
-                        .font(.largeTitle)
+                        .font(Theme.fontLargeTitle)
                         .foregroundStyle(Theme.textSecondary)
                     Text("No matching workouts")
                         .font(Theme.fontBody)
@@ -67,7 +67,7 @@ struct ProfileWorkoutListView: View {
     private func workoutCard(_ workout: Workout) -> some View {
         VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
             HStack {
-                VStack(alignment: .leading, spacing: 4) {
+                VStack(alignment: .leading, spacing: Theme.Spacing.tight) {
                     Text(workout.name)
                         .font(.subheadline.weight(.bold))
                         .foregroundStyle(Theme.textPrimary)
@@ -80,19 +80,19 @@ struct ProfileWorkoutListView: View {
                     .font(.caption.weight(.bold).monospaced())
                     .foregroundStyle(Theme.accent)
                     .padding(.horizontal, 10)
-                    .padding(.vertical, 4)
+                    .padding(.vertical, Theme.Spacing.tight)
                     .background(Theme.accent.opacity(0.12))
                     .clipShape(.rect(cornerRadius: 6))
             }
 
-            HStack(spacing: 16) {
+            HStack(spacing: Theme.Spacing.md) {
                 statLabel(value: "\(workout.exercises.count)", label: "exercises")
                 statLabel(value: "\(workout.totalSets)", label: "sets")
                 statLabel(value: workout.formattedVolume, label: "lbs")
                 if workout.totalPRs > 0 {
                     HStack(spacing: 3) {
                         Image(systemName: "trophy.fill")
-                            .font(.caption2)
+                            .font(Theme.fontCaption2)
                         Text("\(workout.totalPRs) PRs")
                             .font(Theme.fontCaption)
                     }
@@ -101,13 +101,13 @@ struct ProfileWorkoutListView: View {
             }
 
             if !workout.muscleGroups.isEmpty {
-                HStack(spacing: 4) {
+                HStack(spacing: Theme.Spacing.tight) {
                     ForEach(workout.muscleGroups.prefix(4), id: \.self) { mg in
                         Text(mg.displayName)
                             .font(.caption2.weight(.medium))
                             .foregroundStyle(Theme.textSecondary)
                             .padding(.horizontal, 6)
-                            .padding(.vertical, 2)
+                            .padding(.vertical, Theme.Spacing.tighter)
                             .background(Theme.surfaceSecondary)
                             .clipShape(.rect(cornerRadius: 4))
                     }
@@ -133,7 +133,7 @@ struct ProfileWorkoutListView: View {
     private var emptyState: some View {
         VStack(spacing: Theme.Spacing.sm) {
             Image(systemName: "figure.strengthtraining.traditional")
-                .font(.largeTitle)
+                .font(Theme.fontLargeTitle)
                 .foregroundStyle(Theme.textSecondary)
             Text("No workouts yet")
                 .font(Theme.fontBody)

--- a/Xomfit/Views/Profile/SettingsView.swift
+++ b/Xomfit/Views/Profile/SettingsView.swift
@@ -137,9 +137,9 @@ struct SettingsView: View {
             Toggle(isOn: workoutRemindersBinding) {
                 HStack(spacing: Theme.Spacing.md) {
                     Image(systemName: "alarm.fill")
-                        .frame(width: 24)
+                        .frame(width: Theme.Spacing.lg)
                         .foregroundStyle(Theme.accent)
-                    VStack(alignment: .leading, spacing: 2) {
+                    VStack(alignment: .leading, spacing: Theme.Spacing.tighter) {
                         Text("Workout reminders")
                             .foregroundStyle(Theme.textPrimary)
                         if !notificationsAuthorized {
@@ -158,7 +158,7 @@ struct SettingsView: View {
             } label: {
                 HStack(spacing: Theme.Spacing.md) {
                     Image(systemName: "bell.fill")
-                        .frame(width: 24)
+                        .frame(width: Theme.Spacing.lg)
                         .foregroundStyle(Theme.accent)
                     Text("Notification Settings")
                         .foregroundStyle(Theme.textPrimary)
@@ -177,7 +177,7 @@ struct SettingsView: View {
             // Weight unit
             HStack(spacing: Theme.Spacing.md) {
                 Image(systemName: "scalemass.fill")
-                    .frame(width: 24)
+                    .frame(width: Theme.Spacing.lg)
                     .foregroundStyle(Theme.accent)
                 Text("Weight unit")
                     .foregroundStyle(Theme.textPrimary)
@@ -194,7 +194,7 @@ struct SettingsView: View {
             // Default rest duration (seconds)
             HStack(spacing: Theme.Spacing.md) {
                 Image(systemName: "timer")
-                    .frame(width: 24)
+                    .frame(width: Theme.Spacing.lg)
                     .foregroundStyle(Theme.accent)
                 Stepper(value: $restDurationSeconds, in: 30...600, step: 15) {
                     HStack {
@@ -214,7 +214,7 @@ struct SettingsView: View {
             // Week start day
             HStack(spacing: Theme.Spacing.md) {
                 Image(systemName: "calendar")
-                    .frame(width: 24)
+                    .frame(width: Theme.Spacing.lg)
                     .foregroundStyle(Theme.accent)
                 Text("Week starts on")
                     .foregroundStyle(Theme.textPrimary)
@@ -231,7 +231,7 @@ struct SettingsView: View {
             // Theme
             HStack(spacing: Theme.Spacing.md) {
                 Image(systemName: "paintbrush.fill")
-                    .frame(width: 24)
+                    .frame(width: Theme.Spacing.lg)
                     .foregroundStyle(Theme.accent)
                 Text("Theme")
                     .foregroundStyle(Theme.textPrimary)
@@ -262,7 +262,7 @@ struct SettingsView: View {
             } label: {
                 HStack(spacing: Theme.Spacing.md) {
                     Image(systemName: "target")
-                        .frame(width: 24)
+                        .frame(width: Theme.Spacing.lg)
                         .foregroundStyle(Theme.accent)
                     Text("Fitness Goals")
                         .foregroundStyle(Theme.textPrimary)
@@ -281,7 +281,7 @@ struct SettingsView: View {
             } label: {
                 HStack(spacing: Theme.Spacing.md) {
                     Image(systemName: "doc.text.magnifyingglass")
-                        .frame(width: 24)
+                        .frame(width: Theme.Spacing.lg)
                         .foregroundStyle(Theme.accent)
                     Text("Reports")
                         .foregroundStyle(Theme.textPrimary)
@@ -303,7 +303,7 @@ struct SettingsView: View {
             } label: {
                 HStack(spacing: Theme.Spacing.md) {
                     Image(systemName: "sparkles")
-                        .frame(width: 24)
+                        .frame(width: Theme.Spacing.lg)
                         .foregroundStyle(Theme.accent)
                     Text("AI Coach")
                         .foregroundStyle(Theme.textPrimary)
@@ -313,7 +313,7 @@ struct SettingsView: View {
 
             HStack(spacing: Theme.Spacing.md) {
                 Image(systemName: "key.fill")
-                    .frame(width: 24)
+                    .frame(width: Theme.Spacing.lg)
                     .foregroundStyle(Theme.accent)
                 SecureField("Anthropic API Key", text: $anthropicAPIKey)
                     .foregroundStyle(Theme.textPrimary)
@@ -341,7 +341,7 @@ struct SettingsView: View {
             } label: {
                 HStack(spacing: Theme.Spacing.md) {
                     Image(systemName: "square.and.arrow.up")
-                        .frame(width: 24)
+                        .frame(width: Theme.Spacing.lg)
                         .foregroundStyle(Theme.accent)
                     Text("Export workouts")
                         .foregroundStyle(Theme.textPrimary)
@@ -360,7 +360,7 @@ struct SettingsView: View {
             } label: {
                 HStack(spacing: Theme.Spacing.md) {
                     Image(systemName: "trash.fill")
-                        .frame(width: 24)
+                        .frame(width: Theme.Spacing.lg)
                         .foregroundStyle(Theme.destructive)
                     Text("Delete account")
                         .foregroundStyle(Theme.destructive)
@@ -380,7 +380,7 @@ struct SettingsView: View {
             } label: {
                 HStack(spacing: Theme.Spacing.md) {
                     Image(systemName: "envelope.open.fill")
-                        .frame(width: 24)
+                        .frame(width: Theme.Spacing.lg)
                         .foregroundStyle(Theme.accent)
                     Text("Send feedback")
                         .foregroundStyle(Theme.textPrimary)
@@ -393,7 +393,7 @@ struct SettingsView: View {
             } label: {
                 HStack(spacing: Theme.Spacing.md) {
                     Image(systemName: "star.fill")
-                        .frame(width: 24)
+                        .frame(width: Theme.Spacing.lg)
                         .foregroundStyle(Theme.prGold)
                     Text("Rate XomFit")
                         .foregroundStyle(Theme.textPrimary)
@@ -404,13 +404,13 @@ struct SettingsView: View {
             Link(destination: URL(string: "https://xomware.com/privacy")!) {
                 HStack(spacing: Theme.Spacing.md) {
                     Image(systemName: "lock.shield.fill")
-                        .frame(width: 24)
+                        .frame(width: Theme.Spacing.lg)
                         .foregroundStyle(Theme.accent)
                     Text("Privacy Policy")
                         .foregroundStyle(Theme.textPrimary)
                     Spacer()
                     Image(systemName: "arrow.up.right.square")
-                        .font(.caption)
+                        .font(Theme.fontCaption)
                         .foregroundStyle(Theme.textTertiary)
                 }
             }
@@ -440,7 +440,7 @@ struct SettingsView: View {
             } label: {
                 HStack(spacing: Theme.Spacing.md) {
                     Image(systemName: "rectangle.portrait.and.arrow.right")
-                        .frame(width: 24)
+                        .frame(width: Theme.Spacing.lg)
                         .foregroundStyle(Theme.destructive)
                     Text("Sign Out")
                         .foregroundStyle(Theme.destructive)
@@ -493,7 +493,7 @@ struct SettingsView: View {
     private func settingsRow(icon: String, iconColor: Color, label: String, value: String) -> some View {
         HStack(spacing: Theme.Spacing.md) {
             Image(systemName: icon)
-                .frame(width: 24)
+                .frame(width: Theme.Spacing.lg)
                 .foregroundStyle(iconColor)
             Text(label)
                 .foregroundStyle(Theme.textPrimary)
@@ -626,7 +626,7 @@ extension SettingsView {
     fileprivate func toolRow(icon: String, label: String) -> some View {
         HStack(spacing: Theme.Spacing.md) {
             Image(systemName: icon)
-                .frame(width: 24)
+                .frame(width: Theme.Spacing.lg)
                 .foregroundStyle(Theme.accent)
             Text(label)
                 .foregroundStyle(Theme.textPrimary)

--- a/Xomfit/Views/Profile/StreakCard.swift
+++ b/Xomfit/Views/Profile/StreakCard.swift
@@ -34,12 +34,12 @@ struct StreakCard: View {
                         .fill(iconColor.opacity(0.15))
                         .frame(width: 44, height: 44)
                     Image(systemName: "flame.fill")
-                        .font(.title3)
+                        .font(Theme.fontTitle3)
                         .foregroundStyle(iconColor)
                         .symbolEffect(.bounce, value: currentStreak)
                 }
 
-                VStack(alignment: .leading, spacing: 2) {
+                VStack(alignment: .leading, spacing: Theme.Spacing.tighter) {
                     Text(headlineText)
                         .font(.headline.weight(.bold))
                         .foregroundStyle(Theme.textPrimary)
@@ -60,7 +60,7 @@ struct StreakCard: View {
 }
 
 #Preview {
-    VStack(spacing: 16) {
+    VStack(spacing: Theme.Spacing.md) {
         StreakCard(currentStreak: 7, longestStreak: 12)
         StreakCard(currentStreak: 1, longestStreak: 12)
         StreakCard(currentStreak: 0, longestStreak: 12)

--- a/Xomfit/Views/Profile/TopExerciseRow.swift
+++ b/Xomfit/Views/Profile/TopExerciseRow.swift
@@ -31,7 +31,7 @@ struct TopExerciseRow: View {
 
                 Spacer()
 
-                VStack(alignment: .trailing, spacing: 2) {
+                VStack(alignment: .trailing, spacing: Theme.Spacing.tighter) {
                     Text("\(formattedVolume) lbs")
                         .font(Theme.fontNumberMedium)
                         .foregroundStyle(Theme.textPrimary)
@@ -49,7 +49,7 @@ struct TopExerciseRow: View {
                         .frame(width: proxy.size.width * fillFraction)
                 }
             }
-            .frame(height: 4)
+            .frame(height: Theme.Spacing.tight)
         }
         .padding(.horizontal, Theme.Spacing.sm)
         .padding(.vertical, Theme.Spacing.xs)

--- a/Xomfit/Views/Profile/VolumeTrendChart.swift
+++ b/Xomfit/Views/Profile/VolumeTrendChart.swift
@@ -63,7 +63,7 @@ struct VolumeTrendChart: View {
                     AxisValueLabel {
                         if let v = value.as(Double.self) {
                             Text(formattedVolume(v))
-                                .font(.caption2)
+                                .font(Theme.fontCaption2)
                                 .foregroundStyle(Theme.textTertiary)
                         }
                     }
@@ -72,7 +72,7 @@ struct VolumeTrendChart: View {
             .chartXAxis {
                 AxisMarks { _ in
                     AxisValueLabel()
-                        .font(.caption2)
+                        .font(Theme.fontCaption2)
                         .foregroundStyle(Theme.textTertiary)
                 }
             }

--- a/Xomfit/Views/Profile/WorkoutHistorySearchView.swift
+++ b/Xomfit/Views/Profile/WorkoutHistorySearchView.swift
@@ -71,7 +71,7 @@ struct WorkoutHistorySearchView: View {
     private var emptyState: some View {
         VStack(spacing: Theme.Spacing.sm) {
             Image(systemName: "magnifyingglass")
-                .font(.largeTitle)
+                .font(Theme.fontLargeTitle)
                 .foregroundStyle(Theme.textTertiary)
             Text("No matching workouts. Try a broader filter.")
                 .font(Theme.fontBody)

--- a/Xomfit/Views/Progress/LeaderboardView.swift
+++ b/Xomfit/Views/Progress/LeaderboardView.swift
@@ -67,9 +67,9 @@ struct LeaderboardView: View {
     // MARK: - Filter Bar
 
     private var filterBar: some View {
-        VStack(spacing: 8) {
+        VStack(spacing: Theme.Spacing.sm) {
             // Metric + Timeframe row
-            HStack(spacing: 8) {
+            HStack(spacing: Theme.Spacing.sm) {
                 filterMenu(
                     label: viewModel.selectedMetric.rawValue,
                     icon: "chart.bar.fill"
@@ -174,7 +174,7 @@ struct LeaderboardView: View {
     private func podiumColumn(entry: LeaderboardEntry, height: CGFloat) -> some View {
         VStack(spacing: Theme.Spacing.xs) {
             Text(entry.badge ?? "")
-                .font(.title)
+                .font(Theme.fontTitle)
 
             XomAvatar(name: entry.displayName, size: entry.rank == 1 ? 56 : 44)
 
@@ -220,7 +220,7 @@ struct LeaderboardView: View {
 
                 XomAvatar(name: entry.displayName, size: 40)
 
-                VStack(alignment: .leading, spacing: 2) {
+                VStack(alignment: .leading, spacing: Theme.Spacing.tighter) {
                     Text(entry.displayName)
                         .font(.subheadline.weight(isCurrentUser ? .bold : .medium))
                         .foregroundStyle(isCurrentUser ? Theme.textPrimary : Theme.textPrimary)
@@ -256,9 +256,9 @@ struct LeaderboardView: View {
         Menu {
             content()
         } label: {
-            HStack(spacing: 4) {
+            HStack(spacing: Theme.Spacing.tight) {
                 Image(systemName: icon)
-                    .font(.caption2)
+                    .font(Theme.fontCaption2)
                 Text(label)
                     .font(.caption.weight(.semibold))
                 Image(systemName: "chevron.down")

--- a/Xomfit/Views/Progress/XomProgressView.swift
+++ b/Xomfit/Views/Progress/XomProgressView.swift
@@ -109,9 +109,9 @@ private struct CountUpStatCard: View {
 
     var body: some View {
         XomCard(padding: Theme.Spacing.sm) {
-            VStack(spacing: 4) {
+            VStack(spacing: Theme.Spacing.tight) {
                 Image(systemName: icon)
-                    .font(.headline)
+                    .font(Theme.fontHeadline)
                     .foregroundStyle(iconColor)
                 CountUpNumber(target: count)
                 XomMetricLabel(label)
@@ -164,11 +164,11 @@ private struct LiftProgressionChart: View {
                             }
                         }
                     } label: {
-                        HStack(spacing: 4) {
+                        HStack(spacing: Theme.Spacing.tight) {
                             Text(selectedExercise)
                                 .font(Theme.fontCaption)
                             Image(systemName: "chevron.up.chevron.down")
-                                .font(.caption2)
+                                .font(Theme.fontCaption2)
                         }
                         .foregroundStyle(Theme.accent)
                     }

--- a/Xomfit/Views/Reports/ReportDetailView.swift
+++ b/Xomfit/Views/Reports/ReportDetailView.swift
@@ -178,14 +178,14 @@ struct ReportDetailView: View {
             Text("\(rank)")
                 .font(.subheadline.weight(.bold).monospacedDigit())
                 .foregroundStyle(Theme.accent)
-                .frame(width: 24)
+                .frame(width: Theme.Spacing.lg)
 
-            VStack(alignment: .leading, spacing: 2) {
+            VStack(alignment: .leading, spacing: Theme.Spacing.tighter) {
                 Text(exercise.name)
                     .font(.subheadline.weight(.semibold))
                     .foregroundStyle(Theme.textPrimary)
                 Text("\(exercise.sets) set\(exercise.sets == 1 ? "" : "s")")
-                    .font(.caption)
+                    .font(Theme.fontCaption)
                     .foregroundStyle(Theme.textTertiary)
             }
 
@@ -223,9 +223,9 @@ struct ReportDetailView: View {
     private func newPRRow(_ pr: UserReport.NewPR) -> some View {
         HStack(spacing: Theme.Spacing.md) {
             Image(systemName: "trophy.fill")
-                .font(.body.weight(.semibold))
+                .font(Theme.fontBodyEmphasized)
                 .foregroundStyle(Theme.prGold)
-                .frame(width: 24)
+                .frame(width: Theme.Spacing.lg)
 
             Text(pr.exercise)
                 .font(.subheadline.weight(.semibold))

--- a/Xomfit/Views/Reports/ReportsListView.swift
+++ b/Xomfit/Views/Reports/ReportsListView.swift
@@ -171,7 +171,7 @@ private struct ReportRow: View {
                     .fill(Theme.accentMuted)
                     .frame(width: 36, height: 36)
                 Image(systemName: iconName)
-                    .font(.body.weight(.semibold))
+                    .font(Theme.fontBodyEmphasized)
                     .foregroundStyle(Theme.accent)
             }
 
@@ -183,13 +183,13 @@ private struct ReportRow: View {
                     if isUnread {
                         Circle()
                             .fill(Theme.accent)
-                            .frame(width: 8, height: 8)
+                            .frame(width: Theme.Spacing.sm, height: Theme.Spacing.sm)
                             .accessibilityLabel("Unread")
                     }
                 }
 
                 Text(excerpt)
-                    .font(.footnote)
+                    .font(Theme.fontFootnote)
                     .foregroundStyle(Theme.textSecondary)
                     .lineLimit(2)
                     .multilineTextAlignment(.leading)
@@ -197,7 +197,7 @@ private struct ReportRow: View {
 
             Spacer(minLength: 0)
         }
-        .padding(.vertical, 4)
+        .padding(.vertical, Theme.Spacing.tight)
         .accessibilityElement(children: .combine)
         .accessibilityLabel(
             "\(report.kind.rawValue.capitalized) report, \(dateRangeText)\(isUnread ? ", unread" : "")"

--- a/Xomfit/Views/Shared/PRBadgeRow.swift
+++ b/Xomfit/Views/Shared/PRBadgeRow.swift
@@ -7,7 +7,7 @@ struct PRBadgeRow: View {
         HStack(spacing: Theme.Spacing.sm) {
             Image(systemName: "trophy.fill")
                 .foregroundStyle(Theme.prGold)
-                .font(.subheadline)
+                .font(Theme.fontSubheadline)
                 .frame(width: 20)
 
             Text(pr.exerciseName)

--- a/Xomfit/Views/Tools/OneRMEstimatorView.swift
+++ b/Xomfit/Views/Tools/OneRMEstimatorView.swift
@@ -137,7 +137,7 @@ struct OneRMEstimatorView: View {
 
     private func estimateRow(name: String, value: Double, note: String) -> some View {
         HStack(alignment: .firstTextBaseline, spacing: Theme.Spacing.md) {
-            VStack(alignment: .leading, spacing: 2) {
+            VStack(alignment: .leading, spacing: Theme.Spacing.tighter) {
                 Text(name)
                     .font(.subheadline.weight(.semibold))
                     .foregroundStyle(Theme.textPrimary)
@@ -186,7 +186,7 @@ struct OneRMEstimatorView: View {
     // MARK: - Helpers
 
     private func inputField(label: String, text: Binding<String>, keyboard: UIKeyboardType) -> some View {
-        VStack(alignment: .leading, spacing: 4) {
+        VStack(alignment: .leading, spacing: Theme.Spacing.tight) {
             Text(label.uppercased())
                 .font(.caption2.weight(.semibold))
                 .foregroundStyle(Theme.textTertiary)

--- a/Xomfit/Views/Tools/PlateCalculatorView.swift
+++ b/Xomfit/Views/Tools/PlateCalculatorView.swift
@@ -108,7 +108,7 @@ struct PlateCalculatorView: View {
                         Text("\(w.formattedWeight)")
                             .font(.subheadline.weight(.semibold).monospacedDigit())
                             .foregroundStyle(barWeight == w && !useCustomBar ? .black : Theme.textPrimary)
-                            .padding(.vertical, 8)
+                            .padding(.vertical, Theme.Spacing.sm)
                             .frame(maxWidth: .infinity)
                             .background(barWeight == w && !useCustomBar ? Theme.accent : Theme.surfaceElevated)
                             .clipShape(.rect(cornerRadius: Theme.cornerRadiusSmall))
@@ -124,7 +124,7 @@ struct PlateCalculatorView: View {
                     Text("Custom")
                         .font(.subheadline.weight(.semibold))
                         .foregroundStyle(useCustomBar ? .black : Theme.textPrimary)
-                        .padding(.vertical, 8)
+                        .padding(.vertical, Theme.Spacing.sm)
                         .frame(maxWidth: .infinity)
                         .background(useCustomBar ? Theme.accent : Theme.surfaceElevated)
                         .clipShape(.rect(cornerRadius: Theme.cornerRadiusSmall))
@@ -220,7 +220,7 @@ struct PlateCalculatorView: View {
 
     private var plateStackVisualization: some View {
         ScrollView(.horizontal, showsIndicators: false) {
-            HStack(alignment: .center, spacing: 4) {
+            HStack(alignment: .center, spacing: Theme.Spacing.tight) {
                 // Bar nub
                 Rectangle()
                     .fill(Theme.textTertiary)
@@ -300,7 +300,7 @@ struct PlateCalculatorView: View {
     }
 
     private func summaryStat(label: String, value: String) -> some View {
-        VStack(alignment: .leading, spacing: 2) {
+        VStack(alignment: .leading, spacing: Theme.Spacing.tighter) {
             Text(label.uppercased())
                 .font(.caption2.weight(.semibold))
                 .foregroundStyle(Theme.textTertiary)
@@ -401,7 +401,7 @@ private struct FlowChipRow: View {
                             .font(.caption.weight(.semibold).monospacedDigit())
                             .foregroundStyle(isSelected ? .black : Theme.textPrimary)
                             .padding(.horizontal, Theme.Spacing.md)
-                            .padding(.vertical, 8)
+                            .padding(.vertical, Theme.Spacing.sm)
                             .background(isSelected ? Theme.accent : Theme.surfaceElevated)
                             .clipShape(.capsule)
                             .overlay(

--- a/Xomfit/Views/Workout/ActiveWorkoutView.swift
+++ b/Xomfit/Views/Workout/ActiveWorkoutView.swift
@@ -193,7 +193,7 @@ struct ActiveWorkoutView: View {
             // existing top safe-area, an active island (e.g. music app) can still
             // occlude the workout header — bump everything down deterministically.
             .safeAreaInset(edge: .top, spacing: 0) {
-                Color.clear.frame(height: 8)
+                Color.clear.frame(height: Theme.Spacing.sm)
             }
             .safeAreaInset(edge: .bottom, spacing: 0) {
                 // Empty — just ensures keyboard inset is respected; actual toolbar is above
@@ -290,7 +290,7 @@ struct ActiveWorkoutView: View {
                                         .foregroundStyle(Theme.textPrimary)
                                     Spacer()
                                     Text("\(remaining) sets left")
-                                        .font(.caption)
+                                        .font(Theme.fontCaption)
                                         .foregroundStyle(Theme.textSecondary)
                                 }
                             }
@@ -351,11 +351,11 @@ struct ActiveWorkoutView: View {
 
             // Timer cluster — total time prominent + rest timer chip so both stay visible
             // around the Dynamic Island. Name is secondary (can be hidden by island).
-            VStack(spacing: 2) {
+            VStack(spacing: Theme.Spacing.tighter) {
                 HStack(spacing: 6) {
                     HStack(spacing: 3) {
                         Image(systemName: "clock.fill")
-                            .font(.caption2)
+                            .font(Theme.fontCaption2)
                         Text(viewModel.durationString)
                             .font(Theme.fontNumberMedium)
                             .lineLimit(1)
@@ -368,7 +368,7 @@ struct ActiveWorkoutView: View {
                         let isOvertime = viewModel.restTimeRemaining <= 0
                         HStack(spacing: 3) {
                             Image(systemName: "timer")
-                                .font(.caption2)
+                                .font(Theme.fontCaption2)
                             Text(headerRestString)
                                 .font(Theme.fontNumberMedium)
                                 .lineLimit(1)
@@ -377,7 +377,7 @@ struct ActiveWorkoutView: View {
                         }
                         .foregroundStyle(isOvertime ? Theme.destructive : Theme.textPrimary)
                         .padding(.horizontal, 7)
-                        .padding(.vertical, 2)
+                        .padding(.vertical, Theme.Spacing.tighter)
                         .background(
                             Capsule()
                                 .fill((isOvertime ? Theme.destructive : Theme.accent).opacity(0.15))
@@ -429,7 +429,7 @@ struct ActiveWorkoutView: View {
                 Image(systemName: viewModel.focusMode ? "list.bullet" : "eye")
                     .font(.subheadline.weight(.semibold))
                     .foregroundStyle(viewModel.focusMode ? Theme.accent : Theme.textSecondary)
-                    .frame(width: 32, height: 32)
+                    .frame(width: Theme.Spacing.xl, height: Theme.Spacing.xl)
                     .background(viewModel.focusMode ? Theme.accent.opacity(0.15) : Theme.textSecondary.opacity(0.15))
                     .clipShape(Circle())
                     .frame(width: 44, height: 44)
@@ -668,10 +668,10 @@ private struct PRCelebrationBanner: View {
     var body: some View {
         HStack(spacing: Theme.Spacing.md) {
             Image(systemName: "trophy.fill")
-                .font(.title3)
+                .font(Theme.fontTitle3)
                 .foregroundStyle(.black)
 
-            VStack(alignment: .leading, spacing: 2) {
+            VStack(alignment: .leading, spacing: Theme.Spacing.tighter) {
                 Text("New Personal Record!")
                     .font(.subheadline.weight(.black))
                     .foregroundStyle(.black)
@@ -743,7 +743,7 @@ private struct ExerciseCard: View {
                                 .font(.caption2.weight(.black))
                                 .foregroundStyle(.black)
                                 .padding(.horizontal, 6)
-                                .padding(.vertical, 2)
+                                .padding(.vertical, Theme.Spacing.tighter)
                                 .background(Theme.accent)
                                 .clipShape(.capsule)
                                 .accessibilityLabel("Superset \(letter)")
@@ -752,13 +752,13 @@ private struct ExerciseCard: View {
                             .font(.body.weight(.bold))
                             .foregroundStyle(Theme.textPrimary)
                     }
-                    HStack(spacing: 4) {
+                    HStack(spacing: Theme.Spacing.tight) {
                         ForEach(exercise.exercise.muscleGroups.prefix(2), id: \.self) { mg in
                             Text(mg.displayName)
                                 .font(Theme.fontSmall)
                                 .foregroundStyle(Theme.accent)
                                 .padding(.horizontal, 6)
-                                .padding(.vertical, 2)
+                                .padding(.vertical, Theme.Spacing.tighter)
                                 .background(Theme.accent.opacity(0.15))
                                 .clipShape(.rect(cornerRadius: 4))
                         }
@@ -772,7 +772,7 @@ private struct ExerciseCard: View {
                     Image(systemName: "info.circle")
                         .font(.subheadline.weight(.semibold))
                         .foregroundStyle(Theme.textSecondary)
-                        .frame(width: 32, height: 32)
+                        .frame(width: Theme.Spacing.xl, height: Theme.Spacing.xl)
                         .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
@@ -864,15 +864,15 @@ private struct ExerciseCard: View {
 
             // Laterality badge
             if exercise.exercise.supportsUnilateral && exercise.selectedLaterality != .bilateral {
-                HStack(spacing: 4) {
+                HStack(spacing: Theme.Spacing.tight) {
                     Image(systemName: "arrow.left.and.right")
-                        .font(.caption2)
+                        .font(Theme.fontCaption2)
                     Text(exercise.selectedLaterality.displayName)
                         .font(.caption2.weight(.semibold))
                 }
                 .foregroundStyle(Theme.accent)
                 .padding(.horizontal, 6)
-                .padding(.vertical, 2)
+                .padding(.vertical, Theme.Spacing.tighter)
                 .background(Theme.accent.opacity(0.15))
                 .clipShape(.capsule)
             }
@@ -882,7 +882,7 @@ private struct ExerciseCard: View {
                 HStack(spacing: Theme.Spacing.sm) {
                     Spacer().frame(width: 30) // delete button spacer
                     Text("SET")
-                        .frame(width: 24)
+                        .frame(width: Theme.Spacing.lg)
                     Spacer()
                     Text("WEIGHT")
                         .frame(maxWidth: .infinity)
@@ -952,7 +952,7 @@ private struct ExerciseCard: View {
                 .background(Theme.accent.opacity(0.08))
                 .clipShape(.rect(cornerRadius: Theme.cornerRadiusSmall))
             }
-            .padding(.top, 4)
+            .padding(.top, Theme.Spacing.tight)
         }
         .padding(Theme.Spacing.md)
         .background(Theme.surface)
@@ -961,7 +961,7 @@ private struct ExerciseCard: View {
             if isInSuperset {
                 Rectangle()
                     .fill(Theme.accent)
-                    .frame(width: 4)
+                    .frame(width: Theme.Spacing.tight)
                     .accessibilityHidden(true)
             }
         }
@@ -1039,7 +1039,7 @@ private struct ExerciseTransitionCard: View {
             // Header: completed exercise name
             HStack(spacing: Theme.Spacing.sm) {
                 Image(systemName: "checkmark.circle.fill")
-                    .font(.title2)
+                    .font(Theme.fontTitle2)
                     .foregroundStyle(Theme.accent)
                 Text("\(viewModel.completedExerciseName) Complete")
                     .font(.headline.weight(.bold))
@@ -1062,7 +1062,7 @@ private struct ExerciseTransitionCard: View {
             Button {
                 withAnimation { viewModel.addAnotherSet() }
             } label: {
-                HStack(spacing: 8) {
+                HStack(spacing: Theme.Spacing.sm) {
                     Image(systemName: "plus")
                         .font(.subheadline.weight(.bold))
                     Text("Do Another Set")
@@ -1084,8 +1084,8 @@ private struct ExerciseTransitionCard: View {
                 Button {
                     withAnimation { viewModel.moveToExercise(index: nextIdx) }
                 } label: {
-                    VStack(spacing: 4) {
-                        HStack(spacing: 8) {
+                    VStack(spacing: Theme.Spacing.tight) {
+                        HStack(spacing: Theme.Spacing.sm) {
                             Image(systemName: "arrow.right")
                                 .font(.subheadline.weight(.bold))
                             Text("Move to \(nextEx.exercise.name)")
@@ -1110,7 +1110,7 @@ private struct ExerciseTransitionCard: View {
                 VStack(spacing: Theme.Spacing.sm) {
                     HStack(spacing: 6) {
                         Image(systemName: "trophy.fill")
-                            .font(.body)
+                            .font(Theme.fontBody)
                             .foregroundStyle(Theme.accent)
                         Text("All exercises complete!")
                             .font(.subheadline.weight(.bold))
@@ -1118,7 +1118,7 @@ private struct ExerciseTransitionCard: View {
                     }
 
                     Text("Add another exercise or finish your workout.")
-                        .font(.caption)
+                        .font(Theme.fontCaption)
                         .foregroundStyle(Theme.textSecondary)
 
                     // Add Exercise
@@ -1127,7 +1127,7 @@ private struct ExerciseTransitionCard: View {
                             withAnimation { viewModel.dismissTransition() }
                             onAddExercise()
                         } label: {
-                            HStack(spacing: 8) {
+                            HStack(spacing: Theme.Spacing.sm) {
                                 Image(systemName: "plus")
                                     .font(.subheadline.weight(.bold))
                                 Text("Add Exercise")
@@ -1150,7 +1150,7 @@ private struct ExerciseTransitionCard: View {
                             withAnimation { viewModel.dismissTransition() }
                             onFinishWorkout()
                         } label: {
-                            HStack(spacing: 8) {
+                            HStack(spacing: Theme.Spacing.sm) {
                                 Image(systemName: "checkmark")
                                     .font(.subheadline.weight(.bold))
                                 Text("Finish Workout")
@@ -1176,7 +1176,7 @@ private struct ExerciseTransitionCard: View {
                             showRemainingList.toggle()
                         }
                     } label: {
-                        HStack(spacing: 8) {
+                        HStack(spacing: Theme.Spacing.sm) {
                             Image(systemName: "list.bullet")
                                 .font(.subheadline.weight(.bold))
                             Text("Choose Different")
@@ -1274,11 +1274,11 @@ private struct FinishWorkoutSheet: View {
                 ScrollView {
                     VStack(spacing: Theme.Spacing.lg) {
                         // Star Rating
-                        VStack(alignment: .leading, spacing: 8) {
+                        VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
                             Text("How was your workout?")
                                 .font(.subheadline.weight(.semibold))
                                 .foregroundStyle(Theme.textPrimary)
-                            HStack(spacing: 8) {
+                            HStack(spacing: Theme.Spacing.sm) {
                                 ForEach(1...5, id: \.self) { star in
                                     Button {
                                         withAnimation(.xomChill) {
@@ -1286,7 +1286,7 @@ private struct FinishWorkoutSheet: View {
                                         }
                                     } label: {
                                         Image(systemName: star <= rating ? "star.fill" : "star")
-                                            .font(.title2)
+                                            .font(Theme.fontTitle2)
                                             .foregroundStyle(star <= rating ? Theme.accent : Theme.textSecondary.opacity(0.4))
                                     }
                                     .buttonStyle(.plain)
@@ -1297,13 +1297,13 @@ private struct FinishWorkoutSheet: View {
                         }
 
                         // Location
-                        VStack(alignment: .leading, spacing: 8) {
+                        VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
                             Text("Location")
                                 .font(.subheadline.weight(.semibold))
                                 .foregroundStyle(Theme.textPrimary)
-                            HStack(spacing: 8) {
+                            HStack(spacing: Theme.Spacing.sm) {
                                 Image(systemName: "location.fill")
-                                    .font(.caption)
+                                    .font(Theme.fontCaption)
                                     .foregroundStyle(Theme.textSecondary)
                                 TextField("Gym name", text: $location)
                                     .font(Theme.fontBody)
@@ -1319,7 +1319,7 @@ private struct FinishWorkoutSheet: View {
                         }
 
                         // Description
-                        VStack(alignment: .leading, spacing: 8) {
+                        VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
                             Text("Caption")
                                 .font(.subheadline.weight(.semibold))
                                 .foregroundStyle(Theme.textPrimary)
@@ -1344,7 +1344,7 @@ private struct FinishWorkoutSheet: View {
 
                         // Save as template toggle
                         Toggle(isOn: $saveAsTemplate) {
-                            HStack(spacing: 8) {
+                            HStack(spacing: Theme.Spacing.sm) {
                                 Image(systemName: "bookmark.fill")
                                     .foregroundStyle(Theme.accent)
                                 Text("Save as Template")
@@ -1355,7 +1355,7 @@ private struct FinishWorkoutSheet: View {
                         .tint(Theme.accent)
 
                         // Photos
-                        VStack(alignment: .leading, spacing: 8) {
+                        VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
                             Text("Photos")
                                 .font(.subheadline.weight(.semibold))
                                 .foregroundStyle(Theme.textPrimary)
@@ -1365,7 +1365,7 @@ private struct FinishWorkoutSheet: View {
 
                             if !photoImages.isEmpty {
                                 ScrollView(.horizontal, showsIndicators: false) {
-                                    HStack(spacing: 8) {
+                                    HStack(spacing: Theme.Spacing.sm) {
                                         ForEach(photoImages.indices, id: \.self) { index in
                                             ZStack(alignment: .topTrailing) {
                                                 Image(uiImage: photoImages[index])
@@ -1381,7 +1381,7 @@ private struct FinishWorkoutSheet: View {
                                                     }
                                                 } label: {
                                                     Image(systemName: "xmark.circle.fill")
-                                                        .font(.caption)
+                                                        .font(Theme.fontCaption)
                                                         .foregroundStyle(.white)
                                                         .shadow(radius: 2)
                                                 }
@@ -1404,7 +1404,7 @@ private struct FinishWorkoutSheet: View {
                                 }
                                 .foregroundStyle(Theme.accent)
                                 .padding(.horizontal, 12)
-                                .padding(.vertical, 8)
+                                .padding(.vertical, Theme.Spacing.sm)
                                 .background(Theme.accent.opacity(0.12))
                                 .clipShape(.rect(cornerRadius: Theme.cornerRadiusSmall))
                             }

--- a/Xomfit/Views/Workout/ExerciseConfigRow.swift
+++ b/Xomfit/Views/Workout/ExerciseConfigRow.swift
@@ -21,7 +21,7 @@ struct ExerciseConfigRow: View {
     @State private var showRestSheet = false
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 4) {
+        VStack(alignment: .leading, spacing: Theme.Spacing.tight) {
             if let grips = exercise.exercise.supportedGrips {
                 configSection(label: "Grip") {
                     ForEach(grips) { grip in
@@ -113,7 +113,7 @@ struct ExerciseConfigRow: View {
             Haptics.selection()
             showNotesSheet = true
         } label: {
-            HStack(spacing: 4) {
+            HStack(spacing: Theme.Spacing.tight) {
                 Image(systemName: hasNote ? "note.text" : "plus")
                     .font(.caption2.weight(.semibold))
                 if hasNote, let preview = notePreview(exercise.notes) {
@@ -126,8 +126,8 @@ struct ExerciseConfigRow: View {
                 }
             }
             .foregroundStyle(hasNote ? .black : Theme.textSecondary)
-            .padding(.horizontal, 8)
-            .padding(.vertical, 4)
+            .padding(.horizontal, Theme.Spacing.sm)
+            .padding(.vertical, Theme.Spacing.tight)
             .background(hasNote ? Theme.accent : Theme.surfaceSecondary)
             .clipShape(.capsule)
         }
@@ -142,15 +142,15 @@ struct ExerciseConfigRow: View {
             Haptics.selection()
             showRestSheet = true
         } label: {
-            HStack(spacing: 4) {
+            HStack(spacing: Theme.Spacing.tight) {
                 Image(systemName: "timer")
                     .font(.caption2.weight(.semibold))
                 Text("Rest: \(formatRest(seconds))")
                     .font(.caption2.weight(.semibold))
             }
             .foregroundStyle(isCustom ? .black : Theme.textSecondary)
-            .padding(.horizontal, 8)
-            .padding(.vertical, 4)
+            .padding(.horizontal, Theme.Spacing.sm)
+            .padding(.vertical, Theme.Spacing.tight)
             .background(isCustom ? Theme.accent : Theme.surfaceSecondary)
             .clipShape(.capsule)
         }
@@ -194,8 +194,8 @@ struct ExerciseConfigRow: View {
             Text(label)
                 .font(.caption2.weight(.semibold))
                 .foregroundStyle(isSelected ? .black : Theme.textSecondary)
-                .padding(.horizontal, 8)
-                .padding(.vertical, 4)
+                .padding(.horizontal, Theme.Spacing.sm)
+                .padding(.vertical, Theme.Spacing.tight)
                 .background(isSelected ? Theme.accent : Theme.surfaceSecondary)
                 .clipShape(.capsule)
         }

--- a/Xomfit/Views/Workout/ExerciseDetailSheet.swift
+++ b/Xomfit/Views/Workout/ExerciseDetailSheet.swift
@@ -52,7 +52,7 @@ struct ExerciseDetailSheet: View {
                 .background(Theme.accentMuted)
                 .clipShape(.rect(cornerRadius: Theme.cornerRadius))
 
-            VStack(alignment: .leading, spacing: 4) {
+            VStack(alignment: .leading, spacing: Theme.Spacing.tight) {
                 Text(exercise.name)
                     .font(Theme.fontTitle2)
                     .foregroundStyle(Theme.textPrimary)
@@ -85,7 +85,7 @@ struct ExerciseDetailSheet: View {
                         .font(.caption.weight(.semibold))
                 }
                 .foregroundStyle(Theme.accent)
-                .padding(.top, 2)
+                .padding(.top, Theme.Spacing.tighter)
             }
             .buttonStyle(.plain)
             .accessibilityLabel("Estimate one rep max")
@@ -103,10 +103,10 @@ struct ExerciseDetailSheet: View {
     private func metaRow(label: String, value: String, icon: String) -> some View {
         HStack(spacing: Theme.Spacing.sm) {
             Image(systemName: icon)
-                .font(.subheadline)
+                .font(Theme.fontSubheadline)
                 .foregroundStyle(Theme.accent)
-                .frame(width: 24)
-            VStack(alignment: .leading, spacing: 2) {
+                .frame(width: Theme.Spacing.lg)
+            VStack(alignment: .leading, spacing: Theme.Spacing.tighter) {
                 Text(label)
                     .font(Theme.fontSmall)
                     .foregroundStyle(Theme.textSecondary)
@@ -207,9 +207,9 @@ struct ExerciseDetailSheet: View {
                 ForEach(exercise.tips, id: \.self) { tip in
                     HStack(alignment: .top, spacing: Theme.Spacing.sm) {
                         Image(systemName: "checkmark.circle.fill")
-                            .font(.subheadline)
+                            .font(Theme.fontSubheadline)
                             .foregroundStyle(Theme.accent)
-                            .padding(.top, 2)
+                            .padding(.top, Theme.Spacing.tighter)
                         Text(tip)
                             .font(Theme.fontBody)
                             .foregroundStyle(Theme.textPrimary.opacity(0.9))

--- a/Xomfit/Views/Workout/ExerciseJumperSheet.swift
+++ b/Xomfit/Views/Workout/ExerciseJumperSheet.swift
@@ -70,7 +70,7 @@ struct ExerciseJumperSheet: View {
                 VStack(alignment: .leading, spacing: 6) {
                     HStack(spacing: 6) {
                         Text(exercise.exercise.name)
-                            .font(.body.weight(.semibold))
+                            .font(Theme.fontBodyEmphasized)
                             .foregroundStyle(allComplete ? Theme.textSecondary : Theme.textPrimary)
                             .lineLimit(2)
                             .multilineTextAlignment(.leading)
@@ -80,7 +80,7 @@ struct ExerciseJumperSheet: View {
                                 .font(.caption2.weight(.bold))
                                 .foregroundStyle(.black)
                                 .padding(.horizontal, 6)
-                                .padding(.vertical, 2)
+                                .padding(.vertical, Theme.Spacing.tighter)
                                 .background(Theme.accent)
                                 .clipShape(.capsule)
                         }
@@ -95,7 +95,7 @@ struct ExerciseJumperSheet: View {
                                 .background(
                                     Circle().fill(setDone ? Theme.accent : Color.clear)
                                 )
-                                .frame(width: 8, height: 8)
+                                .frame(width: Theme.Spacing.sm, height: Theme.Spacing.sm)
                                 .accessibilityHidden(true)
                                 .id(setIdx)
                         }
@@ -103,7 +103,7 @@ struct ExerciseJumperSheet: View {
                         Text("\(completedCount)/\(totalCount)")
                             .font(.caption.weight(.medium))
                             .foregroundStyle(Theme.textSecondary)
-                            .padding(.leading, 4)
+                            .padding(.leading, Theme.Spacing.tight)
                     }
                 }
 

--- a/Xomfit/Views/Workout/ExercisePickerView.swift
+++ b/Xomfit/Views/Workout/ExercisePickerView.swift
@@ -186,17 +186,17 @@ private struct ExerciseRow: View {
         Button(action: onTap) {
             HStack(spacing: Theme.Spacing.md) {
                 Image(systemName: exercise.icon)
-                    .font(.title3)
+                    .font(Theme.fontTitle3)
                     .foregroundStyle(Theme.accent)
                     .frame(width: 36, height: 36)
                     .background(Theme.accentMuted)
                     .clipShape(.rect(cornerRadius: 8))
 
-                VStack(alignment: .leading, spacing: 4) {
+                VStack(alignment: .leading, spacing: Theme.Spacing.tight) {
                     Text(exercise.name)
                         .font(.subheadline.weight(.semibold))
                         .foregroundStyle(Theme.textPrimary)
-                    HStack(spacing: 4) {
+                    HStack(spacing: Theme.Spacing.tight) {
                         XomBadge(exercise.equipment.displayName, variant: .secondary)
                         ForEach(exercise.muscleGroups.prefix(2), id: \.self) { mg in
                             XomBadge(mg.displayName, variant: .secondary)
@@ -210,7 +210,7 @@ private struct ExerciseRow: View {
                     showDetails = true
                 } label: {
                     Image(systemName: "info.circle")
-                        .font(.title3)
+                        .font(Theme.fontTitle3)
                         .foregroundStyle(Theme.textSecondary)
                         .frame(width: 44, height: 44)
                         .contentShape(Rectangle())
@@ -222,7 +222,7 @@ private struct ExerciseRow: View {
                     .foregroundStyle(Theme.accent)
             }
             .frame(minHeight: 48)
-            .padding(.vertical, 4)
+            .padding(.vertical, Theme.Spacing.tight)
         }
         .buttonStyle(.plain)
         .sheet(isPresented: $showDetails) {

--- a/Xomfit/Views/Workout/FirstWorkoutTutorial.swift
+++ b/Xomfit/Views/Workout/FirstWorkoutTutorial.swift
@@ -50,7 +50,7 @@ struct FirstWorkoutTutorial: View {
                 // Header
                 VStack(spacing: Theme.Spacing.xs) {
                     Image(systemName: "sparkles")
-                        .font(.title2)
+                        .font(Theme.fontTitle2)
                         .foregroundStyle(Theme.accent)
                         .accessibilityHidden(true)
 
@@ -124,12 +124,12 @@ private struct CalloutRow: View {
             Image(systemName: callout.icon)
                 .font(.title3.weight(.semibold))
                 .foregroundStyle(Theme.accent)
-                .frame(width: 32, height: 32)
+                .frame(width: Theme.Spacing.xl, height: Theme.Spacing.xl)
                 .background(Theme.accent.opacity(0.15))
                 .clipShape(Circle())
                 .accessibilityHidden(true)
 
-            VStack(alignment: .leading, spacing: 2) {
+            VStack(alignment: .leading, spacing: Theme.Spacing.tighter) {
                 Text(callout.title)
                     .font(.subheadline.weight(.semibold))
                     .foregroundStyle(Theme.textPrimary)

--- a/Xomfit/Views/Workout/LogPastWorkoutView.swift
+++ b/Xomfit/Views/Workout/LogPastWorkoutView.swift
@@ -128,7 +128,7 @@ struct LogPastWorkoutView: View {
                     .font(Theme.fontCaption)
                     .foregroundStyle(Theme.textSecondary)
                 TextField(LogPastWorkoutViewModel.defaultName, text: $viewModel.name)
-                    .font(.body.weight(.semibold))
+                    .font(Theme.fontBodyEmphasized)
                     .foregroundStyle(Theme.textPrimary)
                     .padding(Theme.Spacing.sm)
                     .background(Theme.surfaceElevated)
@@ -196,7 +196,7 @@ struct LogPastWorkoutView: View {
     private var emptyState: some View {
         VStack(spacing: Theme.Spacing.sm) {
             Image(systemName: "calendar.badge.clock")
-                .font(.largeTitle)
+                .font(Theme.fontLargeTitle)
                 .foregroundStyle(Theme.textSecondary.opacity(0.5))
             Text("No exercises yet")
                 .font(Theme.fontBody)
@@ -214,7 +214,7 @@ struct LogPastWorkoutView: View {
             Haptics.light()
             showExercisePicker = true
         } label: {
-            HStack(spacing: 8) {
+            HStack(spacing: Theme.Spacing.sm) {
                 Image(systemName: "plus.circle.fill")
                 Text("Add Exercise")
                     .font(.subheadline.weight(.semibold))
@@ -293,13 +293,13 @@ private struct PastExerciseCard: View {
             // Header
             HStack {
                 Image(systemName: exercise.exercise.icon)
-                    .font(.headline)
+                    .font(Theme.fontHeadline)
                     .foregroundStyle(Theme.accent)
-                    .frame(width: 32, height: 32)
+                    .frame(width: Theme.Spacing.xl, height: Theme.Spacing.xl)
                     .background(Theme.accentMuted)
                     .clipShape(.rect(cornerRadius: 8))
 
-                VStack(alignment: .leading, spacing: 2) {
+                VStack(alignment: .leading, spacing: Theme.Spacing.tighter) {
                     Text(exercise.exercise.name)
                         .font(.subheadline.weight(.bold))
                         .foregroundStyle(Theme.textPrimary)
@@ -315,7 +315,7 @@ private struct PastExerciseCard: View {
                     onDelete()
                 } label: {
                     Image(systemName: "trash")
-                        .font(.subheadline)
+                        .font(Theme.fontSubheadline)
                         .foregroundStyle(Theme.destructive.opacity(0.8))
                         .frame(width: 44, height: 44)
                         .contentShape(Rectangle())
@@ -332,7 +332,7 @@ private struct PastExerciseCard: View {
                 Text("REPS")
                     .frame(maxWidth: .infinity)
                 // Spacer matching trailing delete button width in PastSetRow
-                Color.clear.frame(width: 32)
+                Color.clear.frame(width: Theme.Spacing.xl)
             }
             .font(.caption2.weight(.semibold))
             .foregroundStyle(Theme.textSecondary)
@@ -422,7 +422,7 @@ private struct PastSetRow: View {
                 .keyboardType(.decimalPad)
                 .multilineTextAlignment(.center)
                 .font(Theme.fontNumberMedium)
-                .padding(.vertical, 8)
+                .padding(.vertical, Theme.Spacing.sm)
                 .padding(.horizontal, 6)
                 .background(Theme.surfaceElevated)
                 .clipShape(.rect(cornerRadius: Theme.cornerRadiusSmall))
@@ -446,7 +446,7 @@ private struct PastSetRow: View {
                 .keyboardType(.numberPad)
                 .multilineTextAlignment(.center)
                 .font(Theme.fontNumberMedium)
-                .padding(.vertical, 8)
+                .padding(.vertical, Theme.Spacing.sm)
                 .padding(.horizontal, 6)
                 .background(Theme.surfaceElevated)
                 .clipShape(.rect(cornerRadius: Theme.cornerRadiusSmall))
@@ -472,8 +472,8 @@ private struct PastSetRow: View {
             } label: {
                 Image(systemName: "minus.circle.fill")
                     .foregroundStyle(Theme.destructive)
-                    .font(.headline)
-                    .frame(width: 32, height: 32)
+                    .font(Theme.fontHeadline)
+                    .frame(width: Theme.Spacing.xl, height: Theme.Spacing.xl)
                     .contentShape(Rectangle())
             }
             .buttonStyle(.plain)

--- a/Xomfit/Views/Workout/RecentWorkoutCard.swift
+++ b/Xomfit/Views/Workout/RecentWorkoutCard.swift
@@ -63,16 +63,16 @@ struct RecentWorkoutCard: View {
                 .font(Theme.fontSmall)
                 .foregroundStyle(Theme.textSecondary)
 
-            HStack(spacing: 8) {
+            HStack(spacing: Theme.Spacing.sm) {
                 HStack(spacing: 3) {
                     Image(systemName: "figure.strengthtraining.traditional")
-                        .font(.caption2)
+                        .font(Theme.fontCaption2)
                     Text("\(workout.exercises.count) ex")
                 }
 
                 HStack(spacing: 3) {
                     Image(systemName: "clock")
-                        .font(.caption2)
+                        .font(Theme.fontCaption2)
                     Text(workout.durationString)
                         .foregroundStyle(Theme.accent)
                 }
@@ -94,13 +94,13 @@ struct RecentWorkoutCard: View {
     private var rowBody: some View {
         HStack(spacing: 10) {
             Image(systemName: "figure.strengthtraining.traditional")
-                .font(.headline)
+                .font(Theme.fontHeadline)
                 .foregroundStyle(Theme.accent)
-                .frame(width: 32, height: 32)
+                .frame(width: Theme.Spacing.xl, height: Theme.Spacing.xl)
                 .background(Theme.accent.opacity(0.15))
                 .clipShape(.rect(cornerRadius: 6))
 
-            VStack(alignment: .leading, spacing: 2) {
+            VStack(alignment: .leading, spacing: Theme.Spacing.tighter) {
                 Text(workout.name)
                     .font(.subheadline.weight(.bold))
                     .foregroundStyle(Theme.textPrimary)

--- a/Xomfit/Views/Workout/RestTimerRingView.swift
+++ b/Xomfit/Views/Workout/RestTimerRingView.swift
@@ -36,7 +36,7 @@ struct RestTimerRingView: View {
 // MARK: - Preview
 
 #Preview {
-    HStack(spacing: 24) {
+    HStack(spacing: Theme.Spacing.lg) {
         RestTimerRingView(progress: 0.25, color: Theme.accent, lineWidth: 6)
             .frame(width: 80, height: 80)
         RestTimerRingView(progress: 0.6, color: Theme.accent, lineWidth: 6)

--- a/Xomfit/Views/Workout/RestTimerView.swift
+++ b/Xomfit/Views/Workout/RestTimerView.swift
@@ -67,7 +67,7 @@ struct RestTimerView: View {
             }
 
             // Label + controls
-            VStack(alignment: .leading, spacing: 8) {
+            VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
                 XomMetricLabel("Rest")
 
                 HStack(spacing: 10) {

--- a/Xomfit/Views/Workout/SetRowView.swift
+++ b/Xomfit/Views/Workout/SetRowView.swift
@@ -90,7 +90,7 @@ struct SetRowView: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 2) {
+        VStack(alignment: .leading, spacing: Theme.Spacing.tighter) {
             mainRow
             if hasHints || beatsPriorPR {
                 hintRow
@@ -150,14 +150,14 @@ struct SetRowView: View {
                 // PR trophy / DROP badge / set number
                 if isPR {
                     Image(systemName: "trophy.fill")
-                        .font(.caption2)
+                        .font(Theme.fontCaption2)
                         .foregroundStyle(Theme.prGold)
-                        .frame(width: 16)
+                        .frame(width: Theme.Spacing.md)
                 } else if isDropSet {
                     Text("DROP")
                         .font(.system(size: 9, weight: .black))
                         .foregroundStyle(Theme.accent)
-                        .padding(.horizontal, 4)
+                        .padding(.horizontal, Theme.Spacing.tight)
                         .padding(.vertical, 1)
                         .background(Theme.accent.opacity(0.18))
                         .clipShape(.capsule)
@@ -165,7 +165,7 @@ struct SetRowView: View {
                     Text("\(setNumber)")
                         .font(.subheadline.weight(.bold).monospaced())
                         .foregroundStyle(isCompleted ? Theme.accent : Theme.textSecondary)
-                        .frame(width: 24, alignment: .center)
+                        .frame(width: Theme.Spacing.lg, alignment: .center)
                 }
 
                 // Weight field
@@ -296,7 +296,7 @@ struct SetRowView: View {
                     .font(.caption2.weight(.heavy))
                     .foregroundStyle(.black)
                     .padding(.horizontal, 6)
-                    .padding(.vertical, 2)
+                    .padding(.vertical, Theme.Spacing.tighter)
                     .background(Theme.prGold)
                     .clipShape(.capsule)
                     .accessibilityLabel("New personal record")
@@ -305,7 +305,7 @@ struct SetRowView: View {
             Spacer()
         }
         .padding(.horizontal, Theme.Spacing.md)
-        .padding(.bottom, 4)
+        .padding(.bottom, Theme.Spacing.tight)
     }
 
     private func hintChip(label: String, value: String, color: Color) -> some View {
@@ -328,14 +328,14 @@ struct SetRowView: View {
             Haptics.light()
             action()
         } label: {
-            HStack(spacing: 4) {
+            HStack(spacing: Theme.Spacing.tight) {
                 Image(systemName: "arrow.down.right")
                     .font(.caption2.weight(.bold))
                 Text("drop set")
                     .font(.caption2.weight(.semibold))
             }
             .foregroundStyle(Theme.accent)
-            .padding(.horizontal, 8)
+            .padding(.horizontal, Theme.Spacing.sm)
             .padding(.vertical, 3)
             .background(Theme.accent.opacity(0.10))
             .clipShape(.capsule)

--- a/Xomfit/Views/Workout/StretchDetailSheet.swift
+++ b/Xomfit/Views/Workout/StretchDetailSheet.swift
@@ -46,7 +46,7 @@ struct StretchDetailSheet: View {
                 .background(Theme.accentMuted)
                 .clipShape(.rect(cornerRadius: Theme.cornerRadius))
 
-            VStack(alignment: .leading, spacing: 4) {
+            VStack(alignment: .leading, spacing: Theme.Spacing.tight) {
                 Text(stretch.name)
                     .font(Theme.fontTitle2)
                     .foregroundStyle(Theme.textPrimary)
@@ -65,10 +65,10 @@ struct StretchDetailSheet: View {
     private var metaSection: some View {
         HStack(spacing: Theme.Spacing.sm) {
             Image(systemName: "timer")
-                .font(.subheadline)
+                .font(Theme.fontSubheadline)
                 .foregroundStyle(Theme.accent)
-                .frame(width: 24)
-            VStack(alignment: .leading, spacing: 2) {
+                .frame(width: Theme.Spacing.lg)
+            VStack(alignment: .leading, spacing: Theme.Spacing.tighter) {
                 Text("Hold Time")
                     .font(Theme.fontSmall)
                     .foregroundStyle(Theme.textSecondary)

--- a/Xomfit/Views/Workout/TemplateCardView.swift
+++ b/Xomfit/Views/Workout/TemplateCardView.swift
@@ -47,19 +47,19 @@ struct TemplateCardView: View {
         HStack(spacing: 10) {
             // Category icon
             Image(systemName: template.category.icon)
-                .font(.headline)
+                .font(Theme.fontHeadline)
                 .foregroundStyle(Theme.accent)
-                .frame(width: 32, height: 32)
+                .frame(width: Theme.Spacing.xl, height: Theme.Spacing.xl)
                 .background(Theme.accent.opacity(0.15))
                 .clipShape(.rect(cornerRadius: 6))
 
-            VStack(alignment: .leading, spacing: 2) {
+            VStack(alignment: .leading, spacing: Theme.Spacing.tighter) {
                 Text(template.name)
                     .font(style == .row ? .subheadline.weight(.bold) : .caption.weight(.bold))
                     .foregroundStyle(Theme.textPrimary)
                     .lineLimit(1)
 
-                HStack(spacing: 4) {
+                HStack(spacing: Theme.Spacing.tight) {
                     Text("\(template.exercises.count) ex")
                     Text("~\(template.estimatedDuration)m")
                         .foregroundStyle(Theme.accent)

--- a/Xomfit/Views/Workout/TemplateDetailView.swift
+++ b/Xomfit/Views/Workout/TemplateDetailView.swift
@@ -189,13 +189,13 @@ struct TemplateDetailView: View {
         VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
             HStack(spacing: 10) {
                 Image(systemName: draft.category.icon)
-                    .font(.title3)
+                    .font(Theme.fontTitle3)
                     .foregroundStyle(Theme.accent)
                     .frame(width: 40, height: 40)
                     .background(Theme.accent.opacity(0.15))
                     .clipShape(.rect(cornerRadius: Theme.Radius.xs))
 
-                VStack(alignment: .leading, spacing: 2) {
+                VStack(alignment: .leading, spacing: Theme.Spacing.tighter) {
                     Text(draft.category.displayName)
                         .font(Theme.fontCaption)
                         .foregroundStyle(Theme.accent)
@@ -264,9 +264,9 @@ struct TemplateDetailView: View {
     }
 
     private func statPill(icon: String, label: String, value: String) -> some View {
-        VStack(spacing: 4) {
+        VStack(spacing: Theme.Spacing.tight) {
             Image(systemName: icon)
-                .font(.subheadline)
+                .font(Theme.fontSubheadline)
                 .foregroundStyle(Theme.accent)
             Text(value)
                 .font(.subheadline.weight(.bold))
@@ -306,7 +306,7 @@ struct TemplateDetailView: View {
     private var emptyState: some View {
         VStack(spacing: Theme.Spacing.sm) {
             Image(systemName: "figure.strengthtraining.traditional")
-                .font(.largeTitle)
+                .font(Theme.fontLargeTitle)
                 .foregroundStyle(Theme.textSecondary.opacity(0.5))
             Text("No exercises yet")
                 .font(Theme.fontBody)
@@ -324,7 +324,7 @@ struct TemplateDetailView: View {
             Haptics.light()
             showExercisePicker = true
         } label: {
-            HStack(spacing: 8) {
+            HStack(spacing: Theme.Spacing.sm) {
                 Image(systemName: "plus.circle.fill")
                 Text("Add Exercise")
                     .font(.subheadline.weight(.semibold))
@@ -352,11 +352,11 @@ struct TemplateDetailView: View {
             HStack(spacing: 10) {
                 Image(systemName: "play.fill")
                 Text(hasUnsavedChanges ? "Start Lift" : "Start Workout")
-                    .font(.headline)
+                    .font(Theme.fontHeadline)
             }
             .foregroundStyle(.black)
             .frame(maxWidth: .infinity)
-            .padding(.vertical, 16)
+            .padding(.vertical, Theme.Spacing.md)
             .background(Theme.accent)
             .clipShape(.rect(cornerRadius: Theme.cornerRadius))
         }
@@ -381,7 +381,7 @@ struct TemplateDetailView: View {
                         .frame(maxWidth: .infinity, alignment: .leading)
 
                     TextField("Template name", text: $newTemplateName)
-                        .font(.body.weight(.semibold))
+                        .font(Theme.fontBodyEmphasized)
                         .foregroundStyle(Theme.textPrimary)
                         .padding(Theme.Spacing.md)
                         .background(Theme.surface)
@@ -642,7 +642,7 @@ private struct EditableExerciseRow: View {
                 Text("\(index)")
                     .font(.caption.weight(.bold).monospaced())
                     .foregroundStyle(Theme.accent)
-                    .frame(width: 24, height: 24)
+                    .frame(width: Theme.Spacing.lg, height: Theme.Spacing.lg)
                     .background(Theme.accent.opacity(0.15))
                     .clipShape(.rect(cornerRadius: Theme.Radius.xs))
 
@@ -669,7 +669,7 @@ private struct EditableExerciseRow: View {
                     Image(systemName: "info.circle")
                         .font(.subheadline.weight(.semibold))
                         .foregroundStyle(Theme.textSecondary)
-                        .frame(width: 32, height: 32)
+                        .frame(width: Theme.Spacing.xl, height: Theme.Spacing.xl)
                         .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
@@ -680,7 +680,7 @@ private struct EditableExerciseRow: View {
                     onDelete()
                 } label: {
                     Image(systemName: "trash")
-                        .font(.subheadline)
+                        .font(Theme.fontSubheadline)
                         .foregroundStyle(Theme.destructive.opacity(0.85))
                         .frame(width: 44, height: 44)
                         .contentShape(Rectangle())
@@ -691,11 +691,11 @@ private struct EditableExerciseRow: View {
             // Editable controls: sets stepper, reps, weight
             HStack(alignment: .center, spacing: Theme.Spacing.sm) {
                 // Sets stepper
-                VStack(alignment: .leading, spacing: 4) {
+                VStack(alignment: .leading, spacing: Theme.Spacing.tight) {
                     Text("Sets")
                         .font(Theme.fontSmall)
                         .foregroundStyle(Theme.textSecondary)
-                    HStack(spacing: 4) {
+                    HStack(spacing: Theme.Spacing.tight) {
                         Button {
                             Haptics.selection()
                             onUpdateSets(exercise.targetSets - 1)
@@ -725,7 +725,7 @@ private struct EditableExerciseRow: View {
                 }
 
                 // Reps text field
-                VStack(alignment: .leading, spacing: 4) {
+                VStack(alignment: .leading, spacing: Theme.Spacing.tight) {
                     Text("Reps")
                         .font(Theme.fontSmall)
                         .foregroundStyle(Theme.textSecondary)
@@ -735,8 +735,8 @@ private struct EditableExerciseRow: View {
                         .keyboardType(.numbersAndPunctuation)
                         .multilineTextAlignment(.center)
                         .frame(width: 64)
-                        .padding(.horizontal, 8)
-                        .padding(.vertical, 8)
+                        .padding(.horizontal, Theme.Spacing.sm)
+                        .padding(.vertical, Theme.Spacing.sm)
                         .background(Theme.surfaceElevated)
                         .clipShape(.rect(cornerRadius: Theme.Radius.sm))
                         .onChange(of: repsText) { _, newValue in
@@ -746,7 +746,7 @@ private struct EditableExerciseRow: View {
                 }
 
                 // Target weight text field
-                VStack(alignment: .leading, spacing: 4) {
+                VStack(alignment: .leading, spacing: Theme.Spacing.tight) {
                     Text("Weight")
                         .font(Theme.fontSmall)
                         .foregroundStyle(Theme.textSecondary)
@@ -756,8 +756,8 @@ private struct EditableExerciseRow: View {
                         .keyboardType(.decimalPad)
                         .multilineTextAlignment(.center)
                         .frame(width: 70)
-                        .padding(.horizontal, 8)
-                        .padding(.vertical, 8)
+                        .padding(.horizontal, Theme.Spacing.sm)
+                        .padding(.vertical, Theme.Spacing.sm)
                         .background(Theme.surfaceElevated)
                         .clipShape(.rect(cornerRadius: Theme.Radius.sm))
                         .onChange(of: weightText) { _, newValue in

--- a/Xomfit/Views/Workout/TemplateListView.swift
+++ b/Xomfit/Views/Workout/TemplateListView.swift
@@ -67,7 +67,7 @@ struct TemplateListView: View {
         } label: {
             HStack(spacing: Theme.Spacing.md) {
                 Image(systemName: template.category.icon)
-                    .font(.headline)
+                    .font(Theme.fontHeadline)
                     .foregroundStyle(Theme.accent)
                     .frame(width: 36, height: 36)
                     .background(Theme.accent.opacity(0.15))
@@ -94,7 +94,7 @@ struct TemplateListView: View {
                         .foregroundStyle(Theme.accent)
                 }
             }
-            .padding(.vertical, 4)
+            .padding(.vertical, Theme.Spacing.tight)
         }
         .buttonStyle(.plain)
         .deleteDisabled(!template.isCustom)

--- a/Xomfit/Views/Workout/WarmupView.swift
+++ b/Xomfit/Views/Workout/WarmupView.swift
@@ -150,7 +150,7 @@ struct WarmupView: View {
                 .foregroundStyle(Theme.textPrimary)
             HStack(spacing: 6) {
                 Image(systemName: "clock.fill")
-                    .font(.caption)
+                    .font(Theme.fontCaption)
                     .foregroundStyle(Theme.accent)
                 Text("\(stretches.count) stretches · \(formatTime(estimatedTotalDuration))")
                     .font(Theme.fontSubheadline)
@@ -159,7 +159,7 @@ struct WarmupView: View {
             Text("Tap a stretch to see how it's done.")
                 .font(Theme.fontCaption)
                 .foregroundStyle(Theme.textSecondary.opacity(0.8))
-                .padding(.top, 2)
+                .padding(.top, Theme.Spacing.tighter)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .accessibilityElement(children: .combine)
@@ -191,7 +191,7 @@ struct WarmupView: View {
                 .background(Theme.accent.opacity(0.15))
                 .clipShape(.rect(cornerRadius: Theme.Radius.xs))
 
-            VStack(alignment: .leading, spacing: 4) {
+            VStack(alignment: .leading, spacing: Theme.Spacing.tight) {
                 HStack(alignment: .firstTextBaseline) {
                     Text(stretch.name)
                         .font(.subheadline.weight(.semibold))
@@ -211,7 +211,7 @@ struct WarmupView: View {
             Image(systemName: "chevron.right")
                 .font(.caption.weight(.semibold))
                 .foregroundStyle(Theme.textSecondary.opacity(0.6))
-                .padding(.top, 4)
+                .padding(.top, Theme.Spacing.tight)
         }
         .padding(Theme.Spacing.md)
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -243,7 +243,7 @@ struct WarmupView: View {
     }
 
     private var timerHeader: some View {
-        VStack(spacing: 4) {
+        VStack(spacing: Theme.Spacing.tight) {
             Text("Loosen up first")
                 .font(Theme.fontTitle2)
                 .foregroundStyle(Theme.textPrimary)
@@ -284,13 +284,13 @@ struct WarmupView: View {
             VStack(alignment: .leading, spacing: Theme.Spacing.md) {
                 HStack(alignment: .top, spacing: Theme.Spacing.md) {
                     Image(systemName: stretch.icon)
-                        .font(.title2)
+                        .font(Theme.fontTitle2)
                         .foregroundStyle(Theme.accent)
                         .frame(width: 44, height: 44)
                         .background(Theme.accent.opacity(0.15))
                         .clipShape(.rect(cornerRadius: 10))
 
-                    VStack(alignment: .leading, spacing: 4) {
+                    VStack(alignment: .leading, spacing: Theme.Spacing.tight) {
                         Text("Now: \(stretch.name)")
                             .font(Theme.fontHeadline)
                             .foregroundStyle(Theme.textPrimary)
@@ -330,7 +330,7 @@ struct WarmupView: View {
                         .font(.subheadline.weight(.semibold))
                         .foregroundStyle(Theme.textSecondary)
                         .padding(.horizontal, 12)
-                        .padding(.vertical, 8)
+                        .padding(.vertical, Theme.Spacing.sm)
                         .background(Theme.surfaceElevated)
                         .clipShape(.rect(cornerRadius: Theme.Radius.sm))
                     }
@@ -380,7 +380,7 @@ struct WarmupView: View {
             Text("\(index + 1)")
                 .font(.caption.weight(.bold).monospaced())
                 .foregroundStyle(Theme.textSecondary)
-                .frame(width: 24, height: 24)
+                .frame(width: Theme.Spacing.lg, height: Theme.Spacing.lg)
                 .background(Theme.surfaceElevated)
                 .clipShape(.rect(cornerRadius: 6))
 

--- a/Xomfit/Views/Workout/WorkoutBuilderView.swift
+++ b/Xomfit/Views/Workout/WorkoutBuilderView.swift
@@ -134,7 +134,7 @@ struct WorkoutBuilderView: View {
 
     private var nameField: some View {
         TextField("Workout Name", text: $viewModel.name)
-            .font(.body.weight(.semibold))
+            .font(Theme.fontBodyEmphasized)
             .foregroundStyle(Theme.textPrimary)
             .padding(Theme.Spacing.md)
             .background(Theme.surface)
@@ -150,15 +150,15 @@ struct WorkoutBuilderView: View {
                     Button {
                         viewModel.category = cat
                     } label: {
-                        HStack(spacing: 4) {
+                        HStack(spacing: Theme.Spacing.tight) {
                             Image(systemName: cat.icon)
-                                .font(.caption2)
+                                .font(Theme.fontCaption2)
                             Text(cat.displayName)
                                 .font(Theme.fontSmall)
                         }
                         .foregroundStyle(viewModel.category == cat ? .black : Theme.textSecondary)
                         .padding(.horizontal, 12)
-                        .padding(.vertical, 8)
+                        .padding(.vertical, Theme.Spacing.sm)
                         .background(viewModel.category == cat ? Theme.accent : Theme.surface)
                         .clipShape(.rect(cornerRadius: 20))
                     }
@@ -201,7 +201,7 @@ struct WorkoutBuilderView: View {
     private var emptyState: some View {
         VStack(spacing: Theme.Spacing.sm) {
             Image(systemName: "figure.strengthtraining.traditional")
-                .font(.largeTitle)
+                .font(Theme.fontLargeTitle)
                 .foregroundStyle(Theme.textSecondary.opacity(0.5))
             Text("No exercises yet")
                 .font(Theme.fontBody)
@@ -221,7 +221,7 @@ struct WorkoutBuilderView: View {
             Haptics.light()
             showExercisePicker = true
         } label: {
-            HStack(spacing: 8) {
+            HStack(spacing: Theme.Spacing.sm) {
                 Image(systemName: "plus.circle.fill")
                 Text("Add Exercise")
                     .font(.subheadline.weight(.semibold))
@@ -326,13 +326,13 @@ private struct BuilderExerciseRow: View {
                         .font(.subheadline.weight(.bold))
                         .foregroundStyle(Theme.textPrimary)
 
-                    HStack(spacing: 4) {
+                    HStack(spacing: Theme.Spacing.tight) {
                         ForEach(exercise.exercise.muscleGroups.prefix(3), id: \.self) { mg in
                             Text(mg.displayName)
                                 .font(Theme.fontSmall)
                                 .foregroundStyle(Theme.textSecondary)
                                 .padding(.horizontal, 6)
-                                .padding(.vertical, 2)
+                                .padding(.vertical, Theme.Spacing.tighter)
                                 .background(Theme.surfaceSecondary)
                                 .clipShape(.rect(cornerRadius: 4))
                         }
@@ -343,7 +343,7 @@ private struct BuilderExerciseRow: View {
 
                 Button(action: onDelete) {
                     Image(systemName: "trash")
-                        .font(.subheadline)
+                        .font(Theme.fontSubheadline)
                         .foregroundStyle(Theme.destructive.opacity(0.8))
                         .frame(width: 44, height: 44)
                         .contentShape(Rectangle())
@@ -354,7 +354,7 @@ private struct BuilderExerciseRow: View {
             // Sets & Reps controls
             HStack(spacing: Theme.Spacing.md) {
                 // Sets stepper
-                HStack(spacing: 8) {
+                HStack(spacing: Theme.Spacing.sm) {
                     Text("Sets")
                         .font(Theme.fontCaption)
                         .foregroundStyle(Theme.textSecondary)
@@ -385,7 +385,7 @@ private struct BuilderExerciseRow: View {
                 Spacer()
 
                 // Reps field
-                HStack(spacing: 8) {
+                HStack(spacing: Theme.Spacing.sm) {
                     Text("Reps")
                         .font(Theme.fontCaption)
                         .foregroundStyle(Theme.textSecondary)
@@ -395,7 +395,7 @@ private struct BuilderExerciseRow: View {
                         .foregroundStyle(Theme.textPrimary)
                         .multilineTextAlignment(.center)
                         .frame(width: 60)
-                        .padding(.horizontal, 8)
+                        .padding(.horizontal, Theme.Spacing.sm)
                         .padding(.vertical, 6)
                         .background(Theme.surfaceSecondary)
                         .clipShape(.rect(cornerRadius: Theme.cornerRadiusSmall))
@@ -445,7 +445,7 @@ private struct BuilderExerciseRow: View {
             Haptics.selection()
             showNotesSheet = true
         } label: {
-            HStack(spacing: 4) {
+            HStack(spacing: Theme.Spacing.tight) {
                 Image(systemName: hasNote ? "note.text" : "plus")
                     .font(.caption2.weight(.semibold))
                 if hasNote, let preview = previewText(exercise.notes) {
@@ -458,8 +458,8 @@ private struct BuilderExerciseRow: View {
                 }
             }
             .foregroundStyle(hasNote ? .black : Theme.textSecondary)
-            .padding(.horizontal, 8)
-            .padding(.vertical, 4)
+            .padding(.horizontal, Theme.Spacing.sm)
+            .padding(.vertical, Theme.Spacing.tight)
             .background(hasNote ? Theme.accent : Theme.surfaceSecondary)
             .clipShape(.capsule)
         }
@@ -474,15 +474,15 @@ private struct BuilderExerciseRow: View {
             Haptics.selection()
             showRestSheet = true
         } label: {
-            HStack(spacing: 4) {
+            HStack(spacing: Theme.Spacing.tight) {
                 Image(systemName: "timer")
                     .font(.caption2.weight(.semibold))
                 Text("Rest: \(formatRest(seconds))")
                     .font(.caption2.weight(.semibold))
             }
             .foregroundStyle(isCustom ? .black : Theme.textSecondary)
-            .padding(.horizontal, 8)
-            .padding(.vertical, 4)
+            .padding(.horizontal, Theme.Spacing.sm)
+            .padding(.vertical, Theme.Spacing.tight)
             .background(isCustom ? Theme.accent : Theme.surfaceSecondary)
             .clipShape(.capsule)
         }

--- a/Xomfit/Views/Workout/WorkoutCategoryPage.swift
+++ b/Xomfit/Views/Workout/WorkoutCategoryPage.swift
@@ -248,7 +248,7 @@ struct WorkoutCategoryPage: View {
     private var emptyState: some View {
         VStack(spacing: Theme.Spacing.sm) {
             Image(systemName: category.icon)
-                .font(.largeTitle)
+                .font(Theme.fontLargeTitle)
                 .foregroundStyle(Theme.textTertiary)
             Text(category.emptyStateTitle)
                 .font(.subheadline.weight(.semibold))
@@ -265,7 +265,7 @@ struct WorkoutCategoryPage: View {
     private var filteredEmptyState: some View {
         VStack(spacing: Theme.Spacing.sm) {
             Image(systemName: "line.3.horizontal.decrease")
-                .font(.largeTitle)
+                .font(Theme.fontLargeTitle)
                 .foregroundStyle(Theme.textTertiary)
             Text("No matches")
                 .font(.subheadline.weight(.semibold))

--- a/Xomfit/Views/Workout/WorkoutDetailView.swift
+++ b/Xomfit/Views/Workout/WorkoutDetailView.swift
@@ -51,7 +51,7 @@ struct WorkoutDetailView: View {
     private var summaryCard: some View {
         VStack(spacing: Theme.Spacing.md) {
             HStack {
-                VStack(alignment: .leading, spacing: 4) {
+                VStack(alignment: .leading, spacing: Theme.Spacing.tight) {
                     Text(workout.startTime.workoutDateString)
                         .font(Theme.fontCaption)
                         .foregroundStyle(Theme.textSecondary)
@@ -63,9 +63,9 @@ struct WorkoutDetailView: View {
                     }
 
                     if let location = workout.location, !location.isEmpty {
-                        HStack(spacing: 4) {
+                        HStack(spacing: Theme.Spacing.tight) {
                             Image(systemName: "location.fill")
-                                .font(.caption2)
+                                .font(Theme.fontCaption2)
                             Text(location)
                                 .font(Theme.fontSmall)
                         }
@@ -75,10 +75,10 @@ struct WorkoutDetailView: View {
                 Spacer()
 
                 if let rating = workout.rating, rating > 0 {
-                    HStack(spacing: 2) {
+                    HStack(spacing: Theme.Spacing.tighter) {
                         ForEach(1...5, id: \.self) { star in
                             Image(systemName: star <= rating ? "star.fill" : "star")
-                                .font(.caption)
+                                .font(Theme.fontCaption)
                                 .foregroundStyle(star <= rating ? Theme.accent : Theme.textSecondary.opacity(0.3))
                         }
                     }
@@ -117,7 +117,7 @@ struct WorkoutDetailView: View {
             if let notes = workout.notes, !notes.isEmpty {
                 HStack {
                     Image(systemName: "note.text")
-                        .font(.caption)
+                        .font(Theme.fontCaption)
                         .foregroundStyle(Theme.textSecondary)
                     Text(notes)
                         .font(Theme.fontCaption)
@@ -166,12 +166,12 @@ struct WorkoutDetailView: View {
                     }
                 }
             } label: {
-                VStack(alignment: .leading, spacing: 4) {
+                VStack(alignment: .leading, spacing: Theme.Spacing.tight) {
                     HStack(spacing: Theme.Spacing.sm) {
                         Text("\(index)")
                             .font(.caption.weight(.bold).monospaced())
                             .foregroundStyle(Theme.accent)
-                            .frame(width: 24, height: 24)
+                            .frame(width: Theme.Spacing.lg, height: Theme.Spacing.lg)
                             .background(Theme.accent.opacity(0.12))
                             .clipShape(.rect(cornerRadius: 6))
 
@@ -188,7 +188,7 @@ struct WorkoutDetailView: View {
                         if exercise.sets.contains(where: { $0.isPersonalRecord }) {
                             HStack(spacing: 3) {
                                 Image(systemName: "trophy.fill")
-                                    .font(.caption2)
+                                    .font(Theme.fontCaption2)
                                 Text("PR")
                                     .font(.caption2.weight(.bold))
                             }
@@ -204,7 +204,7 @@ struct WorkoutDetailView: View {
                             Spacer().frame(width: 24 + Theme.Spacing.sm)
                             Rectangle()
                                 .fill(Theme.accent.opacity(0.6))
-                                .frame(width: 2)
+                                .frame(width: Theme.Spacing.tighter)
                             Text(notes)
                                 .font(Theme.fontSmall)
                                 .italic()
@@ -244,13 +244,13 @@ struct WorkoutDetailView: View {
 
             if set.isPersonalRecord {
                 Image(systemName: "trophy.fill")
-                    .font(.caption2)
+                    .font(Theme.fontCaption2)
                     .foregroundStyle(Theme.prGold)
                     .padding(.leading, 6)
             }
         }
         .font(.subheadline.weight(.medium).monospaced())
-        .padding(.vertical, 4)
+        .padding(.vertical, Theme.Spacing.tight)
         .accessibilityLabel("Set \(number): \(formatWeight(set.weight)) lbs for \(set.reps) reps\(set.isPersonalRecord ? ", personal record" : "")")
     }
 
@@ -302,11 +302,11 @@ struct WorkoutDetailView: View {
     private func soundtrackRow(track: WorkoutTrack) -> some View {
         HStack(spacing: Theme.Spacing.sm) {
             Image(systemName: "music.note")
-                .font(.caption)
+                .font(Theme.fontCaption)
                 .foregroundStyle(Theme.textSecondary)
                 .frame(width: 20)
 
-            VStack(alignment: .leading, spacing: 2) {
+            VStack(alignment: .leading, spacing: Theme.Spacing.tighter) {
                 Text(track.title)
                     .font(.subheadline.weight(.medium))
                     .foregroundStyle(Theme.textPrimary)
@@ -321,7 +321,7 @@ struct WorkoutDetailView: View {
 
             Spacer()
         }
-        .padding(.vertical, 8)
+        .padding(.vertical, Theme.Spacing.sm)
         .accessibilityElement(children: .combine)
         .accessibilityLabel(accessibilityLabel(for: track))
     }

--- a/Xomfit/Views/Workout/WorkoutFocusView.swift
+++ b/Xomfit/Views/Workout/WorkoutFocusView.swift
@@ -86,7 +86,7 @@ struct WorkoutFocusView: View {
         // Push content below any active Dynamic Island (#289). Bumps content
         // down deterministically when an island (e.g. music app) is present.
         .safeAreaInset(edge: .top, spacing: 0) {
-            Color.clear.frame(height: 8)
+            Color.clear.frame(height: Theme.Spacing.sm)
         }
         .sheet(isPresented: $showExercisePicker) {
             ExercisePickerView { exercise in
@@ -104,20 +104,20 @@ struct WorkoutFocusView: View {
     // MARK: - Exercise Header
 
     private func exerciseHeader(exercise: WorkoutExercise) -> some View {
-        VStack(spacing: 4) {
+        VStack(spacing: Theme.Spacing.tight) {
             Text(exercise.exercise.name)
                 .font(.title2.weight(.bold))
                 .foregroundStyle(Theme.textPrimary)
                 .multilineTextAlignment(.center)
                 .accessibilityAddTraits(.isHeader)
 
-            HStack(spacing: 4) {
+            HStack(spacing: Theme.Spacing.tight) {
                 ForEach(exercise.exercise.muscleGroups.prefix(2), id: \.self) { mg in
                     Text(mg.displayName)
                         .font(Theme.fontSmall)
                         .foregroundStyle(Theme.accent)
                         .padding(.horizontal, 6)
-                        .padding(.vertical, 2)
+                        .padding(.vertical, Theme.Spacing.tighter)
                         .background(Theme.accent.opacity(0.15))
                         .clipShape(.rect(cornerRadius: 4))
                 }
@@ -125,13 +125,13 @@ struct WorkoutFocusView: View {
                 if exercise.exercise.supportsUnilateral && exercise.selectedLaterality != .bilateral {
                     HStack(spacing: 3) {
                         Image(systemName: "arrow.left.and.right")
-                            .font(.caption2)
+                            .font(Theme.fontCaption2)
                         Text(exercise.selectedLaterality.displayName)
                             .font(Theme.fontSmall)
                     }
                     .foregroundStyle(Theme.accent)
                     .padding(.horizontal, 6)
-                    .padding(.vertical, 2)
+                    .padding(.vertical, Theme.Spacing.tighter)
                     .background(Theme.accent.opacity(0.15))
                     .clipShape(.capsule)
                 }
@@ -143,7 +143,7 @@ struct WorkoutFocusView: View {
 
     private func setIndicator(exercise: WorkoutExercise) -> some View {
         ScrollView(.horizontal, showsIndicators: false) {
-            HStack(spacing: 8) {
+            HStack(spacing: Theme.Spacing.sm) {
                 ForEach(Array(exercise.sets.enumerated()), id: \.element.id) { idx, set in
                     let isCompleted = set.completedAt != Date.distantPast
                     let isFocused = idx == viewModel.focusSetIndex
@@ -182,7 +182,7 @@ struct WorkoutFocusView: View {
                         viewModel.focusSetIndex = max(viewModel.exercises[exerciseIndex].sets.count - 1, 0)
                     }
                 } label: {
-                    HStack(spacing: 4) {
+                    HStack(spacing: Theme.Spacing.tight) {
                         Image(systemName: "plus")
                             .font(.subheadline.weight(.bold))
                         Text("Set")
@@ -217,7 +217,7 @@ struct WorkoutFocusView: View {
                             viewModel.focusSetIndex = parentSetIndex + 1
                         }
                     } label: {
-                        HStack(spacing: 4) {
+                        HStack(spacing: Theme.Spacing.tight) {
                             Image(systemName: "arrow.down.right")
                                 .font(.subheadline.weight(.bold))
                             Text("drop set")
@@ -242,7 +242,7 @@ struct WorkoutFocusView: View {
     // MARK: - Weight Display
 
     private func weightDisplay(currentSet: WorkoutSet) -> some View {
-        VStack(spacing: 4) {
+        VStack(spacing: Theme.Spacing.tight) {
             Text("WEIGHT")
                 .font(Theme.fontSmall)
                 .foregroundStyle(Theme.textSecondary)
@@ -292,7 +292,7 @@ struct WorkoutFocusView: View {
     // MARK: - Reps Display
 
     private func repsDisplay(currentSet: WorkoutSet) -> some View {
-        VStack(spacing: 4) {
+        VStack(spacing: Theme.Spacing.tight) {
             Text("REPS")
                 .font(Theme.fontSmall)
                 .foregroundStyle(Theme.textSecondary)
@@ -411,7 +411,7 @@ struct WorkoutFocusView: View {
             // Rest timer config (compact, visible in focus mode)
             HStack(spacing: 6) {
                 Image(systemName: "timer")
-                    .font(.caption2)
+                    .font(Theme.fontCaption2)
                     .foregroundStyle(Theme.accent)
                 Text("Rest:")
                     .font(.caption2.weight(.semibold))
@@ -427,7 +427,7 @@ struct WorkoutFocusView: View {
                     Text(viewModel.defaultRestDuration > 0 ? "\(Int(viewModel.defaultRestDuration))s" : "Off")
                         .font(.caption2.weight(.bold))
                         .foregroundStyle(Theme.accent)
-                        .padding(.horizontal, 8)
+                        .padding(.horizontal, Theme.Spacing.sm)
                         .padding(.vertical, 3)
                         .background(Theme.accent.opacity(0.12))
                         .clipShape(.capsule)
@@ -459,7 +459,7 @@ struct WorkoutFocusView: View {
                     // Discoverable expand affordance — chevron + diagonal arrows
                     // hint that tapping anywhere on the banner re-opens the
                     // full-screen timer.
-                    VStack(spacing: 2) {
+                    VStack(spacing: Theme.Spacing.tighter) {
                         Image(systemName: "chevron.up")
                             .font(.caption2.weight(.bold))
                         Image(systemName: "arrow.up.left.and.arrow.down.right")
@@ -520,7 +520,7 @@ struct WorkoutFocusView: View {
                         withAnimation(.xomChill) { isRestTimerMinimized = true }
                     } label: {
                         Image(systemName: "arrow.down.right.and.arrow.up.left")
-                            .font(.body.weight(.semibold))
+                            .font(Theme.fontBodyEmphasized)
                             .foregroundStyle(Theme.textSecondary)
                             .frame(width: 44, height: 44)
                             .background(Theme.surface.opacity(0.3))
@@ -544,7 +544,7 @@ struct WorkoutFocusView: View {
                         .rotationEffect(.degrees(-90))
                         .animation(.linear(duration: 1), value: restProgress)
 
-                    VStack(spacing: 4) {
+                    VStack(spacing: Theme.Spacing.tight) {
                         Text("REST")
                             .font(.caption.weight(.bold))
                             .foregroundStyle(Theme.textSecondary)
@@ -558,7 +558,7 @@ struct WorkoutFocusView: View {
 
                 // Next exercise hint
                 if let nextEx = viewModel.upcomingExercise {
-                    VStack(spacing: 4) {
+                    VStack(spacing: Theme.Spacing.tight) {
                         Text("NEXT UP")
                             .font(.caption2.weight(.bold))
                             .foregroundStyle(Theme.accent)

--- a/Xomfit/Views/Workout/WorkoutView.swift
+++ b/Xomfit/Views/Workout/WorkoutView.swift
@@ -81,7 +81,7 @@ struct WorkoutView: View {
                                     Haptics.light()
                                     showBuilder = true
                                 } label: {
-                                    HStack(spacing: 8) {
+                                    HStack(spacing: Theme.Spacing.sm) {
                                         Image(systemName: "hammer.fill")
                                         Text("Build")
                                     }
@@ -92,7 +92,7 @@ struct WorkoutView: View {
                                     Haptics.light()
                                     showLogPastWorkout = true
                                 } label: {
-                                    HStack(spacing: 8) {
+                                    HStack(spacing: Theme.Spacing.sm) {
                                         Image(systemName: "calendar.badge.clock")
                                         Text("Log Past")
                                     }
@@ -221,7 +221,7 @@ struct WorkoutView: View {
                     }
                 }
             } label: {
-                HStack(spacing: 8) {
+                HStack(spacing: Theme.Spacing.sm) {
                     Image(systemName: "play.fill")
                     Text("Start Guided Workout")
                 }
@@ -256,7 +256,7 @@ struct WorkoutView: View {
                 NavigationLink {
                     WorkoutCategoryPage(category: category, viewModel: viewModel)
                 } label: {
-                    HStack(spacing: 4) {
+                    HStack(spacing: Theme.Spacing.tight) {
                         Text("See All")
                             .font(.caption.weight(.semibold))
                         Image(systemName: "chevron.right")


### PR DESCRIPTION
Closes #314. Theme tokens added: Spacing.tighter/.tight, fontTitle3/Callout/Footnote/Caption2/BodyEmphasized. Spacing literals on 8pt grid replaced. Font, color, and icon usage standardized across 77 view files. Off-grid literals (6/10/12/14) and semantic colors (.black on accent, .white on photos) intentionally preserved.