### PR TITLE
#353 add debug auth bypass + mock fixtures for agent UI verification

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -41,4 +41,48 @@ test_commands:
 - Supabase handles auth — no custom auth logic
 - iOS minimum target: iOS 17
 
+## Verification (Agent UI Screenshots)
+
+For agents that need to launch the app and screenshot UI flows without real
+Supabase credentials, the Debug build supports a sign-in bypass via the
+`XOMFIT_AUTH_BYPASS=1` env var (added in #353).
+
+When set, `AuthService` injects a mock signed-in user, skips all Supabase auth
+calls, and hydrates `WorkoutService` + `TemplateService` caches with mock
+fixtures so history / templates / detail views render.
+
+Build + install + launch + screenshot:
+
+```bash
+# 1. Build a Debug .app for the simulator
+xcodebuild \
+  -project Xomfit.xcodeproj \
+  -scheme Xomfit \
+  -destination 'platform=iOS Simulator,name=iPhone 17' \
+  -configuration Debug \
+  -derivedDataPath build \
+  build
+
+# 2. Boot the sim + install + launch with the bypass env var
+xcrun simctl boot "iPhone 17" 2>/dev/null || true
+xcrun simctl install booted build/Build/Products/Debug-iphonesimulator/Xomfit.app
+xcrun simctl launch --setenv XOMFIT_AUTH_BYPASS=1 booted com.Xomware.Xomfit
+
+# 3. Wait for first render, then screenshot
+sleep 3
+xcrun simctl io booted screenshot ~/check.png
+```
+
+Deep links (only fire after the app is already launched & bypassed in):
+
+```bash
+# Resume the active workout (xomfit://workout) — requires an in-progress session
+xcrun simctl openurl booted "xomfit://workout"
+
+# Open the Reports list and auto-push a specific report detail
+xcrun simctl openurl booted "xomfit://report/<report-id>"
+```
+
+The bypass is `#if DEBUG`-gated and compiles out of Release builds.
+
 ## Lessons

--- a/Xomfit/Models/Workout.swift
+++ b/Xomfit/Models/Workout.swift
@@ -182,4 +182,97 @@ extension Workout {
         endTime: Date().addingTimeInterval(-3600),
         notes: nil
     )
+
+    // MARK: - Debug Fixtures (#353)
+    /// Mock workouts hydrated into `WorkoutService` cache when the
+    /// `XOMFIT_AUTH_BYPASS=1` env var is set. DEBUG-only; lets agents launch
+    /// the app and screenshot history / detail views without real Supabase data.
+    /// All workouts share `AuthService.mockDebugUserId` so they show up for the
+    /// bypassed user.
+    static func mockFixtures(userId: String) -> [Workout] {
+        let now = Date()
+        let day: TimeInterval = 86_400
+
+        return [
+            Workout(
+                id: "mock-workout-1",
+                userId: userId,
+                name: "Push Day",
+                exercises: [
+                    WorkoutExercise(
+                        id: "mock-we-1",
+                        exercise: .benchPress,
+                        sets: [
+                            WorkoutSet(id: "mock-s-1", exerciseId: "ex-1", weight: 185, reps: 8, rpe: 7, isPersonalRecord: false, completedAt: now),
+                            WorkoutSet(id: "mock-s-2", exerciseId: "ex-1", weight: 205, reps: 6, rpe: 8, isPersonalRecord: false, completedAt: now),
+                            WorkoutSet(id: "mock-s-3", exerciseId: "ex-1", weight: 225, reps: 4, rpe: 9, isPersonalRecord: true, completedAt: now)
+                        ],
+                        notes: "Felt strong on the top set"
+                    )
+                ],
+                startTime: now.addingTimeInterval(-3_600),
+                endTime: now.addingTimeInterval(-300),
+                notes: "Solid push session"
+            ),
+            Workout(
+                id: "mock-workout-2",
+                userId: userId,
+                name: "Leg Day",
+                exercises: [
+                    WorkoutExercise(
+                        id: "mock-we-2",
+                        exercise: .squat,
+                        sets: [
+                            WorkoutSet(id: "mock-s-4", exerciseId: "ex-2", weight: 245, reps: 8, rpe: 7, isPersonalRecord: false, completedAt: now.addingTimeInterval(-day)),
+                            WorkoutSet(id: "mock-s-5", exerciseId: "ex-2", weight: 285, reps: 5, rpe: 8.5, isPersonalRecord: false, completedAt: now.addingTimeInterval(-day)),
+                            WorkoutSet(id: "mock-s-6", exerciseId: "ex-2", weight: 315, reps: 3, rpe: 9.5, isPersonalRecord: true, completedAt: now.addingTimeInterval(-day))
+                        ],
+                        notes: nil
+                    )
+                ],
+                startTime: now.addingTimeInterval(-day - 4_200),
+                endTime: now.addingTimeInterval(-day - 900),
+                notes: nil
+            ),
+            Workout(
+                id: "mock-workout-3",
+                userId: userId,
+                name: "Pull Day",
+                exercises: [
+                    WorkoutExercise(
+                        id: "mock-we-3",
+                        exercise: .deadlift,
+                        sets: [
+                            WorkoutSet(id: "mock-s-7", exerciseId: "ex-3", weight: 315, reps: 5, rpe: 8, isPersonalRecord: false, completedAt: now.addingTimeInterval(-3 * day)),
+                            WorkoutSet(id: "mock-s-8", exerciseId: "ex-3", weight: 365, reps: 3, rpe: 9, isPersonalRecord: false, completedAt: now.addingTimeInterval(-3 * day)),
+                            WorkoutSet(id: "mock-s-9", exerciseId: "ex-3", weight: 405, reps: 1, rpe: 10, isPersonalRecord: true, completedAt: now.addingTimeInterval(-3 * day))
+                        ],
+                        notes: "PR on the single"
+                    )
+                ],
+                startTime: now.addingTimeInterval(-3 * day - 3_900),
+                endTime: now.addingTimeInterval(-3 * day - 600),
+                notes: "Heavy pull day"
+            ),
+            Workout(
+                id: "mock-workout-4",
+                userId: userId,
+                name: "Upper Body",
+                exercises: [
+                    WorkoutExercise(
+                        id: "mock-we-4",
+                        exercise: .benchPress,
+                        sets: [
+                            WorkoutSet(id: "mock-s-10", exerciseId: "ex-1", weight: 165, reps: 10, rpe: 7, isPersonalRecord: false, completedAt: now.addingTimeInterval(-6 * day)),
+                            WorkoutSet(id: "mock-s-11", exerciseId: "ex-1", weight: 185, reps: 8, rpe: 8, isPersonalRecord: false, completedAt: now.addingTimeInterval(-6 * day))
+                        ],
+                        notes: nil
+                    )
+                ],
+                startTime: now.addingTimeInterval(-6 * day - 3_300),
+                endTime: now.addingTimeInterval(-6 * day - 600),
+                notes: nil
+            )
+        ]
+    }
 }

--- a/Xomfit/Models/WorkoutTemplate.swift
+++ b/Xomfit/Models/WorkoutTemplate.swift
@@ -245,3 +245,45 @@ extension WorkoutTemplate {
         ),
     ]
 }
+
+// MARK: - Debug Fixtures (#353)
+extension WorkoutTemplate {
+    /// Custom templates hydrated into `TemplateService` cache when the
+    /// `XOMFIT_AUTH_BYPASS=1` env var is set. DEBUG-only; lets agents launch
+    /// the app and screenshot the templates list / builder without real data.
+    static let mockFixtures: [WorkoutTemplate] = [
+        WorkoutTemplate(
+            id: "mock-tpl-1",
+            name: "Heavy Push",
+            description: "Mock push session — strength focus",
+            exercises: [
+                .init(id: "mock-te-1", exercise: ex("ex-bench-flat"), targetSets: 5, targetReps: "5", notes: "Top set RPE 9"),
+                .init(id: "mock-te-2", exercise: ex("ex-incline-db"), targetSets: 3, targetReps: "8-10", notes: nil),
+                .init(id: "mock-te-3", exercise: ex("ex-tricep-pushdown"), targetSets: 3, targetReps: "10-12", notes: nil)
+            ],
+            estimatedDuration: 55, category: .push, isCustom: true
+        ),
+        WorkoutTemplate(
+            id: "mock-tpl-2",
+            name: "Lower Volume",
+            description: "Mock lower body — hypertrophy focus",
+            exercises: [
+                .init(id: "mock-te-4", exercise: ex("ex-squat"), targetSets: 4, targetReps: "8-10", notes: nil),
+                .init(id: "mock-te-5", exercise: ex("ex-rdl"), targetSets: 3, targetReps: "10-12", notes: nil),
+                .init(id: "mock-te-6", exercise: ex("ex-leg-curl"), targetSets: 3, targetReps: "12-15", notes: nil)
+            ],
+            estimatedDuration: 50, category: .lowerBody, isCustom: true
+        ),
+        WorkoutTemplate(
+            id: "mock-tpl-3",
+            name: "Quick Pull",
+            description: "Mock 30-minute pull session",
+            exercises: [
+                .init(id: "mock-te-7", exercise: ex("ex-lat-pulldown"), targetSets: 3, targetReps: "8-12", notes: nil),
+                .init(id: "mock-te-8", exercise: ex("ex-cable-row"), targetSets: 3, targetReps: "10-12", notes: nil),
+                .init(id: "mock-te-9", exercise: ex("ex-barbell-curl"), targetSets: 3, targetReps: "10-12", notes: nil)
+            ],
+            estimatedDuration: 35, category: .pull, isCustom: true
+        )
+    ]
+}

--- a/Xomfit/Services/AuthService.swift
+++ b/Xomfit/Services/AuthService.swift
@@ -18,6 +18,26 @@ final class AuthService {
     private var currentNonce: String?
 
     init() {
+        #if DEBUG
+        if ProcessInfo.processInfo.environment["XOMFIT_AUTH_BYPASS"] == "1" {
+            // Inject a mock signed-in user. Never hits Supabase. See #353.
+            // Hydrates WorkoutService + TemplateService caches so screenshot
+            // flows have data to render.
+            let mockUser = User.mockDebug
+            self.currentUser = mockUser
+            self.currentSession = nil
+            self.isAuthenticated = true
+            self.needsProfileCompletion = false
+            self.needsOnboarding = false
+            self.isLoading = false
+
+            WorkoutService.shared.seedDebugFixtures(userId: mockUser.id.uuidString)
+            TemplateService.shared.seedDebugFixtures()
+
+            print("[AuthService] DEBUG bypass active — using mock user \(mockUser.id.uuidString)")
+            return
+        }
+        #endif
         Task { await listenForAuthChanges() }
     }
 
@@ -224,3 +244,47 @@ final class AuthService {
         return hashedData.compactMap { String(format: "%02x", $0) }.joined()
     }
 }
+
+// MARK: - Debug Mock User (#353)
+#if DEBUG
+extension User {
+    /// Mock Supabase auth user used by the `XOMFIT_AUTH_BYPASS=1` flow.
+    /// All fields are placeholders — never hit any Supabase row.
+    static let mockDebug = User(
+        id: UUID(uuidString: "00000000-0000-0000-0000-00000000DEB6") ?? UUID(),
+        appMetadata: [:],
+        userMetadata: [
+            "display_name": .string("Debug User"),
+            "first_name": .string("Debug"),
+            "last_name": .string("User"),
+            "username": .string("debug_user")
+        ],
+        aud: "authenticated",
+        email: "debug@xomfit.local",
+        createdAt: Date(timeIntervalSince1970: 1_700_000_000),
+        updatedAt: Date(timeIntervalSince1970: 1_700_000_000)
+    )
+}
+
+extension AppUser {
+    /// Profile-shaped mock paired with `User.mockDebug` for views that consume
+    /// `AppUser` rather than the Supabase auth `User`. Mirrors the debug user's id.
+    static let mockDebug = AppUser(
+        id: "00000000-0000-0000-0000-00000000DEB6",
+        username: "debug_user",
+        displayName: "Debug User",
+        avatarURL: nil,
+        bio: "Debug bypass — used by agent UI verification (#353)",
+        stats: UserStats(
+            totalWorkouts: 4,
+            totalVolume: 25_400,
+            totalPRs: 3,
+            currentStreak: 2,
+            longestStreak: 12,
+            favoriteExercise: "Bench Press"
+        ),
+        isPrivate: false,
+        createdAt: Date(timeIntervalSince1970: 1_700_000_000)
+    )
+}
+#endif

--- a/Xomfit/Services/TemplateService.swift
+++ b/Xomfit/Services/TemplateService.swift
@@ -51,4 +51,16 @@ final class TemplateService {
             UserDefaults.standard.set(data, forKey: key)
         }
     }
+
+    // MARK: - Debug Fixtures (#353)
+
+    #if DEBUG
+    /// Hydrates the custom-templates cache with `WorkoutTemplate.mockFixtures`.
+    /// Only invoked when `XOMFIT_AUTH_BYPASS=1` from `AuthService` so future
+    /// agents can screenshot the templates list / builder without real data.
+    /// Safe to call repeatedly — overwrites the custom-template cache.
+    func seedDebugFixtures() {
+        encode(WorkoutTemplate.mockFixtures)
+    }
+    #endif
 }

--- a/Xomfit/Services/WorkoutService.swift
+++ b/Xomfit/Services/WorkoutService.swift
@@ -503,4 +503,18 @@ final class WorkoutService {
         let data = try? JSONEncoder().encode(all)
         UserDefaults.standard.set(data, forKey: storageKey)
     }
+
+    // MARK: - Debug Fixtures (#353)
+
+    #if DEBUG
+    /// Hydrates the local cache with `Workout.mockFixtures(userId:)` for the
+    /// bypassed agent user. Only invoked when `XOMFIT_AUTH_BYPASS=1` from
+    /// `AuthService` so future agents can screenshot history / detail views
+    /// without real Supabase data. Safe to call repeatedly — overwrites this
+    /// user's cached workouts.
+    func seedDebugFixtures(userId: String) {
+        let fixtures = Workout.mockFixtures(userId: userId)
+        overwriteCache(fixtures, userId: userId)
+    }
+    #endif
 }


### PR DESCRIPTION
Closes #353. DEBUG-only env var XOMFIT_AUTH_BYPASS=1 skips Supabase auth and injects a mock user + 4 mock workouts + 3 mock templates. Lets agents drive the simulator and screenshot real UI flows. Verification recipe in .claude/CLAUDE.md.