### PR TITLE
#365 edit mode on WorkoutDetailView (sets/exercises/metadata/order)

### DIFF
--- a/Xomfit/Services/FeedService.swift
+++ b/Xomfit/Services/FeedService.swift
@@ -164,6 +164,94 @@ final class FeedService {
         photoURLs: [String]? = nil,
         compact: Bool = true
     ) async throws {
+        let activity = buildWorkoutActivity(from: workout, photoURLs: photoURLs, compact: compact)
+
+        let payloadData = try jsonEncoder.encode(activity)
+        let payloadString = String(data: payloadData, encoding: .utf8) ?? "{}"
+
+        let insert = FeedItemInsert(
+            id: UUID().uuidString,
+            user_id: userId,
+            activity_type: ActivityType.workout.rawValue,
+            caption: caption,
+            payload: payloadString,
+            visibility: SocialFeedItem.FeedVisibility.friends.rawValue
+        )
+
+        try await supabase
+            .from("feed_items")
+            .insert(insert)
+            .execute()
+    }
+
+    // MARK: - Update Feed Item for Workout (#365)
+
+    /// Rewrites the payload of an existing workout-type feed item after the user
+    /// edits the workout. Matches the same lookup strategy as
+    /// `deleteFeedItemsForWorkout`: fetch the user's workout-type rows, decode
+    /// each payload, find the one whose `workoutId` matches.
+    ///
+    /// If no feed item matches (e.g. workout was edited before the post-to-feed
+    /// flow ran) this is a no-op.
+    ///
+    /// `caption` and `photoURLs` are preserved from the existing row when not
+    /// passed in — only the activity payload is rebuilt from the new workout.
+    func updateFeedItemForWorkout(
+        workout: Workout,
+        userId: String
+    ) async throws {
+        // Find existing workout-type feed items for this user
+        let rows: [FeedItemRow] = try await supabase
+            .from("feed_items")
+            .select()
+            .eq("user_id", value: userId)
+            .eq("activity_type", value: ActivityType.workout.rawValue)
+            .execute()
+            .value
+
+        // Pick the row whose payload's workoutId matches
+        let match = rows.first { row in
+            guard let data = row.payload.data(using: .utf8),
+                  let activity = try? jsonDecoder.decode(WorkoutActivity.self, from: data) else {
+                return false
+            }
+            return activity.workoutId == workout.id
+        }
+
+        guard let row = match else {
+            // No existing feed post for this workout — nothing to update.
+            return
+        }
+
+        // Preserve existing photoURLs from the prior payload so we don't drop
+        // attached photos when rewriting the activity from the edited workout.
+        let existingPhotoURLs: [String]? = {
+            guard let data = row.payload.data(using: .utf8),
+                  let activity = try? jsonDecoder.decode(WorkoutActivity.self, from: data) else {
+                return nil
+            }
+            return activity.photoURLs
+        }()
+
+        let activity = buildWorkoutActivity(from: workout, photoURLs: existingPhotoURLs, compact: true)
+        let payloadData = try jsonEncoder.encode(activity)
+        let payloadString = String(data: payloadData, encoding: .utf8) ?? "{}"
+
+        try await supabase
+            .from("feed_items")
+            .update(["payload": payloadString])
+            .eq("id", value: row.id)
+            .execute()
+    }
+
+    /// Builds the `WorkoutActivity` payload shared by `postWorkoutToFeed` and
+    /// `updateFeedItemForWorkout` so both call sites stay in lock-step on the
+    /// compact-vs-full set encoding (#321).
+    private func buildWorkoutActivity(
+        from workout: Workout,
+        photoURLs: [String]?,
+        compact: Bool
+    ) -> WorkoutActivity {
         let exercises = workout.exercises.map { ex in
             WorkoutActivity.ExerciseSummary(
                 id: ex.id,
@@ -187,7 +275,7 @@ final class FeedService {
         let trackCount: Int? = workout.tracks.isEmpty ? nil : workout.tracks.count
         let firstTrackTitle: String? = workout.tracks.first?.title
 
-        let activity = WorkoutActivity(
+        return WorkoutActivity(
             workoutId: workout.id,
             workoutName: workout.name,
             duration: workout.duration,
@@ -202,23 +290,6 @@ final class FeedService {
             trackCount: trackCount,
             firstTrackTitle: firstTrackTitle
         )
-
-        let payloadData = try jsonEncoder.encode(activity)
-        let payloadString = String(data: payloadData, encoding: .utf8) ?? "{}"
-
-        let insert = FeedItemInsert(
-            id: UUID().uuidString,
-            user_id: userId,
-            activity_type: ActivityType.workout.rawValue,
-            caption: caption,
-            payload: payloadString,
-            visibility: SocialFeedItem.FeedVisibility.friends.rawValue
-        )
-
-        try await supabase
-            .from("feed_items")
-            .insert(insert)
-            .execute()
     }
 
     // MARK: - Post Generic Item

--- a/Xomfit/Services/WorkoutService.swift
+++ b/Xomfit/Services/WorkoutService.swift
@@ -212,6 +212,54 @@ final class WorkoutService {
         }
     }
 
+    // MARK: - Update (#365)
+
+    /// Updates a previously-saved workout. The base `workouts` row already upserts
+    /// in `saveToSupabase`, but child rows (`workout_exercises`, `workout_sets`,
+    /// `workout_tracks`) only upsert by id — so if the user removed an exercise
+    /// or set during edit those orphan rows would survive. To keep the source of
+    /// truth in sync we delete the child rows first and then re-run the standard
+    /// save path, which re-inserts them from the edited `Workout`.
+    ///
+    /// Always writes to local cache. Returns `true` if Supabase succeeded,
+    /// `false` if the write was queued via `SyncManager` for retry.
+    @discardableResult
+    func updateWorkout(_ workout: Workout) async -> Bool {
+        // Cache first — instant.
+        saveToCache(workout)
+
+        // Wipe children so removed exercises/sets/tracks don't leak.
+        // workout_sets cascade-deletes from workout_exercises in the schema.
+        do {
+            try await supabase
+                .from("workout_exercises")
+                .delete()
+                .eq("workout_id", value: workout.id)
+                .execute()
+
+            try await supabase
+                .from("workout_tracks")
+                .delete()
+                .eq("workout_id", value: workout.id)
+                .execute()
+
+            try await saveToSupabase(workout)
+            return true
+        } catch {
+            print("[WorkoutService] Supabase update failed, queuing for retry: \(error.localizedDescription)")
+            if let data = try? JSONEncoder().encode(workout),
+               let payload = String(data: data, encoding: .utf8) {
+                SyncManager.shared.enqueue(SyncOperation(
+                    type: .saveWorkout,
+                    entityId: workout.id,
+                    userId: workout.userId,
+                    payload: payload
+                ))
+            }
+            return false
+        }
+    }
+
     // MARK: - Fetch
 
     func fetchWorkout(id: String) async -> Workout? {

--- a/Xomfit/ViewModels/WorkoutDetailViewModel.swift
+++ b/Xomfit/ViewModels/WorkoutDetailViewModel.swift
@@ -1,0 +1,252 @@
+import Foundation
+import SwiftUI
+
+/// View model backing the edit mode on `WorkoutDetailView` (#365).
+///
+/// Holds an editable copy of a previously-saved `Workout` so the user can
+/// fix mistakes (date, name, notes, location, rating, end time, per-set
+/// weight/reps, add/remove sets, add/remove/reorder exercises) without
+/// touching the original until they tap Save. Cancel reverts to the
+/// originally-passed-in workout.
+///
+/// Save path mirrors `LogPastWorkoutViewModel.saveWorkout`: write through
+/// `WorkoutService.updateWorkout` (upsert by id, wipes orphan child rows)
+/// and patch the existing social-feed item via
+/// `FeedService.updateFeedItemForWorkout` so the feed card stays in sync.
+@MainActor
+@Observable
+final class WorkoutDetailViewModel {
+    // MARK: - Original snapshot
+
+    /// The pristine workout we were given. `cancel()` reverts `draft` to this.
+    private(set) var original: Workout
+
+    // MARK: - Editable draft
+
+    /// Mutable copy the edit UI binds against. Mutated freely during edit mode;
+    /// committed via `save()` or rolled back via `cancel()`.
+    var draft: Workout
+
+    // MARK: - Save State
+
+    var isSaving: Bool = false
+    var errorMessage: String? = nil
+
+    // MARK: - Init
+
+    init(workout: Workout) {
+        self.original = workout
+        self.draft = workout
+    }
+
+    // MARK: - Editable fields (typed bridges where Workout has optionals)
+
+    /// `endTime` exposed as a non-optional date for the DatePicker. Falls back
+    /// to `startTime` when the workout was never finished. Writing this back
+    /// keeps `endTime` in sync.
+    var endTimeBinding: Date {
+        get { draft.endTime ?? draft.startTime }
+        set { draft.endTime = newValue }
+    }
+
+    /// `notes` exposed as a non-optional string. Empty string round-trips to
+    /// nil on save so we don't write back empty notes that decode awkwardly.
+    var notesBinding: String {
+        get { draft.notes ?? "" }
+        set { draft.notes = newValue.isEmpty ? nil : newValue }
+    }
+
+    /// `location` exposed as a non-optional string. Empty string → nil on save.
+    var locationBinding: String {
+        get { draft.location ?? "" }
+        set { draft.location = newValue.isEmpty ? nil : newValue }
+    }
+
+    /// `rating` exposed as a non-optional Int (0 = unset).
+    var ratingBinding: Int {
+        get { draft.rating ?? 0 }
+        set { draft.rating = newValue > 0 ? newValue : nil }
+    }
+
+    // MARK: - Exercise Management
+
+    /// Append a brand-new exercise with a single empty set (matching the
+    /// `LogPastWorkoutViewModel` shape — user fills in weight/reps next).
+    func addExercise(_ exercise: Exercise) {
+        let newSet = WorkoutSet(
+            id: UUID().uuidString,
+            exerciseId: exercise.id,
+            weight: 0,
+            reps: 0,
+            rpe: nil,
+            isPersonalRecord: false,
+            completedAt: draft.startTime
+        )
+        var we = WorkoutExercise(
+            id: UUID().uuidString,
+            exercise: exercise,
+            sets: [newSet],
+            notes: nil
+        )
+        we.selectedLaterality = exercise.defaultLaterality
+        draft.exercises.append(we)
+    }
+
+    func removeExercise(at index: Int) {
+        guard draft.exercises.indices.contains(index) else { return }
+        draft.exercises.remove(at: index)
+    }
+
+    /// Swap the exercise at `index` with the one above it. No-op when at top.
+    func moveExerciseUp(_ index: Int) {
+        guard index > 0, draft.exercises.indices.contains(index) else { return }
+        draft.exercises.swapAt(index, index - 1)
+    }
+
+    /// Swap the exercise at `index` with the one below it. No-op when at bottom.
+    func moveExerciseDown(_ index: Int) {
+        guard draft.exercises.indices.contains(index),
+              index < draft.exercises.count - 1 else { return }
+        draft.exercises.swapAt(index, index + 1)
+    }
+
+    // MARK: - Set Management
+
+    /// Adds a set to an exercise, defaulting weight/reps to the prior set so
+    /// the user doesn't have to retype.
+    func addSet(to exerciseIndex: Int) {
+        guard draft.exercises.indices.contains(exerciseIndex) else { return }
+        let ex = draft.exercises[exerciseIndex]
+        let last = ex.sets.last
+        let newSet = WorkoutSet(
+            id: UUID().uuidString,
+            exerciseId: ex.exercise.id,
+            weight: last?.weight ?? 0,
+            reps: last?.reps ?? 0,
+            rpe: nil,
+            isPersonalRecord: false,
+            completedAt: last?.completedAt ?? draft.startTime
+        )
+        draft.exercises[exerciseIndex].sets.append(newSet)
+    }
+
+    func removeSet(exerciseIndex: Int, setIndex: Int) {
+        guard draft.exercises.indices.contains(exerciseIndex),
+              draft.exercises[exerciseIndex].sets.indices.contains(setIndex) else { return }
+        draft.exercises[exerciseIndex].sets.remove(at: setIndex)
+    }
+
+    func updateSet(exerciseIndex: Int, setIndex: Int, weight: Double, reps: Int) {
+        guard draft.exercises.indices.contains(exerciseIndex),
+              draft.exercises[exerciseIndex].sets.indices.contains(setIndex) else { return }
+        draft.exercises[exerciseIndex].sets[setIndex].weight = weight
+        draft.exercises[exerciseIndex].sets[setIndex].reps = reps
+    }
+
+    // MARK: - Validation
+
+    /// Allow save only when there's a name and at least one set with reps.
+    /// Mirrors the constraints used at log time so we never write a workout
+    /// the rest of the app can't sensibly render.
+    var canSave: Bool {
+        let trimmedName = draft.name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedName.isEmpty else { return false }
+        guard !draft.exercises.isEmpty else { return false }
+        return draft.exercises.contains { ex in
+            ex.sets.contains { $0.reps > 0 }
+        }
+    }
+
+    /// True when the draft diverged from the original — used to gate
+    /// the discard-changes prompt on cancel.
+    var hasChanges: Bool {
+        guard let lhs = try? JSONEncoder().encode(draft),
+              let rhs = try? JSONEncoder().encode(original) else {
+            return true
+        }
+        return lhs != rhs
+    }
+
+    // MARK: - Save / Cancel
+
+    /// Persists the draft via `WorkoutService.updateWorkout`, then patches the
+    /// matching feed item. Returns `true` on success so the caller can drop
+    /// edit mode.
+    func save() async -> Bool {
+        guard canSave else { return false }
+        isSaving = true
+        errorMessage = nil
+        defer { isSaving = false }
+
+        // Strip empty sets (reps == 0) the same way the log-past flow does so
+        // we never persist hollow rows.
+        let cleaned = draft.exercises.compactMap { ex -> WorkoutExercise? in
+            let valid = ex.sets.filter { $0.reps > 0 }
+            guard !valid.isEmpty else { return nil }
+            return WorkoutExercise(
+                id: ex.id,
+                exercise: ex.exercise,
+                sets: valid,
+                notes: ex.notes,
+                selectedGrip: ex.selectedGrip,
+                selectedAttachment: ex.selectedAttachment,
+                selectedPosition: ex.selectedPosition,
+                selectedLaterality: ex.selectedLaterality,
+                supersetGroupId: ex.supersetGroupId,
+                restSeconds: ex.restSeconds
+            )
+        }
+
+        guard !cleaned.isEmpty else {
+            errorMessage = "Add at least one set with reps before saving."
+            return false
+        }
+
+        // Trim name; fall back to the original if the user cleared it.
+        let trimmedName = draft.name.trimmingCharacters(in: .whitespacesAndNewlines)
+        let resolvedName = trimmedName.isEmpty ? original.name : trimmedName
+
+        // Keep `endTime` nil if the user dragged it back before startTime.
+        let normalizedEnd: Date? = {
+            guard let end = draft.endTime else { return nil }
+            return end > draft.startTime ? end : nil
+        }()
+
+        let finalWorkout = Workout(
+            id: draft.id,
+            userId: draft.userId,
+            name: resolvedName,
+            exercises: cleaned,
+            startTime: draft.startTime,
+            endTime: normalizedEnd,
+            notes: draft.notes,
+            location: draft.location,
+            rating: draft.rating,
+            tracks: draft.tracks
+        )
+
+        _ = await WorkoutService.shared.updateWorkout(finalWorkout)
+
+        // Feed sync — best-effort. Don't fail the save if it errors.
+        do {
+            try await FeedService.shared.updateFeedItemForWorkout(
+                workout: finalWorkout,
+                userId: finalWorkout.userId
+            )
+        } catch {
+            print("[WorkoutDetailViewModel] Feed update failed: \(error.localizedDescription)")
+        }
+
+        // Promote the saved workout as the new baseline so subsequent edits
+        // diff against the just-saved state.
+        original = finalWorkout
+        draft = finalWorkout
+        return true
+    }
+
+    /// Reverts the draft back to the originally-passed-in workout.
+    func cancel() {
+        draft = original
+        errorMessage = nil
+    }
+}

--- a/Xomfit/Views/Profile/ProfileWorkoutListView.swift
+++ b/Xomfit/Views/Profile/ProfileWorkoutListView.swift
@@ -69,7 +69,9 @@ struct ProfileWorkoutListView: View {
         List {
             ForEach(workouts) { workout in
                 NavigationLink {
-                    WorkoutDetailView(workout: workout)
+                    // #365 — surface the same pull-to-refresh closure as
+                    // `onUpdated` so saving an edit re-fetches the list.
+                    WorkoutDetailView(workout: workout, onUpdated: onRefresh)
                 } label: {
                     workoutCard(workout)
                 }

--- a/Xomfit/Views/Workout/WorkoutDetailView.swift
+++ b/Xomfit/Views/Workout/WorkoutDetailView.swift
@@ -2,9 +2,25 @@ import SwiftUI
 
 struct WorkoutDetailView: View {
     let workout: Workout
+    /// Called after a successful edit-mode save (#365) so the parent list can
+    /// refresh and reflect the new name/sets/etc. Optional — existing call
+    /// sites that haven't migrated still compile.
+    var onUpdated: (() async -> Void)? = nil
 
     @Environment(AuthService.self) private var authService
     @Environment(WorkoutLoggerViewModel.self) private var workoutSession
+
+    /// Edit mode (#365). When `true` the read-only summary/exercise cards are
+    /// swapped for editable forms, and the toolbar surfaces Cancel / Save in
+    /// place of the share button.
+    @State private var isEditing = false
+    /// View model owning the editable draft of `workout` while in edit mode.
+    /// Lazily seeded from `workout` the first time the user taps the pencil.
+    @State private var editVM: WorkoutDetailViewModel?
+    /// Confirmation dialog presented when the user taps Cancel with unsaved changes.
+    @State private var showDiscardAlert = false
+    /// Exercise picker presented from the Add Exercise button in edit mode.
+    @State private var showExercisePicker = false
 
     /// Image rendered for sharing (#320). Held while the share sheet is presented
     /// so `UIActivityViewController` doesn't see a stale image.
@@ -41,31 +57,104 @@ struct WorkoutDetailView: View {
             Theme.background.ignoresSafeArea()
 
             ScrollView {
-                VStack(spacing: Theme.Spacing.md) {
-                    summaryCard
-                    exerciseList
-                    soundtrackSection
-                    startThisWorkoutButton
+                if isEditing, let editVM {
+                    WorkoutDetailEditBody(viewModel: editVM, onAddExercise: {
+                        Haptics.light()
+                        showExercisePicker = true
+                    })
+                    .padding(.horizontal, Theme.Spacing.md)
+                    .padding(.vertical, Theme.Spacing.sm)
+                    .padding(.bottom, Theme.Spacing.xxl)
+                } else {
+                    VStack(spacing: Theme.Spacing.md) {
+                        summaryCard
+                        exerciseList
+                        soundtrackSection
+                        startThisWorkoutButton
+                    }
+                    .padding(.horizontal, Theme.Spacing.md)
+                    .padding(.vertical, Theme.Spacing.sm)
                 }
-                .padding(.horizontal, Theme.Spacing.md)
-                .padding(.vertical, Theme.Spacing.sm)
             }
+            .scrollDismissesKeyboard(.interactively)
         }
-        .navigationTitle(workout.name)
+        .navigationTitle(isEditing ? "Edit Workout" : workout.name)
         .navigationBarTitleDisplayMode(.inline)
+        .navigationBarBackButtonHidden(isEditing)
         .toolbarColorScheme(.dark, for: .navigationBar)
         .hideTabBar()
         .toolbar {
-            ToolbarItem(placement: .topBarTrailing) {
-                Button {
-                    Haptics.light()
-                    shareImage = WorkoutImageRenderer.render(workout: workout)
-                } label: {
-                    Image(systemName: "square.and.arrow.up")
-                        .foregroundStyle(Theme.accent)
+            if isEditing, let editVM {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") {
+                        if editVM.hasChanges {
+                            showDiscardAlert = true
+                        } else {
+                            exitEditMode()
+                        }
+                    }
+                    .foregroundStyle(Theme.accent)
                 }
-                .accessibilityLabel("Share workout as image")
+                ToolbarItem(placement: .confirmationAction) {
+                    Button {
+                        Task { await commitSave() }
+                    } label: {
+                        if editVM.isSaving {
+                            ProgressView().tint(Theme.accent)
+                        } else {
+                            Text("Save").fontWeight(.bold)
+                        }
+                    }
+                    .foregroundStyle(editVM.canSave ? Theme.accent : Theme.textSecondary)
+                    .disabled(!editVM.canSave || editVM.isSaving)
+                }
+                ToolbarItemGroup(placement: .keyboard) {
+                    Spacer()
+                    Button("Done") {
+                        UIApplication.shared.sendAction(
+                            #selector(UIResponder.resignFirstResponder),
+                            to: nil, from: nil, for: nil
+                        )
+                    }
+                    .foregroundStyle(Theme.accent)
+                }
+            } else {
+                ToolbarItem(placement: .topBarTrailing) {
+                    HStack(spacing: Theme.Spacing.sm) {
+                        Button {
+                            Haptics.light()
+                            enterEditMode()
+                        } label: {
+                            Image(systemName: "pencil")
+                                .foregroundStyle(Theme.accent)
+                        }
+                        .accessibilityLabel("Edit workout")
+
+                        Button {
+                            Haptics.light()
+                            shareImage = WorkoutImageRenderer.render(workout: workout)
+                        } label: {
+                            Image(systemName: "square.and.arrow.up")
+                                .foregroundStyle(Theme.accent)
+                        }
+                        .accessibilityLabel("Share workout as image")
+                    }
+                }
             }
+        }
+        .sheet(isPresented: $showExercisePicker) {
+            ExercisePickerView { exercise in
+                editVM?.addExercise(exercise)
+            }
+        }
+        .alert("Discard changes?", isPresented: $showDiscardAlert) {
+            Button("Discard", role: .destructive) {
+                editVM?.cancel()
+                exitEditMode()
+            }
+            Button("Keep Editing", role: .cancel) {}
+        } message: {
+            Text("Your edits to this workout will be lost.")
         }
         .sheet(item: Binding(
             get: { shareImage.map { ShareImageWrapper(image: $0) } },
@@ -545,6 +634,43 @@ struct WorkoutDetailView: View {
         formatter.dateFormat = "h:mm a"
         return "\(formatter.string(from: start)) - \(formatter.string(from: end))"
     }
+
+    // MARK: - Edit Mode (#365)
+
+    /// Seeds the edit view model from the current workout and flips into edit mode.
+    private func enterEditMode() {
+        editVM = WorkoutDetailViewModel(workout: workout)
+        withAnimation(.easeInOut(duration: 0.2)) {
+            isEditing = true
+        }
+    }
+
+    /// Drops out of edit mode without persisting. Caller is expected to have
+    /// already called `editVM?.cancel()` when discarding pending changes.
+    private func exitEditMode() {
+        withAnimation(.easeInOut(duration: 0.2)) {
+            isEditing = false
+        }
+        // Clear the draft so the next pencil tap rebuilds it from `workout`.
+        editVM = nil
+    }
+
+    /// Pushes the draft through `WorkoutDetailViewModel.save` then notifies the
+    /// parent list to refresh its data. The parent re-fetch is what makes the
+    /// next push into this detail view show the new values — we keep showing
+    /// the original `workout` constant here so the read-only view stays stable.
+    private func commitSave() async {
+        guard let editVM else { return }
+        Haptics.medium()
+        let ok = await editVM.save()
+        if ok {
+            Haptics.success()
+            await onUpdated?()
+            exitEditMode()
+        } else {
+            Haptics.error()
+        }
+    }
 }
 
 // MARK: - Share Image Wrapper (#320)
@@ -553,4 +679,511 @@ struct WorkoutDetailView: View {
 private struct ShareImageWrapper: Identifiable {
     let id = UUID()
     let image: UIImage
+}
+
+// MARK: - Edit Mode Body (#365)
+
+/// Top-level container for the edit-mode UI. Kept private to this file so the
+/// only entry point stays `WorkoutDetailView.isEditing`. Splits the long edit
+/// form into a metadata card, a per-exercise list, and an "Add Exercise"
+/// affordance so each leaf view stays well under the 100-line guideline.
+private struct WorkoutDetailEditBody: View {
+    @Bindable var viewModel: WorkoutDetailViewModel
+    let onAddExercise: () -> Void
+
+    var body: some View {
+        VStack(spacing: Theme.Spacing.md) {
+            WorkoutEditMetadataCard(viewModel: viewModel)
+            WorkoutEditExerciseList(viewModel: viewModel)
+            addExerciseButton
+
+            if let error = viewModel.errorMessage {
+                errorBanner(error)
+            }
+        }
+    }
+
+    private var addExerciseButton: some View {
+        Button {
+            onAddExercise()
+        } label: {
+            HStack(spacing: Theme.Spacing.sm) {
+                Image(systemName: "plus.circle.fill")
+                Text("Add Exercise")
+                    .font(.subheadline.weight(.semibold))
+            }
+            .foregroundStyle(Theme.accent)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 14)
+            .background(Theme.accent.opacity(0.1))
+            .clipShape(.rect(cornerRadius: Theme.cornerRadius))
+            .overlay(
+                RoundedRectangle(cornerRadius: Theme.cornerRadius)
+                    .strokeBorder(Theme.accent.opacity(0.3), lineWidth: 1)
+            )
+        }
+        .accessibilityLabel("Add exercise to workout")
+    }
+
+    private func errorBanner(_ text: String) -> some View {
+        HStack(spacing: Theme.Spacing.sm) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(Theme.destructive)
+            Text(text)
+                .font(Theme.fontCaption)
+                .foregroundStyle(Theme.textPrimary)
+        }
+        .padding(Theme.Spacing.md)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Theme.destructive.opacity(0.12))
+        .clipShape(.rect(cornerRadius: Theme.Radius.sm))
+    }
+}
+
+// MARK: - Edit Metadata Card
+
+/// Editable workout metadata: name, date+start, end time, location, notes,
+/// rating. Mirrors the layout of `LogPastWorkoutView.metadataCard` so users
+/// familiar with that flow recognize this one.
+private struct WorkoutEditMetadataCard: View {
+    @Bindable var viewModel: WorkoutDetailViewModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.md) {
+            nameField
+            dateRow
+            locationField
+            ratingRow
+            notesField
+        }
+        .padding(Theme.Spacing.md)
+        .background(Theme.surface)
+        .clipShape(.rect(cornerRadius: Theme.cornerRadius))
+    }
+
+    private var nameField: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.xs) {
+            fieldLabel("Name")
+            TextField("Workout", text: $viewModel.draft.name)
+                .font(Theme.fontBodyEmphasized)
+                .foregroundStyle(Theme.textPrimary)
+                .padding(Theme.Spacing.sm)
+                .background(Theme.surfaceElevated)
+                .clipShape(.rect(cornerRadius: Theme.Radius.sm))
+                .overlay(
+                    RoundedRectangle(cornerRadius: Theme.Radius.sm)
+                        .strokeBorder(Theme.hairline, lineWidth: 0.5)
+                )
+                .accessibilityLabel("Workout name")
+        }
+    }
+
+    private var dateRow: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.xs) {
+            fieldLabel("Start")
+            DatePicker(
+                "",
+                selection: $viewModel.draft.startTime,
+                displayedComponents: [.date, .hourAndMinute]
+            )
+            .labelsHidden()
+            .datePickerStyle(.compact)
+            .tint(Theme.accent)
+            .accessibilityLabel("Workout start time")
+
+            fieldLabel("End")
+            DatePicker(
+                "",
+                selection: Binding(
+                    get: { viewModel.endTimeBinding },
+                    set: { viewModel.endTimeBinding = $0 }
+                ),
+                in: viewModel.draft.startTime...,
+                displayedComponents: [.date, .hourAndMinute]
+            )
+            .labelsHidden()
+            .datePickerStyle(.compact)
+            .tint(Theme.accent)
+            .accessibilityLabel("Workout end time")
+
+            Text("Duration: \(viewModel.draft.durationString)")
+                .font(Theme.fontCaption)
+                .foregroundStyle(Theme.textSecondary)
+                .accessibilityLabel("Calculated duration: \(viewModel.draft.durationString)")
+        }
+    }
+
+    private var locationField: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.xs) {
+            fieldLabel("Location")
+            TextField("e.g. Home gym", text: Binding(
+                get: { viewModel.locationBinding },
+                set: { viewModel.locationBinding = $0 }
+            ))
+            .font(Theme.fontBody)
+            .foregroundStyle(Theme.textPrimary)
+            .padding(Theme.Spacing.sm)
+            .background(Theme.surfaceElevated)
+            .clipShape(.rect(cornerRadius: Theme.Radius.sm))
+            .overlay(
+                RoundedRectangle(cornerRadius: Theme.Radius.sm)
+                    .strokeBorder(Theme.hairline, lineWidth: 0.5)
+            )
+            .accessibilityLabel("Workout location")
+        }
+    }
+
+    private var ratingRow: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.xs) {
+            fieldLabel("Rating")
+            HStack(spacing: Theme.Spacing.xs) {
+                ForEach(1...5, id: \.self) { star in
+                    Button {
+                        Haptics.selection()
+                        // Tap the active star a second time to clear.
+                        let current = viewModel.ratingBinding
+                        viewModel.ratingBinding = (current == star) ? 0 : star
+                    } label: {
+                        Image(systemName: star <= viewModel.ratingBinding ? "star.fill" : "star")
+                            .font(.title3)
+                            .foregroundStyle(star <= viewModel.ratingBinding ? Theme.accent : Theme.textSecondary.opacity(0.4))
+                            .frame(width: 44, height: 44)
+                            .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("\(star) star\(star == 1 ? "" : "s")")
+                    .accessibilityAddTraits(star <= viewModel.ratingBinding ? .isSelected : [])
+                }
+                Spacer()
+            }
+        }
+    }
+
+    private var notesField: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.xs) {
+            fieldLabel("Notes")
+            TextEditor(text: Binding(
+                get: { viewModel.notesBinding },
+                set: { viewModel.notesBinding = $0 }
+            ))
+            .font(Theme.fontBody)
+            .scrollContentBackground(.hidden)
+            .foregroundStyle(Theme.textPrimary)
+            .padding(Theme.Spacing.xs)
+            .frame(minHeight: 80)
+            .background(Theme.surfaceElevated)
+            .clipShape(.rect(cornerRadius: Theme.Radius.sm))
+            .overlay(
+                RoundedRectangle(cornerRadius: Theme.Radius.sm)
+                    .strokeBorder(Theme.hairline, lineWidth: 0.5)
+            )
+            .accessibilityLabel("Workout notes")
+        }
+    }
+
+    private func fieldLabel(_ text: String) -> some View {
+        Text(text)
+            .font(Theme.fontCaption)
+            .foregroundStyle(Theme.textSecondary)
+    }
+}
+
+// MARK: - Edit Exercise List
+
+/// Renders each exercise as an editable card with up/down reorder chevrons,
+/// per-set weight/reps fields, add/remove set buttons, and a remove-exercise
+/// button. Mirrors `PastExerciseCard` from `LogPastWorkoutView`.
+private struct WorkoutEditExerciseList: View {
+    @Bindable var viewModel: WorkoutDetailViewModel
+
+    var body: some View {
+        VStack(spacing: Theme.Spacing.md) {
+            if viewModel.draft.exercises.isEmpty {
+                emptyState
+            } else {
+                ForEach(viewModel.draft.exercises.indices, id: \.self) { index in
+                    WorkoutEditExerciseCard(
+                        viewModel: viewModel,
+                        index: index,
+                        isFirst: index == 0,
+                        isLast: index == viewModel.draft.exercises.count - 1
+                    )
+                }
+            }
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: Theme.Spacing.sm) {
+            Image(systemName: "figure.strengthtraining.traditional")
+                .font(Theme.fontLargeTitle)
+                .foregroundStyle(Theme.textSecondary.opacity(0.5))
+            Text("No exercises")
+                .font(Theme.fontBody)
+                .foregroundStyle(Theme.textSecondary)
+            Text("Add at least one to save")
+                .font(Theme.fontCaption)
+                .foregroundStyle(Theme.textSecondary.opacity(0.7))
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, Theme.Spacing.lg)
+    }
+}
+
+private struct WorkoutEditExerciseCard: View {
+    @Bindable var viewModel: WorkoutDetailViewModel
+    let index: Int
+    let isFirst: Bool
+    let isLast: Bool
+
+    private var exercise: WorkoutExercise {
+        viewModel.draft.exercises[index]
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+            header
+            columnHeader
+            setList
+            addSetButton
+        }
+        .padding(Theme.Spacing.md)
+        .background(Theme.surface)
+        .clipShape(.rect(cornerRadius: Theme.cornerRadius))
+    }
+
+    private var header: some View {
+        HStack(spacing: Theme.Spacing.sm) {
+            Image(systemName: exercise.exercise.icon)
+                .font(Theme.fontHeadline)
+                .foregroundStyle(Theme.accent)
+                .frame(width: Theme.Spacing.xl, height: Theme.Spacing.xl)
+                .background(Theme.accentMuted)
+                .clipShape(.rect(cornerRadius: 8))
+
+            VStack(alignment: .leading, spacing: Theme.Spacing.tighter) {
+                Text(exercise.exercise.name)
+                    .font(.subheadline.weight(.bold))
+                    .foregroundStyle(Theme.textPrimary)
+                Text(exercise.exercise.muscleGroups.first?.displayName ?? "")
+                    .font(Theme.fontSmall)
+                    .foregroundStyle(Theme.textSecondary)
+            }
+
+            Spacer()
+
+            reorderControls
+            removeButton
+        }
+    }
+
+    private var reorderControls: some View {
+        VStack(spacing: 0) {
+            Button {
+                Haptics.selection()
+                viewModel.moveExerciseUp(index)
+            } label: {
+                Image(systemName: "chevron.up")
+                    .font(Theme.fontCaption.weight(.bold))
+                    .foregroundStyle(isFirst ? Theme.textTertiary : Theme.accent)
+                    .frame(width: 30, height: 22)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .disabled(isFirst)
+            .accessibilityLabel("Move \(exercise.exercise.name) up")
+
+            Button {
+                Haptics.selection()
+                viewModel.moveExerciseDown(index)
+            } label: {
+                Image(systemName: "chevron.down")
+                    .font(Theme.fontCaption.weight(.bold))
+                    .foregroundStyle(isLast ? Theme.textTertiary : Theme.accent)
+                    .frame(width: 30, height: 22)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .disabled(isLast)
+            .accessibilityLabel("Move \(exercise.exercise.name) down")
+        }
+    }
+
+    private var removeButton: some View {
+        Button {
+            Haptics.light()
+            viewModel.removeExercise(at: index)
+        } label: {
+            Image(systemName: "trash")
+                .font(Theme.fontSubheadline)
+                .foregroundStyle(Theme.destructive.opacity(0.8))
+                .frame(width: 44, height: 44)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Remove \(exercise.exercise.name)")
+    }
+
+    private var columnHeader: some View {
+        HStack(spacing: Theme.Spacing.sm) {
+            Text("SET")
+                .frame(width: 36, alignment: .center)
+            Text("WEIGHT (LBS)")
+                .frame(maxWidth: .infinity)
+            Text("REPS")
+                .frame(maxWidth: .infinity)
+            Color.clear.frame(width: Theme.Spacing.xl)
+        }
+        .font(.caption2.weight(.semibold))
+        .foregroundStyle(Theme.textSecondary)
+        .padding(.horizontal, Theme.Spacing.xs)
+    }
+
+    private var setList: some View {
+        VStack(spacing: Theme.Spacing.xs) {
+            ForEach(exercise.sets.indices, id: \.self) { setIdx in
+                WorkoutEditSetRow(
+                    setNumber: setIdx + 1,
+                    workoutSet: exercise.sets[setIdx],
+                    onWeightChange: { newWeight in
+                        let currentReps = viewModel.draft.exercises[index].sets[setIdx].reps
+                        viewModel.updateSet(exerciseIndex: index, setIndex: setIdx, weight: newWeight, reps: currentReps)
+                    },
+                    onRepsChange: { newReps in
+                        let currentWeight = viewModel.draft.exercises[index].sets[setIdx].weight
+                        viewModel.updateSet(exerciseIndex: index, setIndex: setIdx, weight: currentWeight, reps: newReps)
+                    },
+                    onDelete: {
+                        viewModel.removeSet(exerciseIndex: index, setIndex: setIdx)
+                    }
+                )
+            }
+        }
+    }
+
+    private var addSetButton: some View {
+        Button {
+            Haptics.light()
+            viewModel.addSet(to: index)
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: "plus")
+                Text("Add Set")
+            }
+            .font(.caption.weight(.semibold))
+            .foregroundStyle(Theme.accent)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 10)
+            .background(Theme.accent.opacity(0.08))
+            .clipShape(.rect(cornerRadius: Theme.Radius.sm))
+        }
+        .accessibilityLabel("Add set to \(exercise.exercise.name)")
+    }
+}
+
+// MARK: - Edit Set Row
+
+/// Plain weight + reps row used by the edit-mode card. Mirrors `PastSetRow`
+/// from `LogPastWorkoutView` — no rest timer, no complete checkmark, just
+/// numeric input + a delete affordance.
+private struct WorkoutEditSetRow: View {
+    let setNumber: Int
+    let workoutSet: WorkoutSet
+    let onWeightChange: (Double) -> Void
+    let onRepsChange: (Int) -> Void
+    let onDelete: () -> Void
+
+    @State private var weightText: String
+    @State private var repsText: String
+    @FocusState private var isWeightFocused: Bool
+    @FocusState private var isRepsFocused: Bool
+
+    init(
+        setNumber: Int,
+        workoutSet: WorkoutSet,
+        onWeightChange: @escaping (Double) -> Void,
+        onRepsChange: @escaping (Int) -> Void,
+        onDelete: @escaping () -> Void
+    ) {
+        self.setNumber = setNumber
+        self.workoutSet = workoutSet
+        self.onWeightChange = onWeightChange
+        self.onRepsChange = onRepsChange
+        self.onDelete = onDelete
+        let w = workoutSet.weight
+        let r = workoutSet.reps
+        _weightText = State(initialValue: w > 0 ? w.formattedWeight : "")
+        _repsText   = State(initialValue: r > 0 ? "\(r)" : "")
+    }
+
+    var body: some View {
+        HStack(spacing: Theme.Spacing.sm) {
+            Text("\(setNumber)")
+                .font(.subheadline.weight(.bold).monospaced())
+                .foregroundStyle(Theme.textSecondary)
+                .frame(width: 36, alignment: .center)
+
+            TextField("0", text: $weightText)
+                .keyboardType(.decimalPad)
+                .multilineTextAlignment(.center)
+                .font(Theme.fontNumberMedium)
+                .padding(.vertical, Theme.Spacing.sm)
+                .padding(.horizontal, 6)
+                .background(Theme.surfaceElevated)
+                .clipShape(.rect(cornerRadius: Theme.cornerRadiusSmall))
+                .overlay(
+                    RoundedRectangle(cornerRadius: Theme.cornerRadiusSmall)
+                        .strokeBorder(isWeightFocused ? Theme.hairlineStrong : Theme.hairline, lineWidth: 0.5)
+                )
+                .foregroundStyle(Theme.textPrimary)
+                .frame(maxWidth: .infinity)
+                .focused($isWeightFocused)
+                .onChange(of: weightText) { _, newValue in
+                    if newValue.isEmpty {
+                        onWeightChange(0)
+                    } else if let w = Double(newValue) {
+                        onWeightChange(w)
+                    }
+                }
+                .accessibilityLabel("Weight for set \(setNumber)")
+
+            TextField("0", text: $repsText)
+                .keyboardType(.numberPad)
+                .multilineTextAlignment(.center)
+                .font(Theme.fontNumberMedium)
+                .padding(.vertical, Theme.Spacing.sm)
+                .padding(.horizontal, 6)
+                .background(Theme.surfaceElevated)
+                .clipShape(.rect(cornerRadius: Theme.cornerRadiusSmall))
+                .overlay(
+                    RoundedRectangle(cornerRadius: Theme.cornerRadiusSmall)
+                        .strokeBorder(isRepsFocused ? Theme.hairlineStrong : Theme.hairline, lineWidth: 0.5)
+                )
+                .foregroundStyle(Theme.textPrimary)
+                .frame(maxWidth: .infinity)
+                .focused($isRepsFocused)
+                .onChange(of: repsText) { _, newValue in
+                    if newValue.isEmpty {
+                        onRepsChange(0)
+                    } else if let r = Int(newValue) {
+                        onRepsChange(r)
+                    }
+                }
+                .accessibilityLabel("Reps for set \(setNumber)")
+
+            Button {
+                Haptics.light()
+                onDelete()
+            } label: {
+                Image(systemName: "minus.circle.fill")
+                    .foregroundStyle(Theme.destructive)
+                    .font(Theme.fontHeadline)
+                    .frame(minWidth: 44, minHeight: 44)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Delete set \(setNumber)")
+        }
+        .frame(minHeight: 44)
+    }
 }


### PR DESCRIPTION
Closes #365. New WorkoutDetailViewModel owns the editable draft. Toolbar pencil → edit mode → metadata + sets/reps + reorder + add/remove exercises + add/remove sets. Save calls new WorkoutService.updateWorkout (wipes children then re-runs saveToSupabase) and FeedService.updateFeedItemForWorkout (updates the existing feed item's payload). ProfileWorkoutListView refreshes via onUpdated callback.