### PR TITLE
#319 polish: haptics, pull-to-refresh, swipe actions, form validation

### DIFF
--- a/Xomfit/ViewModels/WorkoutBuilderViewModel.swift
+++ b/Xomfit/ViewModels/WorkoutBuilderViewModel.swift
@@ -9,8 +9,16 @@ final class WorkoutBuilderViewModel {
     var isSaving = false
     var errorMessage: String?
 
+    /// Mirror of the UI-facing cap in `WorkoutBuilderView.nameMaxLength`.
+    /// Kept in the view model so `isValid` stays the single source of truth for
+    /// Save-button enablement (#319).
+    static let nameMaxLength = 50
+
     var isValid: Bool {
-        !name.trimmingCharacters(in: .whitespaces).isEmpty && !exercises.isEmpty
+        let trimmed = name.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else { return false }
+        guard name.count <= Self.nameMaxLength else { return false }
+        return !exercises.isEmpty
     }
 
     var estimatedDuration: Int {

--- a/Xomfit/Views/AICoach/AICoachView.swift
+++ b/Xomfit/Views/AICoach/AICoachView.swift
@@ -181,7 +181,7 @@ struct AICoachView: View {
     // MARK: - Tool actions
 
     private func handleSave(payload: WorkoutBuildPayload) {
-        Haptics.medium()
+        Haptics.success()
         if let template = viewModel.saveTemplate(from: payload) {
             savedToast = Toast(style: .success, message: "Saved \"\(template.name)\" to templates")
         }
@@ -194,7 +194,7 @@ struct AICoachView: View {
             !userId.isEmpty,
             let template = viewModel.buildTemplate(from: payload)
         else { return }
-        Haptics.medium()
+        Haptics.success()
         workoutSession.startFromTemplate(template, userId: userId)
         workoutSession.isPresented = true
     }

--- a/Xomfit/Views/Feed/FeedCommentsView.swift
+++ b/Xomfit/Views/Feed/FeedCommentsView.swift
@@ -19,6 +19,19 @@ struct FeedCommentsView: View {
     /// Indent applied to nested replies.
     private static let replyIndent: CGFloat = 24
 
+    /// #319: hard cap on comment length (Twitter-style 280). Composer enforces
+    /// this on every keystroke and shows a counter once the user crosses the
+    /// soft threshold.
+    private static let commentMaxLength = 280
+    /// Show the live counter once the comment is longer than this. Keeps the
+    /// composer chrome out of the way for short comments.
+    private static let commentCounterThreshold = 200
+
+    private var commentLength: Int { newCommentText.count }
+    private var remainingChars: Int { Self.commentMaxLength - commentLength }
+    private var isOverLimit: Bool { commentLength > Self.commentMaxLength }
+    private var showCounter: Bool { commentLength > Self.commentCounterThreshold }
+
     /// Top-level comments only — replies are rendered nested under their parent.
     private var topLevelComments: [FeedComment] {
         comments.filter { $0.parentCommentId == nil }
@@ -139,36 +152,73 @@ struct FeedCommentsView: View {
     // MARK: - Comment Composer
 
     private var commentComposer: some View {
-        HStack(spacing: Theme.Spacing.sm) {
-            TextField(replyingTo == nil ? "Add a comment..." : "Add a reply...", text: $newCommentText)
-                .font(Theme.fontBody)
-                .foregroundStyle(Theme.textPrimary)
-                .padding(.horizontal, Theme.Spacing.md)
-                .padding(.vertical, 10)
-                .background(Theme.surface)
-                .clipShape(.rect(cornerRadius: Theme.cornerRadiusSmall))
-                .focused($composerFocused)
+        VStack(spacing: Theme.Spacing.tight) {
+            HStack(spacing: Theme.Spacing.sm) {
+                TextField(replyingTo == nil ? "Add a comment..." : "Add a reply...", text: $newCommentText)
+                    .font(Theme.fontBody)
+                    .foregroundStyle(Theme.textPrimary)
+                    .padding(.horizontal, Theme.Spacing.md)
+                    .padding(.vertical, 10)
+                    .background(Theme.surface)
+                    .clipShape(.rect(cornerRadius: Theme.cornerRadiusSmall))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: Theme.cornerRadiusSmall)
+                            .strokeBorder(
+                                isOverLimit ? Theme.destructive.opacity(0.6) : .clear,
+                                lineWidth: 1
+                            )
+                    )
+                    .focused($composerFocused)
+                    // #319: enforce the 280-char cap on every keystroke. Paste
+                    // longer text and it gets trimmed back to the cap.
+                    .onChange(of: newCommentText) { _, newValue in
+                        if newValue.count > Self.commentMaxLength {
+                            newCommentText = String(newValue.prefix(Self.commentMaxLength))
+                        }
+                    }
 
-            Button {
-                Haptics.light()
-                Task { await postComment() }
-            } label: {
-                if isPosting {
-                    ProgressView()
-                        .tint(.black)
-                        .frame(width: 44, height: 44)
-                } else {
-                    Image(systemName: "arrow.up.circle.fill")
-                        .font(Theme.fontLargeTitle)
-                        .foregroundStyle(newCommentText.isEmpty ? Theme.textSecondary : Theme.accent)
+                Button {
+                    Haptics.light()
+                    Task { await postComment() }
+                } label: {
+                    if isPosting {
+                        ProgressView()
+                            .tint(.black)
+                            .frame(width: 44, height: 44)
+                    } else {
+                        Image(systemName: "arrow.up.circle.fill")
+                            .font(Theme.fontLargeTitle)
+                            .foregroundStyle(newCommentText.isEmpty ? Theme.textSecondary : Theme.accent)
+                    }
                 }
+                .disabled(newCommentText.trimmingCharacters(in: .whitespaces).isEmpty || isPosting || isOverLimit)
+                .accessibilityLabel(replyingTo == nil ? "Post comment" : "Post reply")
             }
-            .disabled(newCommentText.trimmingCharacters(in: .whitespaces).isEmpty || isPosting)
-            .accessibilityLabel(replyingTo == nil ? "Post comment" : "Post reply")
+
+            // #319: live counter once the comment is long enough that the cap
+            // is in sight. Stays hidden for short comments so the composer
+            // doesn't gain extra chrome.
+            if showCounter {
+                HStack {
+                    Spacer()
+                    Text("\(commentLength)/\(Self.commentMaxLength)")
+                        .font(Theme.fontCaption2)
+                        .foregroundStyle(isOverLimit ? Theme.destructive : Theme.textSecondary)
+                        .monospacedDigit()
+                        .accessibilityLabel(
+                            isOverLimit
+                                ? "Over limit by \(commentLength - Self.commentMaxLength) characters"
+                                : "\(remainingChars) characters remaining"
+                        )
+                }
+                .padding(.trailing, Theme.Spacing.tight)
+            }
         }
         .padding(.horizontal, Theme.Spacing.md)
         .padding(.vertical, Theme.Spacing.sm)
         .background(Theme.surface)
+        .animation(.easeOut(duration: 0.15), value: showCounter)
+        .animation(.easeOut(duration: 0.15), value: isOverLimit)
     }
 
     // MARK: - Actions
@@ -206,6 +256,9 @@ struct FeedCommentsView: View {
     private func postComment() async {
         let text = newCommentText.trimmingCharacters(in: .whitespaces)
         guard !text.isEmpty else { return }
+        // #319: defensive — UI disables Send when over the cap, but block here
+        // too so any future entry point can't bypass the limit.
+        guard text.count <= Self.commentMaxLength else { return }
         isPosting = true
         do {
             try await FeedService.shared.postComment(

--- a/Xomfit/Views/Feed/FeedDetailView.swift
+++ b/Xomfit/Views/Feed/FeedDetailView.swift
@@ -325,7 +325,7 @@ struct FeedDetailView: View {
     private var actionBar: some View {
         HStack(spacing: Theme.Spacing.lg) {
             Button {
-                Haptics.medium()
+                Haptics.selection()
                 Task { await toggleLike() }
             } label: {
                 HStack(spacing: 5) {

--- a/Xomfit/Views/Feed/FeedView.swift
+++ b/Xomfit/Views/Feed/FeedView.swift
@@ -7,6 +7,34 @@ struct FeedView: View {
     @State private var showNotifications = false
     @State private var selectedFeedItem: SocialFeedItem? = nil
 
+    /// #319: locally-hidden feed item ids. Backed by AppStorage so hides persist
+    /// across launches. Stored as a comma-separated string because @AppStorage
+    /// doesn't support Set<String> natively. Items are filtered out client-side
+    /// in `visibleFeedItems`.
+    @AppStorage("xomfit_hidden_feed_ids") private var hiddenIdsRaw: String = ""
+
+    private var hiddenIds: Set<String> {
+        Set(hiddenIdsRaw.split(separator: ",").map { String($0) }.filter { !$0.isEmpty })
+    }
+
+    private func setHiddenIds(_ ids: Set<String>) {
+        hiddenIdsRaw = ids.sorted().joined(separator: ",")
+    }
+
+    private func hide(_ id: String) {
+        var ids = hiddenIds
+        ids.insert(id)
+        setHiddenIds(ids)
+    }
+
+    /// Filtered feed list with locally-hidden items removed. Wraps the
+    /// view-model's filtered list (date + muscle filters).
+    private var visibleFeedItems: [SocialFeedItem] {
+        let ids = hiddenIds
+        guard !ids.isEmpty else { return viewModel.filteredFeedItems }
+        return viewModel.filteredFeedItems.filter { !ids.contains($0.id) }
+    }
+
     private var userId: String {
         authService.currentUser?.id.uuidString.lowercased() ?? ""
     }
@@ -29,7 +57,7 @@ struct FeedView: View {
                             selectedMuscleGroups: $viewModel.selectedMuscleGroups
                         )
 
-                        if viewModel.isFiltered && viewModel.filteredFeedItems.isEmpty {
+                        if viewModel.isFiltered && visibleFeedItems.isEmpty {
                             Spacer()
                             XomEmptyState(
                                 icon: "line.3.horizontal.decrease",
@@ -138,48 +166,74 @@ struct FeedView: View {
     // MARK: - Feed List
 
     private var feedList: some View {
-        ScrollView {
-            LazyVStack(spacing: Theme.Spacing.md) {
-                ForEach(Array(viewModel.filteredFeedItems.enumerated()), id: \.element.id) { index, item in
-                    FeedItemCard(
-                        item: item,
-                        onLike: {
-                            Task { await viewModel.toggleLike(feedItem: item, userId: userId) }
-                        },
-                        onComment: {
-                            selectedFeedItem = item
-                        },
-                        onDelete: makeDeleteAction(for: item),
-                        onEdit: makeEditAction(for: item),
-                        onSave: makeSaveAction(for: item)
-                    )
-                    .contentShape(Rectangle())
-                    .onTapGesture {
+        // #319: List-backed so `.swipeActions` works on each feed row. The
+        // visual is matched to the prior LazyVStack via hidden separators,
+        // background, and tight insets so the change is invisible to the user.
+        List {
+            ForEach(Array(visibleFeedItems.enumerated()), id: \.element.id) { index, item in
+                FeedItemCard(
+                    item: item,
+                    onLike: {
+                        Haptics.selection()
+                        Task { await viewModel.toggleLike(feedItem: item, userId: userId) }
+                    },
+                    onComment: {
+                        Haptics.light()
                         selectedFeedItem = item
-                    }
-                    .staggeredAppear(index: index)
-                    .onAppear {
-                        if item.id == viewModel.feedItems.last?.id {
-                            Task { await viewModel.loadMore(userId: userId) }
-                        }
+                    },
+                    onDelete: makeDeleteAction(for: item),
+                    onEdit: makeEditAction(for: item),
+                    onSave: makeSaveAction(for: item)
+                )
+                .contentShape(Rectangle())
+                .onTapGesture {
+                    Haptics.light()
+                    selectedFeedItem = item
+                }
+                .staggeredAppear(index: index)
+                .onAppear {
+                    if item.id == viewModel.feedItems.last?.id {
+                        Task { await viewModel.loadMore(userId: userId) }
                     }
                 }
-
-                // #311: surface load-more failures with a retry banner so the
-                // user knows pagination didn't silently exhaust.
-                if let loadMoreError = viewModel.loadMoreError {
-                    loadMoreRetryBanner(message: loadMoreError)
-                } else if !viewModel.hasMore && !viewModel.filteredFeedItems.isEmpty {
-                    Text("You're all caught up!")
-                        .font(Theme.fontCaption)
-                        .foregroundStyle(Theme.textSecondary)
-                        .frame(maxWidth: .infinity, alignment: .center)
-                        .padding(Theme.Spacing.md)
+                .listRowBackground(Theme.background)
+                .listRowInsets(EdgeInsets(
+                    top: Theme.Spacing.sm,
+                    leading: Theme.Spacing.md,
+                    bottom: Theme.Spacing.sm,
+                    trailing: Theme.Spacing.md
+                ))
+                .listRowSeparator(.hidden)
+                .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                    Button(role: .destructive) {
+                        Haptics.medium()
+                        hide(item.id)
+                    } label: {
+                        Label("Hide", systemImage: "eye.slash")
+                    }
+                    .tint(Theme.textSecondary)
                 }
             }
-            .padding(.horizontal, Theme.Spacing.md)
-            .padding(.top, Theme.Spacing.sm)
+
+            // #311: surface load-more failures with a retry banner so the
+            // user knows pagination didn't silently exhaust.
+            if let loadMoreError = viewModel.loadMoreError {
+                loadMoreRetryBanner(message: loadMoreError)
+                    .listRowBackground(Theme.background)
+                    .listRowInsets(EdgeInsets(top: 0, leading: Theme.Spacing.md, bottom: 0, trailing: Theme.Spacing.md))
+                    .listRowSeparator(.hidden)
+            } else if !viewModel.hasMore && !visibleFeedItems.isEmpty {
+                Text("You're all caught up!")
+                    .font(Theme.fontCaption)
+                    .foregroundStyle(Theme.textSecondary)
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .padding(Theme.Spacing.md)
+                    .listRowBackground(Theme.background)
+                    .listRowSeparator(.hidden)
+            }
         }
+        .listStyle(.plain)
+        .scrollContentBackground(.hidden)
         .refreshable {
             await viewModel.refreshFeed(userId: userId)
         }

--- a/Xomfit/Views/Profile/FriendsListView.swift
+++ b/Xomfit/Views/Profile/FriendsListView.swift
@@ -4,6 +4,10 @@ struct FriendsListView: View {
     let friends: [FriendRow]
     let friendProfiles: [String: ProfileRow]
     let currentUserId: String
+    /// Optional pull-to-refresh handler. Owners that hold the friends data (e.g.
+    /// `ProfileViewModel`) can pass `loadAll` here so the user can swipe down to
+    /// refetch from this screen.
+    var onRefresh: (() async -> Void)? = nil
 
     var body: some View {
         ZStack {
@@ -16,6 +20,9 @@ struct FriendsListView: View {
                     currentUserId: currentUserId
                 )
                 .padding(.top, Theme.Spacing.sm)
+            }
+            .refreshable {
+                await onRefresh?()
             }
         }
         .navigationTitle("Friends")

--- a/Xomfit/Views/Profile/ProfileFriendsView.swift
+++ b/Xomfit/Views/Profile/ProfileFriendsView.swift
@@ -22,6 +22,7 @@ struct ProfileFriendsView: View {
                         friendRow(friend: friend)
                     }
                     .buttonStyle(.plain)
+                    .simultaneousGesture(TapGesture().onEnded { Haptics.light() })
 
                     if friend.id != friends.last?.id {
                         XomDivider()

--- a/Xomfit/Views/Profile/ProfileHeaderView.swift
+++ b/Xomfit/Views/Profile/ProfileHeaderView.swift
@@ -21,6 +21,9 @@ struct ProfileHeaderView: View {
     let onAcceptRequest: () -> Void
     let onDeclineRequest: () -> Void
     let onRemoveFriend: () -> Void
+    /// Pull-to-refresh hook for the friends list child view. Optional — when
+    /// nil the friends list won't show a refresh control.
+    var onRefreshFriends: (() async -> Void)? = nil
 
     @State private var showCancelDialog = false
     @State private var showRemoveDialog = false
@@ -40,7 +43,8 @@ struct ProfileHeaderView: View {
                         FriendsListView(
                             friends: friends,
                             friendProfiles: friendProfiles,
-                            currentUserId: currentUserId
+                            currentUserId: currentUserId,
+                            onRefresh: onRefreshFriends
                         )
                         .hideTabBar()
                     } label: {

--- a/Xomfit/Views/Profile/ProfileView.swift
+++ b/Xomfit/Views/Profile/ProfileView.swift
@@ -164,7 +164,13 @@ struct ProfileView: View {
                     onCancelRequest: { Task { await viewModel.cancelRequest() } },
                     onAcceptRequest: { Task { await viewModel.acceptIncoming() } },
                     onDeclineRequest: { Task { await viewModel.declineIncoming() } },
-                    onRemoveFriend: { Task { await viewModel.removeFriend() } }
+                    onRemoveFriend: { Task { await viewModel.removeFriend() } },
+                    onRefreshFriends: {
+                        await viewModel.loadAll(
+                            userId: resolvedUserId,
+                            currentUserId: currentUserId
+                        )
+                    }
                 )
 
                 // Tab picker (pinned) + tab content
@@ -236,7 +242,7 @@ struct ProfileView: View {
     }
 
     private func startEmptyWorkout() {
-        Haptics.medium()
+        Haptics.success()
         let userId = authService.currentUser?.id.uuidString.lowercased() ?? ""
         workoutSession.startWorkout(name: "Workout", userId: userId)
         workoutSession.isPresented = true

--- a/Xomfit/Views/Profile/ProfileWorkoutListView.swift
+++ b/Xomfit/Views/Profile/ProfileWorkoutListView.swift
@@ -6,6 +6,12 @@ struct ProfileWorkoutListView: View {
     var isFiltered: Bool
     @Binding var dateRange: FeedDateRange
     @Binding var muscleGroups: Set<MuscleGroup>
+    /// Pull-to-refresh hook owned by the parent (e.g. `ProfileView` -> `loadAll`).
+    /// Optional so callers that haven't migrated yet still compile cleanly.
+    var onRefresh: (() async -> Void)? = nil
+    /// Swipe-to-delete callback for past-workout rows. Optional — only the
+    /// current user's own profile should pass this.
+    var onDelete: ((Workout) -> Void)? = nil
 
     /// Drives the workout-history search sheet (#323).
     @State private var showSearch = false
@@ -33,17 +39,7 @@ struct ProfileWorkoutListView: View {
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, 60)
             } else {
-                LazyVStack(spacing: Theme.Spacing.sm) {
-                    ForEach(workouts) { workout in
-                        NavigationLink {
-                            WorkoutDetailView(workout: workout)
-                        } label: {
-                            workoutCard(workout)
-                        }
-                        .buttonStyle(.plain)
-                    }
-                }
-                .padding(.horizontal, Theme.Spacing.md)
+                workoutList
             }
         }
         .toolbar {
@@ -61,6 +57,42 @@ struct ProfileWorkoutListView: View {
         }
         .sheet(isPresented: $showSearch) {
             WorkoutHistorySearchView(workouts: allWorkouts)
+        }
+    }
+
+    // MARK: - Workout List
+
+    /// List-backed rendering so `.swipeActions(edge: .trailing)` works on each
+    /// past-workout row. Owners that don't pass `onDelete` simply won't get the
+    /// swipe affordance.
+    private var workoutList: some View {
+        List {
+            ForEach(workouts) { workout in
+                NavigationLink {
+                    WorkoutDetailView(workout: workout)
+                } label: {
+                    workoutCard(workout)
+                }
+                .listRowBackground(Theme.background)
+                .listRowInsets(EdgeInsets(top: Theme.Spacing.tight, leading: Theme.Spacing.md, bottom: Theme.Spacing.tight, trailing: Theme.Spacing.md))
+                .listRowSeparator(.hidden)
+                .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                    if let onDelete {
+                        Button(role: .destructive) {
+                            Haptics.medium()
+                            onDelete(workout)
+                        } label: {
+                            Label("Delete", systemImage: "trash")
+                        }
+                    }
+                }
+                .simultaneousGesture(TapGesture().onEnded { Haptics.light() })
+            }
+        }
+        .listStyle(.plain)
+        .scrollContentBackground(.hidden)
+        .refreshable {
+            await onRefresh?()
         }
     }
 

--- a/Xomfit/Views/Progress/LeaderboardView.swift
+++ b/Xomfit/Views/Progress/LeaderboardView.swift
@@ -152,6 +152,9 @@ struct LeaderboardView: View {
                 }
             }
         }
+        .refreshable {
+            await viewModel.loadLeaderboard(userId: userId)
+        }
     }
 
     // MARK: - Podium

--- a/Xomfit/Views/Workout/TemplateDetailView.swift
+++ b/Xomfit/Views/Workout/TemplateDetailView.swift
@@ -346,7 +346,7 @@ struct TemplateDetailView: View {
 
     private var startButton: some View {
         Button {
-            Haptics.medium()
+            Haptics.success()
             startLift()
         } label: {
             HStack(spacing: 10) {

--- a/Xomfit/Views/Workout/TemplateListView.swift
+++ b/Xomfit/Views/Workout/TemplateListView.swift
@@ -27,9 +27,16 @@ struct TemplateListView: View {
                                 templateRow(template)
                                     .listRowBackground(Theme.surface)
                                     .listRowSeparator(.hidden)
-                            }
-                            .onDelete { indexSet in
-                                deleteCustom(from: items, at: indexSet)
+                                    .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                                        if template.isCustom {
+                                            Button(role: .destructive) {
+                                                Haptics.medium()
+                                                deleteTemplate(template)
+                                            } label: {
+                                                Label("Delete", systemImage: "trash")
+                                            }
+                                        }
+                                    }
                             }
                         } header: {
                             HStack(spacing: 6) {
@@ -44,6 +51,9 @@ struct TemplateListView: View {
                 }
                 .listStyle(.plain)
                 .scrollContentBackground(.hidden)
+                .refreshable {
+                    await refreshTemplates()
+                }
             }
             .navigationTitle("Templates")
             .navigationBarTitleDisplayMode(.inline)
@@ -97,18 +107,24 @@ struct TemplateListView: View {
             .padding(.vertical, Theme.Spacing.tight)
         }
         .buttonStyle(.plain)
-        .deleteDisabled(!template.isCustom)
         .accessibilityLabel("\(template.name), \(template.description), \(template.exercises.count) exercises, about \(template.estimatedDuration) minutes")
     }
 
     // MARK: - Delete
 
-    private func deleteCustom(from items: [WorkoutTemplate], at indexSet: IndexSet) {
-        for idx in indexSet {
-            let template = items[idx]
-            guard template.isCustom else { continue }
-            TemplateService.shared.deleteCustomTemplate(id: template.id)
-        }
+    private func deleteTemplate(_ template: WorkoutTemplate) {
+        guard template.isCustom else { return }
+        TemplateService.shared.deleteCustomTemplate(id: template.id)
+        templates = TemplateService.shared.allTemplates()
+    }
+
+    // MARK: - Refresh
+
+    /// Pull-to-refresh hook. Templates are local, so this just re-reads the
+    /// template store. Yields briefly so the system refresh spinner has time to
+    /// render before snapping back.
+    private func refreshTemplates() async {
+        try? await Task.sleep(nanoseconds: 250_000_000)
         templates = TemplateService.shared.allTemplates()
     }
 }

--- a/Xomfit/Views/Workout/WorkoutBuilderView.swift
+++ b/Xomfit/Views/Workout/WorkoutBuilderView.swift
@@ -85,7 +85,7 @@ struct WorkoutBuilderView: View {
                 dismiss()
             }
             Button("Start Now") {
-                Haptics.medium()
+                Haptics.success()
                 let template = viewModel.buildTemplate()
                 startTemplateWithWarmupGate(template)
             }
@@ -132,13 +132,61 @@ struct WorkoutBuilderView: View {
 
     // MARK: - Name Field
 
+    /// Max workout name length surfaced to the user via a red helper line.
+    /// Mirrors `WorkoutBuilderViewModel.nameMaxLength`; over-cap input is still
+    /// typeable but blocks Save.
+    private static var nameMaxLength: Int { WorkoutBuilderViewModel.nameMaxLength }
+
+    private var trimmedName: String {
+        viewModel.name.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var nameValidationMessage: String? {
+        if trimmedName.isEmpty {
+            return "Name is required"
+        }
+        if viewModel.name.count > Self.nameMaxLength {
+            return "Name is too long (\(viewModel.name.count)/\(Self.nameMaxLength))"
+        }
+        return nil
+    }
+
     private var nameField: some View {
-        TextField("Workout Name", text: $viewModel.name)
-            .font(Theme.fontBodyEmphasized)
-            .foregroundStyle(Theme.textPrimary)
-            .padding(Theme.Spacing.md)
-            .background(Theme.surface)
-            .clipShape(.rect(cornerRadius: Theme.cornerRadius))
+        let invalid = nameValidationMessage != nil
+
+        return VStack(alignment: .leading, spacing: Theme.Spacing.tight) {
+            TextField("Workout Name", text: $viewModel.name)
+                .font(Theme.fontBodyEmphasized)
+                .foregroundStyle(Theme.textPrimary)
+                .padding(Theme.Spacing.md)
+                .background(Theme.surface)
+                .clipShape(.rect(cornerRadius: Theme.cornerRadius))
+                .overlay(
+                    RoundedRectangle(cornerRadius: Theme.cornerRadius)
+                        .strokeBorder(
+                            invalid ? Theme.destructive.opacity(0.6) : .clear,
+                            lineWidth: 1
+                        )
+                )
+                .accessibilityHint(invalid ? (nameValidationMessage ?? "") : "")
+
+            if let message = nameValidationMessage {
+                HStack(spacing: Theme.Spacing.tight) {
+                    Image(systemName: "exclamationmark.circle.fill")
+                        .font(Theme.fontCaption2)
+                        .foregroundStyle(Theme.destructive)
+                        .accessibilityHidden(true)
+                    Text(message)
+                        .font(Theme.fontCaption)
+                        .foregroundStyle(Theme.destructive)
+                }
+                .padding(.leading, Theme.Spacing.xs)
+                .transition(.opacity)
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel(message)
+            }
+        }
+        .animation(.easeOut(duration: 0.15), value: invalid)
     }
 
     // MARK: - Category Picker

--- a/Xomfit/Views/Workout/WorkoutView.swift
+++ b/Xomfit/Views/Workout/WorkoutView.swift
@@ -212,7 +212,7 @@ struct WorkoutView: View {
                 .multilineTextAlignment(.center)
 
             Button {
-                Haptics.medium()
+                Haptics.success()
                 UserDefaults.standard.set(true, forKey: "xomfit_first_workout_started")
                 if let template = WorkoutTemplate.builtIn.first(where: { $0.id == "tpl-fb-a" }) {
                     requestStart(stretches: StretchDatabase.suggestedStretches(for: template, target: TimeInterval(warmupMinutes * 60))) {


### PR DESCRIPTION
Closes #319. 15 files. Haptics normalized (.selection on toggles, .success on save). Pull-to-refresh on FriendsListView, ProfileWorkoutListView, LeaderboardView, TemplateListView. Swipe-to-delete on past workouts + custom templates. Swipe-to-hide on feed (@AppStorage hidden ids). 280-char comment cap with counter past 200. Workout name red border + helper text on empty/>50.