### PR TITLE
fix(ci): make Free-cert-slot step non-fatal

### DIFF
--- a/.github/workflows/testflight-deploy.yml
+++ b/.github/workflows/testflight-deploy.yml
@@ -79,6 +79,7 @@ jobs:
         run: pip3 install --quiet --break-system-packages PyJWT cryptography requests
 
       - name: Free Apple Development cert slot (revoke oldest if at limit)
+        continue-on-error: true
         env:
           ASC_API_KEY_ID: ${{ secrets.ASC_API_KEY_ID }}
           ASC_API_ISSUER_ID: ${{ secrets.ASC_API_ISSUER_ID }}


### PR DESCRIPTION
ASC API key returns 403 listing /v1/certificates — kills deploys at pre-flight before build even starts. The revoke step is housekeeping. Adding continue-on-error: true so deploys proceed. Real fix: grant Developer/App-Manager scope on the ASC API key.