### PR TITLE
#367 clickable users in feed + comments + friends → profile

### DIFF
--- a/Xomfit/Views/Feed/FeedCommentsView.swift
+++ b/Xomfit/Views/Feed/FeedCommentsView.swift
@@ -284,26 +284,53 @@ private struct CommentRow: View {
     /// Tapped when the user taps the Reply button on this row.
     let onReply: () -> Void
 
+    /// #367: handle used in accessibility label for the profile link.
+    private var profileHandle: String {
+        if let username = comment.user?.username, !username.isEmpty { return username }
+        return comment.user?.displayName ?? "user"
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             HStack(alignment: .top, spacing: Theme.Spacing.sm) {
-                XomAvatar(
-                    name: comment.user?.displayName ?? "User",
-                    size: 32
-                )
-                .accessibilityHidden(true)
+                // #367: avatar + name push the commenter's ProfileView.
+                NavigationLink {
+                    ProfileView(userId: comment.userId)
+                        .hideTabBar()
+                } label: {
+                    HStack(alignment: .center, spacing: Theme.Spacing.sm) {
+                        XomAvatar(
+                            name: comment.user?.displayName ?? "User",
+                            size: 32
+                        )
+
+                        HStack(spacing: 6) {
+                            Text(comment.user?.displayName ?? "User")
+                                .font(.caption.weight(.semibold))
+                                .foregroundStyle(Theme.textPrimary)
+                            Text(comment.createdAt.timeAgo)
+                                .font(Theme.fontSmall)
+                                .foregroundStyle(Theme.textTertiary)
+                        }
+                    }
+                    .frame(minHeight: 44)
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(PressableCardStyle())
+                .simultaneousGesture(TapGesture().onEnded { Haptics.light() })
+                .accessibilityLabel("View profile of @\(profileHandle)")
+                .accessibilityHint("Opens this user's profile")
+
+                Spacer()
+            }
+            .padding(.top, 10)
+
+            // Body text + Reply button stay outside the profile link so taps on
+            // them don't navigate. Indented to align under the name.
+            HStack(alignment: .top, spacing: Theme.Spacing.sm) {
+                Color.clear.frame(width: 32, height: 0)
 
                 VStack(alignment: .leading, spacing: 3) {
-                    HStack(spacing: 6) {
-                        Text(comment.user?.displayName ?? "User")
-                            .font(.caption.weight(.semibold))
-                            .foregroundStyle(Theme.textPrimary)
-                        Text(comment.createdAt.timeAgo)
-                            .font(Theme.fontSmall)
-                            .foregroundStyle(Theme.textTertiary)
-                    }
-                    .accessibilityElement(children: .combine)
-                    .accessibilityLabel("\(comment.user?.displayName ?? "User"), \(comment.createdAt.timeAgo)")
                     Text(comment.text)
                         .font(Theme.fontBody)
                         .foregroundStyle(Theme.textPrimary)
@@ -324,7 +351,7 @@ private struct CommentRow: View {
 
                 Spacer()
             }
-            .padding(.vertical, 10)
+            .padding(.bottom, 10)
 
             XomDivider()
         }

--- a/Xomfit/Views/Feed/FeedDetailView.swift
+++ b/Xomfit/Views/Feed/FeedDetailView.swift
@@ -293,19 +293,33 @@ struct FeedDetailView: View {
 
     private var headerRow: some View {
         HStack(spacing: Theme.Spacing.sm) {
-            XomAvatar(
-                name: localItem.user.displayName.isEmpty ? localItem.user.username : localItem.user.displayName,
-                size: 48
-            )
+            // #367: avatar + display name push the poster's ProfileView.
+            NavigationLink {
+                ProfileView(userId: localItem.userId)
+                    .hideTabBar()
+            } label: {
+                HStack(spacing: Theme.Spacing.sm) {
+                    XomAvatar(
+                        name: localItem.user.displayName.isEmpty ? localItem.user.username : localItem.user.displayName,
+                        size: 48
+                    )
 
-            VStack(alignment: .leading, spacing: Theme.Spacing.tighter) {
-                Text(localItem.user.displayName.isEmpty ? localItem.user.username : localItem.user.displayName)
-                    .font(.subheadline.weight(.semibold))
-                    .foregroundStyle(Theme.textPrimary)
-                Text("\(activityTypeLabel) · \(localItem.createdAt.timeAgo)")
-                    .font(Theme.fontSmall)
-                    .foregroundStyle(Theme.textTertiary)
+                    VStack(alignment: .leading, spacing: Theme.Spacing.tighter) {
+                        Text(localItem.user.displayName.isEmpty ? localItem.user.username : localItem.user.displayName)
+                            .font(.subheadline.weight(.semibold))
+                            .foregroundStyle(Theme.textPrimary)
+                        Text("\(activityTypeLabel) · \(localItem.createdAt.timeAgo)")
+                            .font(Theme.fontSmall)
+                            .foregroundStyle(Theme.textTertiary)
+                    }
+                }
+                .frame(minHeight: 44)
+                .contentShape(Rectangle())
             }
+            .buttonStyle(PressableCardStyle())
+            .simultaneousGesture(TapGesture().onEnded { Haptics.light() })
+            .accessibilityLabel("View profile of @\(localItem.user.username.isEmpty ? localItem.user.displayName : localItem.user.username)")
+            .accessibilityHint("Opens this user's profile")
 
             Spacer()
         }

--- a/Xomfit/Views/Feed/FeedItemCard.swift
+++ b/Xomfit/Views/Feed/FeedItemCard.swift
@@ -80,23 +80,38 @@ struct FeedItemCard: View {
 
     private var headerRow: some View {
         HStack(spacing: Theme.Spacing.sm) {
-            XomAvatar(
-                name: item.user.displayName.isEmpty ? item.user.username : item.user.displayName,
-                size: 48
-            )
+            // #367: avatar + display name push the poster's ProfileView.
+            // Nested inside the parent NavigationLink that opens FeedDetailView —
+            // SwiftUI's NavigationStack routes taps to the inner link when the
+            // tap hits its frame, leaving the rest of the card to the parent.
+            NavigationLink {
+                ProfileView(userId: item.userId)
+                    .hideTabBar()
+            } label: {
+                HStack(spacing: Theme.Spacing.sm) {
+                    XomAvatar(
+                        name: item.user.displayName.isEmpty ? item.user.username : item.user.displayName,
+                        size: 48
+                    )
 
-            VStack(alignment: .leading, spacing: Theme.Spacing.tighter) {
-                Text(item.user.displayName.isEmpty ? item.user.username : item.user.displayName)
-                    .font(.subheadline.weight(.semibold))
-                    .foregroundStyle(Theme.textPrimary)
-                    .accessibilityAddTraits(.isHeader)
+                    VStack(alignment: .leading, spacing: Theme.Spacing.tighter) {
+                        Text(item.user.displayName.isEmpty ? item.user.username : item.user.displayName)
+                            .font(.subheadline.weight(.semibold))
+                            .foregroundStyle(Theme.textPrimary)
 
-                // Activity context line under display name
-                Text("\(activityTypeLabel) · \(item.createdAt.timeAgo)")
-                    .font(Theme.fontSmall)
-                    .foregroundStyle(Theme.textTertiary)
-                    .accessibilityLabel("\(activityTypeLabel), \(item.createdAt.timeAgo)")
+                        // Activity context line under display name
+                        Text("\(activityTypeLabel) · \(item.createdAt.timeAgo)")
+                            .font(Theme.fontSmall)
+                            .foregroundStyle(Theme.textTertiary)
+                    }
+                }
+                .frame(minHeight: 44)
+                .contentShape(Rectangle())
             }
+            .buttonStyle(PressableCardStyle())
+            .simultaneousGesture(TapGesture().onEnded { Haptics.light() })
+            .accessibilityLabel("View profile of @\(item.user.username.isEmpty ? item.user.displayName : item.user.username)")
+            .accessibilityHint("Opens this user's profile")
 
             Spacer()
 

--- a/Xomfit/Views/Profile/ProfileFriendsView.swift
+++ b/Xomfit/Views/Profile/ProfileFriendsView.swift
@@ -9,20 +9,39 @@ struct ProfileFriendsView: View {
         friend.requesterId == currentUserId ? friend.addresseeId : friend.requesterId
     }
 
+    /// #367: profile-link a11y label — uses username when available, falls
+    /// back to display name. Mirrors the format used across feed avatars.
+    private func rowAccessibilityLabel(for friend: FriendRow) -> String {
+        let profile = friendProfiles[otherUserId(friend)]
+        let handle: String
+        if let username = profile?.username, !username.isEmpty {
+            handle = username
+        } else if let name = profile?.displayName, !name.isEmpty {
+            handle = name
+        } else {
+            handle = "user"
+        }
+        return "View profile of @\(handle)"
+    }
+
     var body: some View {
         if friends.isEmpty {
             emptyState
         } else {
             LazyVStack(spacing: 0) {
                 ForEach(friends) { friend in
+                    // #367: row pushes ProfileView for the other user with
+                    // press feedback + a profile-specific accessibility label.
                     NavigationLink {
                         ProfileView(userId: otherUserId(friend))
                             .hideTabBar()
                     } label: {
                         friendRow(friend: friend)
                     }
-                    .buttonStyle(.plain)
+                    .buttonStyle(PressableCardStyle())
                     .simultaneousGesture(TapGesture().onEnded { Haptics.light() })
+                    .accessibilityLabel(rowAccessibilityLabel(for: friend))
+                    .accessibilityHint("Opens this user's profile")
 
                     if friend.id != friends.last?.id {
                         XomDivider()
@@ -65,9 +84,7 @@ struct ProfileFriendsView: View {
         }
         .padding(Theme.Spacing.md)
         .frame(minHeight: 44)
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel("\(name)\(username.isEmpty ? "" : ", @\(username)")")
-        .accessibilityAddTraits(.isButton)
+        .contentShape(Rectangle())
     }
 
     // MARK: - Empty State


### PR DESCRIPTION
Closes #367. FeedItemCard, FeedDetailView, FeedCommentsView, ProfileFriendsView all route the avatar+name region to ProfileView(userId:). 44pt min hit area, press feedback, accessibility labels. Inner-NavigationLink-inside-outer-NavigationLink behaves correctly per SwiftUI hit testing.