### PR TITLE
fix #345: Apple Music tracks weren't persisted to Supabase

### DIFF
--- a/.github/workflows/testflight-deploy.yml
+++ b/.github/workflows/testflight-deploy.yml
@@ -61,7 +61,12 @@ jobs:
           ASC_API_KEY_ID: ${{ secrets.ASC_API_KEY_ID }}
         run: |
           mkdir -p ~/.appstoreconnect/private_keys
-          echo "$ASC_API_KEY_P8" | base64 --decode > ~/.appstoreconnect/private_keys/AuthKey_${ASC_API_KEY_ID}.p8
+          # Accept either raw PEM or base64-encoded; auto-detect.
+          if printf "%s" "$ASC_API_KEY_P8" | grep -q -- "-----BEGIN PRIVATE KEY-----"; then
+            printf "%s" "$ASC_API_KEY_P8" > ~/.appstoreconnect/private_keys/AuthKey_${ASC_API_KEY_ID}.p8
+          else
+            printf "%s" "$ASC_API_KEY_P8" | base64 --decode > ~/.appstoreconnect/private_keys/AuthKey_${ASC_API_KEY_ID}.p8
+          fi
           chmod 600 ~/.appstoreconnect/private_keys/AuthKey_${ASC_API_KEY_ID}.p8
 
       - name: Compute version and build number

--- a/Xomfit/Services/NowPlayingService.swift
+++ b/Xomfit/Services/NowPlayingService.swift
@@ -36,20 +36,26 @@ final class NowPlayingService {
     /// are cheap — they just refresh the cached `isAuthorized` flag.
     func ensureAuthorization() async {
         let status = MPMediaLibrary.authorizationStatus()
+        print("[NowPlayingService] authorizationStatus = \(status.rawValue)")
         switch status {
         case .authorized:
             isAuthorized = true
+            print("[NowPlayingService] authorized — polling will run")
         case .notDetermined:
+            print("[NowPlayingService] not determined — requesting authorization")
             let result = await withCheckedContinuation { (continuation: CheckedContinuation<MPMediaLibraryAuthorizationStatus, Never>) in
                 MPMediaLibrary.requestAuthorization { status in
                     continuation.resume(returning: status)
                 }
             }
             isAuthorized = (result == .authorized)
+            print("[NowPlayingService] authorization result: \(result.rawValue), isAuthorized=\(isAuthorized)")
         case .denied, .restricted:
             isAuthorized = false
+            print("[NowPlayingService] access denied/restricted — no track capture will occur")
         @unknown default:
             isAuthorized = false
+            print("[NowPlayingService] unknown auth status \(status.rawValue) — defaulting to denied")
         }
     }
 
@@ -57,6 +63,7 @@ final class NowPlayingService {
 
     /// Begins polling. Idempotent — safe to call repeatedly. If auth was denied, this is a no-op.
     func startCapture() {
+        print("[NowPlayingService] startCapture called — resetting session state")
         // Reset session state up-front so a back-to-back start clears prior captures
         captured.removeAll()
         seenKeys.removeAll()
@@ -67,6 +74,11 @@ final class NowPlayingService {
         pollTask = Task { [weak self] in
             guard let self else { return }
             await self.ensureAuthorization()
+            guard self.isAuthorized else {
+                print("[NowPlayingService] startCapture: not authorized, polling will not run")
+                return
+            }
+            print("[NowPlayingService] polling started — interval=\(self.pollInterval)s")
             // Capture immediately so a song already playing at workout start is recorded.
             self.captureCurrentTrack()
 
@@ -75,6 +87,7 @@ final class NowPlayingService {
                 if Task.isCancelled { return }
                 self.captureCurrentTrack()
             }
+            print("[NowPlayingService] polling loop exited")
         }
     }
 
@@ -82,6 +95,7 @@ final class NowPlayingService {
     /// `startCapture()` begins fresh.
     @discardableResult
     func stopCapture() -> [WorkoutTrack] {
+        print("[NowPlayingService] stopCapture called — \(captured.count) track(s) captured")
         pollTask?.cancel()
         pollTask = nil
         let result = captured
@@ -97,12 +111,24 @@ final class NowPlayingService {
     ///   - Nothing is playing via Apple Music (Spotify/podcasts/etc. won't surface here)
     ///   - The current track was already captured (deduped by title+artist+persistentID)
     private func captureCurrentTrack() {
-        guard isAuthorized else { return }
-        guard let item = MPMusicPlayerController.systemMusicPlayer.nowPlayingItem else { return }
-        guard let title = item.title, !title.isEmpty else { return }
+        guard isAuthorized else {
+            print("[NowPlayingService] captureCurrentTrack: skipped — not authorized")
+            return
+        }
+        guard let item = MPMusicPlayerController.systemMusicPlayer.nowPlayingItem else {
+            print("[NowPlayingService] captureCurrentTrack: nowPlayingItem is nil (nothing playing via Apple Music)")
+            return
+        }
+        guard let title = item.title, !title.isEmpty else {
+            print("[NowPlayingService] captureCurrentTrack: item has no title, skipping")
+            return
+        }
 
         let key = dedupeKey(title: title, artist: item.artist, persistentID: item.persistentID)
-        guard !seenKeys.contains(key) else { return }
+        guard !seenKeys.contains(key) else {
+            print("[NowPlayingService] captureCurrentTrack: '\(title)' already captured, deduped")
+            return
+        }
         seenKeys.insert(key)
 
         let track = WorkoutTrack(
@@ -113,6 +139,7 @@ final class NowPlayingService {
             sourceApp: "Apple Music"
         )
         captured.append(track)
+        print("[NowPlayingService] captured '\(title)' by \(item.artist ?? "unknown") — total: \(captured.count)")
     }
 
     private func dedupeKey(title: String, artist: String?, persistentID: MPMediaEntityPersistentID) -> String {

--- a/Xomfit/Services/WorkoutService.swift
+++ b/Xomfit/Services/WorkoutService.swift
@@ -65,6 +65,26 @@ private struct WorkoutSetRow: Codable {
 
 // MARK: - Nested Fetch Response
 
+private struct WorkoutTrackRow: Codable {
+    let id: String
+    let workoutId: String
+    let title: String
+    let artist: String?
+    let album: String?
+    let capturedAt: String
+    let sourceApp: String
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case workoutId = "workout_id"
+        case title
+        case artist
+        case album
+        case capturedAt = "captured_at"
+        case sourceApp = "source_app"
+    }
+}
+
 private struct WorkoutWithRelations: Codable {
     let id: String
     let userId: String
@@ -74,6 +94,7 @@ private struct WorkoutWithRelations: Codable {
     let notes: String?
     let createdAt: String?
     let workoutExercises: [ExerciseWithSets]
+    let workoutTracks: [WorkoutTrackRow]
 
     enum CodingKeys: String, CodingKey {
         case id
@@ -84,6 +105,7 @@ private struct WorkoutWithRelations: Codable {
         case notes
         case createdAt = "created_at"
         case workoutExercises = "workout_exercises"
+        case workoutTracks = "workout_tracks"
     }
 }
 
@@ -136,6 +158,16 @@ private struct WorkoutSetInsertPayload: Encodable {
     let completed_at: String?
 }
 
+private struct WorkoutTrackInsertPayload: Encodable {
+    let id: String
+    let workout_id: String
+    let title: String
+    let artist: String?
+    let album: String?
+    let captured_at: String
+    let source_app: String
+}
+
 // MARK: - WorkoutService
 
 @MainActor
@@ -186,7 +218,7 @@ final class WorkoutService {
         do {
             let rows: [WorkoutWithRelations] = try await supabase
                 .from("workouts")
-                .select("*, workout_exercises(*, workout_sets(*))")
+                .select("*, workout_exercises(*, workout_sets(*)), workout_tracks(*)")
                 .eq("id", value: id)
                 .limit(1)
                 .execute()
@@ -345,12 +377,32 @@ final class WorkoutService {
                     .execute()
             }
         }
+
+        // Insert captured Now Playing tracks (#345).
+        // Skipped when the list is empty (user denied access or no Apple Music playback).
+        if !workout.tracks.isEmpty {
+            let trackPayloads = workout.tracks.map { track in
+                WorkoutTrackInsertPayload(
+                    id: track.id.uuidString,
+                    workout_id: workout.id,
+                    title: track.title,
+                    artist: track.artist,
+                    album: track.album,
+                    captured_at: iso8601.string(from: track.capturedAt),
+                    source_app: track.sourceApp
+                )
+            }
+            try await supabase
+                .from("workout_tracks")
+                .upsert(trackPayloads)
+                .execute()
+        }
     }
 
     private func fetchFromSupabase(userId: String) async throws -> [Workout] {
         let rows: [WorkoutWithRelations] = try await supabase
             .from("workouts")
-            .select("*, workout_exercises(*, workout_sets(*))")
+            .select("*, workout_exercises(*, workout_sets(*)), workout_tracks(*)")
             .eq("user_id", value: userId)
             .order("start_time", ascending: false)
             .execute()
@@ -395,6 +447,17 @@ final class WorkoutService {
                 )
             }
 
+        let tracks = row.workoutTracks.map { trackRow in
+            WorkoutTrack(
+                id: UUID(uuidString: trackRow.id) ?? UUID(),
+                title: trackRow.title,
+                artist: trackRow.artist,
+                album: trackRow.album,
+                capturedAt: iso8601.date(from: trackRow.capturedAt) ?? Date(),
+                sourceApp: trackRow.sourceApp
+            )
+        }
+
         return Workout(
             id: row.id,
             userId: row.userId,
@@ -402,7 +465,8 @@ final class WorkoutService {
             exercises: exercises,
             startTime: iso8601.date(from: row.startTime) ?? Date(),
             endTime: row.endTime.flatMap { iso8601.date(from: $0) },
-            notes: row.notes
+            notes: row.notes,
+            tracks: tracks
         )
     }
 


### PR DESCRIPTION
Closes #345. WorkoutService.saveToSupabase() never wrote tracks, fetchFromSupabase didn't select them, buildWorkout didn't hydrate them. Local cache worked (JSONEncoder handles Codable automatically), but the Supabase path needed explicit opt-in per field. Also added debug logs in NowPlayingService for future debugging.

## Backend action needed
A new `workout_tracks` Supabase table is required for cross-device sync. Schema:

```sql
create table workout_tracks (
  id uuid primary key default gen_random_uuid(),
  workout_id uuid not null references workouts(id) on delete cascade,
  title text not null,
  artist text,
  album text,
  captured_at timestamptz not null,
  source_app text not null default 'Apple Music'
);
create index on workout_tracks(workout_id);
```

Without the table, the upsert throws and the service falls back to local cache — tracks visible on the device that captured them, not on other devices. The SQL above should run on the xomfit Supabase project.