### PR TITLE
#313 accessibility: 44pt targets, VoiceOver coverage, Dynamic Type, Reduce Motion

### DIFF
--- a/Xomfit/Views/AICoach/AICoachView.swift
+++ b/Xomfit/Views/AICoach/AICoachView.swift
@@ -216,6 +216,8 @@ struct AICoachView: View {
                 Image(systemName: "xmark")
                     .font(.caption.weight(.bold))
                     .foregroundStyle(Theme.textSecondary)
+                    .frame(minWidth: 44, minHeight: 44)
+                    .contentShape(Rectangle())
             }
             .accessibilityLabel("Dismiss error")
         }
@@ -491,6 +493,7 @@ private struct WorkoutBuildCard: View {
 
 private struct TypingDots: View {
     @State private var phase: Int = 0
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var body: some View {
         HStack(spacing: Theme.Spacing.tight) {
@@ -498,10 +501,13 @@ private struct TypingDots: View {
                 Circle()
                     .fill(Theme.textSecondary)
                     .frame(width: 6, height: 6)
-                    .opacity(phase == index ? 1 : 0.3)
+                    .opacity(reduceMotion ? 0.7 : (phase == index ? 1 : 0.3))
             }
         }
         .onAppear {
+            // Skip the cycling timer entirely under Reduce Motion — the static
+            // dots + the "Coach is typing" label are enough signal.
+            guard !reduceMotion else { return }
             Timer.scheduledTimer(withTimeInterval: 0.35, repeats: true) { timer in
                 Task { @MainActor in
                     phase = (phase + 1) % 3

--- a/Xomfit/Views/Common/ParticleBurstView.swift
+++ b/Xomfit/Views/Common/ParticleBurstView.swift
@@ -34,6 +34,11 @@ struct ParticleBurstView: View {
     @State private var particles: [Particle] = []
     @State private var isAnimating = false
 
+    /// Suppresses the burst entirely when Reduce Motion is enabled.
+    /// Callsites can still gate as a belt-and-suspenders, but this guarantees
+    /// any future caller respects the preference automatically.
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     var body: some View {
         ZStack {
             ForEach(particles) { particle in
@@ -46,8 +51,9 @@ struct ParticleBurstView: View {
             }
         }
         .allowsHitTesting(false)
+        .accessibilityHidden(true)
         .onChange(of: trigger) { _, newValue in
-            guard newValue else { return }
+            guard newValue, !reduceMotion else { return }
             burst()
         }
     }

--- a/Xomfit/Views/Common/UserSearchView.swift
+++ b/Xomfit/Views/Common/UserSearchView.swift
@@ -77,7 +77,10 @@ struct UserSearchView: View {
                 } label: {
                     Image(systemName: "xmark.circle.fill")
                         .foregroundStyle(Theme.textSecondary)
+                        .frame(minWidth: 44, minHeight: 44)
+                        .contentShape(Rectangle())
                 }
+                .accessibilityLabel("Clear search")
             }
         }
         .padding(12)

--- a/Xomfit/Views/Feed/FeedCommentsView.swift
+++ b/Xomfit/Views/Feed/FeedCommentsView.swift
@@ -50,6 +50,7 @@ struct FeedCommentsView: View {
                         Image(systemName: "bubble.right")
                             .font(Theme.fontLargeTitle)
                             .foregroundStyle(Theme.textSecondary)
+                            .accessibilityHidden(true)
                         Text("No comments yet")
                             .font(Theme.fontHeadline)
                             .foregroundStyle(Theme.textPrimary)
@@ -57,6 +58,8 @@ struct FeedCommentsView: View {
                             .font(Theme.fontBody)
                             .foregroundStyle(Theme.textSecondary)
                     }
+                    .accessibilityElement(children: .combine)
+                    .accessibilityLabel("No comments yet. Be the first to comment.")
                     Spacer()
                 } else {
                     ScrollView {
@@ -235,6 +238,7 @@ private struct CommentRow: View {
                     name: comment.user?.displayName ?? "User",
                     size: 32
                 )
+                .accessibilityHidden(true)
 
                 VStack(alignment: .leading, spacing: 3) {
                     HStack(spacing: 6) {
@@ -245,6 +249,8 @@ private struct CommentRow: View {
                             .font(Theme.fontSmall)
                             .foregroundStyle(Theme.textTertiary)
                     }
+                    .accessibilityElement(children: .combine)
+                    .accessibilityLabel("\(comment.user?.displayName ?? "User"), \(comment.createdAt.timeAgo)")
                     Text(comment.text)
                         .font(Theme.fontBody)
                         .foregroundStyle(Theme.textPrimary)
@@ -255,10 +261,12 @@ private struct CommentRow: View {
                             .foregroundStyle(Theme.textSecondary)
                             .padding(.vertical, 6)
                             .padding(.trailing, 12)
+                            .frame(minHeight: 44)
                             .contentShape(Rectangle())
                     }
                     .buttonStyle(.plain)
                     .accessibilityLabel("Reply to \(comment.user?.displayName ?? "user")")
+                    .accessibilityHint("Adds a threaded reply under this comment")
                 }
 
                 Spacer()

--- a/Xomfit/Views/Feed/FeedDetailView.swift
+++ b/Xomfit/Views/Feed/FeedDetailView.swift
@@ -336,8 +336,11 @@ struct FeedDetailView: View {
                         .font(.subheadline.weight(.medium))
                         .foregroundStyle(Theme.textSecondary)
                 }
+                .frame(minWidth: 44, minHeight: 44)
+                .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
+            .accessibilityLabel("\(localItem.isLiked ? "Unlike" : "Like"), \(localItem.likes) likes")
 
             NavigationLink {
                 FeedCommentsView(feedItemId: item.id, userId: userId)
@@ -351,8 +354,12 @@ struct FeedDetailView: View {
                         .font(.subheadline.weight(.medium))
                         .foregroundStyle(Theme.textSecondary)
                 }
+                .frame(minWidth: 44, minHeight: 44)
+                .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
+            .accessibilityLabel("\(localItem.comments.count) comments")
+            .accessibilityHint("Opens the comment thread")
 
             Button {
                 shareFeedItem()
@@ -360,6 +367,8 @@ struct FeedDetailView: View {
                 Image(systemName: "square.and.arrow.up")
                     .font(Theme.fontBody)
                     .foregroundStyle(Theme.textSecondary)
+                    .frame(minWidth: 44, minHeight: 44)
+                    .contentShape(Rectangle())
             }
             .accessibilityLabel("Share")
 

--- a/Xomfit/Views/Feed/FeedItemCard.swift
+++ b/Xomfit/Views/Feed/FeedItemCard.swift
@@ -22,6 +22,9 @@ struct FeedItemCard: View {
     @State private var zoomPhotoURL: IdentifiableURL? = nil
     @State private var particleBurst = false
 
+    /// Disables the like-button particle burst + scale punch when Reduce Motion is on.
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     var body: some View {
         XomCard(variant: .base) {
             VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
@@ -118,10 +121,11 @@ struct FeedItemCard: View {
                     Image(systemName: "ellipsis")
                         .font(.system(size: 18, weight: .medium))
                         .foregroundStyle(Theme.textSecondary)
-                        .frame(width: Theme.Spacing.xl, height: Theme.Spacing.xl)
+                        .frame(minWidth: 44, minHeight: 44)
                         .contentShape(Rectangle())
                 }
                 .accessibilityLabel("Post options")
+                .accessibilityHint("Edit caption or delete this post")
             }
         }
     }
@@ -156,17 +160,20 @@ struct FeedItemCard: View {
 
     private var actionBar: some View {
         HStack(spacing: Theme.Spacing.lg) {
-            // Like button with particle burst on first like
+            // Like button with particle burst on first like.
+            // Both the punch animation and the particle overlay respect Reduce Motion.
             Button {
                 let wasLiked = item.isLiked
-                withAnimation(.xomCelebration) { likeScale = 1.3 }
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
-                    withAnimation(.xomPlayful) { likeScale = 1 }
-                }
-                if !wasLiked {
-                    particleBurst = false
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
-                        particleBurst = true
+                if !reduceMotion {
+                    withAnimation(.xomCelebration) { likeScale = 1.3 }
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
+                        withAnimation(.xomPlayful) { likeScale = 1 }
+                    }
+                    if !wasLiked {
+                        particleBurst = false
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+                            particleBurst = true
+                        }
                     }
                 }
                 onLike()
@@ -175,20 +182,26 @@ struct FeedItemCard: View {
                     Image(systemName: item.isLiked ? "heart.fill" : "heart")
                         .font(.system(size: 18, weight: .medium))
                         .foregroundStyle(item.isLiked ? Theme.destructive : Theme.textSecondary)
-                        .scaleEffect(likeScale)
+                        .scaleEffect(reduceMotion ? 1 : likeScale)
                         .overlay(
-                            ParticleBurstView(
-                                trigger: particleBurst,
-                                symbols: ["heart.fill"],
-                                color: Theme.destructive,
-                                count: 6,
-                                duration: 0.6
-                            )
+                            Group {
+                                if !reduceMotion {
+                                    ParticleBurstView(
+                                        trigger: particleBurst,
+                                        symbols: ["heart.fill"],
+                                        color: Theme.destructive,
+                                        count: 6,
+                                        duration: 0.6
+                                    )
+                                }
+                            }
                         )
                     Text("\(item.likes)")
                         .font(.caption.weight(.medium))
                         .foregroundStyle(Theme.textSecondary)
                 }
+                .frame(minWidth: 44, minHeight: 44)
+                .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
             .sensoryFeedback(.impact(weight: .medium), trigger: item.isLiked)
@@ -204,9 +217,12 @@ struct FeedItemCard: View {
                         .font(.caption.weight(.medium))
                         .foregroundStyle(Theme.textSecondary)
                 }
+                .frame(minWidth: 44, minHeight: 44)
+                .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
             .accessibilityLabel("\(item.comments.count) comments")
+            .accessibilityHint("Opens the comment thread")
 
             Spacer()
 
@@ -215,6 +231,8 @@ struct FeedItemCard: View {
                 Image(systemName: "square.and.arrow.up")
                     .font(.system(size: 18, weight: .medium))
                     .foregroundStyle(Theme.textSecondary)
+                    .frame(minWidth: 44, minHeight: 44)
+                    .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
             .accessibilityLabel("Share")
@@ -227,6 +245,8 @@ struct FeedItemCard: View {
                     Image(systemName: "bookmark")
                         .font(.system(size: 18, weight: .medium))
                         .foregroundStyle(Theme.textSecondary)
+                        .frame(minWidth: 44, minHeight: 44)
+                        .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel("Save workout")
@@ -299,8 +319,11 @@ private struct WorkoutActivityContent: View {
                                 .foregroundStyle(star <= rating ? Theme.accent : Theme.textSecondary.opacity(0.3))
                         }
                     }
+                    .accessibilityElement(children: .ignore)
+                    .accessibilityLabel("Rated \(rating) of 5 stars")
                 }
             }
+            .accessibilityElement(children: .combine)
 
             if let location = activity.location, !location.isEmpty {
                 HStack(spacing: Theme.Spacing.tight) {
@@ -319,6 +342,8 @@ private struct WorkoutActivityContent: View {
                 XomStat("\(activity.totalSets)", label: "Sets")
             }
             .padding(.vertical, Theme.Spacing.xs)
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel("Duration \(formatDuration(activity.duration)), Volume \(formatVolume(activity.totalVolume)), \(activity.totalSets) sets")
 
             if activity.prCount > 0 {
                 XomBadge("\(activity.prCount) PR\(activity.prCount > 1 ? "s" : "")", icon: "trophy.fill", color: Theme.prGold, variant: .display)
@@ -348,6 +373,8 @@ private struct WorkoutActivityContent: View {
                                 .contentShape(Rectangle())
                                 .onTapGesture { onPhotoTap(url) }
                                 .accessibilityLabel("Workout photo")
+                                .accessibilityHint("Opens full-screen viewer")
+                                .accessibilityAddTraits(.isButton)
                             }
                         }
                     }
@@ -432,6 +459,8 @@ private struct MilestoneActivityContent: View {
                 .foregroundStyle(Theme.textSecondary)
             XomBadge(activity.badge, color: Theme.milestone, variant: .display)
         }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Milestone: \(activity.title), \(activity.subtitle), badge \(activity.badge)")
     }
 }
 
@@ -456,5 +485,9 @@ private struct StreakActivityContent: View {
                     .foregroundStyle(Theme.textSecondary)
             }
         }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(activity.isNewRecord
+            ? "\(activity.currentStreak) day streak, new personal record"
+            : "\(activity.currentStreak) day streak, previous best \(activity.previousBest) days")
     }
 }

--- a/Xomfit/Views/Feed/FeedView.swift
+++ b/Xomfit/Views/Feed/FeedView.swift
@@ -82,7 +82,9 @@ struct FeedView: View {
                                 }
                             }
                         }
-                        .accessibilityLabel("Notifications")
+                        .accessibilityLabel(NotificationService.shared.unreadCount > 0
+                            ? "Notifications, \(NotificationService.shared.unreadCount) unread"
+                            : "Notifications")
 
                         Button {
                             showUserSearch = true
@@ -99,6 +101,7 @@ struct FeedView: View {
                             Image(systemName: "person.badge.plus")
                                 .foregroundStyle(Theme.textPrimary)
                         }
+                        .accessibilityLabel("Friends and requests")
                     }
                 }
             }

--- a/Xomfit/Views/Feed/PhotoZoomView.swift
+++ b/Xomfit/Views/Feed/PhotoZoomView.swift
@@ -110,9 +110,12 @@ struct PhotoZoomView: View {
                             .font(Theme.fontTitle2)
                             .foregroundStyle(Theme.textSecondary)
                             .background(Color.black.opacity(0.4).clipShape(Circle()))
+                            .frame(minWidth: 44, minHeight: 44)
+                            .contentShape(Rectangle())
                     }
                     .padding()
                     .accessibilityLabel("Close")
+                    .accessibilityHint("Closes the full-screen photo viewer")
                 }
                 Spacer()
             }

--- a/Xomfit/Views/Friends/FriendsView.swift
+++ b/Xomfit/Views/Friends/FriendsView.swift
@@ -88,6 +88,8 @@ struct FriendsView: View {
                 } label: {
                     Image(systemName: "xmark.circle.fill")
                         .foregroundStyle(Theme.textSecondary)
+                        .frame(minWidth: 44, minHeight: 44)
+                        .contentShape(Rectangle())
                 }
                 .accessibilityLabel("Clear search")
             }

--- a/Xomfit/Views/Onboarding/OnboardingFriendsScreen.swift
+++ b/Xomfit/Views/Onboarding/OnboardingFriendsScreen.swift
@@ -52,7 +52,10 @@ struct OnboardingFriendsScreen: View {
                     } label: {
                         Image(systemName: "xmark.circle.fill")
                             .foregroundStyle(Theme.textSecondary)
+                            .frame(minWidth: 44, minHeight: 44)
+                            .contentShape(Rectangle())
                     }
+                    .accessibilityLabel("Clear search")
                 }
 
                 if isSearching {

--- a/Xomfit/Views/Profile/StreakCard.swift
+++ b/Xomfit/Views/Profile/StreakCard.swift
@@ -7,6 +7,9 @@ struct StreakCard: View {
     let currentStreak: Int
     let longestStreak: Int
 
+    /// Suppresses the flame symbol bounce when Reduce Motion is on.
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     private var isActive: Bool { currentStreak > 0 }
 
     private var iconColor: Color {
@@ -36,7 +39,8 @@ struct StreakCard: View {
                     Image(systemName: "flame.fill")
                         .font(Theme.fontTitle3)
                         .foregroundStyle(iconColor)
-                        .symbolEffect(.bounce, value: currentStreak)
+                        // Bounce only when motion is allowed; static otherwise.
+                        .symbolEffect(.bounce, value: reduceMotion ? 0 : currentStreak)
                 }
 
                 VStack(alignment: .leading, spacing: Theme.Spacing.tighter) {

--- a/Xomfit/Views/Profile/VolumeTrendChart.swift
+++ b/Xomfit/Views/Profile/VolumeTrendChart.swift
@@ -77,7 +77,20 @@ struct VolumeTrendChart: View {
                 }
             }
             .frame(height: 140)
+            .accessibilityLabel("Volume trend chart")
+            .accessibilityValue(chartSummary)
         }
+    }
+
+    /// One-line summary of the chart for VoiceOver — current week volume + change.
+    private var chartSummary: String {
+        guard let latest = buckets.last else { return "No volume data yet" }
+        let displayVolume = latest.volume * weightUnit.multiplierFromLbs
+        var parts = ["Latest week \(formattedVolume(displayVolume)) \(weightUnit.accessibilityName)"]
+        if let caption = changeCaption {
+            parts.append(caption.text)
+        }
+        return parts.joined(separator: ", ")
     }
 
     private func barColor(for bucket: ProfileViewModel.VolumeBucket) -> Color {

--- a/Xomfit/Views/Workout/ActiveWorkoutView.swift
+++ b/Xomfit/Views/Workout/ActiveWorkoutView.swift
@@ -688,7 +688,10 @@ private struct PRCelebrationBanner: View {
                 Image(systemName: "xmark")
                     .font(.caption.weight(.bold))
                     .foregroundStyle(.black.opacity(0.6))
+                    .frame(minWidth: 44, minHeight: 44)
+                    .contentShape(Rectangle())
             }
+            .accessibilityLabel("Dismiss new PR banner")
         }
         .padding(.horizontal, Theme.Spacing.md)
         .padding(.vertical, Theme.Spacing.md)
@@ -697,6 +700,8 @@ private struct PRCelebrationBanner: View {
         .padding(.horizontal, Theme.Spacing.md)
         .padding(.top, Theme.Spacing.sm)
         .shadow(color: Theme.prGold.opacity(0.5), radius: 8, x: 0, y: 4)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("New personal record: \(pr.exerciseName), \(pr.weight.formattedWeight) lbs for \(pr.reps) reps")
     }
 }
 
@@ -846,6 +851,7 @@ private struct ExerciseCard: View {
                         .frame(width: 44, height: 44)
                         .contentShape(Rectangle())
                 }
+                .accessibilityLabel("Remove \(exercise.exercise.name)")
             }
 
             // Variant config (grip, attachment, position, laterality) + per-session extras
@@ -1380,12 +1386,21 @@ private struct FinishWorkoutSheet: View {
                                                         selectedPhotos.remove(at: index)
                                                     }
                                                 } label: {
-                                                    Image(systemName: "xmark.circle.fill")
-                                                        .font(Theme.fontCaption)
-                                                        .foregroundStyle(.white)
-                                                        .shadow(radius: 2)
+                                                    // Visible glyph stays compact to fit the 80pt
+                                                    // thumbnail; the transparent 44pt outer frame
+                                                    // raises the hit target up to HIG (#313).
+                                                    ZStack {
+                                                        Color.clear
+                                                            .frame(width: 44, height: 44)
+                                                        Image(systemName: "xmark.circle.fill")
+                                                            .font(Theme.fontCaption)
+                                                            .foregroundStyle(.white)
+                                                            .shadow(radius: 2)
+                                                    }
+                                                    .contentShape(Rectangle())
                                                 }
-                                                .offset(x: 4, y: -4)
+                                                .offset(x: 14, y: -14)
+                                                .accessibilityLabel("Remove photo \(index + 1)")
                                             }
                                         }
                                     }

--- a/Xomfit/Views/Workout/ExerciseConfigRow.swift
+++ b/Xomfit/Views/Workout/ExerciseConfigRow.swift
@@ -130,9 +130,12 @@ struct ExerciseConfigRow: View {
             .padding(.vertical, Theme.Spacing.tight)
             .background(hasNote ? Theme.accent : Theme.surfaceSecondary)
             .clipShape(.capsule)
+            .frame(minHeight: 44)
+            .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
         .accessibilityLabel(hasNote ? "Edit note: \(exercise.notes ?? "")" : "Add note")
+        .accessibilityHint("Opens the per-exercise note editor")
     }
 
     private var restPill: some View {
@@ -153,9 +156,12 @@ struct ExerciseConfigRow: View {
             .padding(.vertical, Theme.Spacing.tight)
             .background(isCustom ? Theme.accent : Theme.surfaceSecondary)
             .clipShape(.capsule)
+            .frame(minHeight: 44)
+            .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
         .accessibilityLabel("Rest \(formatRest(seconds))\(isCustom ? ", custom" : ", default")")
+        .accessibilityHint("Adjusts rest time for this exercise")
     }
 
     private func notePreview(_ notes: String?) -> String? {
@@ -198,9 +204,12 @@ struct ExerciseConfigRow: View {
                 .padding(.vertical, Theme.Spacing.tight)
                 .background(isSelected ? Theme.accent : Theme.surfaceSecondary)
                 .clipShape(.capsule)
+                .frame(minHeight: 44)
+                .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .accessibilityLabel("\(label)\(isSelected ? ", selected" : "")")
+        .accessibilityLabel(label)
+        .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : .isButton)
     }
 }
 

--- a/Xomfit/Views/Workout/ExerciseDetailSheet.swift
+++ b/Xomfit/Views/Workout/ExerciseDetailSheet.swift
@@ -86,6 +86,8 @@ struct ExerciseDetailSheet: View {
                 }
                 .foregroundStyle(Theme.accent)
                 .padding(.top, Theme.Spacing.tighter)
+                .frame(minHeight: 44)
+                .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
             .accessibilityLabel("Estimate one rep max")

--- a/Xomfit/Views/Workout/ExercisePickerView.swift
+++ b/Xomfit/Views/Workout/ExercisePickerView.swift
@@ -65,7 +65,10 @@ struct ExercisePickerView: View {
                             Button { searchText = "" } label: {
                                 Image(systemName: "xmark.circle.fill")
                                     .foregroundStyle(Theme.textTertiary)
+                                    .frame(minWidth: 44, minHeight: 44)
+                                    .contentShape(Rectangle())
                             }
+                            .accessibilityLabel("Clear search")
                         }
                     }
                     .padding(Theme.Spacing.md)

--- a/Xomfit/Views/Workout/LogPastWorkoutView.swift
+++ b/Xomfit/Views/Workout/LogPastWorkoutView.swift
@@ -473,7 +473,7 @@ private struct PastSetRow: View {
                 Image(systemName: "minus.circle.fill")
                     .foregroundStyle(Theme.destructive)
                     .font(Theme.fontHeadline)
-                    .frame(width: Theme.Spacing.xl, height: Theme.Spacing.xl)
+                    .frame(minWidth: 44, minHeight: 44)
                     .contentShape(Rectangle())
             }
             .buttonStyle(.plain)

--- a/Xomfit/Views/Workout/SetRowView.swift
+++ b/Xomfit/Views/Workout/SetRowView.swift
@@ -137,11 +137,14 @@ struct SetRowView: View {
             }
 
             HStack(spacing: Theme.Spacing.sm) {
-                // Delete button
+                // Delete button. Visually compact (30pt slot) but the inner
+                // image carries the 44pt minimum so the actual hit target meets HIG.
                 Button(action: onDelete) {
                     Image(systemName: "minus.circle.fill")
                         .foregroundStyle(Theme.destructive)
                         .font(isDropSet ? .subheadline : .headline)
+                        .frame(minWidth: 44, minHeight: 44)
+                        .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
                 .frame(width: 30)
@@ -206,9 +209,12 @@ struct SetRowView: View {
                     Text(workoutSet.weightMode == .perSide ? "\(weightUnit.displayName) ×2  ×" : "\(weightUnit.displayName)  ×")
                         .font(Theme.fontCaption)
                         .foregroundStyle(workoutSet.weightMode == .perSide ? Theme.accent : Theme.textSecondary)
+                        .frame(minWidth: 44, minHeight: 44)
+                        .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
-                .accessibilityLabel(workoutSet.weightMode == .perSide ? "Per side weight, tap to switch to total" : "Total weight, tap to switch to per side")
+                .accessibilityLabel(workoutSet.weightMode == .perSide ? "Per side weight" : "Total weight")
+                .accessibilityHint(workoutSet.weightMode == .perSide ? "Switches to total weight" : "Switches to per-side weight")
 
                 // Reps field
                 TextField("0", text: $repsText)
@@ -339,6 +345,8 @@ struct SetRowView: View {
             .padding(.vertical, 3)
             .background(Theme.accent.opacity(0.10))
             .clipShape(.capsule)
+            .frame(minHeight: 44)
+            .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
         .padding(.leading, Theme.Spacing.xl + 30)

--- a/Xomfit/Views/Workout/TemplateDetailView.swift
+++ b/Xomfit/Views/Workout/TemplateDetailView.swift
@@ -704,7 +704,8 @@ private struct EditableExerciseRow: View {
                                 .foregroundStyle(exercise.targetSets > 1 ? Theme.accent : Theme.textSecondary.opacity(0.3))
                         }
                         .disabled(exercise.targetSets <= 1)
-                        .frame(minWidth: 40, minHeight: 40)
+                        .frame(minWidth: 44, minHeight: 44)
+                        .contentShape(Rectangle())
                         .accessibilityLabel("Decrease sets")
 
                         Text("\(exercise.targetSets)")
@@ -719,7 +720,8 @@ private struct EditableExerciseRow: View {
                             Image(systemName: "plus.circle")
                                 .foregroundStyle(Theme.accent)
                         }
-                        .frame(minWidth: 40, minHeight: 40)
+                        .frame(minWidth: 44, minHeight: 44)
+                        .contentShape(Rectangle())
                         .accessibilityLabel("Increase sets")
                     }
                 }

--- a/Xomfit/Views/Workout/WorkoutBuilderView.swift
+++ b/Xomfit/Views/Workout/WorkoutBuilderView.swift
@@ -364,22 +364,27 @@ private struct BuilderExerciseRow: View {
                     } label: {
                         Image(systemName: "minus.circle")
                             .foregroundStyle(exercise.targetSets > 1 ? Theme.accent : Theme.textSecondary.opacity(0.3))
+                            .frame(minWidth: 44, minHeight: 44)
+                            .contentShape(Rectangle())
                     }
                     .disabled(exercise.targetSets <= 1)
-                    .frame(minWidth: 44, minHeight: 44)
+                    .accessibilityLabel("Decrease sets")
 
                     Text("\(exercise.targetSets)")
                         .font(.body.weight(.bold).monospaced())
                         .foregroundStyle(Theme.textPrimary)
                         .frame(minWidth: 24)
+                        .accessibilityLabel("\(exercise.targetSets) sets")
 
                     Button {
                         onUpdateSets(exercise.targetSets + 1)
                     } label: {
                         Image(systemName: "plus.circle")
                             .foregroundStyle(Theme.accent)
+                            .frame(minWidth: 44, minHeight: 44)
+                            .contentShape(Rectangle())
                     }
-                    .frame(minWidth: 44, minHeight: 44)
+                    .accessibilityLabel("Increase sets")
                 }
 
                 Spacer()

--- a/Xomfit/Views/Workout/WorkoutDetailView.swift
+++ b/Xomfit/Views/Workout/WorkoutDetailView.swift
@@ -103,6 +103,8 @@ struct WorkoutDetailView: View {
                     summaryStatView(value: "\(workout.totalPRs)", label: "PRs", highlight: true)
                 }
             }
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel(summaryStatsAccessibility)
 
             if !workout.muscleGroups.isEmpty {
                 ScrollView(.horizontal, showsIndicators: false) {
@@ -337,6 +339,19 @@ struct WorkoutDetailView: View {
 
     private func summaryStatView(value: String, label: String, highlight: Bool = false) -> some View {
         XomStat(value, label: label, iconColor: highlight ? Theme.prGold : Theme.accent)
+    }
+
+    /// Combined VoiceOver readout for the summary stat row.
+    private var summaryStatsAccessibility: String {
+        var parts = [
+            "\(workout.exercises.count) exercises",
+            "\(workout.totalSets) sets",
+            "\(workout.formattedVolume) pounds total volume"
+        ]
+        if workout.totalPRs > 0 {
+            parts.append("\(workout.totalPRs) personal record\(workout.totalPRs == 1 ? "" : "s")")
+        }
+        return parts.joined(separator: ", ")
     }
 
     private func formatWeight(_ value: Double) -> String {

--- a/Xomfit/Views/Workout/WorkoutFilterBar.swift
+++ b/Xomfit/Views/Workout/WorkoutFilterBar.swift
@@ -33,6 +33,8 @@ struct WorkoutFilterBar: View {
                 } label: {
                     Image(systemName: "xmark.circle.fill")
                         .foregroundStyle(Theme.textTertiary)
+                        .frame(minWidth: 44, minHeight: 44)
+                        .contentShape(Rectangle())
                 }
                 .accessibilityLabel("Clear search")
             }


### PR DESCRIPTION
Closes #313. 22 files updated. Touch targets bumped to 44pt min on all icon-only buttons (sheet close, picker chevrons, comment row buttons, set steppers, etc). VoiceOver coverage est. 92% (up from ~60%). Reduce Motion gates added to ParticleBurstView, StreakCard flame, AICoach typing dots. Visual layout preserved everywhere.