### PR TITLE
#359 fix audit bugs 1,2,3,4,6,9 (VM + insights cluster)

### DIFF
--- a/Xomfit/Utils/WorkoutInsights.swift
+++ b/Xomfit/Utils/WorkoutInsights.swift
@@ -120,7 +120,7 @@ enum WorkoutInsights {
 
         // Find PR sets logged within the last day that the user hasn't seen yet.
         var candidates: [(workout: Workout, exercise: WorkoutExercise, set: WorkoutSet)] = []
-        for workout in workouts where workout.startTime >= lookbackStart && workout.startTime < today {
+        for workout in workouts where workout.startTime >= lookbackStart {
             for ex in workout.exercises {
                 for set in ex.sets where set.isPersonalRecord {
                     if let lastSeen = lastSeenDate, set.completedAt <= lastSeen { continue }

--- a/Xomfit/ViewModels/MeasurementsViewModel.swift
+++ b/Xomfit/ViewModels/MeasurementsViewModel.swift
@@ -93,7 +93,7 @@ final class MeasurementsViewModel {
         let series = byKind[kind] ?? []
         guard let latest = series.first else { return nil }
 
-        let cutoff = Calendar.current.date(byAdding: .day, value: -days, to: latest.recordedAt) ?? .distantPast
+        let cutoff = Calendar.current.date(byAdding: .day, value: -days, to: Date()) ?? .distantPast
         // Pick the oldest point at or after the cutoff (so a 30-day delta uses the
         // first reading inside the window, not the latest one).
         let baseline = series

--- a/Xomfit/ViewModels/WorkoutLoggerViewModel.swift
+++ b/Xomfit/ViewModels/WorkoutLoggerViewModel.swift
@@ -139,6 +139,7 @@ final class WorkoutLoggerViewModel {
     // MARK: - Workout Lifecycle
 
     func startWorkout(name: String, userId: String = "") {
+        defaultRestDuration = WorkoutLoggerViewModel.loadRestDuration()
         workoutName = name.isEmpty ? "Workout" : name
         exercises = []
         startTime = Date()
@@ -274,7 +275,9 @@ final class WorkoutLoggerViewModel {
         let workouts = WorkoutService.shared.fetchWorkoutsFromCache(userId: activeUserId)
         for workout in workouts {
             if let workoutExercise = workout.exercises.first(where: { $0.exercise.id == exerciseId }),
-               let bestSet = workoutExercise.sets.last {
+               let bestSet = workoutExercise.sets
+                .filter({ $0.completedAt != Date.distantPast && !$0.isDropSet })
+                .max(by: { $0.weight < $1.weight }) {
                 return bestSet
             }
         }
@@ -998,7 +1001,7 @@ final class WorkoutLoggerViewModel {
             let weekStart = Calendar.current.date(from: Calendar.current.dateComponents([.yearForWeekOfYear, .weekOfYear], from: Date())) ?? Date()
             let weekWorkouts = allWorkouts.filter { $0.startTime >= weekStart }
             let weeklyVolume = weekWorkouts.reduce(0.0) { $0 + $1.totalVolume }
-            let streak = calculateStreak(from: allWorkouts)
+            let streak = WorkoutInsights.currentStreak(workouts: allWorkouts)
             let latestPR = allWorkouts.flatMap { $0.exercises.flatMap { $0.sets } }
                 .filter { $0.isPersonalRecord }
                 .max(by: { $0.completedAt < $1.completedAt })
@@ -1026,16 +1029,4 @@ final class WorkoutLoggerViewModel {
         }
     }
 
-    private func calculateStreak(from workouts: [Workout]) -> Int {
-        let calendar = Calendar.current
-        let workoutDays = Set(workouts.map { calendar.startOfDay(for: $0.startTime) })
-        var streak = 0
-        var day = calendar.startOfDay(for: Date())
-        while workoutDays.contains(day) {
-            streak += 1
-            guard let prev = calendar.date(byAdding: .day, value: -1, to: day) else { break }
-            day = prev
-        }
-        return streak
-    }
 }

--- a/Xomfit/Views/Workout/ActiveWorkoutView.swift
+++ b/Xomfit/Views/Workout/ActiveWorkoutView.swift
@@ -618,7 +618,6 @@ struct ActiveWorkoutView: View {
     private func finishWorkout() {
         guard !viewModel.isSaving else { return }
         guard let user = authService.currentUser else { return }
-        viewModel.isSaving = true
         let userId = user.id.uuidString.lowercased()
         let notes = workoutDescription.trimmingCharacters(in: .whitespacesAndNewlines)
 


### PR DESCRIPTION
Closes part of #359.
- Bug 1: removed view's pre-set isSaving=true; VM owns lifecycle
- Bug 2: unseenRecentPR no longer excludes today's PRs
- Bug 3: VM uses WorkoutInsights.currentStreak instead of inline duplicate
- Bug 4: lastSetForExercise picks heaviest completed non-drop set, not .last
- Bug 6: startWorkout re-reads restDuration AppStorage so Settings changes propagate
- Bug 9: Measurements delta anchored to Date() not latest.recordedAt