### PR TITLE
#346 add full-body anatomy heatmap (Hevy-style) with muscle drill-in

### DIFF
--- a/Xomfit/ViewModels/BodyHeatmapViewModel.swift
+++ b/Xomfit/ViewModels/BodyHeatmapViewModel.swift
@@ -1,0 +1,221 @@
+import Foundation
+import SwiftUI
+
+// MARK: - Time Range
+
+/// Filter for the full-body heatmap (#346).
+///
+/// Decoupled from the older `HeatmapTimeFilter` (Week/Month) because the new
+/// silhouette heatmap also supports 3-month and all-time views.
+enum HeatmapTimeRange: String, CaseIterable, Identifiable {
+    case week        = "1W"
+    case month       = "1M"
+    case threeMonths = "3M"
+    case allTime     = "All"
+
+    var id: String { rawValue }
+
+    var displayName: String { rawValue }
+
+    var accessibilityName: String {
+        switch self {
+        case .week:        return "Last week"
+        case .month:       return "Last month"
+        case .threeMonths: return "Last three months"
+        case .allTime:     return "All time"
+        }
+    }
+
+    /// Start date for the range. `nil` means "no lower bound" (.allTime).
+    func startDate(now: Date = .now, calendar: Calendar = .current) -> Date? {
+        switch self {
+        case .week:
+            return calendar.date(byAdding: .weekOfYear, value: -1, to: now)
+        case .month:
+            return calendar.date(byAdding: .month, value: -1, to: now)
+        case .threeMonths:
+            return calendar.date(byAdding: .month, value: -3, to: now)
+        case .allTime:
+            return nil
+        }
+    }
+}
+
+// MARK: - ExerciseVolumeEntry
+
+/// One exercise's contribution to a muscle group within the selected range.
+/// Surfaced by `MuscleDetailSheet` so users can drill from "lats hit hardest"
+/// → "deadlift was 80% of that".
+struct ExerciseVolumeEntry: Identifiable, Hashable {
+    let exercise: Exercise
+    /// Total set count across the selected range.
+    let setCount: Int
+    /// Total volume (lbs · reps) attributed to this muscle from this exercise.
+    /// Volume is split evenly across the exercise's primary muscle groups.
+    let volume: Double
+    /// Best-set weight × reps, displayed as a quick PR-ish summary.
+    let bestSetWeight: Double
+    let bestSetReps: Int
+
+    var id: String { exercise.id }
+}
+
+// MARK: - BodyHeatmapViewModel
+
+/// Derives per-muscle volume from a workout history for the full-body heatmap.
+///
+/// Volume distribution rule: an exercise's total volume is split *evenly across
+/// its primary muscle groups*. Bench press (chest, triceps, shoulders) with
+/// 9,000 lbs volume contributes 3,000 to each. This matches the simplifying
+/// assumption called out in #346 — we don't have prime/synergist data in the
+/// `Exercise` model, so equal split is the honest aggregation.
+@Observable
+@MainActor
+final class BodyHeatmapViewModel {
+    // MARK: - Inputs
+
+    /// Workout history backing the heatmap. Re-assign to recompute.
+    var workouts: [Workout] {
+        didSet { recompute() }
+    }
+
+    /// Selected time range. Re-assign to recompute.
+    var range: HeatmapTimeRange {
+        didSet { recompute() }
+    }
+
+    // MARK: - Outputs
+
+    /// Total volume per muscle group within the selected range.
+    private(set) var volumeByMuscle: [MuscleGroup: Double] = [:]
+
+    /// Exercises that contributed to each muscle, ranked by descending volume.
+    /// Populated alongside `volumeByMuscle`.
+    private(set) var exercisesByMuscle: [MuscleGroup: [ExerciseVolumeEntry]] = [:]
+
+    /// Max value in `volumeByMuscle`. Cached so `intensity(for:)` is O(1).
+    private(set) var maxVolume: Double = 0
+
+    // MARK: - Init
+
+    init(workouts: [Workout] = [], range: HeatmapTimeRange = .week) {
+        self.workouts = workouts
+        self.range = range
+        recompute()
+    }
+
+    // MARK: - Public Helpers
+
+    /// Returns 0.0–1.0 intensity for the given muscle relative to the busiest
+    /// muscle in the current range. Returns 0 when the muscle has no recorded
+    /// volume or the dataset is empty.
+    func intensity(for muscle: MuscleGroup) -> Double {
+        guard maxVolume > 0 else { return 0 }
+        let volume = volumeByMuscle[muscle] ?? 0
+        return max(0, min(1, volume / maxVolume))
+    }
+
+    /// Exercises that hit `muscle` in the selected range, ranked by volume.
+    func exercises(for muscle: MuscleGroup) -> [ExerciseVolumeEntry] {
+        exercisesByMuscle[muscle] ?? []
+    }
+
+    /// Total volume contributed to `muscle` in the selected range.
+    func totalVolume(for muscle: MuscleGroup) -> Double {
+        volumeByMuscle[muscle] ?? 0
+    }
+
+    // MARK: - Compute
+
+    private func recompute() {
+        let start = range.startDate()
+        var byMuscle: [MuscleGroup: Double] = [:]
+        // Per-muscle, per-exercise rollup so we can rebuild `ExerciseVolumeEntry`
+        // without re-walking the workout list a second time.
+        var perMuscleAgg: [MuscleGroup: [String: MuscleAggregate]] = [:]
+
+        for workout in workouts {
+            if let start, workout.startTime < start { continue }
+
+            for workoutExercise in workout.exercises {
+                let exercise = workoutExercise.exercise
+                let muscles = exercise.muscleGroups
+                guard !muscles.isEmpty else { continue }
+
+                let totalVolume = workoutExercise.totalVolume
+                let share = totalVolume / Double(muscles.count)
+                guard share > 0 else { continue }
+
+                // Best set across all sets of this exercise instance.
+                let best = workoutExercise.sets.max(by: { $0.volume < $1.volume })
+                let setCount = workoutExercise.sets.count
+
+                for muscle in muscles {
+                    byMuscle[muscle, default: 0] += share
+
+                    var bucket = perMuscleAgg[muscle] ?? [:]
+                    var entry = bucket[exercise.id] ?? MuscleAggregate(exercise: exercise)
+                    entry.volume += share
+                    entry.setCount += setCount
+                    if let best, best.volume > entry.bestSetVolume {
+                        entry.bestSetVolume = best.volume
+                        entry.bestSetWeight = best.weight
+                        entry.bestSetReps = best.reps
+                    }
+                    bucket[exercise.id] = entry
+                    perMuscleAgg[muscle] = bucket
+                }
+            }
+        }
+
+        volumeByMuscle = byMuscle
+        maxVolume = byMuscle.values.max() ?? 0
+
+        // Flatten the aggregates into ranked entry lists.
+        var ranked: [MuscleGroup: [ExerciseVolumeEntry]] = [:]
+        for (muscle, bucket) in perMuscleAgg {
+            ranked[muscle] = bucket.values
+                .map {
+                    ExerciseVolumeEntry(
+                        exercise: $0.exercise,
+                        setCount: $0.setCount,
+                        volume: $0.volume,
+                        bestSetWeight: $0.bestSetWeight,
+                        bestSetReps: $0.bestSetReps
+                    )
+                }
+                .sorted { $0.volume > $1.volume }
+        }
+        exercisesByMuscle = ranked
+    }
+
+    /// Internal rollup struct kept private — `ExerciseVolumeEntry` is the
+    /// Identifiable façade we expose to views.
+    private struct MuscleAggregate {
+        let exercise: Exercise
+        var volume: Double = 0
+        var setCount: Int = 0
+        var bestSetVolume: Double = 0
+        var bestSetWeight: Double = 0
+        var bestSetReps: Int = 0
+    }
+}
+
+// MARK: - Color Helpers
+
+extension BodyHeatmapViewModel {
+    /// Convenience: build the `[MuscleGroup: Color]` map a silhouette consumes.
+    /// Color is `Theme.accent` shaded by relative intensity, with a floor so even
+    /// touched muscles read as "hit" rather than invisible.
+    func fillMap(accent: Color = Theme.accent, floor: Double = 0.18) -> [MuscleGroup: Color] {
+        var map: [MuscleGroup: Color] = [:]
+        for muscle in MuscleGroup.allCases {
+            let i = intensity(for: muscle)
+            guard i > 0 else { continue }
+            // Floor non-zero intensities to `floor` so a lightly-hit muscle still shows.
+            let opacity = floor + (1 - floor) * i
+            map[muscle] = accent.opacity(opacity)
+        }
+        return map
+    }
+}

--- a/Xomfit/Views/Common/BodySilhouetteView.swift
+++ b/Xomfit/Views/Common/BodySilhouetteView.swift
@@ -1,0 +1,399 @@
+import SwiftUI
+
+/// Front or back of the anatomical silhouette.
+///
+/// Used by `FullBodyHeatmapView` (#346) and the mini silhouette inside
+/// `ExerciseDetailSheet`. Front/back is a toggle, not two views shown at once,
+/// so the same vertical real estate renders both sides.
+enum BodySide: String, CaseIterable, Identifiable {
+    case front
+    case back
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .front: return "Front"
+        case .back:  return "Back"
+        }
+    }
+}
+
+// MARK: - BodySilhouetteView
+
+/// Stylised front/back human silhouette with per-muscle shading and tap-to-drill.
+///
+/// Each muscle group is an independent `Shape` so we can fill it with an
+/// intensity-scaled accent color. The body itself is composed of simple
+/// rounded primitives — no realistic anatomy, just enough mass to make the
+/// shading legible. Black background + green accent gives the Hevy / Strong
+/// aesthetic.
+///
+/// Coordinate system: shapes are authored in a canonical 200×400 layout, then
+/// scaled by `GeometryReader` so the silhouette fills whatever size SwiftUI
+/// hands it. This keeps every path tweak in one normalised space.
+struct BodySilhouetteView: View {
+    /// Which side to render. Use a SwiftUI `@State` in the caller and pass a binding-free value.
+    let side: BodySide
+
+    /// Fill color per muscle group. Missing keys render as `defaultMuscleFill`.
+    /// Pass `Theme.accent.opacity(intensity)` here for the heatmap effect.
+    let fillByMuscle: [MuscleGroup: Color]
+
+    /// Optional tap handler. When nil, the silhouette is non-interactive (mini variant).
+    var onMuscleTap: ((MuscleGroup) -> Void)? = nil
+
+    /// Default fill for any muscle without an explicit entry in `fillByMuscle`.
+    /// Slightly lifted vs `Theme.background` so the silhouette reads against the card.
+    var defaultMuscleFill: Color = Theme.surface
+
+    /// Outline color for the silhouette body + muscle borders.
+    var outlineColor: Color = Theme.hairlineStrong
+
+    /// Canonical authoring space. All paths are written against this size, then scaled.
+    private static let canvasSize = CGSize(width: 200, height: 400)
+
+    var body: some View {
+        GeometryReader { proxy in
+            let scale = min(
+                proxy.size.width / Self.canvasSize.width,
+                proxy.size.height / Self.canvasSize.height
+            )
+            let scaledWidth = Self.canvasSize.width * scale
+            let scaledHeight = Self.canvasSize.height * scale
+            let originX = (proxy.size.width - scaledWidth) / 2
+            let originY = (proxy.size.height - scaledHeight) / 2
+
+            ZStack(alignment: .topLeading) {
+                // Body outline silhouette — drawn first so muscles paint over it.
+                BodyOutlineShape(side: side)
+                    .fill(Theme.surface.opacity(0.6))
+                    .overlay(
+                        BodyOutlineShape(side: side)
+                            .stroke(outlineColor, lineWidth: 1.0)
+                    )
+                    .frame(width: scaledWidth, height: scaledHeight)
+                    .offset(x: originX, y: originY)
+
+                // Muscle group shapes — one per group, on the visible side.
+                ForEach(MuscleLayout.groups(for: side), id: \.self) { muscle in
+                    let shape = MuscleShape(muscle: muscle, side: side)
+                    shape
+                        .fill(fillByMuscle[muscle] ?? defaultMuscleFill)
+                        .overlay(
+                            shape.stroke(outlineColor.opacity(0.7), lineWidth: 0.6)
+                        )
+                        .frame(width: scaledWidth, height: scaledHeight)
+                        .offset(x: originX, y: originY)
+                        .contentShape(shape)
+                        .onTapGesture {
+                            guard let handler = onMuscleTap else { return }
+                            Haptics.selection()
+                            handler(muscle)
+                        }
+                        .accessibilityElement()
+                        .accessibilityLabel(Text(muscle.displayName))
+                        .accessibilityAddTraits(onMuscleTap != nil ? .isButton : [])
+                }
+            }
+        }
+        .aspectRatio(Self.canvasSize.width / Self.canvasSize.height, contentMode: .fit)
+    }
+}
+
+// MARK: - MuscleLayout
+
+/// Static mapping of which muscle groups are visible on each side.
+/// Keep in lockstep with `MuscleShape.path(for:side:in:)`.
+private enum MuscleLayout {
+    static func groups(for side: BodySide) -> [MuscleGroup] {
+        switch side {
+        case .front:
+            return [.chest, .shoulders, .biceps, .forearms, .abs, .quads]
+        case .back:
+            return [.traps, .back, .lats, .triceps, .glutes, .hamstrings, .calves]
+        }
+    }
+}
+
+// MARK: - Body Outline Shape
+
+/// The overall body silhouette — head + torso + arms + legs. Same primitives
+/// for front/back; the difference is which muscles paint over it.
+private struct BodyOutlineShape: Shape {
+    let side: BodySide
+
+    func path(in rect: CGRect) -> Path {
+        let sx = rect.width / 200.0
+        let sy = rect.height / 400.0
+        var p = Path()
+
+        // Head
+        p.addEllipse(in: CGRect(x: 80 * sx, y: 8 * sy, width: 40 * sx, height: 48 * sy))
+
+        // Neck
+        p.addRect(CGRect(x: 92 * sx, y: 50 * sy, width: 16 * sx, height: 14 * sy))
+
+        // Torso (trapezoid-ish via rounded rect)
+        p.addRoundedRect(
+            in: CGRect(x: 60 * sx, y: 62 * sy, width: 80 * sx, height: 140 * sy),
+            cornerSize: CGSize(width: 18 * sx, height: 18 * sy)
+        )
+
+        // Shoulders / deltoid caps so the silhouette reads as upper-body wide
+        p.addEllipse(in: CGRect(x: 44 * sx, y: 64 * sy, width: 36 * sx, height: 38 * sy))
+        p.addEllipse(in: CGRect(x: 120 * sx, y: 64 * sy, width: 36 * sx, height: 38 * sy))
+
+        // Upper arms
+        p.addRoundedRect(
+            in: CGRect(x: 40 * sx, y: 80 * sy, width: 26 * sx, height: 90 * sy),
+            cornerSize: CGSize(width: 12 * sx, height: 12 * sy)
+        )
+        p.addRoundedRect(
+            in: CGRect(x: 134 * sx, y: 80 * sy, width: 26 * sx, height: 90 * sy),
+            cornerSize: CGSize(width: 12 * sx, height: 12 * sy)
+        )
+
+        // Forearms (slightly narrower)
+        p.addRoundedRect(
+            in: CGRect(x: 42 * sx, y: 168 * sy, width: 22 * sx, height: 70 * sy),
+            cornerSize: CGSize(width: 10 * sx, height: 10 * sy)
+        )
+        p.addRoundedRect(
+            in: CGRect(x: 136 * sx, y: 168 * sy, width: 22 * sx, height: 70 * sy),
+            cornerSize: CGSize(width: 10 * sx, height: 10 * sy)
+        )
+
+        // Pelvis / waist
+        p.addRoundedRect(
+            in: CGRect(x: 64 * sx, y: 198 * sy, width: 72 * sx, height: 36 * sy),
+            cornerSize: CGSize(width: 14 * sx, height: 14 * sy)
+        )
+
+        // Upper legs
+        p.addRoundedRect(
+            in: CGRect(x: 66 * sx, y: 230 * sy, width: 32 * sx, height: 100 * sy),
+            cornerSize: CGSize(width: 14 * sx, height: 14 * sy)
+        )
+        p.addRoundedRect(
+            in: CGRect(x: 102 * sx, y: 230 * sy, width: 32 * sx, height: 100 * sy),
+            cornerSize: CGSize(width: 14 * sx, height: 14 * sy)
+        )
+
+        // Lower legs (calves area)
+        p.addRoundedRect(
+            in: CGRect(x: 70 * sx, y: 326 * sy, width: 26 * sx, height: 66 * sy),
+            cornerSize: CGSize(width: 10 * sx, height: 10 * sy)
+        )
+        p.addRoundedRect(
+            in: CGRect(x: 104 * sx, y: 326 * sy, width: 26 * sx, height: 66 * sy),
+            cornerSize: CGSize(width: 10 * sx, height: 10 * sy)
+        )
+
+        _ = side // body outline is identical for front/back today; reserved for future side-specific tweaks.
+        return p
+    }
+}
+
+// MARK: - Muscle Shape
+
+/// Renders the path for a single muscle group on a given side. Authored against
+/// the same 200×400 canonical space as `BodyOutlineShape`, so the muscle sits
+/// on top of the underlying body silhouette without drift.
+private struct MuscleShape: Shape {
+    let muscle: MuscleGroup
+    let side: BodySide
+
+    func path(in rect: CGRect) -> Path {
+        let sx = rect.width / 200.0
+        let sy = rect.height / 400.0
+
+        switch (side, muscle) {
+        // MARK: Front
+
+        case (.front, .chest):
+            // Two pec slabs side-by-side near the upper torso.
+            var p = Path()
+            p.addRoundedRect(
+                in: CGRect(x: 66 * sx, y: 78 * sy, width: 32 * sx, height: 40 * sy),
+                cornerSize: CGSize(width: 10 * sx, height: 10 * sy)
+            )
+            p.addRoundedRect(
+                in: CGRect(x: 102 * sx, y: 78 * sy, width: 32 * sx, height: 40 * sy),
+                cornerSize: CGSize(width: 10 * sx, height: 10 * sy)
+            )
+            return p
+
+        case (.front, .shoulders):
+            // Front deltoid caps — overlap shoulder ovals.
+            var p = Path()
+            p.addEllipse(in: CGRect(x: 46 * sx, y: 66 * sy, width: 30 * sx, height: 30 * sy))
+            p.addEllipse(in: CGRect(x: 124 * sx, y: 66 * sy, width: 30 * sx, height: 30 * sy))
+            return p
+
+        case (.front, .biceps):
+            // Upper arms, slightly narrower than the outline so the body edge shows.
+            var p = Path()
+            p.addRoundedRect(
+                in: CGRect(x: 44 * sx, y: 96 * sy, width: 20 * sx, height: 64 * sy),
+                cornerSize: CGSize(width: 8 * sx, height: 8 * sy)
+            )
+            p.addRoundedRect(
+                in: CGRect(x: 136 * sx, y: 96 * sy, width: 20 * sx, height: 64 * sy),
+                cornerSize: CGSize(width: 8 * sx, height: 8 * sy)
+            )
+            return p
+
+        case (.front, .forearms):
+            var p = Path()
+            p.addRoundedRect(
+                in: CGRect(x: 44 * sx, y: 170 * sy, width: 18 * sx, height: 60 * sy),
+                cornerSize: CGSize(width: 8 * sx, height: 8 * sy)
+            )
+            p.addRoundedRect(
+                in: CGRect(x: 138 * sx, y: 170 * sy, width: 18 * sx, height: 60 * sy),
+                cornerSize: CGSize(width: 8 * sx, height: 8 * sy)
+            )
+            return p
+
+        case (.front, .abs):
+            // Stacked rectangle block over the lower torso.
+            var p = Path()
+            p.addRoundedRect(
+                in: CGRect(x: 84 * sx, y: 124 * sy, width: 32 * sx, height: 74 * sy),
+                cornerSize: CGSize(width: 8 * sx, height: 8 * sy)
+            )
+            return p
+
+        case (.front, .quads):
+            var p = Path()
+            p.addRoundedRect(
+                in: CGRect(x: 68 * sx, y: 236 * sy, width: 28 * sx, height: 88 * sy),
+                cornerSize: CGSize(width: 12 * sx, height: 12 * sy)
+            )
+            p.addRoundedRect(
+                in: CGRect(x: 104 * sx, y: 236 * sy, width: 28 * sx, height: 88 * sy),
+                cornerSize: CGSize(width: 12 * sx, height: 12 * sy)
+            )
+            return p
+
+        // MARK: Back
+
+        case (.back, .traps):
+            // Upper-back trapezoid between shoulders.
+            var p = Path()
+            p.move(to: CGPoint(x: 80 * sx, y: 64 * sy))
+            p.addLine(to: CGPoint(x: 120 * sx, y: 64 * sy))
+            p.addLine(to: CGPoint(x: 110 * sx, y: 96 * sy))
+            p.addLine(to: CGPoint(x: 90 * sx, y: 96 * sy))
+            p.closeSubpath()
+            return p
+
+        case (.back, .back):
+            // Upper-mid back slab (general "back" group used by deadlift, rows).
+            var p = Path()
+            p.addRoundedRect(
+                in: CGRect(x: 72 * sx, y: 96 * sy, width: 56 * sx, height: 36 * sy),
+                cornerSize: CGSize(width: 8 * sx, height: 8 * sy)
+            )
+            return p
+
+        case (.back, .lats):
+            // Two flared wings on either side of the mid back.
+            var p = Path()
+            p.addRoundedRect(
+                in: CGRect(x: 62 * sx, y: 130 * sy, width: 28 * sx, height: 66 * sy),
+                cornerSize: CGSize(width: 12 * sx, height: 12 * sy)
+            )
+            p.addRoundedRect(
+                in: CGRect(x: 110 * sx, y: 130 * sy, width: 28 * sx, height: 66 * sy),
+                cornerSize: CGSize(width: 12 * sx, height: 12 * sy)
+            )
+            return p
+
+        case (.back, .triceps):
+            // Upper arm — same slot as biceps on front, painted on the back side.
+            var p = Path()
+            p.addRoundedRect(
+                in: CGRect(x: 44 * sx, y: 96 * sy, width: 20 * sx, height: 64 * sy),
+                cornerSize: CGSize(width: 8 * sx, height: 8 * sy)
+            )
+            p.addRoundedRect(
+                in: CGRect(x: 136 * sx, y: 96 * sy, width: 20 * sx, height: 64 * sy),
+                cornerSize: CGSize(width: 8 * sx, height: 8 * sy)
+            )
+            return p
+
+        case (.back, .glutes):
+            // Two rounded glute lobes at the pelvis.
+            var p = Path()
+            p.addEllipse(in: CGRect(x: 68 * sx, y: 200 * sy, width: 30 * sx, height: 36 * sy))
+            p.addEllipse(in: CGRect(x: 102 * sx, y: 200 * sy, width: 30 * sx, height: 36 * sy))
+            return p
+
+        case (.back, .hamstrings):
+            // Posterior thigh — slightly higher than quads to leave the calves visible.
+            var p = Path()
+            p.addRoundedRect(
+                in: CGRect(x: 68 * sx, y: 240 * sy, width: 28 * sx, height: 84 * sy),
+                cornerSize: CGSize(width: 12 * sx, height: 12 * sy)
+            )
+            p.addRoundedRect(
+                in: CGRect(x: 104 * sx, y: 240 * sy, width: 28 * sx, height: 84 * sy),
+                cornerSize: CGSize(width: 12 * sx, height: 12 * sy)
+            )
+            return p
+
+        case (.back, .calves):
+            var p = Path()
+            p.addRoundedRect(
+                in: CGRect(x: 72 * sx, y: 330 * sy, width: 22 * sx, height: 58 * sy),
+                cornerSize: CGSize(width: 8 * sx, height: 8 * sy)
+            )
+            p.addRoundedRect(
+                in: CGRect(x: 106 * sx, y: 330 * sy, width: 22 * sx, height: 58 * sy),
+                cornerSize: CGSize(width: 8 * sx, height: 8 * sy)
+            )
+            return p
+
+        // Muscles that aren't visible on the given side render an empty path
+        // (so they're invisible / non-interactive).
+        default:
+            return Path()
+        }
+    }
+}
+
+// MARK: - Preview
+
+#Preview("Front") {
+    BodySilhouetteView(
+        side: .front,
+        fillByMuscle: [
+            .chest: Theme.accent.opacity(0.8),
+            .biceps: Theme.accent.opacity(0.5),
+            .abs: Theme.accent.opacity(0.3),
+            .quads: Theme.accent.opacity(0.65),
+        ],
+        onMuscleTap: { _ in }
+    )
+    .padding()
+    .background(Theme.background)
+    .preferredColorScheme(.dark)
+}
+
+#Preview("Back") {
+    BodySilhouetteView(
+        side: .back,
+        fillByMuscle: [
+            .lats: Theme.accent.opacity(0.7),
+            .glutes: Theme.accent.opacity(0.45),
+            .hamstrings: Theme.accent.opacity(0.55),
+            .calves: Theme.accent.opacity(0.25),
+        ],
+        onMuscleTap: { _ in }
+    )
+    .padding()
+    .background(Theme.background)
+    .preferredColorScheme(.dark)
+}

--- a/Xomfit/Views/Profile/FullBodyHeatmapView.swift
+++ b/Xomfit/Views/Profile/FullBodyHeatmapView.swift
@@ -1,0 +1,204 @@
+import SwiftUI
+
+/// Hevy-style full-body anatomy heatmap (#346).
+///
+/// Layout:
+/// ┌────────────────────────────┐
+/// │ Time range picker          │
+/// │ Front / Back toggle        │
+/// │   ┌──────────┐             │
+/// │   │ silhouette│  ← tappable │
+/// │   └──────────┘             │
+/// │ Intensity legend           │
+/// └────────────────────────────┘
+///
+/// Tap a muscle → presents `MuscleDetailSheet` with the exercises that hit it
+/// in the selected range. The card lives on `ProfileStatsView` and replaces
+/// the older grid-style `BodyHeatmapView`.
+struct FullBodyHeatmapView: View {
+    let workouts: [Workout]
+
+    @State private var viewModel = BodyHeatmapViewModel()
+    @State private var side: BodySide = .front
+    @State private var selectedMuscle: MuscleGroup?
+
+    init(workouts: [Workout]) {
+        self.workouts = workouts
+        // `_viewModel = State(initialValue: ...)` so the initial range/workouts are correct.
+        _viewModel = State(initialValue: BodyHeatmapViewModel(workouts: workouts, range: .week))
+    }
+
+    /// Stable signature for `onChange` since `Workout` isn't `Equatable`. We
+    /// use count + last-id which catches every real-world mutation (append,
+    /// reload, swap) without forcing a full deep-equal walk.
+    private var workoutsSignature: String {
+        "\(workouts.count)-\(workouts.last?.id ?? "")"
+    }
+
+    var body: some View {
+        VStack(spacing: Theme.Spacing.md) {
+            header
+            rangePicker
+            sideToggle
+            silhouette
+            legend
+        }
+        .padding(Theme.Spacing.md)
+        .background(
+            RoundedRectangle(cornerRadius: Theme.cornerRadius)
+                .fill(Theme.surface)
+                .overlay(
+                    RoundedRectangle(cornerRadius: Theme.cornerRadius)
+                        .strokeBorder(Theme.hairline, lineWidth: 0.5)
+                )
+        )
+        // `Workout` isn't Equatable, so compare a stable signature of the
+        // workout list to know when to push fresh data into the view model.
+        .onChange(of: workoutsSignature) { _, _ in
+            viewModel.workouts = workouts
+        }
+        .sheet(item: $selectedMuscle) { muscle in
+            MuscleDetailSheet(
+                muscle: muscle,
+                range: viewModel.range,
+                totalVolume: viewModel.totalVolume(for: muscle),
+                exercises: viewModel.exercises(for: muscle)
+            )
+            .presentationDetents([.medium, .large])
+            .presentationDragIndicator(.visible)
+        }
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: Theme.Spacing.tighter) {
+                Text("Muscle Heatmap")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(Theme.textSecondary)
+                Text("Tap a muscle to see what hit it")
+                    .font(Theme.fontSmall)
+                    .foregroundStyle(Theme.textTertiary)
+            }
+            Spacer()
+        }
+    }
+
+    // MARK: - Range Picker
+
+    private var rangePicker: some View {
+        Picker("Time Range", selection: rangeBinding) {
+            ForEach(HeatmapTimeRange.allCases) { r in
+                Text(r.displayName).tag(r)
+            }
+        }
+        .pickerStyle(.segmented)
+        .accessibilityLabel("Time range")
+    }
+
+    /// Binding wrapper so segmented picker writes flow into the view model.
+    private var rangeBinding: Binding<HeatmapTimeRange> {
+        Binding(
+            get: { viewModel.range },
+            set: { newValue in
+                Haptics.selection()
+                viewModel.range = newValue
+            }
+        )
+    }
+
+    // MARK: - Front / Back Toggle
+
+    private var sideToggle: some View {
+        HStack(spacing: 0) {
+            ForEach(BodySide.allCases) { s in
+                Button {
+                    Haptics.selection()
+                    withAnimation(.xomSnappy) { side = s }
+                } label: {
+                    Text(s.label)
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(side == s ? Theme.background : Theme.textSecondary)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, Theme.Spacing.xs + 2)
+                        .background(
+                            RoundedRectangle(cornerRadius: Theme.Radius.xs)
+                                .fill(side == s ? Theme.accent : Color.clear)
+                        )
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .frame(minHeight: 44)
+                .accessibilityLabel("\(s.label) view")
+                .accessibilityAddTraits(side == s ? .isSelected : [])
+            }
+        }
+        .padding(2)
+        .background(
+            RoundedRectangle(cornerRadius: Theme.Radius.xs)
+                .fill(Theme.surfaceElevated)
+        )
+    }
+
+    // MARK: - Silhouette
+
+    private var silhouette: some View {
+        BodySilhouetteView(
+            side: side,
+            fillByMuscle: viewModel.fillMap(),
+            onMuscleTap: { muscle in
+                selectedMuscle = muscle
+            }
+        )
+        .frame(maxWidth: 280)
+        .frame(height: 360)
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, Theme.Spacing.xs)
+    }
+
+    // MARK: - Legend
+
+    private var legend: some View {
+        HStack(spacing: Theme.Spacing.sm) {
+            legendItem(color: Theme.surface, label: "None")
+            legendItem(color: Theme.accent.opacity(0.30), label: "Light")
+            legendItem(color: Theme.accent.opacity(0.55), label: "Some")
+            legendItem(color: Theme.accent.opacity(0.75), label: "Moderate")
+            legendItem(color: Theme.accent.opacity(0.95), label: "Heavy")
+        }
+        .frame(maxWidth: .infinity)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Intensity legend: None, Light, Some, Moderate, Heavy")
+    }
+
+    private func legendItem(color: Color, label: String) -> some View {
+        VStack(spacing: Theme.Spacing.tighter) {
+            RoundedRectangle(cornerRadius: 3)
+                .fill(color)
+                .frame(width: 20, height: 10)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 3)
+                        .stroke(Theme.hairline, lineWidth: 0.5)
+                )
+            Text(label)
+                .font(.caption2.weight(.medium))
+                .foregroundStyle(Theme.textSecondary)
+        }
+    }
+}
+
+// MARK: - MuscleGroup: Identifiable for sheet(item:)
+// `MuscleGroup` already conforms to Identifiable via Models/Exercise.swift,
+// so no extra conformance is needed here.
+
+// MARK: - Preview
+
+#Preview {
+    ScrollView {
+        FullBodyHeatmapView(workouts: [Workout.mock, Workout.mockFriendWorkout])
+            .padding()
+    }
+    .background(Theme.background)
+    .preferredColorScheme(.dark)
+}

--- a/Xomfit/Views/Profile/MuscleDetailSheet.swift
+++ b/Xomfit/Views/Profile/MuscleDetailSheet.swift
@@ -1,0 +1,220 @@
+import SwiftUI
+
+/// Drill-in sheet for the full-body heatmap (#346).
+///
+/// Shows which exercises hit `muscle` in the selected range, ranked by volume
+/// contribution. Tapping a row opens `ExerciseDetailSheet` so the user can
+/// review the lift's form notes without leaving Profile > Stats.
+struct MuscleDetailSheet: View {
+    let muscle: MuscleGroup
+    let range: HeatmapTimeRange
+    let totalVolume: Double
+    let exercises: [ExerciseVolumeEntry]
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var detailExercise: Exercise?
+
+    /// Display unit. Volume is shown in the user's preferred unit (Body convention).
+    @AppStorage("weightUnit") private var weightUnitRaw: String = WeightUnit.lbs.rawValue
+    private var weightUnit: WeightUnit { WeightUnit(rawValue: weightUnitRaw) ?? .lbs }
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Theme.background.ignoresSafeArea()
+
+                ScrollView {
+                    VStack(alignment: .leading, spacing: Theme.Spacing.lg) {
+                        header
+                        if exercises.isEmpty {
+                            emptyState
+                        } else {
+                            exerciseList
+                        }
+                    }
+                    .padding(Theme.Spacing.md)
+                }
+            }
+            .navigationTitle(muscle.displayName)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbarColorScheme(.dark, for: .navigationBar)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { dismiss() }
+                        .foregroundStyle(Theme.accent)
+                }
+            }
+            .sheet(item: $detailExercise) { exercise in
+                ExerciseDetailSheet(exercise: exercise)
+            }
+        }
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+            HStack(spacing: Theme.Spacing.md) {
+                Image(systemName: muscle.icon)
+                    .font(.system(size: 28))
+                    .foregroundStyle(Theme.accent)
+                    .frame(width: 56, height: 56)
+                    .background(Theme.accentMuted)
+                    .clipShape(Circle())
+
+                VStack(alignment: .leading, spacing: Theme.Spacing.tighter) {
+                    Text(muscle.displayName)
+                        .font(Theme.fontTitle2)
+                        .foregroundStyle(Theme.textPrimary)
+                    Text(range.accessibilityName)
+                        .font(Theme.fontCaption)
+                        .foregroundStyle(Theme.textSecondary)
+                }
+                Spacer()
+            }
+
+            HStack(spacing: Theme.Spacing.lg) {
+                stat(label: "Total Volume", value: formattedVolume(totalVolume))
+                stat(label: "Exercises", value: "\(exercises.count)")
+            }
+        }
+        .padding(Theme.Spacing.md)
+        .background(Theme.surface)
+        .clipShape(.rect(cornerRadius: Theme.cornerRadius))
+    }
+
+    private func stat(label: String, value: String) -> some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.tighter) {
+            Text(label)
+                .font(Theme.fontSmall)
+                .foregroundStyle(Theme.textSecondary)
+            Text(value)
+                .font(Theme.fontNumberMedium)
+                .foregroundStyle(Theme.textPrimary)
+        }
+    }
+
+    // MARK: - Exercise List
+
+    private var exerciseList: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+            Text("Exercises")
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(Theme.textSecondary)
+
+            VStack(spacing: Theme.Spacing.xs) {
+                ForEach(exercises) { entry in
+                    Button {
+                        Haptics.selection()
+                        detailExercise = entry.exercise
+                    } label: {
+                        row(for: entry)
+                    }
+                    .buttonStyle(PressableCardStyle())
+                    .accessibilityLabel(accessibilityLabel(for: entry))
+                    .accessibilityHint("Opens exercise details")
+                }
+            }
+        }
+    }
+
+    private func row(for entry: ExerciseVolumeEntry) -> some View {
+        HStack(spacing: Theme.Spacing.md) {
+            Image(systemName: entry.exercise.icon)
+                .font(Theme.fontSubheadline)
+                .foregroundStyle(Theme.accent)
+                .frame(width: 36, height: 36)
+                .background(Theme.accentMuted)
+                .clipShape(Circle())
+
+            VStack(alignment: .leading, spacing: Theme.Spacing.tighter) {
+                Text(entry.exercise.name)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(Theme.textPrimary)
+                    .lineLimit(1)
+                Text("\(entry.setCount) sets · best \(bestSetText(entry))")
+                    .font(Theme.fontCaption)
+                    .foregroundStyle(Theme.textSecondary)
+            }
+
+            Spacer()
+
+            VStack(alignment: .trailing, spacing: Theme.Spacing.tighter) {
+                Text(formattedVolume(entry.volume))
+                    .font(Theme.fontNumberMedium)
+                    .foregroundStyle(Theme.textPrimary)
+                Text("Volume")
+                    .font(.caption2.weight(.medium))
+                    .foregroundStyle(Theme.textTertiary)
+            }
+        }
+        .padding(Theme.Spacing.sm)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Theme.surface)
+        .clipShape(.rect(cornerRadius: Theme.Radius.sm))
+        .contentShape(Rectangle())
+    }
+
+    // MARK: - Empty State
+
+    private var emptyState: some View {
+        XomEmptyState(
+            icon: muscle.icon,
+            title: "No \(muscle.displayName.lowercased()) work yet",
+            subtitle: "Log a workout that hits this muscle in the selected range.",
+            ctaLabel: nil,
+            ctaAction: nil
+        )
+        .cardStyle()
+    }
+
+    // MARK: - Helpers
+
+    private func bestSetText(_ entry: ExerciseVolumeEntry) -> String {
+        let weight = entry.bestSetWeight.formattedWeight(unit: weightUnit)
+        return "\(weight) \(weightUnit.displayName) \u{00D7} \(entry.bestSetReps)"
+    }
+
+    /// Volume is in lbs · reps. We show it in the user's unit and pretty-format.
+    private func formattedVolume(_ volume: Double) -> String {
+        let converted = volume * weightUnit.multiplierFromLbs
+        if converted >= 1_000_000 {
+            return String(format: "%.1fM %@", converted / 1_000_000, weightUnit.displayName)
+        } else if converted >= 1_000 {
+            return String(format: "%.1fk %@", converted / 1_000, weightUnit.displayName)
+        }
+        return String(format: "%.0f %@", converted, weightUnit.displayName)
+    }
+
+    private func accessibilityLabel(for entry: ExerciseVolumeEntry) -> String {
+        let volume = formattedVolume(entry.volume)
+        return "\(entry.exercise.name), \(entry.setCount) sets, \(volume) volume"
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    MuscleDetailSheet(
+        muscle: .chest,
+        range: .month,
+        totalVolume: 24_500,
+        exercises: [
+            ExerciseVolumeEntry(
+                exercise: .benchPress,
+                setCount: 12,
+                volume: 14_000,
+                bestSetWeight: 225,
+                bestSetReps: 5
+            ),
+            ExerciseVolumeEntry(
+                exercise: Exercise.mockExercises[0],
+                setCount: 8,
+                volume: 10_500,
+                bestSetWeight: 185,
+                bestSetReps: 8
+            ),
+        ]
+    )
+    .preferredColorScheme(.dark)
+}

--- a/Xomfit/Views/Profile/ProfileStatsView.swift
+++ b/Xomfit/Views/Profile/ProfileStatsView.swift
@@ -26,18 +26,14 @@ struct ProfileStatsView: View {
     /// When nil, the empty-state card hides its action button.
     var onStartWorkout: (() -> Void)? = nil
 
-    @State private var heatmapFilter: HeatmapTimeFilter = .week
-
     /// Display unit for weight values. Stored values stay lbs.
     @AppStorage("weightUnit") private var weightUnitRaw: String = WeightUnit.lbs.rawValue
     private var weightUnit: WeightUnit { WeightUnit(rawValue: weightUnitRaw) ?? .lbs }
 
-    private var activeMuscleGroupSets: [String: Int] {
-        switch heatmapFilter {
-        case .week: return muscleGroupSetsThisWeek
-        case .month: return muscleGroupSetsThisMonth
-        }
-    }
+    // #346: The legacy week/month muscle-set rollups (`muscleGroupSetsThisWeek`,
+    // `muscleGroupSetsThisMonth`) are kept as inputs for binary compatibility
+    // with `ProfileView`, but the new `FullBodyHeatmapView` derives intensity
+    // directly from `workouts` so these are no longer read here.
 
     var body: some View {
         VStack(spacing: Theme.Spacing.sm) {
@@ -251,29 +247,13 @@ struct ProfileStatsView: View {
     }
 
     // MARK: - Heatmap Section
+    //
+    // #346: replaced the grid `BodyHeatmapView` with the full-body anatomy
+    // silhouette. The new view owns its own range picker + front/back toggle,
+    // so we drop the local `heatmapFilter` UI here and pass raw workouts in.
 
     private var heatmapSection: some View {
-        VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
-            HStack {
-                Text("Muscle Heatmap")
-                    .font(.subheadline.weight(.semibold))
-                    .foregroundStyle(Theme.textSecondary)
-
-                Spacer()
-
-                Picker("Time Range", selection: $heatmapFilter) {
-                    ForEach(HeatmapTimeFilter.allCases) { filter in
-                        Text(filter.rawValue).tag(filter)
-                    }
-                }
-                .pickerStyle(.segmented)
-                .frame(width: 140)
-            }
-            .padding(.horizontal, Theme.Spacing.sm)
-
-            BodyHeatmapView(muscleGroupSets: activeMuscleGroupSets)
-        }
-        .cardStyle()
+        FullBodyHeatmapView(workouts: workouts)
     }
 
     // MARK: - PR Section

--- a/Xomfit/Views/Workout/ExerciseDetailSheet.swift
+++ b/Xomfit/Views/Workout/ExerciseDetailSheet.swift
@@ -23,6 +23,9 @@ struct ExerciseDetailSheet: View {
                         if !exercise.tips.isEmpty {
                             tipsSection
                         }
+                        // #346: Mini silhouette highlighting only the muscles
+                        // this exercise hits. Non-tappable — just a visual aid.
+                        miniSilhouetteSection
                         if exercise.supportsUnilateral {
                             unilateralNote
                         }
@@ -224,6 +227,51 @@ struct ExerciseDetailSheet: View {
         .padding(Theme.Spacing.md)
         .background(Theme.surface)
         .clipShape(.rect(cornerRadius: Theme.cornerRadius))
+    }
+
+    // MARK: - Mini Silhouette (#346)
+
+    /// 200x300pt silhouette highlighting only this exercise's muscles. Shows
+    /// front + back side-by-side so all primary muscles are visible without a
+    /// toggle. Non-interactive — `onMuscleTap: nil`.
+    private var miniSilhouetteSection: some View {
+        let highlightedFill: [MuscleGroup: Color] = Dictionary(
+            uniqueKeysWithValues: exercise.muscleGroups.map { ($0, Theme.accent.opacity(0.85)) }
+        )
+
+        return VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+            Text("Muscles Worked")
+                .font(Theme.fontHeadline)
+                .foregroundStyle(Theme.textPrimary)
+
+            HStack(spacing: Theme.Spacing.md) {
+                miniBody(side: .front, fill: highlightedFill)
+                miniBody(side: .back, fill: highlightedFill)
+            }
+            .frame(maxWidth: .infinity)
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(
+                "Muscles worked diagram. Highlights: \(exercise.muscleGroups.map(\.displayName).joined(separator: ", "))"
+            )
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(Theme.Spacing.md)
+        .background(Theme.surface)
+        .clipShape(.rect(cornerRadius: Theme.cornerRadius))
+    }
+
+    private func miniBody(side: BodySide, fill: [MuscleGroup: Color]) -> some View {
+        VStack(spacing: Theme.Spacing.tighter) {
+            BodySilhouetteView(
+                side: side,
+                fillByMuscle: fill,
+                onMuscleTap: nil
+            )
+            .frame(width: 100, height: 200)
+            Text(side.label)
+                .font(.caption2.weight(.semibold))
+                .foregroundStyle(Theme.textSecondary)
+        }
     }
 
     private var unilateralNote: some View {


### PR DESCRIPTION
Closes #346.

- New BodySilhouetteView: vector front+back silhouette with each muscle as its own Shape (tappable).
- BodyHeatmapViewModel: @Observable, splits exercise volume across primary muscle groups, scales intensity 0-1 relative to max.
- FullBodyHeatmapView: segmented time range (1W/1M/3M/All), front/back pill toggle, intensity legend, sheet on muscle tap.
- MuscleDetailSheet: ranked exercises hitting that muscle in range → tap → ExerciseDetailSheet.
- ProfileStatsView heatmap section swapped from grid to new full-body view.
- ExerciseDetailSheet now shows a mini silhouette highlighting only that exercise's primary muscles.