### PR TITLE
#359 fix audit bugs 7,10 (photo removal lockstep + builder name length trimmed)

### DIFF
--- a/Xomfit/Services/PhotoService.swift
+++ b/Xomfit/Services/PhotoService.swift
@@ -17,14 +17,23 @@ final class PhotoService {
     // MARK: - Load from PhotosPicker
 
     func loadImages(from selections: [PhotosPickerItem]) async -> [UIImage] {
-        var images: [UIImage] = []
+        await loadPaired(from: selections).map { $0.1 }
+    }
+
+    /// Paired loader that returns successfully-decoded items together with their
+    /// source `PhotosPickerItem`. Callers that store the picker selection
+    /// separately (e.g. a `PhotosPicker` binding) should use this so the two
+    /// arrays stay in lockstep — `loadImages` silently drops failures, which
+    /// caused per-index removals to target the wrong photo (#359 bug 7).
+    func loadPaired(from selections: [PhotosPickerItem]) async -> [(PhotosPickerItem, UIImage)] {
+        var pairs: [(PhotosPickerItem, UIImage)] = []
         for item in selections.prefix(maxPhotos) {
             if let data = try? await item.loadTransferable(type: Data.self),
                let image = UIImage(data: data) {
-                images.append(image)
+                pairs.append((item, image))
             }
         }
-        return images
+        return pairs
     }
 
     // MARK: - Upload

--- a/Xomfit/ViewModels/WorkoutBuilderViewModel.swift
+++ b/Xomfit/ViewModels/WorkoutBuilderViewModel.swift
@@ -17,7 +17,7 @@ final class WorkoutBuilderViewModel {
     var isValid: Bool {
         let trimmed = name.trimmingCharacters(in: .whitespaces)
         guard !trimmed.isEmpty else { return false }
-        guard name.count <= Self.nameMaxLength else { return false }
+        guard trimmed.count <= Self.nameMaxLength else { return false }
         return !exercises.isEmpty
     }
 

--- a/Xomfit/Views/Workout/ActiveWorkoutView.swift
+++ b/Xomfit/Views/Workout/ActiveWorkoutView.swift
@@ -618,7 +618,6 @@ struct ActiveWorkoutView: View {
     private func finishWorkout() {
         guard !viewModel.isSaving else { return }
         guard let user = authService.currentUser else { return }
-        viewModel.isSaving = true
         let userId = user.id.uuidString.lowercased()
         let notes = workoutDescription.trimmingCharacters(in: .whitespacesAndNewlines)
 
@@ -1388,8 +1387,12 @@ private struct FinishWorkoutSheet: View {
                                                     .clipShape(.rect(cornerRadius: 8))
 
                                                 Button {
+                                                    // Both arrays are kept in lockstep by the
+                                                    // paired loader in `.onChange(of: selectedPhotos)`,
+                                                    // so we remove from each at the same index (#359 bug 7).
+                                                    guard photoImages.indices.contains(index) else { return }
                                                     photoImages.remove(at: index)
-                                                    if index < selectedPhotos.count {
+                                                    if selectedPhotos.indices.contains(index) {
                                                         selectedPhotos.remove(at: index)
                                                     }
                                                 } label: {
@@ -1432,7 +1435,17 @@ private struct FinishWorkoutSheet: View {
                             }
                             .onChange(of: selectedPhotos) { _, newItems in
                                 Task {
-                                    photoImages = await PhotoService.shared.loadImages(from: newItems)
+                                    // Use the paired loader so `selectedPhotos` and
+                                    // `photoImages` stay in lockstep even when some
+                                    // PhotosPickerItems fail to decode. Without this,
+                                    // index-based removal targets the wrong photo (#359 bug 7).
+                                    let pairs = await PhotoService.shared.loadPaired(from: newItems)
+                                    let loadedItems = pairs.map { $0.0 }
+                                    let loadedImages = pairs.map { $0.1 }
+                                    if loadedItems != selectedPhotos {
+                                        selectedPhotos = loadedItems
+                                    }
+                                    photoImages = loadedImages
                                 }
                             }
                         }

--- a/Xomfit/Views/Workout/WorkoutBuilderView.swift
+++ b/Xomfit/Views/Workout/WorkoutBuilderView.swift
@@ -149,8 +149,8 @@ struct WorkoutBuilderView: View {
         if trimmedName.isEmpty {
             return "Name is required"
         }
-        if viewModel.name.count > Self.nameMaxLength {
-            return "Name is too long (\(viewModel.name.count)/\(Self.nameMaxLength))"
+        if trimmedName.count > Self.nameMaxLength {
+            return "Name is too long (\(trimmedName.count)/\(Self.nameMaxLength))"
         }
         return nil
     }


### PR DESCRIPTION
Closes part of #359.

- Bug 7: photoImages + selectedPhotos kept in lockstep via new PhotoService.loadPaired that returns paired tuples; removal guards both with indices.contains
- Bug 10: WorkoutBuilderViewModel.isValid and view's user-facing counter both use trimmed length