### PR TITLE
#370 add timed-circuit workout type + AI Coach build_workout tool support

### DIFF
--- a/Xomfit/Models/AICoachMessage.swift
+++ b/Xomfit/Models/AICoachMessage.swift
@@ -44,11 +44,50 @@ struct WorkoutBuildPayload: Codable, Equatable {
     var name: String
     var estimatedDurationMinutes: Int?
     var exercises: [Exercise]
+    /// Workout format the model wants the app to run. Defaults to `.setsReps`
+    /// when omitted so older / partial responses still produce a sane workout (#370).
+    var kind: WorkoutKind = .setsReps
+    /// Goal duration in whole minutes for `.timedCircuit`, `.amrap`, `.emom`.
+    /// Independent of `estimatedDurationMinutes`, which is an informational
+    /// estimate for sets/reps workouts.
+    var durationMinutes: Int?
+    /// Target round count for `.amrap` / `.emom`.
+    var rounds: Int?
 
     struct Exercise: Codable, Equatable {
         var exerciseId: String
         var sets: Int
         var targetReps: Int
         var targetWeight: Double?
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case name, estimatedDurationMinutes, exercises, kind, durationMinutes, rounds
+    }
+
+    init(
+        name: String,
+        estimatedDurationMinutes: Int? = nil,
+        exercises: [Exercise],
+        kind: WorkoutKind = .setsReps,
+        durationMinutes: Int? = nil,
+        rounds: Int? = nil
+    ) {
+        self.name = name
+        self.estimatedDurationMinutes = estimatedDurationMinutes
+        self.exercises = exercises
+        self.kind = kind
+        self.durationMinutes = durationMinutes
+        self.rounds = rounds
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        name = try container.decode(String.self, forKey: .name)
+        estimatedDurationMinutes = try container.decodeIfPresent(Int.self, forKey: .estimatedDurationMinutes)
+        exercises = try container.decode([Exercise].self, forKey: .exercises)
+        kind = try container.decodeIfPresent(WorkoutKind.self, forKey: .kind) ?? .setsReps
+        durationMinutes = try container.decodeIfPresent(Int.self, forKey: .durationMinutes)
+        rounds = try container.decodeIfPresent(Int.self, forKey: .rounds)
     }
 }

--- a/Xomfit/Models/Workout.swift
+++ b/Xomfit/Models/Workout.swift
@@ -1,5 +1,20 @@
 import Foundation
 
+/// How a workout is performed. Drives which runner UI is presented when the
+/// session is active and how progress is measured.
+///
+/// - `setsReps`: classic strength/lifting flow (default, backward-compatible).
+/// - `timedCircuit`: rotate through exercises for a fixed total duration. No
+///   per-set reps/weight tracking — just an exercise carousel + countdown.
+/// - `amrap`: as-many-rounds-as-possible (issue #370 follow-up).
+/// - `emom`: every-minute-on-the-minute (issue #370 follow-up).
+enum WorkoutKind: String, Codable, CaseIterable {
+    case setsReps
+    case timedCircuit
+    case amrap
+    case emom
+}
+
 struct Workout: Codable, Identifiable {
     let id: String
     var userId: String
@@ -14,15 +29,25 @@ struct Workout: Codable, Identifiable {
     /// Apple Music only — see `WorkoutTrack` for the iOS platform restriction.
     /// Defaulted so older cached / decoded payloads stay backward-compatible.
     var tracks: [WorkoutTrack] = []
+    /// Workout format. Defaults to `.setsReps` so existing cached / encoded
+    /// workouts continue to decode unchanged (#370).
+    var kind: WorkoutKind = .setsReps
+    /// Target duration in whole minutes. Used by `.timedCircuit`, `.amrap`,
+    /// and `.emom`. Nil for `.setsReps`.
+    var durationGoalMinutes: Int? = nil
+    /// Target round count. Used by `.amrap` (best-effort cap) and `.emom`
+    /// (work intervals). Nil for `.setsReps` and `.timedCircuit`.
+    var roundsGoal: Int? = nil
 
     var startDate: Date { startTime }
 
     // MARK: - Codable
     //
-    // Custom decoder so older cached `Workout` payloads (no `tracks` key) keep decoding.
-    // Encoding stays synthesized.
+    // Custom decoder so older cached `Workout` payloads (no `tracks` / `kind` keys)
+    // keep decoding. Encoding stays synthesized.
     enum CodingKeys: String, CodingKey {
         case id, userId, name, exercises, startTime, endTime, notes, location, rating, tracks
+        case kind, durationGoalMinutes, roundsGoal
     }
 
     init(
@@ -35,7 +60,10 @@ struct Workout: Codable, Identifiable {
         notes: String? = nil,
         location: String? = nil,
         rating: Int? = nil,
-        tracks: [WorkoutTrack] = []
+        tracks: [WorkoutTrack] = [],
+        kind: WorkoutKind = .setsReps,
+        durationGoalMinutes: Int? = nil,
+        roundsGoal: Int? = nil
     ) {
         self.id = id
         self.userId = userId
@@ -47,6 +75,9 @@ struct Workout: Codable, Identifiable {
         self.location = location
         self.rating = rating
         self.tracks = tracks
+        self.kind = kind
+        self.durationGoalMinutes = durationGoalMinutes
+        self.roundsGoal = roundsGoal
     }
 
     init(from decoder: Decoder) throws {
@@ -61,6 +92,9 @@ struct Workout: Codable, Identifiable {
         location = try container.decodeIfPresent(String.self, forKey: .location)
         rating = try container.decodeIfPresent(Int.self, forKey: .rating)
         tracks = try container.decodeIfPresent([WorkoutTrack].self, forKey: .tracks) ?? []
+        kind = try container.decodeIfPresent(WorkoutKind.self, forKey: .kind) ?? .setsReps
+        durationGoalMinutes = try container.decodeIfPresent(Int.self, forKey: .durationGoalMinutes)
+        roundsGoal = try container.decodeIfPresent(Int.self, forKey: .roundsGoal)
     }
 
     var duration: TimeInterval {

--- a/Xomfit/Services/AICoachService.swift
+++ b/Xomfit/Services/AICoachService.swift
@@ -74,6 +74,15 @@ final class AICoachService {
     `build_workout` tool with concrete exercises so the app can render a \
     Save / Start card under your reply. Only use exerciseIds present in the \
     provided exercise catalog.
+
+    The `kind` field controls how the app runs the workout:
+      - "setsReps" (default): classic strength training. Provide sets + targetReps per exercise.
+      - "timedCircuit": rotate through exercises for a total `durationMinutes`. Useful for \
+        ab circuits, conditioning, or any "do X for N minutes" request. Sets/reps are ignored — \
+        send `sets: 1, targetReps: 0` for each exercise.
+      - "amrap": as many rounds as possible in `durationMinutes`. Optionally cap with `rounds`.
+      - "emom": every minute on the minute for `rounds` rounds.
+    Pick the kind that best matches the user's intent. When in doubt, use "setsReps".
     """
 
     // MARK: Init
@@ -349,12 +358,30 @@ extension AICoachService {
     /// catalog injected into the system prompt.
     static let buildWorkoutTool: AnthropicTool = AnthropicTool(
         name: "build_workout",
-        description: "Create a workout plan with exercises and target sets/reps/weight. Return when the user asks for a workout, plan, or routine.",
+        description: "Create a workout plan with exercises. Return when the user asks for a workout, plan, routine, or timed circuit.",
         inputSchema: .object([
             "type": .string("object"),
             "properties": .object([
                 "name": .object(["type": .string("string")]),
                 "estimatedDurationMinutes": .object(["type": .string("integer")]),
+                "kind": .object([
+                    "type": .string("string"),
+                    "enum": .array([
+                        .string("setsReps"),
+                        .string("timedCircuit"),
+                        .string("amrap"),
+                        .string("emom")
+                    ]),
+                    "description": .string("Workout format. Defaults to setsReps. Use timedCircuit for 'do X for N minutes' style ab circuits and conditioning.")
+                ]),
+                "durationMinutes": .object([
+                    "type": .string("integer"),
+                    "description": .string("Total duration for timedCircuit / amrap / emom workouts.")
+                ]),
+                "rounds": .object([
+                    "type": .string("integer"),
+                    "description": .string("Round count for amrap / emom workouts.")
+                ]),
                 "exercises": .object([
                     "type": .string("array"),
                     "items": .object([

--- a/Xomfit/ViewModels/AICoachViewModel.swift
+++ b/Xomfit/ViewModels/AICoachViewModel.swift
@@ -26,6 +26,7 @@ final class AICoachViewModel {
     /// Suggested prompts shown when the conversation is empty.
     let suggestionChips: [String] = [
         "Build me today's workout",
+        "Build me a 10-minute ab circuit",
         "Suggest a 4-day split",
         "Help me hit a 225 bench"
     ]
@@ -224,6 +225,53 @@ final class AICoachViewModel {
         }
         TemplateService.shared.saveCustomTemplate(template)
         return template
+    }
+
+    /// Resolves the payload's exercises against `ExerciseDatabase`, dropping
+    /// unknown ids. Used by the timed-circuit start path which sidesteps
+    /// `WorkoutTemplate` (no sets/reps to project).
+    func resolvedExercises(from payload: WorkoutBuildPayload) -> [Exercise] {
+        payload.exercises.compactMap { ExerciseDatabase.byId[$0.exerciseId] }
+    }
+
+    /// Start the payload as a live workout on the provided `WorkoutLoggerViewModel`.
+    /// Branches on `payload.kind`:
+    /// - `.timedCircuit`: routes into `startTimedCircuit(...)` with the payload's
+    ///   `durationMinutes` (defaulting to 10 when unspecified).
+    /// - everything else (including `.amrap` / `.emom` for v1): falls back to
+    ///   the existing template-based sets/reps flow.
+    /// Returns `true` when the workout started successfully.
+    @discardableResult
+    func startWorkout(
+        from payload: WorkoutBuildPayload,
+        on session: WorkoutLoggerViewModel,
+        userId: String
+    ) -> Bool {
+        switch payload.kind {
+        case .timedCircuit:
+            let resolved = resolvedExercises(from: payload)
+            guard !resolved.isEmpty else {
+                errorMessage = "Couldn't start — none of the suggested exercises matched the catalog."
+                return false
+            }
+            let minutes = payload.durationMinutes ?? payload.estimatedDurationMinutes ?? 10
+            session.startTimedCircuit(
+                name: payload.name,
+                userId: userId,
+                exercises: resolved,
+                durationMinutes: minutes
+            )
+            session.isPresented = true
+            return true
+        case .setsReps, .amrap, .emom:
+            guard let template = buildTemplate(from: payload) else {
+                errorMessage = "Couldn't start — none of the suggested exercises matched the catalog."
+                return false
+            }
+            session.startFromTemplate(template, userId: userId)
+            session.isPresented = true
+            return true
+        }
     }
 
     // MARK: - Private (streaming)

--- a/Xomfit/ViewModels/WorkoutLoggerViewModel.swift
+++ b/Xomfit/ViewModels/WorkoutLoggerViewModel.swift
@@ -97,6 +97,26 @@ final class WorkoutLoggerViewModel {
     var focusExerciseIndex: Int = 0
     var focusSetIndex: Int = 0
 
+    // MARK: - Workout kind (#370)
+    /// Format of the in-progress workout. Drives which runner UI is rendered
+    /// (`ActiveWorkoutView` vs `TimedCircuitView`).
+    var kind: WorkoutKind = .setsReps
+    /// Goal duration in whole minutes for `.timedCircuit` / `.amrap` / `.emom`.
+    var durationGoalMinutes: Int? = nil
+    /// Goal round count for `.amrap` / `.emom`.
+    var roundsGoal: Int? = nil
+
+    /// Circuit rotation: which exercise the runner is currently showing.
+    /// Wraps modulo `exercises.count`.
+    var circuitExerciseIndex: Int = 0
+    /// Circuit rotation: how many full rotations through `exercises` the user
+    /// has completed. Increments when the index wraps past the last exercise.
+    var circuitRound: Int = 0
+    /// Round-by-round checkmarks keyed by exercise index. Each entry is the
+    /// set of rounds (0-indexed) the user marked complete for that exercise.
+    /// Used by `TimedCircuitView` to render per-round check pips.
+    var circuitCompletedRounds: [Int: Set<Int>] = [:]
+
     // Live Activity
     private var liveActivity: Activity<XomfitWidgetAttributes>?
     private var liveActivityUpdateCounter = 0
@@ -158,6 +178,12 @@ final class WorkoutLoggerViewModel {
         isPaused = false
         pausedAt = nil
         totalPausedDuration = 0
+        kind = .setsReps
+        durationGoalMinutes = nil
+        roundsGoal = nil
+        circuitExerciseIndex = 0
+        circuitRound = 0
+        circuitCompletedRounds = [:]
         skipRestTimer()
         startLiveActivity()
 
@@ -190,6 +216,12 @@ final class WorkoutLoggerViewModel {
         totalPausedDuration = 0
         location = ""
         rating = 0
+        kind = .setsReps
+        durationGoalMinutes = nil
+        roundsGoal = nil
+        circuitExerciseIndex = 0
+        circuitRound = 0
+        circuitCompletedRounds = [:]
         skipRestTimer()
 
         // Drop any captured Now Playing tracks — discarding the workout discards the soundtrack.
@@ -233,6 +265,114 @@ final class WorkoutLoggerViewModel {
         }
         exercises = builtExercises
         updateLiveActivity()
+    }
+
+    // MARK: - Timed Circuit (#370)
+
+    /// Start a timed-circuit workout: a rotation through `exercises` for
+    /// `durationMinutes` total. No per-set reps/weight tracking — the runner
+    /// (`TimedCircuitView`) cycles exercises and marks round-by-round completion.
+    ///
+    /// Each exercise gets a single placeholder set so the saved workout still
+    /// renders in history. Sets are marked complete on finish based on
+    /// `circuitCompletedRounds`.
+    func startTimedCircuit(
+        name: String,
+        userId: String,
+        exercises: [Exercise],
+        durationMinutes: Int
+    ) {
+        startWorkout(name: name, userId: userId)
+        kind = .timedCircuit
+        durationGoalMinutes = max(1, durationMinutes)
+
+        // Seed one placeholder set per exercise so the saved Workout has rows.
+        var built: [WorkoutExercise] = []
+        for ex in exercises {
+            let placeholderSet = WorkoutSet(
+                id: UUID().uuidString,
+                exerciseId: ex.id,
+                weight: 0,
+                reps: 0,
+                rpe: nil,
+                isPersonalRecord: false,
+                completedAt: Date.distantPast
+            )
+            var we = WorkoutExercise(
+                id: UUID().uuidString,
+                exercise: ex,
+                sets: [placeholderSet],
+                notes: nil
+            )
+            we.selectedLaterality = ex.defaultLaterality
+            built.append(we)
+        }
+        self.exercises = built
+        circuitExerciseIndex = 0
+        circuitRound = 0
+        circuitCompletedRounds = [:]
+        updateLiveActivity()
+    }
+
+    /// Total elapsed for the active circuit, clamped at the goal duration.
+    var circuitElapsedSeconds: Int {
+        Int(duration)
+    }
+
+    /// Whole seconds remaining toward `durationGoalMinutes`. Floors at 0.
+    var circuitRemainingSeconds: Int {
+        guard let mins = durationGoalMinutes else { return 0 }
+        let total = mins * 60
+        return max(0, total - circuitElapsedSeconds)
+    }
+
+    /// Fraction of the circuit completed (0...1). Returns 0 when no goal is set.
+    var circuitProgress: Double {
+        guard let mins = durationGoalMinutes, mins > 0 else { return 0 }
+        let total = Double(mins * 60)
+        let elapsed = min(Double(circuitElapsedSeconds), total)
+        return total > 0 ? elapsed / total : 0
+    }
+
+    /// True when the countdown has reached zero.
+    var circuitTimeUp: Bool {
+        circuitRemainingSeconds == 0 && durationGoalMinutes != nil
+    }
+
+    /// The exercise the circuit runner is currently showing, if any.
+    var currentCircuitExercise: WorkoutExercise? {
+        guard exercises.indices.contains(circuitExerciseIndex) else { return nil }
+        return exercises[circuitExerciseIndex]
+    }
+
+    /// Advance to the next exercise in the rotation. Wrapping past the last
+    /// exercise increments the round counter.
+    func advanceCircuitExercise() {
+        guard !exercises.isEmpty else { return }
+        let next = circuitExerciseIndex + 1
+        if next >= exercises.count {
+            circuitExerciseIndex = 0
+            circuitRound += 1
+        } else {
+            circuitExerciseIndex = next
+        }
+    }
+
+    /// Toggle a round checkmark for the current circuit exercise.
+    func toggleCurrentCircuitRoundComplete() {
+        guard exercises.indices.contains(circuitExerciseIndex) else { return }
+        var marks = circuitCompletedRounds[circuitExerciseIndex] ?? []
+        if marks.contains(circuitRound) {
+            marks.remove(circuitRound)
+        } else {
+            marks.insert(circuitRound)
+        }
+        circuitCompletedRounds[circuitExerciseIndex] = marks
+    }
+
+    /// True when the current exercise has its current round marked complete.
+    var currentCircuitRoundIsComplete: Bool {
+        circuitCompletedRounds[circuitExerciseIndex]?.contains(circuitRound) ?? false
     }
 
     // MARK: - Exercise Management
@@ -943,24 +1083,58 @@ final class WorkoutLoggerViewModel {
         isSaving = true
         errorMessage = nil
 
-        // Only keep completed sets (completedAt != distantPast) for the saved workout,
-        // but keep all exercises that have at least one set
-        let completedExercises: [WorkoutExercise] = exercises.compactMap { ex in
-            let doneSets = ex.sets.filter { $0.completedAt != Date.distantPast }
-            guard !doneSets.isEmpty else { return nil }
-            var copy = WorkoutExercise(
-                id: ex.id,
-                exercise: ex.exercise,
-                sets: doneSets,
-                notes: ex.notes,
-                selectedGrip: ex.selectedGrip,
-                selectedAttachment: ex.selectedAttachment,
-                selectedPosition: ex.selectedPosition,
-                selectedLaterality: ex.selectedLaterality
-            )
-            copy.supersetGroupId = ex.supersetGroupId
-            copy.restSeconds = ex.restSeconds
-            return copy
+        // For sets/reps workouts: keep only completed sets per exercise.
+        // For timed-circuit workouts: synthesize one "completed" set per round the
+        // user checked off, so the saved Workout reflects what they actually did.
+        let completedExercises: [WorkoutExercise]
+        if kind == .timedCircuit {
+            completedExercises = exercises.enumerated().compactMap { idx, ex in
+                let rounds = circuitCompletedRounds[idx] ?? []
+                guard !rounds.isEmpty else { return nil }
+                let now = Date()
+                let circuitSets: [WorkoutSet] = rounds.sorted().map { _ in
+                    WorkoutSet(
+                        id: UUID().uuidString,
+                        exerciseId: ex.exercise.id,
+                        weight: 0,
+                        reps: 0,
+                        rpe: nil,
+                        isPersonalRecord: false,
+                        completedAt: now
+                    )
+                }
+                var copy = WorkoutExercise(
+                    id: ex.id,
+                    exercise: ex.exercise,
+                    sets: circuitSets,
+                    notes: ex.notes,
+                    selectedGrip: ex.selectedGrip,
+                    selectedAttachment: ex.selectedAttachment,
+                    selectedPosition: ex.selectedPosition,
+                    selectedLaterality: ex.selectedLaterality
+                )
+                copy.supersetGroupId = ex.supersetGroupId
+                copy.restSeconds = ex.restSeconds
+                return copy
+            }
+        } else {
+            completedExercises = exercises.compactMap { ex in
+                let doneSets = ex.sets.filter { $0.completedAt != Date.distantPast }
+                guard !doneSets.isEmpty else { return nil }
+                var copy = WorkoutExercise(
+                    id: ex.id,
+                    exercise: ex.exercise,
+                    sets: doneSets,
+                    notes: ex.notes,
+                    selectedGrip: ex.selectedGrip,
+                    selectedAttachment: ex.selectedAttachment,
+                    selectedPosition: ex.selectedPosition,
+                    selectedLaterality: ex.selectedLaterality
+                )
+                copy.supersetGroupId = ex.supersetGroupId
+                copy.restSeconds = ex.restSeconds
+                return copy
+            }
         }
 
         let trimmedNotes = notes?.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -985,7 +1159,10 @@ final class WorkoutLoggerViewModel {
             notes: trimmedNotes?.isEmpty == false ? trimmedNotes : nil,
             location: trimmedLocation.isEmpty ? nil : trimmedLocation,
             rating: rating > 0 ? rating : nil,
-            tracks: capturedTracks
+            tracks: capturedTracks,
+            kind: kind,
+            durationGoalMinutes: durationGoalMinutes,
+            roundsGoal: roundsGoal
         )
 
         do {

--- a/Xomfit/Views/AICoach/AICoachView.swift
+++ b/Xomfit/Views/AICoach/AICoachView.swift
@@ -191,12 +191,10 @@ struct AICoachView: View {
         guard
             let workoutSession,
             let userId = authService?.currentUser?.id.uuidString.lowercased(),
-            !userId.isEmpty,
-            let template = viewModel.buildTemplate(from: payload)
+            !userId.isEmpty
         else { return }
         Haptics.success()
-        workoutSession.startFromTemplate(template, userId: userId)
-        workoutSession.isPresented = true
+        viewModel.startWorkout(from: payload, on: workoutSession, userId: userId)
     }
 
     // MARK: - Error banner

--- a/Xomfit/Views/Workout/ActiveWorkoutView.swift
+++ b/Xomfit/Views/Workout/ActiveWorkoutView.swift
@@ -37,6 +37,19 @@ struct ActiveWorkoutView: View {
     var body: some View {
         @Bindable var viewModel = viewModel
 
+        // Timed-circuit workouts (#370) use a dedicated runner UI — simpler
+        // exercise carousel + countdown ring, no per-set logging.
+        if viewModel.kind == .timedCircuit {
+            TimedCircuitView()
+        } else {
+            setsRepsBody
+        }
+    }
+
+    @ViewBuilder
+    private var setsRepsBody: some View {
+        @Bindable var viewModel = viewModel
+
         NavigationStack {
             ZStack {
                 Theme.background.ignoresSafeArea()

--- a/Xomfit/Views/Workout/TimedCircuitView.swift
+++ b/Xomfit/Views/Workout/TimedCircuitView.swift
@@ -1,0 +1,343 @@
+import SwiftUI
+
+/// Simplified runner for `.timedCircuit` workouts (#370). No per-set reps or
+/// weight — just a countdown ring, the current exercise, and a tap-to-advance
+/// rotation. Designed for "do X for N minutes" prompts like ab circuits.
+///
+/// Behaviour:
+/// - Big countdown ring up top showing time remaining toward `durationGoalMinutes`.
+/// - The active exercise is named in the center with a check pip for the
+///   current round.
+/// - Exercises auto-advance every `autoAdvanceSeconds` (30s by default) so the
+///   user can keep their hands free, but a "Next" button supports manual cycling.
+/// - "Done" finishes the workout, saving however many rounds the user actually
+///   marked complete (`WorkoutLoggerViewModel.circuitCompletedRounds`).
+struct TimedCircuitView: View {
+    @Environment(AuthService.self) private var authService
+    @Environment(WorkoutLoggerViewModel.self) private var viewModel
+    @Environment(\.dismiss) private var dismiss
+
+    /// One-second tick driving the ring + auto-advance.
+    @State private var timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
+    /// Seconds the current exercise has been on-screen. Resets on advance.
+    @State private var secondsOnCurrent: Int = 0
+    /// True while the finish flow is in-flight (saves, dismiss).
+    @State private var isFinishing = false
+    @State private var showDiscardAlert = false
+    @State private var timeUpHapticFired = false
+
+    /// How long each exercise holds before auto-advancing. Mirrors the issue's
+    /// "every 30s OR manual tap" requirement.
+    private let autoAdvanceSeconds = 30
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Theme.background.ignoresSafeArea()
+
+                VStack(spacing: Theme.Spacing.lg) {
+                    headerBar
+
+                    Spacer(minLength: 0)
+
+                    countdownRing
+
+                    exerciseCard
+
+                    Spacer(minLength: 0)
+
+                    controlsBar
+                }
+                .padding(.horizontal, Theme.Spacing.md)
+                .padding(.bottom, Theme.Spacing.md)
+            }
+            .toolbar(.hidden, for: .navigationBar)
+            .alert("End Circuit?", isPresented: $showDiscardAlert) {
+                Button("Discard", role: .destructive) {
+                    viewModel.discardWorkout()
+                    dismiss()
+                }
+                Button("Keep Going", role: .cancel) {}
+            } message: {
+                Text("Your progress so far will be lost.")
+            }
+        }
+        .onReceive(timer) { _ in
+            tick()
+        }
+        .onChange(of: viewModel.circuitExerciseIndex) { _, _ in
+            secondsOnCurrent = 0
+        }
+    }
+
+    // MARK: - Header
+
+    private var headerBar: some View {
+        HStack(spacing: Theme.Spacing.sm) {
+            Button {
+                Haptics.warning()
+                showDiscardAlert = true
+            } label: {
+                Text("Discard")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(Theme.destructive)
+                    .frame(minHeight: 44)
+                    .contentShape(Rectangle())
+            }
+            .accessibilityLabel("Discard circuit workout")
+
+            Spacer()
+
+            VStack(spacing: Theme.Spacing.tighter) {
+                Text(viewModel.workoutName.isEmpty ? "Timed Circuit" : viewModel.workoutName)
+                    .font(.subheadline.weight(.bold))
+                    .foregroundStyle(Theme.textPrimary)
+                    .lineLimit(1)
+                Text(roundLabel)
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(Theme.textTertiary)
+            }
+
+            Spacer()
+
+            Button {
+                Haptics.success()
+                finish()
+            } label: {
+                Text(isFinishing ? "" : "Done")
+                    .font(.caption.weight(.bold))
+                    .foregroundStyle(.black)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 7)
+                    .frame(minWidth: 60, minHeight: 32)
+                    .background(Theme.accent)
+                    .clipShape(.rect(cornerRadius: 8))
+                    .overlay {
+                        if isFinishing {
+                            ProgressView()
+                                .tint(.black)
+                        }
+                    }
+            }
+            .disabled(isFinishing)
+            .accessibilityLabel("Finish circuit and save")
+        }
+        .padding(.vertical, Theme.Spacing.sm)
+    }
+
+    // MARK: - Countdown Ring
+
+    private var countdownRing: some View {
+        ZStack {
+            Circle()
+                .stroke(Theme.surface, lineWidth: 14)
+
+            Circle()
+                .trim(from: 0, to: max(0.001, 1 - viewModel.circuitProgress))
+                .stroke(
+                    ringTint,
+                    style: StrokeStyle(lineWidth: 14, lineCap: .round)
+                )
+                .rotationEffect(.degrees(-90))
+                .animation(.linear(duration: 0.5), value: viewModel.circuitProgress)
+
+            VStack(spacing: Theme.Spacing.tighter) {
+                Text(timeRemainingString)
+                    .font(.system(size: 56, weight: .heavy, design: .rounded).monospacedDigit())
+                    .foregroundStyle(Theme.textPrimary)
+                    .accessibilityLabel(accessibilityTimeLabel)
+                Text("remaining")
+                    .font(Theme.fontCaption)
+                    .foregroundStyle(Theme.textSecondary)
+            }
+        }
+        .frame(width: 240, height: 240)
+        .accessibilityElement(children: .combine)
+    }
+
+    private var ringTint: Color {
+        viewModel.circuitTimeUp ? Theme.accent : Theme.accent
+    }
+
+    private var timeRemainingString: String {
+        let total = viewModel.circuitRemainingSeconds
+        let mins = total / 60
+        let secs = total % 60
+        return String(format: "%d:%02d", mins, secs)
+    }
+
+    private var accessibilityTimeLabel: String {
+        let total = viewModel.circuitRemainingSeconds
+        let mins = total / 60
+        let secs = total % 60
+        if mins > 0 && secs > 0 {
+            return "\(mins) minute\(mins == 1 ? "" : "s") and \(secs) second\(secs == 1 ? "" : "s") remaining"
+        }
+        if mins > 0 {
+            return "\(mins) minute\(mins == 1 ? "" : "s") remaining"
+        }
+        return "\(secs) second\(secs == 1 ? "" : "s") remaining"
+    }
+
+    // MARK: - Exercise Card
+
+    private var exerciseCard: some View {
+        VStack(spacing: Theme.Spacing.md) {
+            if let exercise = viewModel.currentCircuitExercise {
+                Text(exercise.exercise.name)
+                    .font(.title.weight(.bold))
+                    .foregroundStyle(Theme.textPrimary)
+                    .multilineTextAlignment(.center)
+                    .accessibilityAddTraits(.isHeader)
+
+                if !exercise.exercise.muscleGroups.isEmpty {
+                    HStack(spacing: Theme.Spacing.tight) {
+                        ForEach(exercise.exercise.muscleGroups.prefix(3), id: \.self) { mg in
+                            Text(mg.displayName)
+                                .font(Theme.fontSmall)
+                                .foregroundStyle(Theme.accent)
+                                .padding(.horizontal, 8)
+                                .padding(.vertical, Theme.Spacing.tighter)
+                                .background(Theme.accent.opacity(0.15))
+                                .clipShape(.capsule)
+                        }
+                    }
+                }
+
+                roundCheckmarkButton
+            } else {
+                Text("No exercises queued")
+                    .font(Theme.fontBody)
+                    .foregroundStyle(Theme.textSecondary)
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .padding(Theme.Spacing.md)
+        .background(Theme.surface)
+        .clipShape(.rect(cornerRadius: Theme.cornerRadius))
+    }
+
+    private var roundCheckmarkButton: some View {
+        Button {
+            Haptics.medium()
+            viewModel.toggleCurrentCircuitRoundComplete()
+        } label: {
+            HStack(spacing: Theme.Spacing.sm) {
+                Image(systemName: viewModel.currentCircuitRoundIsComplete
+                      ? "checkmark.circle.fill"
+                      : "circle")
+                    .font(Theme.fontTitle3)
+                Text(viewModel.currentCircuitRoundIsComplete
+                     ? "Round \(viewModel.circuitRound + 1) complete"
+                     : "Mark round \(viewModel.circuitRound + 1) complete")
+                    .font(.subheadline.weight(.semibold))
+            }
+            .foregroundStyle(viewModel.currentCircuitRoundIsComplete ? Theme.accent : Theme.textSecondary)
+            .frame(minHeight: 44)
+            .padding(.horizontal, Theme.Spacing.md)
+            .padding(.vertical, Theme.Spacing.sm)
+            .background(
+                Capsule()
+                    .fill(viewModel.currentCircuitRoundIsComplete
+                          ? Theme.accent.opacity(0.15)
+                          : Theme.surfaceElevated)
+            )
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(viewModel.currentCircuitRoundIsComplete
+                            ? "Unmark round \(viewModel.circuitRound + 1)"
+                            : "Mark round \(viewModel.circuitRound + 1) complete")
+    }
+
+    // MARK: - Controls
+
+    private var controlsBar: some View {
+        VStack(spacing: Theme.Spacing.sm) {
+            // Auto-advance countdown hint
+            if !viewModel.circuitTimeUp, viewModel.exercises.count > 1 {
+                let until = max(0, autoAdvanceSeconds - secondsOnCurrent)
+                Text("Next exercise in \(until)s")
+                    .font(Theme.fontCaption)
+                    .foregroundStyle(Theme.textTertiary)
+                    .monospacedDigit()
+                    .accessibilityHidden(true)
+            }
+
+            HStack(spacing: Theme.Spacing.sm) {
+                XomButton(
+                    "Next",
+                    variant: .secondary,
+                    icon: "arrow.right"
+                ) {
+                    Haptics.selection()
+                    secondsOnCurrent = 0
+                    viewModel.advanceCircuitExercise()
+                }
+                .disabled(viewModel.exercises.count < 2)
+
+                XomButton(
+                    "Done",
+                    variant: .primary,
+                    icon: "checkmark",
+                    isLoading: isFinishing
+                ) {
+                    Haptics.success()
+                    finish()
+                }
+            }
+        }
+    }
+
+    // MARK: - Derived
+
+    private var roundLabel: String {
+        let round = viewModel.circuitRound + 1
+        if viewModel.exercises.isEmpty {
+            return "Round \(round)"
+        }
+        let pos = viewModel.circuitExerciseIndex + 1
+        return "Round \(round) • \(pos) of \(viewModel.exercises.count)"
+    }
+
+    // MARK: - Tick
+
+    private func tick() {
+        viewModel.tickLiveActivity()
+
+        guard !viewModel.circuitTimeUp else {
+            if !timeUpHapticFired {
+                timeUpHapticFired = true
+                Haptics.success()
+            }
+            return
+        }
+
+        secondsOnCurrent += 1
+        if secondsOnCurrent >= autoAdvanceSeconds && viewModel.exercises.count > 1 {
+            secondsOnCurrent = 0
+            Haptics.selection()
+            viewModel.advanceCircuitExercise()
+        }
+    }
+
+    // MARK: - Actions
+
+    private func finish() {
+        guard !isFinishing else { return }
+        guard let user = authService.currentUser else {
+            // No auth — just dismiss locally without saving.
+            viewModel.discardWorkout()
+            dismiss()
+            return
+        }
+        let userId = user.id.uuidString.lowercased()
+        isFinishing = true
+        Task {
+            await viewModel.finishWorkout(userId: userId, notes: nil, photoURLs: nil)
+            isFinishing = false
+            if viewModel.errorMessage == nil {
+                dismiss()
+            }
+        }
+    }
+}


### PR DESCRIPTION
Closes #370. WorkoutKind enum (.setsReps default, .timedCircuit fully wired; .amrap/.emom stubs for follow-up). AICoachService tool schema extended with kind/durationMinutes/rounds, system prompt teaches the model. New TimedCircuitView (countdown ring + per-round checkmark + 30s auto-advance + manual Next). 'Build me a 10-minute ab circuit' suggestion chip added. ActiveWorkoutView routes to TimedCircuitView when kind == .timedCircuit. Backward-compat decoder so old workouts decode unchanged.