### PR TITLE
fix(ci): accept raw PEM or base64 for ASC_API_KEY_P8

### DIFF
--- a/.github/workflows/testflight-deploy.yml
+++ b/.github/workflows/testflight-deploy.yml
@@ -61,7 +61,12 @@ jobs:
           ASC_API_KEY_ID: ${{ secrets.ASC_API_KEY_ID }}
         run: |
           mkdir -p ~/.appstoreconnect/private_keys
-          echo "$ASC_API_KEY_P8" | base64 --decode > ~/.appstoreconnect/private_keys/AuthKey_${ASC_API_KEY_ID}.p8
+          # Accept either raw PEM or base64-encoded; auto-detect.
+          if printf "%s" "$ASC_API_KEY_P8" | grep -q -- "-----BEGIN PRIVATE KEY-----"; then
+            printf "%s" "$ASC_API_KEY_P8" > ~/.appstoreconnect/private_keys/AuthKey_${ASC_API_KEY_ID}.p8
+          else
+            printf "%s" "$ASC_API_KEY_P8" | base64 --decode > ~/.appstoreconnect/private_keys/AuthKey_${ASC_API_KEY_ID}.p8
+          fi
           chmod 600 ~/.appstoreconnect/private_keys/AuthKey_${ASC_API_KEY_ID}.p8
 
       - name: Compute version and build number


### PR DESCRIPTION
The workflow blindly base64-decoded the secret. The new Admin key was uploaded via gh secret set < AuthKey.p8 (raw PEM), so the decode produced garbage. Auto-detect the format now.