### PR TITLE
#347 add Spotify Now-Playing capture (OAuth PKCE + polling)

### DIFF
--- a/Xomfit/Services/SpotifyAuthService.swift
+++ b/Xomfit/Services/SpotifyAuthService.swift
@@ -1,0 +1,381 @@
+import AuthenticationServices
+import CryptoKit
+import Foundation
+import SwiftUI
+import UIKit
+
+/// Spotify OAuth 2.0 Authorization Code with PKCE (#347).
+///
+/// ## Why PKCE (no client secret)
+/// Spotify's recommended flow for native apps. The client id is public; the PKCE verifier
+/// stays in-process and prevents code interception. We never ship or store a client secret.
+///
+/// ## Storage caveat
+/// Tokens are persisted via `@AppStorage` (UserDefaults) for v1 — readable by anyone with
+/// device access. Migrating to Keychain is tracked separately and explicitly out of scope here.
+///
+/// ## Callback delivery
+/// `ASWebAuthenticationSession` returns the redirect URL directly to our completion handler,
+/// so no `CFBundleURLTypes` registration is required. The `XomfitApp.onOpenURL` handler is a
+/// belt-and-suspenders fallback in case Safari View Controller hands the URL back to the app
+/// instead of the session.
+@MainActor
+@Observable
+final class SpotifyAuthService: NSObject {
+    static let shared = SpotifyAuthService()
+
+    // MARK: - Persisted state
+
+    @ObservationIgnored @AppStorage("spotifyClientId") private var clientIdSetting: String = ""
+    @ObservationIgnored @AppStorage("spotify.accessToken") private var accessToken: String = ""
+    @ObservationIgnored @AppStorage("spotify.refreshToken") private var refreshToken: String = ""
+    @ObservationIgnored @AppStorage("spotify.tokenExpiry") private var tokenExpiryEpoch: Double = 0
+    @ObservationIgnored @AppStorage("spotify.displayName") private var displayNameStorage: String = ""
+
+    // MARK: - Observable mirror
+
+    /// Mirror of the `@AppStorage` flags above so SwiftUI views observing `SpotifyAuthService`
+    /// re-render after sign-in / sign-out. `@AppStorage` doesn't notify our `@Observable` macro.
+    private(set) var isAuthenticated: Bool = false
+    private(set) var displayName: String = ""
+
+    // MARK: - In-flight state
+
+    private var pendingPKCEVerifier: String?
+    private var pendingState: String?
+    /// Continuation for the in-flight `signIn()`. Resumed when the deep-link callback hits.
+    private var pendingSignInContinuation: CheckedContinuation<Bool, Error>?
+    private var webAuthSession: ASWebAuthenticationSession?
+
+    private override init() {
+        super.init()
+        // Hydrate observable mirror from persisted storage at launch.
+        isAuthenticated = !accessToken.isEmpty
+        displayName = displayNameStorage
+    }
+
+    // MARK: - Public API
+
+    /// Begin the OAuth dance. Returns `true` on a successful token exchange.
+    ///
+    /// Throws:
+    ///   - `SpotifyAuthError.missingClientId` — user hasn't pasted a client id into Settings yet
+    ///   - `SpotifyAuthError.userCancelled` — user dismissed the in-app browser
+    ///   - `SpotifyAuthError.callbackInvalid` — Spotify returned an error or unexpected payload
+    ///   - `SpotifyAuthError.tokenExchangeFailed` — `/api/token` returned non-2xx
+    @discardableResult
+    func signIn() async throws -> Bool {
+        guard !clientIdSetting.trimmingCharacters(in: .whitespaces).isEmpty else {
+            throw SpotifyAuthError.missingClientId
+        }
+
+        // Build PKCE pair + anti-CSRF state up front, stash for the callback.
+        let verifier = Self.generatePKCEVerifier()
+        let challenge = Self.codeChallenge(for: verifier)
+        let state = Self.randomURLSafeString(length: 16)
+        pendingPKCEVerifier = verifier
+        pendingState = state
+
+        guard let authURL = buildAuthorizeURL(challenge: challenge, state: state) else {
+            throw SpotifyAuthError.callbackInvalid
+        }
+
+        // ASWebAuthenticationSession returns the callback URL via its completion handler.
+        let callbackURL: URL = try await withCheckedThrowingContinuation { (cont: CheckedContinuation<URL, Error>) in
+            let session = ASWebAuthenticationSession(
+                url: authURL,
+                callbackURLScheme: SpotifyConfig.callbackURLScheme
+            ) { url, error in
+                if let error = error as? ASWebAuthenticationSessionError, error.code == .canceledLogin {
+                    cont.resume(throwing: SpotifyAuthError.userCancelled)
+                    return
+                }
+                if let error {
+                    cont.resume(throwing: error)
+                    return
+                }
+                guard let url else {
+                    cont.resume(throwing: SpotifyAuthError.callbackInvalid)
+                    return
+                }
+                cont.resume(returning: url)
+            }
+            session.presentationContextProvider = self
+            session.prefersEphemeralWebBrowserSession = false
+            self.webAuthSession = session
+            if !session.start() {
+                cont.resume(throwing: SpotifyAuthError.callbackInvalid)
+            }
+        }
+
+        let code = try parseCallback(url: callbackURL, expectedState: state)
+        try await exchangeCodeForToken(code: code, verifier: verifier)
+        try await refreshUserDisplayName()
+        return true
+    }
+
+    /// Last-resort callback handler invoked from `XomfitApp.onOpenURL` if the OS routes the
+    /// redirect through the app rather than ASWebAuthenticationSession's completion handler.
+    /// Today this is a no-op success path because the in-flight session handles it; we keep it
+    /// for symmetry + forward-compat if we later switch to a hosted login screen.
+    func handleCallback(url: URL) {
+        guard url.scheme == SpotifyConfig.callbackURLScheme,
+              url.host == "spotify-callback" else { return }
+        // ASWebAuthenticationSession already received this. Nothing to do — log for visibility.
+        print("[SpotifyAuth] handleCallback received url (ASWebAuthSession should have handled it)")
+    }
+
+    /// Forget the tokens locally. Does not call Spotify's token-revoke endpoint (Spotify
+    /// doesn't expose one for end users); the session simply stops polling.
+    func signOut() {
+        accessToken = ""
+        refreshToken = ""
+        tokenExpiryEpoch = 0
+        displayNameStorage = ""
+        isAuthenticated = false
+        displayName = ""
+    }
+
+    /// Returns a fresh access token, refreshing via the stored refresh token if the cached
+    /// one is within 60s of expiry. Returns nil when the user hasn't signed in (or the
+    /// refresh attempt failed — caller treats that as silent no-op).
+    func currentTokenRefreshingIfNeeded() async -> String? {
+        guard !accessToken.isEmpty else { return nil }
+
+        let now = Date().timeIntervalSince1970
+        // Refresh proactively to avoid the racy "401 mid-poll" window.
+        if tokenExpiryEpoch - now < 60, !refreshToken.isEmpty {
+            do {
+                try await refreshAccessToken()
+            } catch {
+                print("[SpotifyAuth] refresh failed: \(error)")
+                return nil
+            }
+        }
+        return accessToken.isEmpty ? nil : accessToken
+    }
+
+    // MARK: - URL construction
+
+    private func buildAuthorizeURL(challenge: String, state: String) -> URL? {
+        var components = URLComponents(url: SpotifyConfig.authBaseURL, resolvingAgainstBaseURL: false)
+        components?.queryItems = [
+            URLQueryItem(name: "client_id", value: clientIdSetting),
+            URLQueryItem(name: "response_type", value: "code"),
+            URLQueryItem(name: "redirect_uri", value: SpotifyConfig.redirectURI),
+            URLQueryItem(name: "code_challenge_method", value: "S256"),
+            URLQueryItem(name: "code_challenge", value: challenge),
+            URLQueryItem(name: "state", value: state),
+            URLQueryItem(name: "scope", value: SpotifyConfig.scopes)
+        ]
+        return components?.url
+    }
+
+    private func parseCallback(url: URL, expectedState: String) throws -> String {
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+            throw SpotifyAuthError.callbackInvalid
+        }
+        let items = components.queryItems ?? []
+        if let err = items.first(where: { $0.name == "error" })?.value {
+            print("[SpotifyAuth] callback error: \(err)")
+            throw SpotifyAuthError.callbackInvalid
+        }
+        guard let returnedState = items.first(where: { $0.name == "state" })?.value,
+              returnedState == expectedState else {
+            throw SpotifyAuthError.callbackInvalid
+        }
+        guard let code = items.first(where: { $0.name == "code" })?.value, !code.isEmpty else {
+            throw SpotifyAuthError.callbackInvalid
+        }
+        return code
+    }
+
+    // MARK: - Token exchange
+
+    private func exchangeCodeForToken(code: String, verifier: String) async throws {
+        var request = URLRequest(url: SpotifyConfig.tokenURL)
+        request.httpMethod = "POST"
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        let body = formEncoded([
+            "client_id": clientIdSetting,
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": SpotifyConfig.redirectURI,
+            "code_verifier": verifier
+        ])
+        request.httpBody = body.data(using: .utf8)
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+            print("[SpotifyAuth] token exchange non-2xx — \(String(data: data, encoding: .utf8) ?? "")")
+            throw SpotifyAuthError.tokenExchangeFailed
+        }
+        let payload = try JSONDecoder().decode(TokenResponse.self, from: data)
+        storeToken(payload)
+    }
+
+    private func refreshAccessToken() async throws {
+        guard !refreshToken.isEmpty else { throw SpotifyAuthError.tokenExchangeFailed }
+        var request = URLRequest(url: SpotifyConfig.tokenURL)
+        request.httpMethod = "POST"
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        let body = formEncoded([
+            "client_id": clientIdSetting,
+            "grant_type": "refresh_token",
+            "refresh_token": refreshToken
+        ])
+        request.httpBody = body.data(using: .utf8)
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+            print("[SpotifyAuth] refresh non-2xx — \(String(data: data, encoding: .utf8) ?? "")")
+            // If Spotify rejected the refresh token (e.g. user revoked), drop local state so
+            // the UI returns to the "Sign In" affordance instead of silently failing forever.
+            if let http = response as? HTTPURLResponse, http.statusCode == 400 {
+                signOut()
+            }
+            throw SpotifyAuthError.tokenExchangeFailed
+        }
+        let payload = try JSONDecoder().decode(TokenResponse.self, from: data)
+        storeToken(payload)
+    }
+
+    private func storeToken(_ payload: TokenResponse) {
+        accessToken = payload.access_token
+        // Spotify may or may not rotate the refresh token. Keep the previous when omitted.
+        if let new = payload.refresh_token, !new.isEmpty {
+            refreshToken = new
+        }
+        let expiresIn = payload.expires_in ?? 3600
+        tokenExpiryEpoch = Date().timeIntervalSince1970 + Double(expiresIn)
+        isAuthenticated = true
+    }
+
+    // MARK: - Profile
+
+    /// Pulls `/v1/me` once after sign-in to surface the user's display name in Settings.
+    /// Failure is non-fatal — we still consider sign-in successful with an empty display.
+    private func refreshUserDisplayName() async throws {
+        guard let token = await currentTokenRefreshingIfNeeded() else { return }
+        var request = URLRequest(url: URL(string: "https://api.spotify.com/v1/me")!)
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else { return }
+            let profile = try JSONDecoder().decode(SpotifyMeResponse.self, from: data)
+            let resolved = profile.display_name ?? profile.id ?? ""
+            displayNameStorage = resolved
+            displayName = resolved
+        } catch {
+            print("[SpotifyAuth] /v1/me lookup failed: \(error)")
+        }
+    }
+
+    // MARK: - PKCE helpers
+
+    private static func generatePKCEVerifier() -> String {
+        // Per RFC 7636: 43–128 chars from the URL-safe alphabet. 64 bytes -> 86 chars (>43).
+        randomURLSafeString(length: 64)
+    }
+
+    private static func codeChallenge(for verifier: String) -> String {
+        let data = Data(verifier.utf8)
+        let hashed = SHA256.hash(data: data)
+        return Data(hashed).base64URLEncodedString()
+    }
+
+    private static func randomURLSafeString(length: Int) -> String {
+        var bytes = [UInt8](repeating: 0, count: length)
+        _ = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
+        return Data(bytes).base64URLEncodedString()
+    }
+
+    private func formEncoded(_ params: [String: String]) -> String {
+        params
+            .map { key, value in
+                let escapedKey = key.addingPercentEncoding(withAllowedCharacters: .urlQueryParamAllowed) ?? key
+                let escapedValue = value.addingPercentEncoding(withAllowedCharacters: .urlQueryParamAllowed) ?? value
+                return "\(escapedKey)=\(escapedValue)"
+            }
+            .joined(separator: "&")
+    }
+}
+
+// MARK: - Presentation context
+
+extension SpotifyAuthService: ASWebAuthenticationPresentationContextProviding {
+    nonisolated func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
+        // Walk to the foreground scene's key window. UIKit on the main actor — bounce off.
+        MainActor.assumeIsolated {
+            let scene = UIApplication.shared.connectedScenes
+                .compactMap { $0 as? UIWindowScene }
+                .first(where: { $0.activationState == .foregroundActive })
+                ?? UIApplication.shared.connectedScenes
+                    .compactMap { $0 as? UIWindowScene }
+                    .first
+            if let key = scene?.keyWindow { return key }
+            // Fallback: construct a transient window in the resolved scene rather than calling
+            // the now-deprecated `ASPresentationAnchor()` initializer. Practically unreachable —
+            // logged in case we ever hit it during sign-in.
+            if let scene { return UIWindow(windowScene: scene) }
+            return UIWindow()
+        }
+    }
+}
+
+// MARK: - Errors + payloads
+
+enum SpotifyAuthError: LocalizedError {
+    case missingClientId
+    case userCancelled
+    case callbackInvalid
+    case tokenExchangeFailed
+
+    var errorDescription: String? {
+        switch self {
+        case .missingClientId:
+            return "Paste your Spotify Client ID in Settings -> Music Sources before signing in."
+        case .userCancelled:
+            return "Spotify sign-in was cancelled."
+        case .callbackInvalid:
+            return "Spotify returned an invalid response."
+        case .tokenExchangeFailed:
+            return "Couldn't exchange the Spotify auth code. Try signing in again."
+        }
+    }
+}
+
+private struct TokenResponse: Decodable {
+    let access_token: String
+    let token_type: String?
+    let expires_in: Int?
+    let refresh_token: String?
+    let scope: String?
+}
+
+private struct SpotifyMeResponse: Decodable {
+    let id: String?
+    let display_name: String?
+}
+
+// MARK: - Base64URL helper
+
+private extension Data {
+    /// RFC 4648 §5 base64url, no padding — required for PKCE code_challenge.
+    func base64URLEncodedString() -> String {
+        base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+}
+
+private extension CharacterSet {
+    /// Strict `application/x-www-form-urlencoded` allowed set. `.urlQueryAllowed` accepts
+    /// `+` and `=` which Spotify's token endpoint mis-parses as the literal characters.
+    static let urlQueryParamAllowed: CharacterSet = {
+        var allowed = CharacterSet.alphanumerics
+        allowed.insert(charactersIn: "-._~")
+        return allowed
+    }()
+}

--- a/Xomfit/Services/SpotifyConfig.swift
+++ b/Xomfit/Services/SpotifyConfig.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+/// Static configuration for the Spotify Web API OAuth + Now-Playing integration (#347).
+///
+/// We use the Authorization Code with PKCE grant — no client secret required, which is
+/// exactly why the `clientId` can ship empty here and be pasted in by the user via
+/// `Settings -> Music Sources -> Spotify Client ID` (read off `@AppStorage("spotifyClientId")`).
+/// Spotify treats the client id as public; only the redirect URI + PKCE verifier protect
+/// the code exchange.
+///
+/// See `docs/features/spotify-347/SETUP.md` for the full Developer App walkthrough.
+enum SpotifyConfig {
+    /// Public Spotify Developer client id. Empty by default — the user pastes their
+    /// own value via Settings, persisted under `@AppStorage("spotifyClientId")`. Reading
+    /// the live value is the responsibility of `SpotifyAuthService` so a paste-in takes
+    /// effect on the very next sign-in attempt without an app restart.
+    static let clientId = ""
+
+    /// Custom URL scheme that ASWebAuthenticationSession listens for. Must match the
+    /// "Redirect URI" registered on the Spotify Developer Dashboard exactly.
+    static let redirectURI = "xomfit://spotify-callback"
+
+    /// Space-delimited scope list. Only what we actually need:
+    /// `user-read-currently-playing` covers the polling endpoint, `user-read-playback-state`
+    /// keeps us forward-compatible with adding "now-playing context" (device, shuffle, etc.).
+    static let scopes = "user-read-currently-playing user-read-playback-state"
+
+    static let authBaseURL = URL(string: "https://accounts.spotify.com/authorize")!
+    static let tokenURL = URL(string: "https://accounts.spotify.com/api/token")!
+    static let nowPlayingURL = URL(string: "https://api.spotify.com/v1/me/player/currently-playing")!
+
+    /// URL scheme component of `redirectURI` — what ASWebAuthenticationSession needs separately.
+    static let callbackURLScheme = "xomfit"
+}

--- a/Xomfit/Services/SpotifyNowPlayingService.swift
+++ b/Xomfit/Services/SpotifyNowPlayingService.swift
@@ -1,0 +1,164 @@
+import Foundation
+
+/// Polls Spotify's `currently-playing` endpoint during an active workout (#347) and accumulates
+/// the tracks for attachment to the saved `Workout`.
+///
+/// ## Why this exists alongside `NowPlayingService`
+/// iOS does NOT expose other apps' Now Playing metadata to third-party apps. Apple Music is the
+/// only system-level source we can read. Spotify offers its own Web API that we hit explicitly
+/// with the user's OAuth token. Same shape (`startCapture` / `stopCapture -> [WorkoutTrack]`)
+/// as `NowPlayingService` so `WorkoutLoggerViewModel` can merge them at finish time.
+///
+/// ## Silent when not authenticated
+/// If `SpotifyAuthService.shared.currentTokenRefreshingIfNeeded()` returns nil (user never signed
+/// in, or token revoked) the polling loop simply no-ops on each tick. No prompts, no errors.
+@MainActor
+final class SpotifyNowPlayingService {
+    static let shared = SpotifyNowPlayingService()
+
+    /// 30s cadence — matches `NowPlayingService` and stays well under Spotify's rate limit.
+    private let pollInterval: TimeInterval = 30
+
+    private var captured: [WorkoutTrack] = []
+    private var seenKeys: Set<String> = []
+    private var pollTask: Task<Void, Never>?
+
+    private init() {}
+
+    // MARK: - Capture lifecycle
+
+    /// Idempotent. Resets per-session state and starts polling. Safe to call when not
+    /// authenticated — the loop checks on each tick.
+    func startCapture() {
+        print("[SpotifyNowPlayingService] startCapture called — resetting session state")
+        captured.removeAll()
+        seenKeys.removeAll()
+        pollTask?.cancel()
+
+        pollTask = Task { [weak self] in
+            guard let self else { return }
+            print("[SpotifyNowPlayingService] polling started — interval=\(self.pollInterval)s")
+            // Capture immediately so a song already playing at workout start is recorded.
+            await self.captureCurrentTrack()
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: UInt64(self.pollInterval * 1_000_000_000))
+                if Task.isCancelled { return }
+                await self.captureCurrentTrack()
+            }
+            print("[SpotifyNowPlayingService] polling loop exited")
+        }
+    }
+
+    /// Stop polling and return the captured tracks. Clears state for the next session.
+    @discardableResult
+    func stopCapture() -> [WorkoutTrack] {
+        print("[SpotifyNowPlayingService] stopCapture called — \(captured.count) track(s) captured")
+        pollTask?.cancel()
+        pollTask = nil
+        let result = captured
+        captured.removeAll()
+        seenKeys.removeAll()
+        return result
+    }
+
+    // MARK: - Polling
+
+    private func captureCurrentTrack() async {
+        guard let token = await SpotifyAuthService.shared.currentTokenRefreshingIfNeeded() else {
+            // Not signed in (or refresh failed). Silent no-op — see class doc.
+            return
+        }
+
+        var request = URLRequest(url: SpotifyConfig.nowPlayingURL)
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        // The endpoint can take a few hundred ms; 10s is a generous upper bound that still
+        // bails fast enough to not stack tasks at 30s intervals.
+        request.timeoutInterval = 10
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            guard let http = response as? HTTPURLResponse else { return }
+            switch http.statusCode {
+            case 204:
+                // Spotify returns 204 when nothing is playing — common during rest sets.
+                return
+            case 200:
+                break
+            case 401:
+                // Token rejected mid-session. Refresh path handles renewal; if this persists
+                // the user can re-auth from Settings. Don't sign them out automatically.
+                print("[SpotifyNowPlayingService] 401 from /currently-playing")
+                return
+            case 429:
+                print("[SpotifyNowPlayingService] rate-limited (429) — skipping this tick")
+                return
+            default:
+                print("[SpotifyNowPlayingService] unexpected status \(http.statusCode)")
+                return
+            }
+
+            guard let payload = try? JSONDecoder().decode(SpotifyNowPlayingResponse.self, from: data),
+                  let item = payload.item else {
+                return
+            }
+            // `is_playing` can be false during transient pauses — still record the track
+            // if it has metadata, since the user clearly had it queued during the workout.
+            let title = item.name
+            guard !title.isEmpty else { return }
+
+            let key = dedupeKey(uri: item.uri, id: item.id, title: title)
+            guard !seenKeys.contains(key) else {
+                print("[SpotifyNowPlayingService] '\(title)' already captured, deduped")
+                return
+            }
+            seenKeys.insert(key)
+
+            let artist = item.artists?.compactMap { $0.name }.joined(separator: ", ")
+            let track = WorkoutTrack(
+                title: title,
+                artist: (artist?.isEmpty == false) ? artist : nil,
+                album: item.album?.name,
+                capturedAt: Date(),
+                sourceApp: "Spotify"
+            )
+            captured.append(track)
+            print("[SpotifyNowPlayingService] captured '\(title)' by \(artist ?? "unknown") — total: \(captured.count)")
+        } catch {
+            // Network blips happen — log and continue. Polling will retry on the next tick.
+            print("[SpotifyNowPlayingService] poll error: \(error)")
+        }
+    }
+
+    private func dedupeKey(uri: String?, id: String?, title: String) -> String {
+        // Prefer the canonical URI, then the bare id, then a title fallback for unusual
+        // edge cases (local tracks have neither uri nor id populated reliably).
+        if let uri, !uri.isEmpty { return "uri|\(uri)" }
+        if let id, !id.isEmpty { return "id|\(id)" }
+        return "title|\(title.lowercased())"
+    }
+}
+
+// MARK: - Spotify payload shapes
+
+/// Trimmed to only the fields we actually consume. Spotify returns far more
+/// (progress_ms, device, context, currently_playing_type, ...) — easy to extend later.
+private struct SpotifyNowPlayingResponse: Decodable {
+    let is_playing: Bool?
+    let item: SpotifyItem?
+}
+
+private struct SpotifyItem: Decodable {
+    let id: String?
+    let uri: String?
+    let name: String
+    let artists: [SpotifyArtist]?
+    let album: SpotifyAlbum?
+}
+
+private struct SpotifyArtist: Decodable {
+    let name: String?
+}
+
+private struct SpotifyAlbum: Decodable {
+    let name: String?
+}

--- a/Xomfit/ViewModels/WorkoutLoggerViewModel.swift
+++ b/Xomfit/ViewModels/WorkoutLoggerViewModel.swift
@@ -163,6 +163,8 @@ final class WorkoutLoggerViewModel {
         // Begin Now Playing capture — Apple Music only (see NowPlayingService docs).
         // Silent no-op when the user denied Apple Music access.
         NowPlayingService.shared.startCapture()
+        // Spotify capture runs in parallel — also a silent no-op when not signed in (#347).
+        SpotifyNowPlayingService.shared.startCapture()
     }
 
     func discardWorkout() {
@@ -191,6 +193,7 @@ final class WorkoutLoggerViewModel {
 
         // Drop any captured Now Playing tracks — discarding the workout discards the soundtrack.
         _ = NowPlayingService.shared.stopCapture()
+        _ = SpotifyNowPlayingService.shared.stopCapture()
     }
 
     func startFromTemplate(_ template: WorkoutTemplate, userId: String) {
@@ -962,7 +965,12 @@ final class WorkoutLoggerViewModel {
 
         // Pull the Now Playing capture and attach it to the saved workout.
         // Empty list when the user denied Apple Music access or only used non-Apple Music sources.
-        let capturedTracks = NowPlayingService.shared.stopCapture()
+        // Spotify tracks (when authed) merge in alongside Apple Music — sort by capture time so
+        // the saved soundtrack reflects actual play order across sources (#347).
+        let appleMusicTracks = NowPlayingService.shared.stopCapture()
+        let spotifyTracks = SpotifyNowPlayingService.shared.stopCapture()
+        let capturedTracks = (appleMusicTracks + spotifyTracks)
+            .sorted { $0.capturedAt < $1.capturedAt }
 
         let workout = Workout(
             id: UUID().uuidString,

--- a/Xomfit/Views/Profile/SettingsView.swift
+++ b/Xomfit/Views/Profile/SettingsView.swift
@@ -1,3 +1,4 @@
+import MediaPlayer
 import StoreKit
 import SwiftUI
 import UIKit
@@ -70,6 +71,7 @@ struct SettingsView: View {
                 trainingSection
                 aiCoachSection
                 toolsSection
+                musicSourcesSection
                 dataPrivacySection
                 supportSection
                 aboutSection
@@ -598,7 +600,67 @@ struct SettingsView: View {
     }
 }
 
+// MARK: - Music Sources (#347)
+
 extension SettingsView {
+    /// Surfaces both music-capture sources side-by-side so the user understands what's
+    /// captured during a workout: Apple Music (system-permission only, read-only) and
+    /// Spotify (explicit OAuth + Web API polling).
+    fileprivate var musicSourcesSection: some View {
+        Section {
+            appleMusicRow
+            SpotifyConnectionView()
+        } header: {
+            XomMetricLabel("Music Sources")
+        } footer: {
+            Text("XomFit captures songs that played during your workout. Apple Music reads from system permission; Spotify requires sign-in.")
+                .font(Theme.fontCaption)
+                .foregroundStyle(Theme.textTertiary)
+        }
+        .listRowBackground(Theme.surface)
+        .listRowSeparatorTint(Theme.hairline)
+    }
+
+    /// Read-only Apple Music status with a deep link to the system Settings app when denied.
+    fileprivate var appleMusicRow: some View {
+        let status = MPMediaLibrary.authorizationStatus()
+        let (statusLabel, isDenied): (String, Bool) = {
+            switch status {
+            case .authorized: return ("Connected", false)
+            case .notDetermined: return ("Permission not yet requested", false)
+            case .denied: return ("Access denied", true)
+            case .restricted: return ("Restricted", true)
+            @unknown default: return ("Unknown", true)
+            }
+        }()
+
+        return HStack(spacing: Theme.Spacing.md) {
+            Image(systemName: "applelogo")
+                .frame(width: Theme.Spacing.lg)
+                .foregroundStyle(Theme.accent)
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Apple Music")
+                    .foregroundStyle(Theme.textPrimary)
+                Text(statusLabel)
+                    .font(Theme.fontCaption)
+                    .foregroundStyle(Theme.textTertiary)
+            }
+            Spacer()
+            if isDenied {
+                Button("Open Settings") {
+                    if let url = URL(string: UIApplication.openSettingsURLString) {
+                        UIApplication.shared.open(url)
+                    }
+                }
+                .font(Theme.fontCaption)
+                .tint(Theme.accent)
+                .accessibilityHint("Opens the iOS Settings app where you can grant Apple Music access")
+            }
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Apple Music: \(statusLabel)")
+    }
+
     fileprivate var toolsSection: some View {
         Section {
             Button {

--- a/Xomfit/Views/Profile/SpotifyConnectionView.swift
+++ b/Xomfit/Views/Profile/SpotifyConnectionView.swift
@@ -1,0 +1,128 @@
+import SwiftUI
+
+/// Spotify connection block embedded in `SettingsView` -> Music Sources (#347).
+///
+/// Renders one of two modes:
+///   - Signed out: client-id paste field + "Sign In with Spotify" button
+///   - Signed in: connected display name + Sign Out button (paste field still visible so the
+///     user can swap accounts without leaving Settings)
+///
+/// Kept as its own view so `SettingsView` doesn't grow another 80 lines of music-source logic.
+struct SpotifyConnectionView: View {
+    @State private var spotifyAuth = SpotifyAuthService.shared
+    @AppStorage("spotifyClientId") private var clientId: String = ""
+
+    @State private var isSigningIn: Bool = false
+    @State private var errorMessage: String? = nil
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+            header
+
+            clientIdField
+
+            actionButton
+
+            if let errorMessage {
+                Text(errorMessage)
+                    .font(Theme.fontCaption)
+                    .foregroundStyle(Theme.destructive)
+                    .accessibilityLabel("Spotify error: \(errorMessage)")
+            }
+        }
+        .padding(.vertical, Theme.Spacing.xs)
+    }
+
+    // MARK: - Subviews
+
+    private var header: some View {
+        HStack(spacing: Theme.Spacing.md) {
+            Image(systemName: "music.note")
+                .frame(width: Theme.Spacing.lg)
+                .foregroundStyle(.green)
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Spotify")
+                    .foregroundStyle(Theme.textPrimary)
+                Text(spotifyAuth.isAuthenticated
+                     ? "Connected\(spotifyAuth.displayName.isEmpty ? "" : " as \(spotifyAuth.displayName)")"
+                     : "Not connected")
+                    .font(Theme.fontCaption)
+                    .foregroundStyle(Theme.textTertiary)
+                    .accessibilityLabel(spotifyAuth.isAuthenticated ? "Spotify connected" : "Spotify not connected")
+            }
+            Spacer()
+        }
+    }
+
+    private var clientIdField: some View {
+        HStack(spacing: Theme.Spacing.md) {
+            Image(systemName: "key.fill")
+                .frame(width: Theme.Spacing.lg)
+                .foregroundStyle(Theme.accent)
+            SecureField("Spotify Client ID", text: $clientId)
+                .foregroundStyle(Theme.textPrimary)
+                .font(Theme.fontBody)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+                .accessibilityLabel("Spotify Client ID")
+                .accessibilityHint("Paste the client id from your Spotify Developer Dashboard")
+        }
+    }
+
+    @ViewBuilder
+    private var actionButton: some View {
+        if spotifyAuth.isAuthenticated {
+            Button(role: .destructive) {
+                Haptics.selection()
+                spotifyAuth.signOut()
+            } label: {
+                HStack(spacing: Theme.Spacing.md) {
+                    Image(systemName: "rectangle.portrait.and.arrow.right")
+                        .frame(width: Theme.Spacing.lg)
+                        .foregroundStyle(Theme.destructive)
+                    Text("Disconnect Spotify")
+                        .foregroundStyle(Theme.destructive)
+                }
+            }
+            .accessibilityHint("Removes Spotify access and stops capturing tracks")
+        } else {
+            Button {
+                Task { await signIn() }
+            } label: {
+                HStack(spacing: Theme.Spacing.md) {
+                    if isSigningIn {
+                        ProgressView().tint(Theme.accent)
+                            .frame(width: Theme.Spacing.lg)
+                    } else {
+                        Image(systemName: "link")
+                            .frame(width: Theme.Spacing.lg)
+                            .foregroundStyle(Theme.accent)
+                    }
+                    Text(isSigningIn ? "Connecting..." : "Sign In with Spotify")
+                        .foregroundStyle(clientId.trimmingCharacters(in: .whitespaces).isEmpty ? Theme.textTertiary : Theme.textPrimary)
+                }
+            }
+            .disabled(isSigningIn || clientId.trimmingCharacters(in: .whitespaces).isEmpty)
+            .accessibilityHint(clientId.isEmpty
+                               ? "Paste a Spotify client id above first"
+                               : "Opens the Spotify login web view")
+        }
+    }
+
+    // MARK: - Actions
+
+    private func signIn() async {
+        guard !isSigningIn else { return }
+        isSigningIn = true
+        errorMessage = nil
+        defer { isSigningIn = false }
+        do {
+            _ = try await spotifyAuth.signIn()
+            Haptics.selection()
+        } catch let err as SpotifyAuthError {
+            errorMessage = err.errorDescription
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}

--- a/Xomfit/XomfitApp.swift
+++ b/Xomfit/XomfitApp.swift
@@ -78,6 +78,12 @@ struct XomFitApp: App {
                     }
                     return
                 }
+                if url.scheme == "xomfit", url.host == "spotify-callback" {
+                    // Belt-and-suspenders: ASWebAuthenticationSession's completion handler
+                    // normally consumes this. Forward anyway in case the OS routes it here.
+                    SpotifyAuthService.shared.handleCallback(url: url)
+                    return
+                }
                 if url.scheme == "xomfit", url.host == "report" {
                     // `xomfit://report/<id>` — first path component is the id.
                     let id = url.pathComponents

--- a/docs/features/spotify-347/SETUP.md
+++ b/docs/features/spotify-347/SETUP.md
@@ -1,0 +1,82 @@
+# Spotify Now-Playing — Setup
+
+XomFit captures the soundtrack of every workout. Apple Music works out of the box via
+system permission. Spotify needs an explicit OAuth sign-in because iOS does not expose
+other apps' Now Playing metadata to third-party apps — we have to ask Spotify directly.
+
+This guide walks you through creating a Spotify Developer App, copying the public client
+id into XomFit, and signing in.
+
+## 1. Create a Spotify Developer App
+
+1. Go to <https://developer.spotify.com/dashboard> and log in with your Spotify account.
+2. Click **Create app**.
+3. Fill in:
+   - **App name:** `XomFit` (or anything you like — only you will see this)
+   - **App description:** `Personal workout soundtrack capture`
+   - **Website:** can be left blank
+   - **Redirect URIs:** `xomfit://spotify-callback` (paste exactly — case + scheme matter)
+   - **APIs used:** check **Web API**
+4. Agree to the developer terms and click **Save**.
+
+## 2. Copy your Client ID
+
+1. On the new app's dashboard, click **Settings** (top-right).
+2. Copy the value labelled **Client ID**.
+   - It looks like `9a1b2c3d4e5f6789...` — 32 hex chars.
+   - You do NOT need the Client Secret. XomFit uses PKCE so the secret stays unused.
+
+## 3. Paste it into XomFit
+
+1. Open XomFit -> **Profile tab** -> **Settings** -> **Music Sources**.
+2. Tap into the **Spotify Client ID** field and paste your client id.
+3. Tap **Sign In with Spotify**.
+4. A web sheet opens at `accounts.spotify.com`. Log in (if you aren't already) and
+   approve the requested scopes:
+   - `user-read-currently-playing` — what XomFit polls during a workout
+   - `user-read-playback-state` — reserved for future "what device is playing" UI
+5. You'll be bounced back to XomFit. The Music Sources row now shows
+   **Connected as `<your Spotify display name>`**.
+
+## 4. (Optional) Add yourself as a tester
+
+Spotify apps start in *Development Mode*, which limits sign-in to users you explicitly
+allow.
+
+1. Dashboard -> your app -> **Settings** -> **User Management**.
+2. Click **Add New User**, enter your Spotify display name and the email tied to the
+   account.
+
+If you skip this you'll still see the Spotify login screen — but the consent step will
+fail with a `User not registered in the Developer Dashboard` message.
+
+## How it works during a workout
+
+- When you tap **Start Workout**, XomFit kicks off a 30s polling task against
+  `https://api.spotify.com/v1/me/player/currently-playing`.
+- Each new track is deduped by URI and appended to the workout's captured tracks.
+- On **Finish Workout**, Apple Music + Spotify captures are merged and sorted by capture
+  time — you get one chronological soundtrack regardless of which app you used.
+- If nothing is playing on Spotify (or you're paused), the endpoint returns 204 and the
+  polling tick is a no-op. No empty entries, no crashes.
+
+## Troubleshooting
+
+- **"Paste your Spotify Client ID in Settings before signing in"** — you tapped Sign In
+  before pasting the id. Drop it in the field above and retry.
+- **Spotify says "INVALID_CLIENT: Invalid redirect URI"** — the redirect URI on the
+  Dashboard does not exactly match `xomfit://spotify-callback`. Re-check casing.
+- **Sign-in succeeds but the workout has no Spotify tracks** — make sure Spotify is
+  actively playing (not paused) on at least one device during the workout. The Web API
+  only reports active playback.
+- **"User not registered in the Developer Dashboard"** — add yourself as a tester
+  (step 4 above) or move the app to Extended Quota Mode via Spotify's review process.
+
+## Security notes
+
+- The client id is a **public** identifier — Spotify treats it that way, and so do we.
+- XomFit uses **PKCE** (RFC 7636), so the client secret is never needed nor stored.
+- Tokens are persisted via `@AppStorage` (UserDefaults) for v1. Anyone with device
+  access could read them. Migrating to Keychain is tracked separately.
+- Tap **Disconnect Spotify** in the same section to forget the tokens. You can also
+  revoke XomFit's access from your Spotify account page at any time.


### PR DESCRIPTION
Closes #347. PKCE OAuth flow via ASWebAuthenticationSession, 30s polling on /v1/me/player/currently-playing. Merges with Apple Music capture in finishWorkout — both sources flow into Workout.tracks sorted by capturedAt. Settings → Music Sources lets user paste their Spotify Developer App client ID, sign in, and disconnect. Setup walkthrough in docs/features/spotify-347/SETUP.md.