### PR TITLE
#337 #338 #339 workouts tab: category segmented nav + start from recents + bottom safe area

### DIFF
--- a/Xomfit/Views/Workout/WorkoutCategoryPage.swift
+++ b/Xomfit/Views/Workout/WorkoutCategoryPage.swift
@@ -2,42 +2,46 @@ import SwiftUI
 
 // MARK: - WorkoutCategory
 
-/// The three "Quick Hitter" sections surfaced on `WorkoutView`.
+/// The four category segments surfaced on the Workouts tab (#338).
 ///
-/// Each case identifies both the preview shown on the main page and the
-/// dedicated `WorkoutCategoryPage` reachable via "See All".
+/// Each case identifies a list shown under the segmented control on `WorkoutView`.
 enum WorkoutCategory: String, CaseIterable, Identifiable, Hashable {
     /// The user's own recent past workouts.
     case recents
-    /// Built-in templates shipped with the app (non-custom).
-    case preGenerated
-    /// Combination of: the user's custom + saved templates and friends' recent workouts.
-    case friendsAndSaved
+    /// The user's own custom templates (built with WorkoutBuilder, not saved-from-friend).
+    case myWorkouts
+    /// Templates the user saved from elsewhere, plus friends' recent workouts.
+    case savedFriendsWorkouts
+    /// Built-in templates shipped with the app.
+    case preGen
 
     var id: String { rawValue }
 
     var title: String {
         switch self {
-        case .recents:         return "Recents"
-        case .preGenerated:    return "Pre-generated"
-        case .friendsAndSaved: return "Friends & Saved"
+        case .recents:              return "Recents"
+        case .myWorkouts:           return "My Workouts"
+        case .savedFriendsWorkouts: return "Saved & Friends"
+        case .preGen:               return "Pre-Gen"
         }
     }
 
     var icon: String {
         switch self {
-        case .recents:         return "clock.fill"
-        case .preGenerated:    return "list.bullet.rectangle.portrait"
-        case .friendsAndSaved: return "person.2.fill"
+        case .recents:              return "clock.fill"
+        case .myWorkouts:           return "star.fill"
+        case .savedFriendsWorkouts: return "person.2.fill"
+        case .preGen:               return "list.bullet.rectangle.portrait"
         }
     }
 
     /// Empty-state copy when the user has no items in this category at all (no filter applied).
     var emptyStateTitle: String {
         switch self {
-        case .recents:         return "No recent workouts"
-        case .preGenerated:    return "No templates available"
-        case .friendsAndSaved: return "Nothing here yet"
+        case .recents:              return "No recent workouts"
+        case .myWorkouts:           return "No custom workouts yet"
+        case .savedFriendsWorkouts: return "Nothing saved yet"
+        case .preGen:               return "No templates available"
         }
     }
 
@@ -45,26 +49,28 @@ enum WorkoutCategory: String, CaseIterable, Identifiable, Hashable {
         switch self {
         case .recents:
             return "Finished workouts will show up here."
-        case .preGenerated:
+        case .myWorkouts:
+            return "Build a workout to save it here for quick reuse."
+        case .savedFriendsWorkouts:
+            return "Save a template or follow friends to populate this list."
+        case .preGen:
             return "Built-in templates will appear once loaded."
-        case .friendsAndSaved:
-            return "Save a template or add friends to populate this list."
         }
     }
 }
 
-// MARK: - WorkoutCategoryPage
+// MARK: - WorkoutCategoryListView
 
-/// Dedicated "See All" page for a single `WorkoutCategory`.
+/// Reusable list body for a `WorkoutCategory` — filter bar + items + empty states.
 ///
-/// Reuses the shared `WorkoutTabViewModel` so filter state survives navigation
-/// while data is loaded once on the parent screen.
-struct WorkoutCategoryPage: View {
+/// Used inline on `WorkoutView` under the segmented control (#338). Receives the
+/// shared `WorkoutTabViewModel` so the same loaded data backs every category
+/// without re-fetching when the segment changes.
+struct WorkoutCategoryListView: View {
     let category: WorkoutCategory
 
-    /// Shared view model owned by `WorkoutView`. Filters apply per-page via the
-    /// local `localFilter` state — we don't mutate the shared filter so each
-    /// "See All" page starts clean.
+    /// Shared view model owned by `WorkoutView`. Local filter state is per-list
+    /// so each category starts with a clean filter.
     let viewModel: WorkoutTabViewModel
 
     @Environment(AuthService.self) private var authService
@@ -87,24 +93,15 @@ struct WorkoutCategoryPage: View {
     }
 
     var body: some View {
-        ZStack {
-            Theme.background.ignoresSafeArea()
+        VStack(spacing: 0) {
+            WorkoutFilterBar(filter: $localFilter)
 
-            VStack(spacing: 0) {
-                WorkoutFilterBar(filter: $localFilter)
-
-                ScrollView {
-                    LazyVStack(spacing: Theme.Spacing.sm) {
-                        contentView
-                    }
-                    .padding(.horizontal, Theme.Spacing.md)
-                    .padding(.vertical, Theme.Spacing.sm)
-                }
+            LazyVStack(spacing: Theme.Spacing.sm) {
+                contentView
             }
+            .padding(.horizontal, Theme.Spacing.md)
+            .padding(.vertical, Theme.Spacing.sm)
         }
-        .navigationTitle(category.title)
-        .navigationBarTitleDisplayMode(.inline)
-        .toolbarColorScheme(.dark, for: .navigationBar)
         .sheet(item: $previewTemplate) { template in
             TemplateDetailView(template: template) {
                 let captured = template
@@ -151,10 +148,12 @@ struct WorkoutCategoryPage: View {
         switch category {
         case .recents:
             recentsContent
-        case .preGenerated:
+        case .myWorkouts:
+            myWorkoutsContent
+        case .savedFriendsWorkouts:
+            savedFriendsContent
+        case .preGen:
             preGeneratedContent
-        case .friendsAndSaved:
-            friendsAndSavedContent
         }
     }
 
@@ -179,9 +178,9 @@ struct WorkoutCategoryPage: View {
     }
 
     @ViewBuilder
-    private var preGeneratedContent: some View {
-        let items = viewModel.builtInTemplates.filter(localFilter.matches)
-        if viewModel.builtInTemplates.isEmpty {
+    private var myWorkoutsContent: some View {
+        let items = viewModel.myTemplates.filter(localFilter.matches)
+        if viewModel.myTemplates.isEmpty {
             emptyState
         } else if items.isEmpty {
             filteredEmptyState
@@ -195,12 +194,10 @@ struct WorkoutCategoryPage: View {
     }
 
     @ViewBuilder
-    private var friendsAndSavedContent: some View {
-        let templates = (viewModel.myTemplates + viewModel.savedTemplates).filter(localFilter.matches)
+    private var savedFriendsContent: some View {
+        let templates = viewModel.savedTemplates.filter(localFilter.matches)
         let workouts = viewModel.friendWorkouts.filter(localFilter.matches)
-        let hasAnySource = !viewModel.myTemplates.isEmpty
-            || !viewModel.savedTemplates.isEmpty
-            || !viewModel.friendWorkouts.isEmpty
+        let hasAnySource = !viewModel.savedTemplates.isEmpty || !viewModel.friendWorkouts.isEmpty
         let hasAnyMatch = !templates.isEmpty || !workouts.isEmpty
 
         if !hasAnySource {
@@ -227,6 +224,22 @@ struct WorkoutCategoryPage: View {
                     }
                     .buttonStyle(PressableCardStyle())
                     .accessibilityLabel("Friend workout: \(workout.name)")
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var preGeneratedContent: some View {
+        let items = viewModel.builtInTemplates.filter(localFilter.matches)
+        if viewModel.builtInTemplates.isEmpty {
+            emptyState
+        } else if items.isEmpty {
+            filteredEmptyState
+        } else {
+            ForEach(items) { template in
+                TemplateCardView(template: template, style: .row) {
+                    previewTemplate = template
                 }
             }
         }

--- a/Xomfit/Views/Workout/WorkoutCategoryTabs.swift
+++ b/Xomfit/Views/Workout/WorkoutCategoryTabs.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+/// Segmented control used at the top of the Workouts tab (#338).
+///
+/// Drives the inline `WorkoutCategoryListView` below the CTAs by exposing a
+/// `WorkoutCategory` binding. Kept as a thin wrapper around `Picker` so we can
+/// swap to a paged `TabView` later if we want without touching call sites.
+struct WorkoutCategoryTabs: View {
+    @Binding var selection: WorkoutCategory
+
+    var body: some View {
+        Picker("Workout category", selection: $selection) {
+            ForEach(WorkoutCategory.allCases) { category in
+                Text(category.title)
+                    .tag(category)
+            }
+        }
+        .pickerStyle(.segmented)
+        .padding(.horizontal, Theme.Spacing.md)
+        .accessibilityLabel("Workout category")
+        .accessibilityHint("Switches between recents, your workouts, saved or friends workouts, and pre-generated templates")
+    }
+}
+
+#Preview {
+    @Previewable @State var selection: WorkoutCategory = .recents
+    return ZStack {
+        Theme.background.ignoresSafeArea()
+        VStack {
+            WorkoutCategoryTabs(selection: $selection)
+            Spacer()
+        }
+    }
+}

--- a/Xomfit/Views/Workout/WorkoutDetailView.swift
+++ b/Xomfit/Views/Workout/WorkoutDetailView.swift
@@ -3,9 +3,30 @@ import SwiftUI
 struct WorkoutDetailView: View {
     let workout: Workout
 
+    @Environment(AuthService.self) private var authService
+    @Environment(WorkoutLoggerViewModel.self) private var workoutSession
+
     /// Image rendered for sharing (#320). Held while the share sheet is presented
     /// so `UIActivityViewController` doesn't see a stale image.
     @State private var shareImage: UIImage?
+
+    // MARK: - Warmup gating (#337)
+    //
+    // "Start this Workout" mirrors the gate used on `WorkoutView`/`WorkoutCategoryListView`:
+    // build a fresh template from the recorded exercises, then either ask, present
+    // the warmup, or start immediately based on the user's saved preference.
+
+    @AppStorage("warmupOptIn") private var warmupOptIn: String = ""
+    @AppStorage("warmupMinutes") private var warmupMinutes: Int = 6
+
+    @State private var pendingStart: (() -> Void)?
+    @State private var pendingStretches: [Stretch] = []
+    @State private var showWarmupPrompt = false
+    @State private var showWarmup = false
+
+    private var userId: String {
+        authService.currentUser?.id.uuidString.lowercased() ?? ""
+    }
 
     var body: some View {
         ZStack {
@@ -16,6 +37,7 @@ struct WorkoutDetailView: View {
                     summaryCard
                     exerciseList
                     soundtrackSection
+                    startThisWorkoutButton
                 }
                 .padding(.horizontal, Theme.Spacing.md)
                 .padding(.vertical, Theme.Spacing.sm)
@@ -43,6 +65,33 @@ struct WorkoutDetailView: View {
         )) { wrapper in
             WorkoutShareSheet(image: wrapper.image)
                 .presentationDetents([.medium, .large])
+        }
+        .confirmationDialog(
+            "Warm up first?",
+            isPresented: $showWarmupPrompt,
+            titleVisibility: .visible
+        ) {
+            Button("Yes, \(warmupMinutes) min") {
+                warmupOptIn = "yes"
+                showWarmup = true
+            }
+            Button("No, skip") {
+                warmupOptIn = "no"
+                runPendingStartImmediately()
+            }
+            Button("Just this once", role: .cancel) {
+                runPendingStartImmediately()
+            }
+        } message: {
+            Text("A 5-10 minute stretch routine helps loosen up before lifting.")
+        }
+        .fullScreenCover(isPresented: $showWarmup) {
+            WarmupView(
+                stretches: pendingStretches.isEmpty ? StretchDatabase.defaultRoutine() : pendingStretches,
+                totalDuration: warmupMinutes * 60
+            ) {
+                runPendingStartImmediately()
+            }
         }
     }
 
@@ -333,6 +382,105 @@ struct WorkoutDetailView: View {
             return "\(track.title) by \(artist)"
         }
         return track.title
+    }
+
+    // MARK: - Start This Workout (#337)
+
+    /// Repeats this workout as a fresh active session — builds a `WorkoutTemplate`
+    /// from the recorded exercises/sets, then runs through the standard warmup gate.
+    @ViewBuilder
+    private var startThisWorkoutButton: some View {
+        Button {
+            Haptics.medium()
+            let template = makeTemplateFromWorkout()
+            requestStart(
+                stretches: StretchDatabase.suggestedStretches(
+                    for: workout,
+                    target: TimeInterval(warmupMinutes * 60)
+                )
+            ) {
+                workoutSession.startFromTemplate(template, userId: userId)
+                workoutSession.isPresented = true
+            }
+        } label: {
+            HStack(spacing: Theme.Spacing.sm) {
+                Image(systemName: "play.fill")
+                Text("Start this Workout")
+            }
+        }
+        .buttonStyle(AccentButtonStyle())
+        .accessibilityHint("Builds a fresh workout using these exercises as a template")
+        .padding(.top, Theme.Spacing.sm)
+    }
+
+    /// Build a fresh `WorkoutTemplate` from this past workout. Target reps are
+    /// derived from the most-common reps value across recorded sets; weight is
+    /// not stored on the template — `WorkoutLoggerViewModel.startFromTemplate`
+    /// will prefill it from the user's last set for that exercise.
+    private func makeTemplateFromWorkout() -> WorkoutTemplate {
+        let templateExercises: [WorkoutTemplate.TemplateExercise] = workout.exercises.map { we in
+            WorkoutTemplate.TemplateExercise(
+                id: UUID().uuidString,
+                exercise: we.exercise,
+                targetSets: max(1, we.sets.count),
+                targetReps: modalRepsString(for: we.sets),
+                notes: we.notes,
+                restSeconds: we.restSeconds
+            )
+        }
+
+        return WorkoutTemplate(
+            id: UUID().uuidString,
+            name: workout.name,
+            description: "Repeat of \(workout.startTime.workoutDateString)",
+            exercises: templateExercises,
+            estimatedDuration: Int(workout.duration / 60),
+            category: .custom,
+            isCustom: true
+        )
+    }
+
+    /// Picks the most-common reps value across the recorded sets as the target.
+    /// Falls back to the first set's reps, then "0" if there are no sets.
+    private func modalRepsString(for sets: [WorkoutSet]) -> String {
+        guard !sets.isEmpty else { return "0" }
+        let counts = Dictionary(sets.map { ($0.reps, 1) }, uniquingKeysWith: +)
+        // Prefer the highest-count reps value; break ties on the larger reps
+        // count so AMRAP-style sets don't get masked by a single warmup set.
+        let mode = counts.max { lhs, rhs in
+            if lhs.value != rhs.value { return lhs.value < rhs.value }
+            return lhs.key < rhs.key
+        }?.key ?? sets[0].reps
+        return "\(mode)"
+    }
+
+    // MARK: - Warmup gating (#337)
+
+    private func requestStart(stretches: [Stretch], action: @escaping () -> Void) {
+        pendingStart = action
+        pendingStretches = stretches
+
+        switch warmupOptIn {
+        case "yes":
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) {
+                showWarmup = true
+            }
+        case "no":
+            runPendingStartImmediately()
+        default:
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) {
+                showWarmupPrompt = true
+            }
+        }
+    }
+
+    private func runPendingStartImmediately() {
+        let action = pendingStart
+        pendingStart = nil
+        pendingStretches = []
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+            action?()
+        }
     }
 
     // MARK: - Helpers

--- a/Xomfit/Views/Workout/WorkoutView.swift
+++ b/Xomfit/Views/Workout/WorkoutView.swift
@@ -10,17 +10,17 @@ struct WorkoutView: View {
     @State private var showLogPastWorkout = false
     @State private var previewTemplate: WorkoutTemplate?
 
-    /// Shared data store for the Quick Hitter previews and the See-All pages.
-    /// Owned here so the same loaded data backs both the previews and the
-    /// dedicated category pages without re-fetching on push.
+    /// Shared data store for every category list (#338). Owned here so all four
+    /// segments share the same loaded data without re-fetching on segment change.
     @State private var viewModel = WorkoutTabViewModel()
+
+    /// Active segment under the CTAs. Defaults to Recents — the most common
+    /// landing point for returning users.
+    @State private var selectedCategory: WorkoutCategory = .recents
 
     private var hasStartedFirstWorkout: Bool {
         UserDefaults.standard.bool(forKey: "xomfit_first_workout_started")
     }
-
-    /// Number of items shown in each Quick Hitter preview before "See All".
-    private let previewCount = 4
 
     // MARK: - Warmup flow (#261)
 
@@ -113,12 +113,16 @@ struct WorkoutView: View {
                                 firstWorkoutCard
                             }
 
-                            // Quick Hitter sections (vertical previews + See All)
-                            recentsQuickHitters
-                            preGeneratedQuickHitters
-                            friendsAndSavedQuickHitters
+                            // Category segmented nav + selected list (#338)
+                            WorkoutCategoryTabs(selection: $selectedCategory)
+                                .padding(.top, Theme.Spacing.sm)
+
+                            WorkoutCategoryListView(category: selectedCategory, viewModel: viewModel)
                         }
                     }
+                    // #339: lift bottom of scroll content above the floating tab
+                    // bar + resume bar so the last item isn't hidden under chrome.
+                    .safeAreaPadding(.bottom, Theme.Spacing.md)
                 }
             }
             .navigationTitle("Workout")
@@ -240,114 +244,6 @@ struct WorkoutView: View {
         .background(Theme.surface)
         .clipShape(.rect(cornerRadius: Theme.cornerRadius))
         .padding(.horizontal, Theme.Spacing.md)
-    }
-
-    // MARK: - Quick Hitter Sections
-
-    /// Header row used by each Quick Hitter section. Tappable "See All" pushes
-    /// the dedicated category page.
-    private func sectionHeader(for category: WorkoutCategory, showSeeAll: Bool) -> some View {
-        HStack {
-            Text(category.title)
-                .font(.body.weight(.bold))
-                .foregroundStyle(Theme.textPrimary)
-            Spacer()
-            if showSeeAll {
-                NavigationLink {
-                    WorkoutCategoryPage(category: category, viewModel: viewModel)
-                } label: {
-                    HStack(spacing: Theme.Spacing.tight) {
-                        Text("See All")
-                            .font(.caption.weight(.semibold))
-                        Image(systemName: "chevron.right")
-                            .font(.caption2.weight(.semibold))
-                    }
-                    .foregroundStyle(Theme.accent)
-                }
-                .accessibilityLabel("See all \(category.title.lowercased())")
-            }
-        }
-        .padding(.horizontal, Theme.Spacing.md)
-    }
-
-    @ViewBuilder
-    private var recentsQuickHitters: some View {
-        if !viewModel.recent.isEmpty {
-            VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
-                sectionHeader(for: .recents, showSeeAll: viewModel.recent.count > previewCount)
-
-                VStack(spacing: Theme.Spacing.xs) {
-                    ForEach(Array(viewModel.recent.prefix(previewCount))) { workout in
-                        NavigationLink {
-                            WorkoutDetailView(workout: workout)
-                        } label: {
-                            RecentWorkoutCard(workout: workout, style: .row)
-                        }
-                        .buttonStyle(PressableCardStyle())
-                        .accessibilityLabel("\(workout.name), \(workout.startTime.timeAgo)")
-                    }
-                }
-                .padding(.horizontal, Theme.Spacing.md)
-            }
-            .padding(.vertical, Theme.Spacing.sm)
-        }
-    }
-
-    @ViewBuilder
-    private var preGeneratedQuickHitters: some View {
-        if !viewModel.builtInTemplates.isEmpty {
-            VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
-                sectionHeader(for: .preGenerated, showSeeAll: viewModel.builtInTemplates.count > previewCount)
-
-                VStack(spacing: Theme.Spacing.xs) {
-                    ForEach(Array(viewModel.builtInTemplates.prefix(previewCount))) { template in
-                        TemplateCardView(template: template, style: .row) {
-                            previewTemplate = template
-                        }
-                    }
-                }
-                .padding(.horizontal, Theme.Spacing.md)
-            }
-            .padding(.vertical, Theme.Spacing.sm)
-        }
-    }
-
-    @ViewBuilder
-    private var friendsAndSavedQuickHitters: some View {
-        let combinedTemplates = viewModel.myTemplates + viewModel.savedTemplates
-        let friendItems = viewModel.friendWorkouts
-        let totalCount = combinedTemplates.count + friendItems.count
-
-        if totalCount > 0 {
-            VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
-                sectionHeader(for: .friendsAndSaved, showSeeAll: totalCount > previewCount)
-
-                VStack(spacing: Theme.Spacing.xs) {
-                    // Templates first (own + saved), then friend workouts, capped at previewCount total.
-                    let templatePreview = Array(combinedTemplates.prefix(previewCount))
-                    let remainingSlots = max(0, previewCount - templatePreview.count)
-                    let friendPreview = Array(friendItems.prefix(remainingSlots))
-
-                    ForEach(templatePreview) { template in
-                        TemplateCardView(template: template, style: .row) {
-                            previewTemplate = template
-                        }
-                    }
-
-                    ForEach(friendPreview) { workout in
-                        NavigationLink {
-                            WorkoutDetailView(workout: workout)
-                        } label: {
-                            RecentWorkoutCard(workout: workout, style: .row)
-                        }
-                        .buttonStyle(PressableCardStyle())
-                        .accessibilityLabel("Friend workout: \(workout.name)")
-                    }
-                }
-                .padding(.horizontal, Theme.Spacing.md)
-            }
-            .padding(.vertical, Theme.Spacing.sm)
-        }
     }
 
     // MARK: - Warmup gating (#261)


### PR DESCRIPTION
Closes #337, #338, #339.

- New WorkoutCategoryTabs (4 segments: Recents / My Workouts / Saved Friends Workouts / Pre-Gen)
- Replaced WorkoutView Quick Hitters scroll with single category list under CTAs
- WorkoutDetailView gains 'Start this Workout' bottom button — builds fresh template from past workout (mode reps + sets count), routes through warmup gate
- .safeAreaPadding(.bottom) added so bottom items aren't hidden behind tab bar