### PR TITLE
fix(bypass): seed fitness profile + skip notif prompt under XOMFIT_AUTH_BYPASS

### DIFF
--- a/Xomfit/Services/AuthService.swift
+++ b/Xomfit/Services/AuthService.swift
@@ -34,6 +34,23 @@ final class AuthService {
             WorkoutService.shared.seedDebugFixtures(userId: mockUser.id.uuidString)
             TemplateService.shared.seedDebugFixtures()
 
+            // Mark fitness questionnaire as completed so bypass agents land in
+            // the main app, not the onboarding gate.
+            var profile = UserFitnessProfile.current
+            if profile.completedAt == nil {
+                profile.primaryGoal = .buildMuscle
+                profile.experience = .intermediate
+                profile.workoutsPerWeek = .four
+                profile.preferredSplit = .upperLower
+                profile.sessionLength = .sixty
+                profile.completedAt = Date()
+                UserFitnessProfile.current = profile
+            }
+            UserDefaults.standard.set(true, forKey: "onboardingSkipped")
+            // Mark the first-workout tutorial seen so it doesn't overlay screenshots.
+            UserDefaults.standard.set(true, forKey: "xomfit_first_workout_tutorial_seen")
+            UserDefaults.standard.set(true, forKey: "xomfit_first_rest_timer_seen")
+
             print("[AuthService] DEBUG bypass active — using mock user \(mockUser.id.uuidString)")
             return
         }

--- a/Xomfit/XomfitApp.swift
+++ b/Xomfit/XomfitApp.swift
@@ -37,7 +37,15 @@ struct XomFitApp: App {
                         .environment(authService)
                         .environment(workoutSession)
                         .task {
+                            #if DEBUG
+                            // Skip permission prompts under auth-bypass so agents can
+                            // drive the UI without dismissing modal dialogs.
+                            if ProcessInfo.processInfo.environment["XOMFIT_AUTH_BYPASS"] != "1" {
+                                await NotificationService.shared.requestPermission()
+                            }
+                            #else
                             await NotificationService.shared.requestPermission()
+                            #endif
                             WatchSyncService.shared.activate()
                             evaluateFitnessQuestionnaireGate()
                         }


### PR DESCRIPTION
Under XOMFIT_AUTH_BYPASS=1, the mock user had no fitness profile so the questionnaire fired every launch and the system notification permission dialog blocked screenshot-driven verification. AuthService now seeds sane defaults + flips onboardingSkipped + first-workout-tutorial flags. XomfitApp .task skips requestPermission() when the env var is set. Verified locally — bypass now lands directly on Feed.