### PR TITLE
#344 (part 2) focus + builder: remove set, drop set visibility, superset toggle + badge

### DIFF
--- a/Xomfit/Models/WorkoutTemplate.swift
+++ b/Xomfit/Models/WorkoutTemplate.swift
@@ -18,6 +18,10 @@ struct WorkoutTemplate: Codable, Identifiable {
         /// Per-exercise rest override in seconds. nil = use the workout's global default.
         /// Optional + default keeps existing templates decodable as-is.
         var restSeconds: Int? = nil
+        /// When non-nil, this template exercise is part of a superset group.
+        /// Mirrors `WorkoutExercise.supersetGroupId` so the live workout inherits the
+        /// grouping. Optional + default keeps existing templates decodable as-is (#344).
+        var supersetGroupId: UUID? = nil
     }
 
     enum TemplateCategory: String, Codable, CaseIterable {

--- a/Xomfit/ViewModels/WorkoutBuilderViewModel.swift
+++ b/Xomfit/ViewModels/WorkoutBuilderViewModel.swift
@@ -96,4 +96,65 @@ final class WorkoutBuilderViewModel {
         category = template.category
         exercises = template.exercises
     }
+
+    // MARK: - Supersets (#344)
+
+    /// Toggle a superset between `index` and the exercise immediately after it.
+    /// - If `index` is already in a superset, the entire group is ungrouped.
+    /// - Otherwise `index` and `index + 1` get a fresh shared group id.
+    /// Mirrors `WorkoutLoggerViewModel.toggleSupersetWithNext` so builder and live
+    /// workout share semantics.
+    func toggleSupersetWithNext(at index: Int) {
+        guard exercises.indices.contains(index) else { return }
+
+        if let groupId = exercises[index].supersetGroupId {
+            // Already in a group — ungroup all members of that group.
+            for i in exercises.indices where exercises[i].supersetGroupId == groupId {
+                exercises[i].supersetGroupId = nil
+            }
+            return
+        }
+
+        let nextIndex = index + 1
+        guard exercises.indices.contains(nextIndex) else { return }
+        let newGroupId = UUID()
+        exercises[index].supersetGroupId = newGroupId
+        exercises[nextIndex].supersetGroupId = newGroupId
+    }
+
+    /// Indices of all template exercises in the same superset group as `index`.
+    /// Returns nil when `index` isn't part of a group.
+    func supersetMembers(forExercise index: Int) -> [Int]? {
+        guard exercises.indices.contains(index),
+              let groupId = exercises[index].supersetGroupId else { return nil }
+        return exercises.indices.filter { exercises[$0].supersetGroupId == groupId }
+    }
+
+    /// Letter label for the superset group `index` belongs to, in workout order
+    /// of appearance ("A", "B", "C", ...). Returns nil when the exercise isn't in a group.
+    func supersetLetter(forExercise index: Int) -> String? {
+        guard exercises.indices.contains(index),
+              let groupId = exercises[index].supersetGroupId else { return nil }
+        let alphabet = ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M",
+                        "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z"]
+        var seen: [UUID: Int] = [:]
+        var next = 0
+        for ex in exercises {
+            guard let gid = ex.supersetGroupId, seen[gid] == nil else { continue }
+            seen[gid] = next
+            next += 1
+        }
+        guard let pos = seen[groupId] else { return nil }
+        return alphabet[pos % alphabet.count]
+    }
+
+    /// Whether `index` can currently be grouped with `index + 1` (i.e. the next
+    /// exercise exists and isn't already in this exercise's group).
+    func canGroupWithNext(at index: Int) -> Bool {
+        guard exercises.indices.contains(index),
+              exercises.indices.contains(index + 1) else { return false }
+        let myGroup = exercises[index].supersetGroupId
+        let nextGroup = exercises[index + 1].supersetGroupId
+        return myGroup == nil || myGroup != nextGroup
+    }
 }

--- a/Xomfit/ViewModels/WorkoutLoggerViewModel.swift
+++ b/Xomfit/ViewModels/WorkoutLoggerViewModel.swift
@@ -223,6 +223,8 @@ final class WorkoutLoggerViewModel {
             )
             we.selectedLaterality = templateExercise.exercise.defaultLaterality
             we.restSeconds = templateExercise.restSeconds
+            // Carry the template's superset grouping into the live workout (#344).
+            we.supersetGroupId = templateExercise.supersetGroupId
             builtExercises.append(we)
         }
         exercises = builtExercises

--- a/Xomfit/Views/Workout/WorkoutBuilderView.swift
+++ b/Xomfit/Views/Workout/WorkoutBuilderView.swift
@@ -228,10 +228,14 @@ struct WorkoutBuilderView: View {
                     ForEach(Array(viewModel.exercises.enumerated()), id: \.element.id) { index, exercise in
                         BuilderExerciseRow(
                             exercise: exercise,
+                            supersetLetter: viewModel.supersetLetter(forExercise: index),
+                            isInSuperset: exercise.supersetGroupId != nil,
+                            canGroupWithNext: viewModel.canGroupWithNext(at: index),
                             onUpdateSets: { viewModel.updateSets(at: index, sets: $0) },
                             onUpdateReps: { viewModel.updateReps(at: index, reps: $0) },
                             onUpdateNotes: { viewModel.updateNotes(at: index, notes: $0) },
                             onUpdateRestSeconds: { viewModel.updateRestSeconds(at: index, seconds: $0) },
+                            onToggleSuperset: { viewModel.toggleSupersetWithNext(at: index) },
                             onDelete: { viewModel.removeExercise(at: index) }
                         )
                     }
@@ -346,10 +350,16 @@ struct WorkoutBuilderView: View {
 
 private struct BuilderExerciseRow: View {
     let exercise: WorkoutTemplate.TemplateExercise
+    /// Letter label ("A", "B", ...) for the superset group this row belongs to,
+    /// or nil when ungrouped (#344).
+    let supersetLetter: String?
+    let isInSuperset: Bool
+    let canGroupWithNext: Bool
     let onUpdateSets: (Int) -> Void
     let onUpdateReps: (String) -> Void
     let onUpdateNotes: (String?) -> Void
     let onUpdateRestSeconds: (Int?) -> Void
+    let onToggleSuperset: () -> Void
     let onDelete: () -> Void
 
     /// Pulled from the same UserDefaults key the rest of the app reads. Lets the
@@ -359,6 +369,10 @@ private struct BuilderExerciseRow: View {
     @State private var repsText: String = ""
     @State private var showNotesSheet = false
     @State private var showRestSheet = false
+    /// Drives the link-icon button's confirmation dialog (#344 E1). Mirrors the
+    /// pattern used by ActiveWorkoutView.ExerciseCard so builder + live workout
+    /// share UX for grouping/ungrouping.
+    @State private var showSupersetToggleConfirm = false
 
     private var defaultRestSeconds: Int {
         let v = defaultRestStored > 0 ? defaultRestStored : 90
@@ -367,12 +381,26 @@ private struct BuilderExerciseRow: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
-            // Header: name + delete
+            // Header: name + superset toggle + delete
             HStack {
                 VStack(alignment: .leading, spacing: 3) {
-                    Text(exercise.exercise.name)
-                        .font(.subheadline.weight(.bold))
-                        .foregroundStyle(Theme.textPrimary)
+                    HStack(spacing: 6) {
+                        // Superset letter badge (#344 E1) — mirrors ActiveWorkoutView so
+                        // the user can see at a glance which exercises are paired.
+                        if let letter = supersetLetter {
+                            Text("Superset \(letter)")
+                                .font(.caption2.weight(.black))
+                                .foregroundStyle(.black)
+                                .padding(.horizontal, 6)
+                                .padding(.vertical, Theme.Spacing.tighter)
+                                .background(Theme.accent)
+                                .clipShape(.capsule)
+                                .accessibilityLabel("Superset \(letter)")
+                        }
+                        Text(exercise.exercise.name)
+                            .font(.subheadline.weight(.bold))
+                            .foregroundStyle(Theme.textPrimary)
+                    }
 
                     HStack(spacing: Theme.Spacing.tight) {
                         ForEach(exercise.exercise.muscleGroups.prefix(3), id: \.self) { mg in
@@ -388,6 +416,28 @@ private struct BuilderExerciseRow: View {
                 }
 
                 Spacer()
+
+                // Superset toggle (#344 E1) — visible affordance for grouping with the
+                // next exercise. Disabled when no group exists and no next exercise to
+                // pair with, so the layout stays stable across rows.
+                Button {
+                    Haptics.selection()
+                    showSupersetToggleConfirm = true
+                } label: {
+                    Image(systemName: isInSuperset ? "link.circle.fill" : "link")
+                        .font(Theme.fontSubheadline)
+                        .foregroundStyle(isInSuperset ? Theme.accent : Theme.textSecondary)
+                        .frame(width: 44, height: 44)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .disabled(!isInSuperset && !canGroupWithNext)
+                .accessibilityLabel(isInSuperset
+                    ? "Ungroup superset"
+                    : "Group with next exercise as superset")
+                .accessibilityHint(isInSuperset
+                    ? "Removes this exercise from its superset"
+                    : "Pairs this exercise with the next one for back-to-back sets")
 
                 Button(action: onDelete) {
                     Image(systemName: "trash")
@@ -487,6 +537,30 @@ private struct BuilderExerciseRow: View {
                 onSave: { onUpdateRestSeconds($0) }
             )
             .presentationDetents([.medium])
+        }
+        // Superset confirm — mirrors ActiveWorkoutView.ExerciseCard so builder
+        // and live workout share UX (#344 E1).
+        .confirmationDialog(
+            isInSuperset ? "Ungroup Superset?" : "Group with Next Exercise?",
+            isPresented: $showSupersetToggleConfirm,
+            titleVisibility: .visible
+        ) {
+            if isInSuperset {
+                Button("Ungroup Superset", role: .destructive) {
+                    Haptics.light()
+                    onToggleSuperset()
+                }
+            } else if canGroupWithNext {
+                Button("Group with Next Exercise") {
+                    Haptics.success()
+                    onToggleSuperset()
+                }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text(isInSuperset
+                 ? "Removes \(exercise.exercise.name) from its superset."
+                 : "Pairs \(exercise.exercise.name) with the next exercise for back-to-back sets.")
         }
     }
 

--- a/Xomfit/Views/Workout/WorkoutFocusView.swift
+++ b/Xomfit/Views/Workout/WorkoutFocusView.swift
@@ -13,8 +13,46 @@ struct WorkoutFocusView: View {
     @State private var isRestTimerMinimized = false
     @AppStorage("restTimerSound") private var restTimerSound = false
 
+    /// Set pill index targeted by a long-press, used to drive the delete
+    /// confirmation dialog (#344 C). Distinct from `focusSetIndex` so the
+    /// long-press path doesn't fight the tap-to-focus path.
+    @State private var pendingDeleteSetIndex: Int?
+    @State private var showDeleteSetConfirm = false
+
     private var exercise: WorkoutExercise? { viewModel.focusExercise }
     private var currentSet: WorkoutSet? { viewModel.focusSet }
+
+    /// Position-aware superset badge ("A1", "A2", "B1", ...) for the focused
+    /// exercise. Returns nil when the focused exercise isn't part of a superset
+    /// group. Computed locally (instead of on the VM) per #344 constraints —
+    /// no logger VM internals are touched (#344 E2).
+    private var supersetBadge: String? {
+        let idx = viewModel.focusExerciseIndex
+        guard viewModel.exercises.indices.contains(idx),
+              let letter = viewModel.supersetLetter(forExercise: idx),
+              let members = viewModel.supersetMembers(forExercise: idx),
+              let pos = members.firstIndex(of: idx) else { return nil }
+        return "\(letter)\(pos + 1)"
+    }
+
+    /// Index of the most-recently-completed non-drop set in the focused exercise,
+    /// or nil if none has been completed yet. Used to gate the "+ drop set"
+    /// capsule (#344 D) AND to choose the insertion point when the user taps it.
+    private var lastCompletedNonDropSetIndex: Int? {
+        guard let exercise = viewModel.focusExercise else { return nil }
+        let candidates = exercise.sets.enumerated().filter { _, s in
+            s.completedAt != Date.distantPast && !s.isDropSet
+        }
+        guard !candidates.isEmpty else { return nil }
+        // Prefer the latest by `completedAt`; tie-break by index so we still get
+        // a deterministic answer if timestamps collide.
+        return candidates.max(by: { lhs, rhs in
+            if lhs.element.completedAt != rhs.element.completedAt {
+                return lhs.element.completedAt < rhs.element.completedAt
+            }
+            return lhs.offset < rhs.offset
+        })?.offset
+    }
 
     var body: some View {
         ZStack {
@@ -96,6 +134,31 @@ struct WorkoutFocusView: View {
                 viewModel.focusSetIndex = 0
             }
         }
+        // Long-press-to-delete confirmation (#344 C). Driven by `pendingDeleteSetIndex`
+        // so the focused set index can still drive tap-to-focus without interference.
+        .confirmationDialog(
+            "Delete this set?",
+            isPresented: $showDeleteSetConfirm,
+            titleVisibility: .visible
+        ) {
+            Button("Delete set", role: .destructive) {
+                guard let idx = pendingDeleteSetIndex else { return }
+                Haptics.warning()
+                let exIdx = viewModel.focusExerciseIndex
+                viewModel.removeSet(exerciseIndex: exIdx, setIndex: idx)
+                // Keep `focusSetIndex` in bounds after the deletion.
+                if viewModel.exercises.indices.contains(exIdx) {
+                    let total = viewModel.exercises[exIdx].sets.count
+                    viewModel.focusSetIndex = min(viewModel.focusSetIndex, max(total - 1, 0))
+                }
+                pendingDeleteSetIndex = nil
+            }
+            Button("Cancel", role: .cancel) {
+                pendingDeleteSetIndex = nil
+            }
+        } message: {
+            Text("Removes this set from the current exercise.")
+        }
         .onChange(of: viewModel.isRestTimerActive) { _, isActive in
             if isActive { isRestTimerMinimized = false }
         }
@@ -105,11 +168,26 @@ struct WorkoutFocusView: View {
 
     private func exerciseHeader(exercise: WorkoutExercise) -> some View {
         VStack(spacing: Theme.Spacing.tight) {
-            Text(exercise.exercise.name)
-                .font(.title2.weight(.bold))
-                .foregroundStyle(Theme.textPrimary)
-                .multilineTextAlignment(.center)
-                .accessibilityAddTraits(.isHeader)
+            HStack(spacing: Theme.Spacing.sm) {
+                // Superset rotation badge (#344 E2) — e.g. "A1", "A2" so the
+                // lifter can see which slot of a paired group is in focus.
+                if let badge = supersetBadge {
+                    Text(badge)
+                        .font(.caption.weight(.black))
+                        .foregroundStyle(.black)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, Theme.Spacing.tighter)
+                        .background(Theme.accent)
+                        .clipShape(.capsule)
+                        .accessibilityLabel("Superset \(badge)")
+                }
+
+                Text(exercise.exercise.name)
+                    .font(.title2.weight(.bold))
+                    .foregroundStyle(Theme.textPrimary)
+                    .multilineTextAlignment(.center)
+                    .accessibilityAddTraits(.isHeader)
+            }
 
             HStack(spacing: Theme.Spacing.tight) {
                 ForEach(exercise.exercise.muscleGroups.prefix(2), id: \.self) { mg in
@@ -142,7 +220,15 @@ struct WorkoutFocusView: View {
     // MARK: - Set Indicator
 
     private func setIndicator(exercise: WorkoutExercise) -> some View {
-        ScrollView(.horizontal, showsIndicators: false) {
+        // Drop-set capsule is now gated on "any non-drop set in this exercise
+        // has been completed" — not just the focused set (#344 D). This lets
+        // users add a drop set even when focus has already moved to a fresh
+        // incomplete set in the same exercise.
+        let dropParentIndex = lastCompletedNonDropSetIndex
+        let dropSetEnabled = dropParentIndex != nil
+        let canDelete = exercise.sets.count > 1
+
+        return ScrollView(.horizontal, showsIndicators: false) {
             HStack(spacing: Theme.Spacing.sm) {
                 ForEach(Array(exercise.sets.enumerated()), id: \.element.id) { idx, set in
                     let isCompleted = set.completedAt != Date.distantPast
@@ -168,7 +254,19 @@ struct WorkoutFocusView: View {
                         .contentShape(Rectangle())
                     }
                     .buttonStyle(.plain)
+                    // Long-press to delete (#344 C). Guarded so the last
+                    // remaining set is never deletable — every exercise needs
+                    // at least one set in focus mode.
+                    .onLongPressGesture(minimumDuration: 0.5) {
+                        guard canDelete else { return }
+                        Haptics.selection()
+                        pendingDeleteSetIndex = idx
+                        showDeleteSetConfirm = true
+                    }
                     .accessibilityLabel("Set \(idx + 1)\(isCompleted ? ", completed" : "")\(isFocused ? ", current" : "")")
+                    .accessibilityHint(canDelete
+                        ? "Long press to delete"
+                        : "Add another set before this one can be deleted")
                 }
 
                 // + Set button — adds a new set to the current exercise without leaving focus mode
@@ -199,22 +297,22 @@ struct WorkoutFocusView: View {
                 .accessibilityLabel("Add set")
                 .accessibilityHint("Adds a new set to the current exercise")
 
-                // + drop set button — only when the focused set is completed AND
-                // is not itself already a drop set (chains stay tidy via SetRow path).
-                // Mirrors the SetRowView styling so the affordance feels familiar.
-                if let focused = viewModel.focusSet,
-                   focused.completedAt != Date.distantPast,
-                   !focused.isDropSet {
+                // + drop set capsule (#344 D) — visible whenever ANY non-drop
+                // set in this exercise is completed, not just the focused one.
+                // Tap inserts the drop set after the most-recently-completed
+                // non-drop set so the affordance stays useful even when focus
+                // has already advanced to a fresh set.
+                if dropSetEnabled, let parentIdx = dropParentIndex {
                     Button {
                         dismissKeyboard()
                         Haptics.light()
                         let exerciseIndex = viewModel.focusExerciseIndex
-                        let parentSetIndex = viewModel.focusSetIndex
-                        viewModel.addDropSet(exerciseIndex: exerciseIndex, parentSetIndex: parentSetIndex)
-                        // Drop set is inserted right after the parent — advance focus to it.
+                        viewModel.addDropSet(exerciseIndex: exerciseIndex, parentSetIndex: parentIdx)
+                        // Drop set is inserted right after the parent — point
+                        // focus at it so the user lands on the new set.
                         if viewModel.exercises.indices.contains(exerciseIndex),
-                           viewModel.exercises[exerciseIndex].sets.indices.contains(parentSetIndex + 1) {
-                            viewModel.focusSetIndex = parentSetIndex + 1
+                           viewModel.exercises[exerciseIndex].sets.indices.contains(parentIdx + 1) {
+                            viewModel.focusSetIndex = parentIdx + 1
                         }
                     } label: {
                         HStack(spacing: Theme.Spacing.tight) {
@@ -231,8 +329,8 @@ struct WorkoutFocusView: View {
                         .contentShape(.capsule)
                     }
                     .buttonStyle(.plain)
-                    .accessibilityLabel("Add drop set after current set")
-                    .accessibilityHint("Inserts a drop set immediately after the current set with reduced weight")
+                    .accessibilityLabel("Add drop set after set \(parentIdx + 1)")
+                    .accessibilityHint("Inserts a drop set immediately after the most recently completed set with reduced weight")
                 }
             }
             .padding(.horizontal, Theme.Spacing.sm)


### PR DESCRIPTION
Closes parts C/D/E of #344.

- C: long-press set pill → confirmation → removeSet (can't delete the last set)
- D: drop-set capsule shows whenever any non-drop set is completed; inserts after most-recently-completed non-drop
- E1: Builder gets link/link.circle.fill toggle on each exercise row (mirrors ActiveWorkoutView.ExerciseCard from #294) + Superset A/B badge
- E2: Focus view shows A1/A2 rotation badge near exercise name when in a superset
- TemplateExercise gains supersetGroupId field (optional, backward-compat)
- startFromTemplate propagates supersetGroupId to live workout exercises