### PR TITLE
#369 wire up notification triggers (rest timer + warmup local + APNS device token)

### DIFF
--- a/Xomfit/AppDelegate.swift
+++ b/Xomfit/AppDelegate.swift
@@ -22,6 +22,15 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
             // Save token to Supabase
             if let token = NotificationService.shared.deviceToken {
                 await saveTokenToSupabase(token)
+                // Also write the latest token to the user's profile row so the
+                // backend has a canonical apns_device_token per user (#369).
+                // Errors are logged but non-fatal — push_tokens upsert above is
+                // the source-of-truth for multi-device delivery.
+                do {
+                    try await ProfileService.shared.updateAPNSToken(token)
+                } catch {
+                    print("[APNs] Failed to update profiles.apns_device_token: \(error.localizedDescription)")
+                }
             }
         }
     }

--- a/Xomfit/Services/NotificationService.swift
+++ b/Xomfit/Services/NotificationService.swift
@@ -3,6 +3,35 @@ import UserNotifications
 import UIKit
 import Supabase
 
+// MARK: - Notification Audit (#369)
+//
+// Local notifications scheduled by this app (fire in-process, no APNs server):
+//   * Rest-timer completion  -> id "rest-{workoutId}"
+//       Scheduled when WorkoutLoggerViewModel.startRestTimer(for:) fires.
+//       Cancelled when skipRestTimer() is called or the rest naturally ends.
+//       Trigger: rest duration (seconds, UNTimeIntervalNotificationTrigger).
+//       Gated by `restTimerLocalEnabled` user toggle.
+//   * Warmup completion      -> id "warmup-completion"
+//       Scheduled when WarmupView's total timer begins.
+//       Cancelled when the warmup finishes (naturally or via "Skip to workout").
+//       Trigger: total warmup duration (seconds).
+//       Gated by `warmupLocalEnabled` user toggle.
+//
+// Remote notifications (delivered via APNs to the registered device token,
+// payload routed through `handlePushPayload`):
+//   * friend_request, friend_accepted          (friendActivity prefs toggle)
+//   * like, comment                            (social prefs toggle)
+//   * new_pr, streak_milestone                 (personalRecords prefs toggle)
+//   * friend_workout                           (friendActivity prefs toggle)
+//   * weekly_report (server-scheduled cron)    (weeklyReportEnabled toggle)
+//
+// Notes:
+//   - Permission is requested at first launch (`requestPermission()`).
+//   - Device token is registered on launch + POSTed to profiles.apns_device_token
+//     via ProfileService.updateAPNSToken (see AppDelegate).
+//   - All UNUserNotificationCenter scheduling no-ops silently when permission
+//     has not been granted (avoids simulator/test crashes).
+
 @MainActor
 @Observable
 final class NotificationService {
@@ -13,10 +42,36 @@ final class NotificationService {
     var unreadCount: Int { notifications.filter { !$0.isRead }.count }
     var notifications: [AppNotification] = []
 
+    /// Local-only toggles (not synced to Supabase — these gate in-process scheduling).
+    /// Defaults true so we surface the notifications to brand-new users until they opt out.
+    var restTimerLocalEnabled: Bool {
+        didSet { UserDefaults.standard.set(restTimerLocalEnabled, forKey: Self.restTimerKey) }
+    }
+    var warmupLocalEnabled: Bool {
+        didSet { UserDefaults.standard.set(warmupLocalEnabled, forKey: Self.warmupKey) }
+    }
+    var weeklyReportEnabled: Bool {
+        didSet { UserDefaults.standard.set(weeklyReportEnabled, forKey: Self.weeklyReportKey) }
+    }
+
+    private static let restTimerKey = "xomfit_notif_rest_timer_enabled"
+    private static let warmupKey = "xomfit_notif_warmup_enabled"
+    private static let weeklyReportKey = "xomfit_notif_weekly_report_enabled"
+    private static let restNotifPrefix = "rest-"
+    static let warmupNotifId = "warmup-completion"
+
     private let storageKey = "xomfit_notifications"
     private let prefsKey = "xomfit_notification_prefs"
 
     private init() {
+        // Default missing keys to `true` (opt-in by default).
+        let defaults = UserDefaults.standard
+        if defaults.object(forKey: Self.restTimerKey) == nil { defaults.set(true, forKey: Self.restTimerKey) }
+        if defaults.object(forKey: Self.warmupKey) == nil { defaults.set(true, forKey: Self.warmupKey) }
+        if defaults.object(forKey: Self.weeklyReportKey) == nil { defaults.set(true, forKey: Self.weeklyReportKey) }
+        self.restTimerLocalEnabled = defaults.bool(forKey: Self.restTimerKey)
+        self.warmupLocalEnabled = defaults.bool(forKey: Self.warmupKey)
+        self.weeklyReportEnabled = defaults.bool(forKey: Self.weeklyReportKey)
         loadNotifications()
         loadPreferences()
     }
@@ -46,6 +101,93 @@ final class NotificationService {
     func setDeviceToken(_ tokenData: Data) {
         let token = tokenData.map { String(format: "%02.2hhx", $0) }.joined()
         deviceToken = token
+    }
+
+    // MARK: - Local Notification Scheduling (#369)
+
+    /// Schedule a local "rest complete" notification keyed by workout id. The
+    /// identifier convention (`"rest-{workoutId}"`) ensures the latest schedule
+    /// replaces any previously pending rest notification for the same workout —
+    /// matching the rule "the latest replaces earlier ones".
+    ///
+    /// Always schedules: the system suppresses delivery when the app is in the
+    /// foreground (the visual timer handles UI in that case), and delivers as a
+    /// banner when the app is backgrounded or screen-locked.
+    ///
+    /// Silent no-op when permission has not been granted (e.g. simulator without
+    /// notification entitlement).
+    func scheduleRestTimerNotification(workoutId: String, duration: TimeInterval) {
+        guard restTimerLocalEnabled else { return }
+        guard isPermissionGranted else { return }
+        guard duration > 0 else { return }
+
+        let identifier = restIdentifier(for: workoutId)
+        // Replace any prior pending notification for this workout up-front.
+        UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: [identifier])
+
+        let content = UNMutableNotificationContent()
+        content.title = "Rest's up"
+        content.body = "Rest done! Time to lift 💪"
+        content.sound = .default
+        content.userInfo = ["type": "rest_complete", "workout_id": workoutId]
+
+        let trigger = UNTimeIntervalNotificationTrigger(timeInterval: duration, repeats: false)
+        let request = UNNotificationRequest(identifier: identifier, content: content, trigger: trigger)
+
+        UNUserNotificationCenter.current().add(request) { error in
+            if let error {
+                print("[NotificationService] Failed to schedule rest notification: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    /// Cancel the pending rest-timer notification for a workout. Safe to call
+    /// when none is pending — UNUserNotificationCenter no-ops on unknown ids.
+    func cancelRestTimerNotification(workoutId: String) {
+        let identifier = restIdentifier(for: workoutId)
+        UNUserNotificationCenter.current().removePendingNotificationRequests(withIdentifiers: [identifier])
+        // Also clear it from the delivered tray when natural completion just fired.
+        UNUserNotificationCenter.current().removeDeliveredNotifications(withIdentifiers: [identifier])
+    }
+
+    private func restIdentifier(for workoutId: String) -> String {
+        Self.restNotifPrefix + workoutId
+    }
+
+    /// Schedule a "warmup complete" notification keyed by a single shared id —
+    /// only one warmup runs at a time so the id is constant.
+    func scheduleWarmupNotification(duration: TimeInterval) {
+        guard warmupLocalEnabled else { return }
+        guard isPermissionGranted else { return }
+        guard duration > 0 else { return }
+
+        UNUserNotificationCenter.current().removePendingNotificationRequests(
+            withIdentifiers: [Self.warmupNotifId]
+        )
+
+        let content = UNMutableNotificationContent()
+        content.title = "Warmup complete"
+        content.body = "You're loose. Let's lift 💪"
+        content.sound = .default
+        content.userInfo = ["type": "warmup_complete"]
+
+        let trigger = UNTimeIntervalNotificationTrigger(timeInterval: duration, repeats: false)
+        let request = UNNotificationRequest(identifier: Self.warmupNotifId, content: content, trigger: trigger)
+
+        UNUserNotificationCenter.current().add(request) { error in
+            if let error {
+                print("[NotificationService] Failed to schedule warmup notification: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    func cancelWarmupNotification() {
+        UNUserNotificationCenter.current().removePendingNotificationRequests(
+            withIdentifiers: [Self.warmupNotifId]
+        )
+        UNUserNotificationCenter.current().removeDeliveredNotifications(
+            withIdentifiers: [Self.warmupNotifId]
+        )
     }
 
     // MARK: - Preferences

--- a/Xomfit/Services/ProfileService.swift
+++ b/Xomfit/Services/ProfileService.swift
@@ -85,4 +85,19 @@ final class ProfileService {
             .eq("id", value: userId)
             .execute()
     }
+
+    /// Persist the APNs device token on the user's profile row (#369). Called
+    /// from `AppDelegate.application(_:didRegisterForRemoteNotificationsWithDeviceToken:)`
+    /// after `UNUserNotificationCenter` hands us back a device token. The
+    /// `push_tokens` upsert in AppDelegate still fires for multi-device support;
+    /// this writes the most-recent token to the user's primary profile row so
+    /// the backend can address a single canonical device per user.
+    func updateAPNSToken(_ token: String) async throws {
+        let userId = try await supabase.auth.session.user.id.uuidString.lowercased()
+        try await supabase
+            .from("profiles")
+            .update(["apns_device_token": token])
+            .eq("id", value: userId)
+            .execute()
+    }
 }

--- a/Xomfit/ViewModels/WorkoutLoggerViewModel.swift
+++ b/Xomfit/ViewModels/WorkoutLoggerViewModel.swift
@@ -104,6 +104,11 @@ final class WorkoutLoggerViewModel {
     // Stored so completeSet can fire PR checks without needing the caller to pass it
     private(set) var activeUserId: String = ""
 
+    /// Stable id for the in-progress workout — used to key local notifications
+    /// (#369) so the latest scheduled rest timer replaces any prior pending one
+    /// (identifier convention: `"rest-{workoutId}"`).
+    private(set) var workoutId: String = UUID().uuidString
+
     // MARK: - Computed
 
     var duration: TimeInterval {
@@ -146,6 +151,7 @@ final class WorkoutLoggerViewModel {
         isActive = true
         errorMessage = nil
         activeUserId = userId
+        workoutId = UUID().uuidString
         newPR = nil
         showPRCelebration = false
         showExerciseTransition = false
@@ -738,6 +744,15 @@ final class WorkoutLoggerViewModel {
         isRestTimerActive = true
         restTimerStartDate = Date()
         updateLiveActivity()
+
+        // Schedule a local "rest done" notification keyed by workoutId (#369).
+        // The "rest-{workoutId}" identifier means a later start (e.g. user
+        // skips and starts a new rest immediately) replaces any prior pending
+        // notification — no duplicates queued.
+        NotificationService.shared.scheduleRestTimerNotification(
+            workoutId: workoutId,
+            duration: duration
+        )
     }
 
     /// Called when the app returns to foreground. Recalculates rest timer based on wall-clock time elapsed.
@@ -757,6 +772,10 @@ final class WorkoutLoggerViewModel {
         restTimeRemaining = 0
         isRestTimerActive = false
         updateLiveActivity()
+        // Cancel any pending local "rest done" notification (#369). Safe to call
+        // when none is pending — also clears delivered notifications if the user
+        // skipped after the timer naturally fired in the background.
+        NotificationService.shared.cancelRestTimerNotification(workoutId: workoutId)
     }
 
     func extendRestTimer(_ seconds: Double = 30) {

--- a/Xomfit/Views/Notifications/NotificationPreferencesView.swift
+++ b/Xomfit/Views/Notifications/NotificationPreferencesView.swift
@@ -5,6 +5,12 @@ struct NotificationPreferencesView: View {
     @State private var prefs: NotificationPreferences?
     @State private var isLoading = true
 
+    // Local-only toggles (#369). These gate in-process scheduling and aren't
+    // synced to Supabase — they live in UserDefaults via NotificationService.
+    @State private var restTimerEnabled: Bool = NotificationService.shared.restTimerLocalEnabled
+    @State private var warmupEnabled: Bool = NotificationService.shared.warmupLocalEnabled
+    @State private var weeklyReportEnabled: Bool = NotificationService.shared.weeklyReportEnabled
+
     private var userId: String {
         authService.currentUser?.id.uuidString.lowercased() ?? ""
     }
@@ -17,6 +23,28 @@ struct NotificationPreferencesView: View {
                 ProgressView()
             } else if let prefs = Binding($prefs) {
                 List {
+                    // In-workout local notifications (#369) — gated by
+                    // UserDefaults toggles in NotificationService, not synced to DB.
+                    Section {
+                        localToggle(
+                            "Rest Timer",
+                            icon: "timer",
+                            isOn: $restTimerEnabled
+                        ) { NotificationService.shared.restTimerLocalEnabled = $0 }
+                        localToggle(
+                            "Warmup",
+                            icon: "figure.cooldown",
+                            isOn: $warmupEnabled
+                        ) { NotificationService.shared.warmupLocalEnabled = $0 }
+                    } header: {
+                        XomMetricLabel("In-Workout")
+                    } footer: {
+                        Text("Local alerts that ping you when a rest or warmup timer completes — useful when your phone is in your pocket.")
+                            .font(Theme.fontCaption)
+                            .foregroundStyle(Theme.textSecondary)
+                    }
+                    .listRowSeparatorTint(Theme.hairline)
+
                     Section {
                         prefToggle("Social", icon: "bubble.left.and.bubble.right.fill", isOn: prefs.social)
                         prefToggle("Friend Activity", icon: "figure.strengthtraining.traditional", isOn: prefs.friendActivity)
@@ -26,9 +54,14 @@ struct NotificationPreferencesView: View {
                     .listRowSeparatorTint(Theme.hairline)
 
                     Section {
-                        prefToggle("Personal Records", icon: "trophy.fill", isOn: prefs.personalRecords)
+                        prefToggle("PR Celebrations", icon: "trophy.fill", isOn: prefs.personalRecords)
                         prefToggle("Workout Reminders", icon: "alarm.fill", isOn: prefs.workoutReminders)
                         prefToggle("Challenges", icon: "flag.fill", isOn: prefs.challenges)
+                        localToggle(
+                            "Weekly Report",
+                            icon: "chart.bar.doc.horizontal",
+                            isOn: $weeklyReportEnabled
+                        ) { NotificationService.shared.weeklyReportEnabled = $0 }
                     } header: {
                         XomMetricLabel("Activity")
                     }
@@ -53,6 +86,35 @@ struct NotificationPreferencesView: View {
 
     private func prefToggle(_ label: String, icon: String, isOn: Binding<Bool>) -> some View {
         Toggle(isOn: isOn) {
+            HStack(spacing: 10) {
+                Image(systemName: icon)
+                    .font(Theme.fontSubheadline)
+                    .foregroundStyle(Theme.accent)
+                    .frame(width: Theme.Spacing.lg)
+                Text(label)
+                    .font(Theme.fontBody)
+                    .foregroundStyle(Theme.textPrimary)
+            }
+        }
+        .tint(Theme.accent)
+        .listRowBackground(Theme.surface)
+    }
+
+    /// Toggle bound to a local UserDefaults flag (#369). `onUpdate` writes back
+    /// into NotificationService so the change persists across launches.
+    private func localToggle(
+        _ label: String,
+        icon: String,
+        isOn: Binding<Bool>,
+        onUpdate: @escaping (Bool) -> Void
+    ) -> some View {
+        Toggle(isOn: Binding(
+            get: { isOn.wrappedValue },
+            set: { newValue in
+                isOn.wrappedValue = newValue
+                onUpdate(newValue)
+            }
+        )) {
             HStack(spacing: 10) {
                 Image(systemName: icon)
                     .font(Theme.fontSubheadline)

--- a/Xomfit/Views/Workout/WarmupView.swift
+++ b/Xomfit/Views/Workout/WarmupView.swift
@@ -85,6 +85,9 @@ struct WarmupView: View {
                     Button("Cancel") {
                         Haptics.light()
                         stopTimer()
+                        // Drop the pending warmup notification on dismiss (#369)
+                        // so the user isn't pinged after backing out.
+                        NotificationService.shared.cancelWarmupNotification()
                         dismiss()
                     }
                     .foregroundStyle(Theme.textSecondary)
@@ -443,6 +446,13 @@ struct WarmupView: View {
         guard !hasStarted else { return }
         hasStarted = true
         startTimer()
+        // Schedule a local "warmup complete" notification keyed to the total
+        // warmup duration (#369). System suppresses delivery while in foreground
+        // (visual timer covers that) and delivers as a banner if the user
+        // backgrounds the app mid-warmup.
+        NotificationService.shared.scheduleWarmupNotification(
+            duration: TimeInterval(totalRemaining)
+        )
     }
 
     private func startTimer() {
@@ -504,6 +514,10 @@ struct WarmupView: View {
         guard !isFinished else { return }
         isFinished = true
         stopTimer()
+        // Cancel any pending warmup completion notification (#369). When the
+        // total timer naturally hits zero, the system has already delivered
+        // (and removed) the request — this call is a safe no-op in that case.
+        NotificationService.shared.cancelWarmupNotification()
         Haptics.success()
         onFinish()
         dismiss()


### PR DESCRIPTION
Closes #369. NotificationService gains rest-timer + warmup local schedule/cancel methods. WorkoutLoggerViewModel hooks them on startRestTimer/skipRestTimer. WarmupView hooks them on beginTimer/finish/cancel. AppDelegate posts the APNS device token to profiles.apns_device_token via new ProfileService.updateAPNSToken. NotificationPreferencesView gets in-workout + weekly report toggles. Audit comment block in NotificationService.swift documents which notifications fire when.