### PR TITLE
#368 fix profile picture upload (entire feature was unwired)

### DIFF
--- a/Xomfit/Services/PhotoService.swift
+++ b/Xomfit/Services/PhotoService.swift
@@ -3,14 +3,40 @@ import SwiftUI
 import PhotosUI
 import Supabase
 
+/// Errors surfaced by PhotoService. Avatar upload failures keep the underlying
+/// Supabase error in `underlying` so they can be logged without losing detail.
+enum PhotoServiceError: LocalizedError {
+    case avatarEncodingFailed
+    case avatarBucketMissing(underlying: Error)
+    case avatarUploadFailed(underlying: Error)
+
+    var errorDescription: String? {
+        switch self {
+        case .avatarEncodingFailed:
+            return "Couldn't encode the selected image."
+        case .avatarBucketMissing:
+            return "Profile photos aren't set up yet on the server. Please try again later."
+        case .avatarUploadFailed(let underlying):
+            return "Couldn't upload your photo: \(underlying.localizedDescription)"
+        }
+    }
+}
+
 @MainActor
 final class PhotoService {
     static let shared = PhotoService()
 
     private let bucketName = "workout-photos"
+    private let avatarBucketName = "avatars"
     private let maxPhotos = 4
     private let maxDimension: CGFloat = 1200
     private let compressionQuality: CGFloat = 0.7
+
+    // Avatar tuning: 512px square is plenty for retina display, JPEG @ 0.75
+    // typically lands well under 500KB.
+    private let avatarDimension: CGFloat = 512
+    private let avatarCompressionQuality: CGFloat = 0.75
+    private let avatarTargetByteSize: Int = 500_000
 
     private init() {}
 
@@ -59,6 +85,76 @@ final class PhotoService {
         }
 
         return urls
+    }
+
+    // MARK: - Avatar Upload (#368)
+
+    /// Loads a single image from a `PhotosPickerItem`. Returns nil if decode fails.
+    func loadImage(from item: PhotosPickerItem) async -> UIImage? {
+        guard let data = try? await item.loadTransferable(type: Data.self),
+              let image = UIImage(data: data) else {
+            return nil
+        }
+        return image
+    }
+
+    /// Uploads an avatar JPEG to the `avatars` bucket at
+    /// `avatars/{userId}/{uuid}.jpg`. Resizes to ~512px square then encodes to
+    /// JPEG, walking compression quality down if the result exceeds the target
+    /// byte budget (~500KB). Returns the public URL of the uploaded file.
+    ///
+    /// Logs every step with the `[ProfileAvatar]` prefix so users can grab a
+    /// console transcript when reporting issues.
+    func uploadAvatar(_ image: UIImage, userId: String) async throws -> String {
+        print("[ProfileAvatar] uploadAvatar starting — userId=\(userId), bucket=\(avatarBucketName)")
+
+        // 1. Resize down to the avatar dimension (square-ish, aspect preserved).
+        let resized = resize(image, maxDimension: avatarDimension)
+        print("[ProfileAvatar] resized from \(image.size) -> \(resized.size)")
+
+        // 2. Encode to JPEG, stepping quality down if needed to hit target size.
+        guard var data = resized.jpegData(compressionQuality: avatarCompressionQuality) else {
+            print("[ProfileAvatar] ERROR encoding JPEG @ q=\(avatarCompressionQuality)")
+            throw PhotoServiceError.avatarEncodingFailed
+        }
+        var currentQuality = avatarCompressionQuality
+        while data.count > avatarTargetByteSize && currentQuality > 0.3 {
+            currentQuality -= 0.1
+            if let smaller = resized.jpegData(compressionQuality: currentQuality) {
+                data = smaller
+            } else {
+                break
+            }
+        }
+        print("[ProfileAvatar] final JPEG size=\(data.count) bytes @ q=\(String(format: "%.2f", currentQuality))")
+
+        // 3. Build a unique path. UUID per upload busts CDN caches automatically.
+        let path = "\(userId)/\(UUID().uuidString).jpg"
+        print("[ProfileAvatar] uploading to \(avatarBucketName)/\(path)")
+
+        // 4. Upload. Translate bucket-not-found errors into a clearer case so
+        // the UI can surface a server-config hint instead of a raw 404.
+        do {
+            try await supabase.storage
+                .from(avatarBucketName)
+                .upload(path, data: data, options: .init(contentType: "image/jpeg", upsert: true))
+        } catch {
+            let message = String(describing: error).lowercased()
+            if message.contains("bucket not found") || message.contains("not_found") {
+                print("[ProfileAvatar] ERROR bucket '\(avatarBucketName)' missing — run supabase/migrations/20260513_avatars_storage.sql")
+                throw PhotoServiceError.avatarBucketMissing(underlying: error)
+            }
+            print("[ProfileAvatar] ERROR upload failed: \(error)")
+            throw PhotoServiceError.avatarUploadFailed(underlying: error)
+        }
+
+        // 5. Resolve public URL (bucket is configured `public = true`).
+        let publicURL = try supabase.storage
+            .from(avatarBucketName)
+            .getPublicURL(path: path)
+        let urlString = publicURL.absoluteString
+        print("[ProfileAvatar] uploadAvatar complete — url=\(urlString)")
+        return urlString
     }
 
     // MARK: - Resize

--- a/Xomfit/Services/ProfileService.swift
+++ b/Xomfit/Services/ProfileService.swift
@@ -77,6 +77,19 @@ final class ProfileService {
             .execute()
     }
 
+    /// Writes the new avatar public URL to the `profiles.avatar_url` column.
+    /// Kept separate from `upsertProfile` so the picker flow can persist the
+    /// avatar without requiring all other edit fields to be present (#368).
+    func updateAvatarURL(userId: String, avatarURL: String) async throws {
+        print("[ProfileAvatar] ProfileService.updateAvatarURL — userId=\(userId), url=\(avatarURL)")
+        try await supabase
+            .from("profiles")
+            .update(["avatar_url": avatarURL])
+            .eq("id", value: userId)
+            .execute()
+        print("[ProfileAvatar] profiles.avatar_url updated")
+    }
+
     func updateTrainingGoals(userId: String, goals: [TrainingGoal]) async throws {
         let goalStrings = goals.map(\.rawValue)
         try await supabase

--- a/Xomfit/ViewModels/ProfileViewModel.swift
+++ b/Xomfit/ViewModels/ProfileViewModel.swift
@@ -1,5 +1,7 @@
 import Foundation
+import PhotosUI
 import Supabase
+import SwiftUI
 
 // MARK: - Profile Tab
 
@@ -61,6 +63,14 @@ final class ProfileViewModel {
     var editDisplayName: String = ""
     var editBio: String = ""
     var editIsPrivate: Bool = false
+
+    // MARK: - Avatar editing (#368)
+    /// PhotosPicker binding for the edit sheet. Reset to nil after upload.
+    var avatarPickerItem: PhotosPickerItem? = nil
+    /// True while an avatar upload is in flight (resize + upload + DB update).
+    var isUploadingAvatar: Bool = false
+    /// Non-nil when the most recent avatar upload failed. Displayed inline.
+    var avatarErrorMessage: String? = nil
 
     // MARK: - Username validation
     var usernameError: String?
@@ -321,6 +331,58 @@ final class ProfileViewModel {
         isSaving = false
     }
 
+    // MARK: - Avatar upload (#368)
+
+    /// Full picker-to-storage-to-DB-to-state flow for changing the profile
+    /// avatar. Triggered from the EditProfileSheet's PhotosPicker `onChange`.
+    ///
+    /// Steps (each one logs with `[ProfileAvatar]` so the user can grab a
+    /// console transcript when reporting issues):
+    /// 1. Load the picked image into a UIImage.
+    /// 2. Upload to Supabase Storage `avatars/{userId}/{uuid}.jpg` (~500KB JPEG).
+    /// 3. Write the public URL to `profiles.avatar_url`.
+    /// 4. Update local `avatarURL` so ProfileHeaderView re-renders immediately.
+    func updateAvatar(item: PhotosPickerItem, userId: String) async {
+        print("[ProfileAvatar] ProfileViewModel.updateAvatar start — userId=\(userId)")
+        isUploadingAvatar = true
+        avatarErrorMessage = nil
+        defer {
+            isUploadingAvatar = false
+            avatarPickerItem = nil
+        }
+
+        // Step 1: decode picker selection into a UIImage.
+        guard let image = await PhotoService.shared.loadImage(from: item) else {
+            print("[ProfileAvatar] ERROR — couldn't decode selected image")
+            avatarErrorMessage = "Couldn't read that photo. Try a different one."
+            return
+        }
+        print("[ProfileAvatar] image decoded — size=\(image.size)")
+
+        // Step 2: upload to Supabase Storage.
+        let newURL: String
+        do {
+            newURL = try await PhotoService.shared.uploadAvatar(image, userId: userId)
+        } catch {
+            print("[ProfileAvatar] ERROR upload step failed: \(error)")
+            avatarErrorMessage = error.localizedDescription
+            return
+        }
+
+        // Step 3: persist to the profiles row.
+        do {
+            try await ProfileService.shared.updateAvatarURL(userId: userId, avatarURL: newURL)
+        } catch {
+            print("[ProfileAvatar] ERROR profile row update failed: \(error)")
+            avatarErrorMessage = "Uploaded the photo but couldn't save it to your profile. \(error.localizedDescription)"
+            return
+        }
+
+        // Step 4: refresh local state so the header avatar swaps in instantly.
+        avatarURL = newURL
+        print("[ProfileAvatar] ProfileViewModel.updateAvatar complete — avatarURL=\(newURL)")
+    }
+
     // MARK: - Edit sheet helpers
 
     func beginEditing() {
@@ -330,6 +392,9 @@ final class ProfileViewModel {
         editIsPrivate = isPrivate
         usernameError = nil
         isCheckingUsername = false
+        avatarPickerItem = nil
+        avatarErrorMessage = nil
+        isUploadingAvatar = false
     }
 
     /// Debounced username uniqueness check against Supabase.

--- a/Xomfit/Views/Profile/EditProfileSheet.swift
+++ b/Xomfit/Views/Profile/EditProfileSheet.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import PhotosUI
 
 struct EditProfileSheet: View {
     let viewModel: ProfileViewModel
@@ -11,6 +12,21 @@ struct EditProfileSheet: View {
                 Theme.background.ignoresSafeArea()
 
                 Form {
+                    // MARK: - Avatar (#368)
+                    Section {
+                        avatarSection
+                            .listRowBackground(Theme.surface)
+                    } footer: {
+                        if let avatarError = viewModel.avatarErrorMessage {
+                            Text(avatarError)
+                                .font(Theme.fontSmall)
+                                .foregroundStyle(Theme.destructive)
+                        } else {
+                            Text("Tap your photo to change it.")
+                                .foregroundStyle(Theme.textSecondary)
+                        }
+                    }
+
                     Section("Username") {
                         TextField("username", text: Bindable(viewModel).editUsername)
                             .textInputAutocapitalization(.never)
@@ -91,5 +107,84 @@ struct EditProfileSheet: View {
             }
         }
         .presentationCornerRadius(Theme.Radius.lg)
+    }
+
+    // MARK: - Avatar Section
+
+    private var avatarSection: some View {
+        // Capture main-actor-isolated view-model state into locals before the
+        // PhotosPicker label closure (which is nonisolated under the iOS 26
+        // SDK / Swift 6 strict concurrency).
+        let avatarName = viewModel.displayName.isEmpty ? viewModel.username : viewModel.displayName
+        let avatarURL = viewModel.avatarURL
+        let isUploading = viewModel.isUploadingAvatar
+
+        return HStack(spacing: Theme.Spacing.md) {
+            PhotosPicker(
+                selection: Bindable(viewModel).avatarPickerItem,
+                matching: .images,
+                photoLibrary: .shared()
+            ) {
+                ZStack {
+                    XomAvatar(
+                        name: avatarName,
+                        size: 80,
+                        imageURL: URL(string: avatarURL ?? "")
+                    )
+
+                    if isUploading {
+                        Circle()
+                            .fill(Color.black.opacity(0.45))
+                            .frame(width: 80, height: 80)
+                        ProgressView()
+                            .tint(.white)
+                    } else {
+                        // Small camera affordance so the tap target is discoverable.
+                        Circle()
+                            .fill(Theme.accent)
+                            .frame(width: 26, height: 26)
+                            .overlay(
+                                Image(systemName: "camera.fill")
+                                    .font(.caption2.weight(.bold))
+                                    .foregroundStyle(.black)
+                            )
+                            .overlay(
+                                Circle().stroke(Theme.surface, lineWidth: 2)
+                            )
+                            .offset(x: 28, y: 28)
+                    }
+                }
+                .frame(width: 80, height: 80)
+            }
+            .disabled(isUploading)
+            .accessibilityLabel("Change profile photo")
+            .accessibilityAddTraits(.isButton)
+            .onChange(of: viewModel.avatarPickerItem) { _, newItem in
+                guard let newItem else { return }
+                print("[ProfileAvatar] PhotosPicker selection changed — kicking off updateAvatar")
+                Task {
+                    await viewModel.updateAvatar(item: newItem, userId: userId)
+                }
+            }
+
+            VStack(alignment: .leading, spacing: Theme.Spacing.tighter) {
+                Text("Profile Photo")
+                    .font(Theme.fontSubheadline.weight(.semibold))
+                    .foregroundStyle(Theme.textPrimary)
+                if isUploading {
+                    Text("Uploading...")
+                        .font(Theme.fontSmall)
+                        .foregroundStyle(Theme.textSecondary)
+                } else {
+                    Text("JPEG, square crop recommended.")
+                        .font(Theme.fontSmall)
+                        .foregroundStyle(Theme.textSecondary)
+                }
+            }
+
+            Spacer(minLength: 0)
+        }
+        .padding(.vertical, Theme.Spacing.tight)
+        .frame(minHeight: 44)
     }
 }

--- a/Xomfit/Views/Profile/ProfileHeaderView.swift
+++ b/Xomfit/Views/Profile/ProfileHeaderView.swift
@@ -5,6 +5,8 @@ struct ProfileHeaderView: View {
     let username: String
     let bio: String
     let initials: String
+    /// Public URL of the profile avatar. Nil falls back to initials (#368).
+    var avatarURL: String? = nil
     let isPrivate: Bool
     let isOwnProfile: Bool
     let feedItemCount: Int
@@ -32,8 +34,12 @@ struct ProfileHeaderView: View {
         VStack(spacing: Theme.Spacing.md) {
             // Top row: avatar + stats
             HStack(alignment: .center, spacing: Theme.Spacing.md) {
-                XomAvatar(name: displayName.isEmpty ? username : displayName, size: 72)
-                    .accessibilityLabel("Profile avatar")
+                XomAvatar(
+                    name: displayName.isEmpty ? username : displayName,
+                    size: 72,
+                    imageURL: URL(string: avatarURL ?? "")
+                )
+                .accessibilityLabel("Profile avatar")
 
                 HStack(spacing: Theme.Spacing.sm) {
                     statColumn(value: feedItemCount, label: "Posts") {

--- a/Xomfit/Views/Profile/ProfileView.swift
+++ b/Xomfit/Views/Profile/ProfileView.swift
@@ -135,6 +135,7 @@ struct ProfileView: View {
                     username: viewModel.username,
                     bio: viewModel.bio,
                     initials: viewModel.initials,
+                    avatarURL: viewModel.avatarURL,
                     isPrivate: viewModel.isPrivate,
                     isOwnProfile: viewModel.isOwnProfile,
                     feedItemCount: viewModel.feedItemCount,

--- a/supabase/migrations/20260513_avatars_storage.sql
+++ b/supabase/migrations/20260513_avatars_storage.sql
@@ -1,0 +1,45 @@
+-- Create storage bucket for profile avatars
+-- Path convention: avatars/{userId}/{uuid}.jpg
+-- See PhotoService.uploadAvatar(...) on iOS for the exact upload contract.
+INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+VALUES (
+    'avatars',
+    'avatars',
+    true,
+    2097152,  -- 2MB max per file (avatars are heavily compressed client-side to ~500KB)
+    ARRAY['image/jpeg', 'image/png', 'image/heic', 'image/webp']
+)
+ON CONFLICT (id) DO NOTHING;
+
+-- RLS: authenticated users can upload to their own folder
+CREATE POLICY "Users can upload own avatar"
+    ON storage.objects FOR INSERT
+    TO authenticated
+    WITH CHECK (
+        bucket_id = 'avatars'
+        AND (storage.foldername(name))[1] = auth.uid()::text
+    );
+
+-- RLS: anyone can read avatars (public bucket — they're shown in feeds, profiles, etc.)
+CREATE POLICY "Public read access for avatars"
+    ON storage.objects FOR SELECT
+    TO public
+    USING (bucket_id = 'avatars');
+
+-- RLS: users can update (upsert) their own avatar
+CREATE POLICY "Users can update own avatar"
+    ON storage.objects FOR UPDATE
+    TO authenticated
+    USING (
+        bucket_id = 'avatars'
+        AND (storage.foldername(name))[1] = auth.uid()::text
+    );
+
+-- RLS: users can delete their own avatar files (housekeeping when replacing)
+CREATE POLICY "Users can delete own avatar"
+    ON storage.objects FOR DELETE
+    TO authenticated
+    USING (
+        bucket_id = 'avatars'
+        AND (storage.foldername(name))[1] = auth.uid()::text
+    );


### PR DESCRIPTION
Closes #368. Feature was effectively unimplemented:
- EditProfileSheet had no PhotosPicker
- PhotoService had no avatar uploader
- ProfileService had no updateAvatarURL
- ProfileHeaderView ignored avatarURL even if present
- avatars storage bucket didn't exist

Wired end-to-end: pick → resize to 512px JPEG <500KB → upload to `avatars/{userId}/{uuid}.jpg` → write profiles.avatar_url → refresh header. [ProfileAvatar] debug logs at every step. **Apply migration `supabase/migrations/20260513_avatars_storage.sql` on Supabase before testing in prod.**