### PR TITLE
#372 replace tab bar with hamburger drawer (top-left avatar)

### DIFF
--- a/Xomfit/Views/Common/AppDrawer.swift
+++ b/Xomfit/Views/Common/AppDrawer.swift
@@ -1,0 +1,214 @@
+import SwiftUI
+
+// MARK: - AppDestination
+//
+// Top-level navigation surfaces reachable from the hamburger drawer (#372).
+// Replaces the previous 4-tab `FloatingTabBar`. Each case carries its title
+// (shown in the shell top bar + drawer row) and SF Symbol icon.
+
+enum AppDestination: String, CaseIterable, Identifiable, Hashable {
+    case feed
+    case workout
+    case progress
+    case profile
+    case reports
+    case tools
+    case settings
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .feed:     "Feed"
+        case .workout:  "Workout"
+        case .progress: "Progress"
+        case .profile:  "Profile"
+        case .reports:  "Reports"
+        case .tools:    "Tools"
+        case .settings: "Settings"
+        }
+    }
+
+    var iconSystemName: String {
+        switch self {
+        case .feed:     "house.fill"
+        case .workout:  "dumbbell.fill"
+        case .progress: "chart.line.uptrend.xyaxis"
+        case .profile:  "person.fill"
+        case .reports:  "doc.text.fill"
+        case .tools:    "wrench.and.screwdriver.fill"
+        case .settings: "gearshape.fill"
+        }
+    }
+}
+
+// MARK: - AppDrawer
+//
+// Left-edge drawer surface presented by `MainTabView` (a.k.a. MainShell). The
+// drawer renders a profile header (avatar + display name + @username), one
+// tappable row per `AppDestination`, and a sign-out CTA at the bottom.
+//
+// All interaction is forwarded to the shell:
+// - `onSelect`: user tapped a destination row.
+// - `onSignOut`: user tapped Sign Out.
+// - `onClose`: user tapped the header close affordance (X).
+
+struct AppDrawer: View {
+    let displayName: String
+    let username: String
+    let avatarURL: URL?
+    let activeDestination: AppDestination
+    let onSelect: (AppDestination) -> Void
+    let onSignOut: () -> Void
+    let onClose: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            header
+                .padding(.horizontal, Theme.Spacing.md)
+                .padding(.top, Theme.Spacing.lg)
+                .padding(.bottom, Theme.Spacing.md)
+
+            Divider()
+                .overlay(Theme.hairline)
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: Theme.Spacing.xs) {
+                    ForEach(AppDestination.allCases) { destination in
+                        drawerRow(for: destination)
+                    }
+                }
+                .padding(.horizontal, Theme.Spacing.sm)
+                .padding(.top, Theme.Spacing.md)
+            }
+
+            Spacer(minLength: 0)
+
+            Divider()
+                .overlay(Theme.hairline)
+
+            signOutButton
+                .padding(.horizontal, Theme.Spacing.md)
+                .padding(.vertical, Theme.Spacing.md)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+        .background(
+            Theme.surface
+                .ignoresSafeArea()
+        )
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack(spacing: Theme.Spacing.md) {
+            XomAvatar(name: displayName.isEmpty ? username : displayName, size: 56, imageURL: avatarURL)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(displayName.isEmpty ? username : displayName)
+                    .font(.headline.weight(.semibold))
+                    .foregroundStyle(Theme.textPrimary)
+                    .lineLimit(1)
+                if !username.isEmpty {
+                    Text("@\(username)")
+                        .font(.subheadline)
+                        .foregroundStyle(Theme.textSecondary)
+                        .lineLimit(1)
+                }
+            }
+
+            Spacer(minLength: 0)
+
+            Button {
+                Haptics.light()
+                onClose()
+            } label: {
+                Image(systemName: "xmark")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(Theme.textSecondary)
+                    .frame(width: 44, height: 44)
+                    .contentShape(Rectangle())
+            }
+            .accessibilityLabel("Close drawer")
+        }
+    }
+
+    // MARK: - Destination Row
+
+    private func drawerRow(for destination: AppDestination) -> some View {
+        let isActive = destination == activeDestination
+        return Button {
+            Haptics.selection()
+            onSelect(destination)
+        } label: {
+            HStack(spacing: Theme.Spacing.md) {
+                Image(systemName: destination.iconSystemName)
+                    .font(.body.weight(.semibold))
+                    .foregroundStyle(isActive ? Theme.accent : Theme.textSecondary)
+                    .frame(width: 28, height: 28)
+
+                Text(destination.title)
+                    .font(.body.weight(isActive ? .semibold : .regular))
+                    .foregroundStyle(isActive ? Theme.textPrimary : Theme.textPrimary.opacity(0.9))
+
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, Theme.Spacing.md)
+            .frame(minHeight: 44)
+            .background(
+                RoundedRectangle(cornerRadius: Theme.Radius.sm)
+                    .fill(isActive ? Theme.accentMuted : Color.clear)
+            )
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(destination.title)
+        .accessibilityAddTraits(isActive ? [.isSelected] : [])
+    }
+
+    // MARK: - Sign Out
+
+    private var signOutButton: some View {
+        Button {
+            Haptics.medium()
+            onSignOut()
+        } label: {
+            HStack(spacing: Theme.Spacing.md) {
+                Image(systemName: "rectangle.portrait.and.arrow.right")
+                    .font(.body.weight(.semibold))
+                    .foregroundStyle(Theme.destructive)
+                    .frame(width: 28, height: 28)
+
+                Text("Sign Out")
+                    .font(.body.weight(.semibold))
+                    .foregroundStyle(Theme.destructive)
+
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, Theme.Spacing.sm)
+            .frame(minHeight: 44)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Sign out")
+    }
+}
+
+// MARK: - Preview
+
+#if DEBUG
+#Preview("Drawer — open") {
+    AppDrawer(
+        displayName: "Debug User",
+        username: "debug_user",
+        avatarURL: nil,
+        activeDestination: .feed,
+        onSelect: { _ in },
+        onSignOut: {},
+        onClose: {}
+    )
+    .frame(width: 300)
+    .background(Theme.background)
+    .preferredColorScheme(.dark)
+}
+#endif

--- a/Xomfit/Views/Feed/FeedView.swift
+++ b/Xomfit/Views/Feed/FeedView.swift
@@ -40,109 +40,114 @@ struct FeedView: View {
     }
 
     var body: some View {
-        NavigationStack {
-            ZStack {
-                Theme.background.ignoresSafeArea()
+        // Lives inside `MainTabView`'s NavigationStack (#372). The hamburger
+        // shell provides the title + drawer affordance; `.navigationTitle`
+        // is kept for back-button labels and any pushed detail views.
+        feedRoot
+    }
 
-                if viewModel.isLoading {
-                    feedSkeleton
-                } else if let error = viewModel.errorMessage {
-                    errorView(message: error)
-                } else if viewModel.feedItems.isEmpty {
-                    emptyState
-                } else {
-                    VStack(spacing: 0) {
-                        FeedFilterBar(
-                            selectedDateRange: $viewModel.dateRange,
-                            selectedMuscleGroups: $viewModel.selectedMuscleGroups
+    private var feedRoot: some View {
+        ZStack {
+            Theme.background.ignoresSafeArea()
+
+            if viewModel.isLoading {
+                feedSkeleton
+            } else if let error = viewModel.errorMessage {
+                errorView(message: error)
+            } else if viewModel.feedItems.isEmpty {
+                emptyState
+            } else {
+                VStack(spacing: 0) {
+                    FeedFilterBar(
+                        selectedDateRange: $viewModel.dateRange,
+                        selectedMuscleGroups: $viewModel.selectedMuscleGroups
+                    )
+
+                    if viewModel.isFiltered && visibleFeedItems.isEmpty {
+                        Spacer()
+                        XomEmptyState(
+                            icon: "line.3.horizontal.decrease",
+                            title: "No matching posts",
+                            subtitle: "Try adjusting your filters"
                         )
-
-                        if viewModel.isFiltered && visibleFeedItems.isEmpty {
-                            Spacer()
-                            XomEmptyState(
-                                icon: "line.3.horizontal.decrease",
-                                title: "No matching posts",
-                                subtitle: "Try adjusting your filters"
-                            )
-                            Spacer()
-                        } else {
-                            ZStack {
-                                feedList
-                                // #311: brief skeleton overlay while a refresh
-                                // or filter change is in flight so the list
-                                // doesn't pop without feedback.
-                                if viewModel.isRefreshing || viewModel.isFiltering {
-                                    feedSkeleton
-                                        .background(Theme.background)
-                                        .transition(.opacity)
-                                }
-                            }
-                            .animation(.easeInOut(duration: 0.2), value: viewModel.isRefreshing)
-                            .animation(.easeInOut(duration: 0.2), value: viewModel.isFiltering)
-                        }
-                    }
-                    // #311: trip the filtering flag whenever the date range or
-                    // muscle-group selection changes so the skeleton flashes.
-                    .onChange(of: viewModel.dateRange) { _, _ in
-                        Task { await viewModel.applyFilterChange() }
-                    }
-                    .onChange(of: viewModel.selectedMuscleGroups) { _, _ in
-                        Task { await viewModel.applyFilterChange() }
-                    }
-                }
-            }
-            .navigationTitle("Feed")
-            .toolbarColorScheme(.dark, for: .navigationBar)
-            .toolbar {
-                ToolbarItem(placement: .topBarTrailing) {
-                    HStack(spacing: Theme.Spacing.md) {
-                        Button {
-                            showNotifications = true
-                        } label: {
-                            ZStack(alignment: .topTrailing) {
-                                Image(systemName: "bell")
-                                    .foregroundStyle(Theme.textPrimary)
-                                if NotificationService.shared.unreadCount > 0 {
-                                    Circle()
-                                        .fill(Theme.destructive)
-                                        .frame(width: Theme.Spacing.sm, height: Theme.Spacing.sm)
-                                        .offset(x: 3, y: -3)
-                                }
+                        Spacer()
+                    } else {
+                        ZStack {
+                            feedList
+                            // #311: brief skeleton overlay while a refresh
+                            // or filter change is in flight so the list
+                            // doesn't pop without feedback.
+                            if viewModel.isRefreshing || viewModel.isFiltering {
+                                feedSkeleton
+                                    .background(Theme.background)
+                                    .transition(.opacity)
                             }
                         }
-                        .accessibilityLabel(NotificationService.shared.unreadCount > 0
-                            ? "Notifications, \(NotificationService.shared.unreadCount) unread"
-                            : "Notifications")
-
-                        Button {
-                            showUserSearch = true
-                        } label: {
-                            Image(systemName: "magnifyingglass")
-                                .foregroundStyle(Theme.textPrimary)
-                        }
-                        .accessibilityLabel("Search users")
-
-                        NavigationLink {
-                            FriendsView()
-                                .hideTabBar()
-                        } label: {
-                            Image(systemName: "person.badge.plus")
-                                .foregroundStyle(Theme.textPrimary)
-                        }
-                        .accessibilityLabel("Friends and requests")
+                        .animation(.easeInOut(duration: 0.2), value: viewModel.isRefreshing)
+                        .animation(.easeInOut(duration: 0.2), value: viewModel.isFiltering)
                     }
                 }
+                // #311: trip the filtering flag whenever the date range or
+                // muscle-group selection changes so the skeleton flashes.
+                .onChange(of: viewModel.dateRange) { _, _ in
+                    Task { await viewModel.applyFilterChange() }
+                }
+                .onChange(of: viewModel.selectedMuscleGroups) { _, _ in
+                    Task { await viewModel.applyFilterChange() }
+                }
             }
-            .navigationDestination(item: $selectedFeedItem) { item in
-                FeedDetailView(item: item, userId: userId)
-                    .hideTabBar()
+        }
+        .navigationTitle("Feed")
+        .toolbarColorScheme(.dark, for: .navigationBar)
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                HStack(spacing: Theme.Spacing.md) {
+                    Button {
+                        showNotifications = true
+                    } label: {
+                        ZStack(alignment: .topTrailing) {
+                            Image(systemName: "bell")
+                                .foregroundStyle(Theme.textPrimary)
+                            if NotificationService.shared.unreadCount > 0 {
+                                Circle()
+                                    .fill(Theme.destructive)
+                                    .frame(width: Theme.Spacing.sm, height: Theme.Spacing.sm)
+                                    .offset(x: 3, y: -3)
+                            }
+                        }
+                    }
+                    .accessibilityLabel(NotificationService.shared.unreadCount > 0
+                        ? "Notifications, \(NotificationService.shared.unreadCount) unread"
+                        : "Notifications")
+
+                    Button {
+                        showUserSearch = true
+                    } label: {
+                        Image(systemName: "magnifyingglass")
+                            .foregroundStyle(Theme.textPrimary)
+                    }
+                    .accessibilityLabel("Search users")
+
+                    NavigationLink {
+                        FriendsView()
+                            .hideTabBar()
+                    } label: {
+                        Image(systemName: "person.badge.plus")
+                            .foregroundStyle(Theme.textPrimary)
+                    }
+                    .accessibilityLabel("Friends and requests")
+                }
             }
-            .sheet(isPresented: $showUserSearch) {
-                UserSearchView()
-            }
-            .sheet(isPresented: $showNotifications) {
-                NotificationInboxView()
-            }
+        }
+        .navigationDestination(item: $selectedFeedItem) { item in
+            FeedDetailView(item: item, userId: userId)
+                .hideTabBar()
+        }
+        .sheet(isPresented: $showUserSearch) {
+            UserSearchView()
+        }
+        .sheet(isPresented: $showNotifications) {
+            NotificationInboxView()
         }
         .onAppear {
             guard !userId.isEmpty else { return }

--- a/Xomfit/Views/MainTabView.swift
+++ b/Xomfit/Views/MainTabView.swift
@@ -1,14 +1,55 @@
 import SwiftUI
 
+// MARK: - MainTabView (now: MainShell)
+//
+// Replaces the previous 4-tab `FloatingTabBar` with a `NavigationStack`-rooted
+// shell that surfaces a left-edge hamburger drawer (#372). The drawer lists
+// every top-level destination (Feed, Workout, Progress, Profile, Reports,
+// Tools, Settings).
+//
+// The type stays named `MainTabView` for binary-compat with `XomfitApp.swift`
+// (and to keep the existing project file pointer stable). All "tab" semantics
+// are gone — what remains is a single active destination + a custom top bar.
+//
+// Existing screens drop their inner `NavigationStack` wrappers and live inside
+// this shell's stack so their `NavigationLink`s and `.navigationDestination`s
+// keep working. Pushed views still get the system navigation bar; the root
+// destination hides it and shows the shell's custom top bar instead.
+
 struct MainTabView: View {
     @Environment(AuthService.self) private var authService
     @Environment(WorkoutLoggerViewModel.self) private var workoutSession
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
-    @State private var selectedTab = 0
-    @State private var tabBarVisible = true
+    // MARK: - Navigation State
+
+    @State private var destination: AppDestination = MainTabView.initialDestination()
+    @State private var isDrawerOpen = false
     @State private var tickId = UUID()
+
+    /// Pulls an optional initial destination from `XOMFIT_INITIAL_DESTINATION`
+    /// (Debug-only). Used by agent UI verification (#372) to land directly on a
+    /// non-Feed destination without scripting taps. Falls back to `.feed`.
+    private static func initialDestination() -> AppDestination {
+        #if DEBUG
+        let raw = ProcessInfo.processInfo.environment["XOMFIT_INITIAL_DESTINATION"]
+        if let raw, let value = AppDestination(rawValue: raw) {
+            return value
+        }
+        #endif
+        return .feed
+    }
+
     /// App-open streak / new-PR celebration toast (#250). Cleared after auto-dismiss.
     @State private var launchBadgeToast: Toast?
+
+    /// Sheets owned by the shell top bar (notifications bell).
+    @State private var showNotifications = false
+
+    /// Local copy of the signed-in user's profile, used to render the drawer
+    /// header without re-fetching every time the drawer opens. Lazily hydrated
+    /// from `ProfileService` after first render.
+    @State private var drawerProfile: DrawerProfile = .empty
 
     /// Theme override from Settings (#312). Empty string = follow system.
     @AppStorage("colorScheme") private var preferredColorSchemeRaw: String = ""
@@ -24,38 +65,69 @@ struct MainTabView: View {
 
     private let resumeTimer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
 
+    /// Default drawer width: ~78% of the screen, clamped so it doesn't grow
+    /// absurd on iPad widths. iOS resolves this via GeometryReader below.
+    private let drawerMaxWidth: CGFloat = 320
+
+    private var drawerAnimation: Animation {
+        reduceMotion ? .linear(duration: 0.0001) : .xomConfident
+    }
+
     var body: some View {
         @Bindable var workoutSession = workoutSession
 
-        ZStack {
-            Group {
-                switch selectedTab {
-                case 0: FeedView()
-                case 1: WorkoutView()
-                case 2: XomProgressView()
-                case 3: ProfileView()
-                default: FeedView()
+        NavigationStack {
+            ZStack(alignment: .topLeading) {
+                // Active destination content
+                Theme.background.ignoresSafeArea()
+
+                VStack(spacing: 0) {
+                    shellTopBar
+                    destinationContent
+                }
+
+                // Dim overlay behind the drawer
+                if isDrawerOpen {
+                    Color.black
+                        .opacity(0.4)
+                        .ignoresSafeArea()
+                        .transition(.opacity)
+                        .onTapGesture {
+                            closeDrawer()
+                        }
+                        .accessibilityHidden(true)
+                }
+
+                // Drawer surface
+                if isDrawerOpen {
+                    GeometryReader { proxy in
+                        let width = min(proxy.size.width * 0.78, drawerMaxWidth)
+                        AppDrawer(
+                            displayName: drawerProfile.displayName,
+                            username: drawerProfile.username,
+                            avatarURL: drawerProfile.avatarURL,
+                            activeDestination: destination,
+                            onSelect: { selected in
+                                select(destination: selected)
+                            },
+                            onSignOut: {
+                                closeDrawer()
+                                Task { await authService.signOut() }
+                            },
+                            onClose: { closeDrawer() }
+                        )
+                        .frame(width: width)
+                        .gesture(drawerCloseDragGesture)
+                    }
+                    .transition(.move(edge: .leading))
+                    .zIndex(1)
                 }
             }
-            .transition(
-                .asymmetric(
-                    insertion: .opacity.combined(with: .offset(y: 8)),
-                    removal: .opacity
-                )
-            )
-            .animation(.spring(response: 0.4, dampingFraction: 0.82), value: selectedTab)
+            .toolbar(.hidden, for: .navigationBar)
+            .animation(drawerAnimation, value: isDrawerOpen)
         }
-        // Tab bar reserves bottom space whenever it's visible.
-        .safeAreaInset(edge: .bottom) {
-            if tabBarVisible {
-                FloatingTabBar(selectedTab: $selectedTab)
-                    .transition(.move(edge: .bottom).combined(with: .opacity))
-                    .animation(.spring(response: 0.4, dampingFraction: 0.82), value: tabBarVisible)
-            }
-        }
-        // Resume bar (#289): when an active workout exists but the cover is dismissed,
-        // reserve real estate above the tab bar so scrollable content (Profile, Workout
-        // list, etc.) is pushed up — never hidden beneath the bar.
+        // Workout resume bar — pinned above home indicator, visible only when a
+        // session exists and its full-screen cover is dismissed.
         .safeAreaInset(edge: .bottom) {
             if workoutSession.isActive && !workoutSession.isPresented {
                 WorkoutResumeBar(
@@ -89,23 +161,216 @@ struct MainTabView: View {
                 // The user must explicitly Discard or Finish to leave the workout.
                 .interactiveDismissDisabled(workoutSession.isActive)
         }
+        .sheet(isPresented: $showNotifications) {
+            NotificationInboxView()
+        }
         .toast($launchBadgeToast)
         .task {
             // App-open streak / PR badge (#250).
-            // Show at most one toast per launch; surface ~1s in so it
-            // doesn't collide with the tab bar's mount animation.
+            // Show at most one toast per launch; surface ~1s in so it doesn't
+            // collide with the shell's mount animation.
             guard let userId = authService.currentUser?.id.uuidString.lowercased() else { return }
             let workouts = WorkoutService.shared.fetchWorkoutsFromCache(userId: userId)
-            guard let badge = BadgeToastService.badgeForLaunch(workouts: workouts) else { return }
-            try? await Task.sleep(for: .seconds(1))
-            launchBadgeToast = Toast(style: .success, message: badge.message)
+            if let badge = BadgeToastService.badgeForLaunch(workouts: workouts) {
+                try? await Task.sleep(for: .seconds(1))
+                launchBadgeToast = Toast(style: .success, message: badge.message)
+            }
         }
-        .environment(\.tabBarVisible, $tabBarVisible)
+        .task(id: authService.currentUser?.id) {
+            await hydrateDrawerProfile()
+        }
+        #if DEBUG
+        .task {
+            // Agent UI verification (#372): when XOMFIT_DRAWER_OPEN=1, force the
+            // drawer open shortly after launch so screenshots can capture it
+            // without needing scripted taps. Compiled out of Release builds.
+            if ProcessInfo.processInfo.environment["XOMFIT_DRAWER_OPEN"] == "1" {
+                try? await Task.sleep(for: .seconds(1))
+                openDrawer()
+            }
+        }
+        #endif
         .preferredColorScheme(resolvedColorScheme)
+    }
+
+    // MARK: - Top Bar
+
+    private var shellTopBar: some View {
+        HStack(spacing: Theme.Spacing.md) {
+            Button {
+                Haptics.light()
+                openDrawer()
+            } label: {
+                XomAvatar(
+                    name: drawerProfile.displayName.isEmpty ? drawerProfile.username : drawerProfile.displayName,
+                    size: 36,
+                    imageURL: drawerProfile.avatarURL
+                )
+                .frame(width: 44, height: 44)
+                .contentShape(Rectangle())
+            }
+            .accessibilityLabel("Open navigation drawer")
+
+            Text(destination.title)
+                .font(.title3.weight(.bold))
+                .foregroundStyle(Theme.textPrimary)
+                .lineLimit(1)
+
+            Spacer(minLength: 0)
+
+            Button {
+                Haptics.light()
+                showNotifications = true
+            } label: {
+                ZStack(alignment: .topTrailing) {
+                    Image(systemName: "bell")
+                        .font(.body.weight(.semibold))
+                        .foregroundStyle(Theme.textPrimary)
+                    if NotificationService.shared.unreadCount > 0 {
+                        Circle()
+                            .fill(Theme.destructive)
+                            .frame(width: Theme.Spacing.sm, height: Theme.Spacing.sm)
+                            .offset(x: 3, y: -3)
+                    }
+                }
+                .frame(width: 44, height: 44)
+                .contentShape(Rectangle())
+            }
+            .accessibilityLabel(NotificationService.shared.unreadCount > 0
+                ? "Notifications, \(NotificationService.shared.unreadCount) unread"
+                : "Notifications")
+        }
+        .padding(.horizontal, Theme.Spacing.md)
+        .padding(.vertical, Theme.Spacing.sm)
+        .background(Theme.background)
+        .overlay(alignment: .bottom) {
+            Rectangle()
+                .fill(Theme.hairline)
+                .frame(height: 0.5)
+        }
+    }
+
+    // MARK: - Destination Switch
+
+    @ViewBuilder
+    private var destinationContent: some View {
+        Group {
+            switch destination {
+            case .feed:     FeedView()
+            case .workout:  WorkoutView()
+            case .progress: XomProgressView()
+            case .profile:  ProfileView()
+            case .reports:  ReportsListView()
+            case .tools:    ToolsView()
+            case .settings: SettingsView()
+            }
+        }
+        .transition(.opacity)
+        .id(destination)
+    }
+
+    // MARK: - Drawer Helpers
+
+    private func openDrawer() {
+        withAnimation(drawerAnimation) {
+            isDrawerOpen = true
+        }
+    }
+
+    private func closeDrawer() {
+        withAnimation(drawerAnimation) {
+            isDrawerOpen = false
+        }
+    }
+
+    private func select(destination newValue: AppDestination) {
+        closeDrawer()
+        // Defer the switch a hair so the close animation reads as intentional.
+        if newValue != destination {
+            withAnimation(.xomChill) {
+                destination = newValue
+            }
+        }
+    }
+
+    /// Swipe-left-to-close gesture wired to the drawer surface.
+    private var drawerCloseDragGesture: some Gesture {
+        DragGesture(minimumDistance: 20)
+            .onEnded { value in
+                // Negative horizontal translation = swipe toward the leading edge.
+                if value.translation.width < -40 {
+                    closeDrawer()
+                }
+            }
+    }
+
+    // MARK: - Drawer Profile Hydration
+
+    private func hydrateDrawerProfile() async {
+        guard let userId = authService.currentUser?.id.uuidString.lowercased() else { return }
+        // Seed from the auth user metadata so the avatar+name show instantly
+        // before the network call resolves. The Supabase `User.userMetadata`
+        // dictionary is keyed by JSON strings.
+        let meta = authService.currentUser?.userMetadata ?? [:]
+        let initialDisplay = stringValue(meta["display_name"]) ?? stringValue(meta["full_name"]) ?? ""
+        let initialUsername = stringValue(meta["username"]) ?? ""
+        if drawerProfile.displayName.isEmpty {
+            drawerProfile = DrawerProfile(
+                displayName: initialDisplay,
+                username: initialUsername,
+                avatarURL: nil
+            )
+        }
+
+        do {
+            let profile = try await ProfileService.shared.fetchProfile(userId: userId)
+            drawerProfile = DrawerProfile(
+                displayName: profile.displayName,
+                username: profile.username,
+                avatarURL: profile.avatarURL.flatMap(URL.init(string:))
+            )
+        } catch {
+            // Non-fatal — drawer still renders with metadata-seeded values or
+            // initials fallback inside XomAvatar.
+        }
+    }
+
+    private func stringValue(_ anyJSON: Any?) -> String? {
+        guard let anyJSON else { return nil }
+        // Supabase `AnyJSON` exposes `.stringValue` in newer SDKs, but to avoid
+        // importing the type here we use Mirror reflection. Fall back to a
+        // raw string if the value is already a String.
+        if let s = anyJSON as? String { return s.isEmpty ? nil : s }
+        let mirror = Mirror(reflecting: anyJSON)
+        if let child = mirror.children.first(where: { $0.label == "string" }),
+           let s = child.value as? String {
+            return s.isEmpty ? nil : s
+        }
+        // Last-ditch: bridge through description for `.string("...")` cases.
+        let desc = String(describing: anyJSON)
+        if desc.hasPrefix("string("), let start = desc.firstIndex(of: "\""), let end = desc.lastIndex(of: "\""), start < end {
+            let value = String(desc[desc.index(after: start)..<end])
+            return value.isEmpty ? nil : value
+        }
+        return nil
     }
 }
 
-// MARK: - Tab Bar Visibility Environment Key
+// MARK: - Drawer Profile
+
+private struct DrawerProfile: Equatable {
+    var displayName: String
+    var username: String
+    var avatarURL: URL?
+
+    static let empty = DrawerProfile(displayName: "", username: "", avatarURL: nil)
+}
+
+// MARK: - Tab Bar Visibility Environment Key (legacy)
+//
+// Kept as a no-op so existing `.hideTabBar()` call sites compile without
+// modification. The hamburger drawer replaces the floating tab bar (#372),
+// so there's nothing to actually hide — the modifier is a graceful shim.
 
 private struct TabBarVisibleKey: EnvironmentKey {
     static let defaultValue: Binding<Bool> = .constant(true)
@@ -118,15 +383,11 @@ extension EnvironmentValues {
     }
 }
 
-/// Apply to any view pushed inside a NavigationStack to hide the floating tab bar.
+/// No-op modifier kept for source compatibility with screens that previously
+/// hid the floating tab bar on push. The drawer replaces the tab bar entirely
+/// (#372); this exists so we don't have to touch ~15 call sites in this PR.
 struct HideTabBar: ViewModifier {
-    @Environment(\.tabBarVisible) private var tabBarVisible
-
-    func body(content: Content) -> some View {
-        content
-            .onAppear { withAnimation(.xomChill) { tabBarVisible.wrappedValue = false } }
-            .onDisappear { withAnimation(.xomChill) { tabBarVisible.wrappedValue = true } }
-    }
+    func body(content: Content) -> some View { content }
 }
 
 extension View {
@@ -137,8 +398,9 @@ extension View {
 
 // MARK: - Workout Resume Bar
 
-/// Compact "Workout in progress" pill shown above the tab bar when a workout is active
-/// but the active workout cover is dismissed. Tap to re-present the cover.
+/// Compact "Workout in progress" pill shown above the home indicator when a
+/// workout is active but the active workout cover is dismissed. Tap to
+/// re-present the cover.
 private struct WorkoutResumeBar: View {
     let workoutName: String
     let durationString: String
@@ -202,63 +464,5 @@ private struct WorkoutResumeBar: View {
             ? "Paused workout \(workoutName.isEmpty ? "Workout" : workoutName)"
             : "Resume workout \(workoutName.isEmpty ? "Workout" : workoutName)")
         .accessibilityHint("Reopens the active workout screen")
-    }
-}
-
-// MARK: - Floating Tab Bar
-
-private struct FloatingTabBar: View {
-    @Binding var selectedTab: Int
-
-    private let tabs: [(icon: String, label: String)] = [
-        ("house.fill", "Feed"),
-        ("dumbbell.fill", "Workout"),
-        ("chart.line.uptrend.xyaxis", "Progress"),
-        ("person.fill", "Profile")
-    ]
-
-    var body: some View {
-        HStack(spacing: 0) {
-            ForEach(tabs.indices, id: \.self) { index in
-                Button {
-                    Haptics.light()
-                    withAnimation(.spring(response: 0.3, dampingFraction: 0.7)) {
-                        selectedTab = index
-                    }
-                } label: {
-                    VStack(spacing: Theme.Spacing.xs) {
-                        Image(systemName: tabs[index].icon)
-                            .font(selectedTab == index ? .title3 : .body)
-                            .symbolEffect(.bounce, value: selectedTab == index)
-
-                        Text(tabs[index].label)
-                            .font(.caption2.weight(.semibold))
-                    }
-                    .foregroundStyle(selectedTab == index ? Theme.accent : Theme.textSecondary)
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, Theme.Spacing.sm)
-                }
-                .accessibilityLabel(tabs[index].label)
-            }
-        }
-        .padding(.horizontal, Theme.Spacing.md)
-        .padding(.top, 12)
-        .safeAreaPadding(.bottom)
-        .background(
-            UnevenRoundedRectangle(
-                topLeadingRadius: Theme.Radius.lg,
-                bottomLeadingRadius: 0,
-                bottomTrailingRadius: 0,
-                topTrailingRadius: Theme.Radius.lg
-            )
-            .fill(.ultraThinMaterial)
-            .overlay(alignment: .top) {
-                // Single 0.5pt top hairline
-                Rectangle()
-                    .fill(Theme.hairline)
-                    .frame(height: 0.5)
-            }
-            .ignoresSafeArea(.container, edges: .bottom)
-        )
     }
 }

--- a/Xomfit/Views/Profile/ProfileView.swift
+++ b/Xomfit/Views/Profile/ProfileView.swift
@@ -18,13 +18,12 @@ struct ProfileView: View {
     }
 
     var body: some View {
-        // Tab root (own profile) gets its own NavigationStack.
-        // Pushed profiles (userId != nil) are already inside a NavigationStack.
+        // Both own-profile (drawer destination) and pushed profiles live
+        // inside `MainTabView`'s NavigationStack (#372). The own-profile case
+        // attaches the toolbar with the edit / settings / AI Coach links.
         if userId == nil {
-            NavigationStack {
-                profileContent
-                    .toolbar { ownProfileToolbar }
-            }
+            profileContent
+                .toolbar { ownProfileToolbar }
         } else {
             profileContent
         }

--- a/Xomfit/Views/Progress/XomProgressView.swift
+++ b/Xomfit/Views/Progress/XomProgressView.swift
@@ -10,30 +10,29 @@ struct XomProgressView: View {
     }
 
     var body: some View {
-        NavigationStack {
-            ZStack {
-                Theme.background.ignoresSafeArea()
+        // Lives inside `MainTabView`'s NavigationStack (#372).
+        ZStack {
+            Theme.background.ignoresSafeArea()
 
-                if viewModel.isLoading {
-                    XomFitLoaderPulse()
-                } else if viewModel.totalWorkouts == 0 {
-                    emptyState
-                } else {
-                    contentView
-                }
+            if viewModel.isLoading {
+                XomFitLoaderPulse()
+            } else if viewModel.totalWorkouts == 0 {
+                emptyState
+            } else {
+                contentView
             }
-            .navigationTitle("Progress")
-            .toolbarColorScheme(.dark, for: .navigationBar)
-            .toolbar {
-                ToolbarItem(placement: .topBarTrailing) {
-                    NavigationLink {
-                        LeaderboardView()
-                    } label: {
-                        Image(systemName: "trophy.fill")
-                            .foregroundStyle(Theme.textPrimary)
-                    }
-                    .accessibilityLabel("Leaderboard")
+        }
+        .navigationTitle("Progress")
+        .toolbarColorScheme(.dark, for: .navigationBar)
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                NavigationLink {
+                    LeaderboardView()
+                } label: {
+                    Image(systemName: "trophy.fill")
+                        .foregroundStyle(Theme.textPrimary)
                 }
+                .accessibilityLabel("Leaderboard")
             }
         }
         .task {

--- a/Xomfit/Views/Tools/ToolsView.swift
+++ b/Xomfit/Views/Tools/ToolsView.swift
@@ -1,0 +1,80 @@
+import SwiftUI
+
+// MARK: - ToolsView
+//
+// Tools destination surfaced via the hamburger drawer (#372). Lists the
+// existing utility tools — Plate Calculator and 1RM Estimator — extracted
+// from the Settings → Tools section so they're discoverable as their own
+// drawer entry. The tool screens themselves remain unchanged and continue
+// to present as sheets.
+
+struct ToolsView: View {
+    @State private var showPlateCalculator = false
+    @State private var showOneRMEstimator = false
+
+    var body: some View {
+        ZStack {
+            Theme.background.ignoresSafeArea()
+
+            List {
+                Section {
+                    Button {
+                        Haptics.selection()
+                        showPlateCalculator = true
+                    } label: {
+                        toolRow(icon: "circle.hexagongrid.fill", label: "Plate Calculator")
+                    }
+                    .buttonStyle(.plain)
+
+                    Button {
+                        Haptics.selection()
+                        showOneRMEstimator = true
+                    } label: {
+                        toolRow(icon: "function", label: "1RM Estimator")
+                    }
+                    .buttonStyle(.plain)
+                } header: {
+                    XomMetricLabel("Tools")
+                }
+                .listRowBackground(Theme.surface)
+                .listRowSeparatorTint(Theme.hairline)
+            }
+            .listStyle(.insetGrouped)
+            .scrollContentBackground(.hidden)
+        }
+        .navigationTitle("Tools")
+        .navigationBarTitleDisplayMode(.large)
+        .toolbarColorScheme(.dark, for: .navigationBar)
+        .sheet(isPresented: $showPlateCalculator) {
+            PlateCalculatorView().presentationDetents([.large])
+        }
+        .sheet(isPresented: $showOneRMEstimator) {
+            OneRMEstimatorView().presentationDetents([.large])
+        }
+    }
+
+    private func toolRow(icon: String, label: String) -> some View {
+        HStack(spacing: Theme.Spacing.md) {
+            Image(systemName: icon)
+                .frame(width: Theme.Spacing.lg)
+                .foregroundStyle(Theme.accent)
+            Text(label)
+                .foregroundStyle(Theme.textPrimary)
+            Spacer()
+            Image(systemName: "chevron.right")
+                .font(.caption2.weight(.semibold))
+                .foregroundStyle(Theme.textTertiary)
+        }
+        .frame(minHeight: 44)
+        .contentShape(Rectangle())
+    }
+}
+
+#if DEBUG
+#Preview {
+    NavigationStack {
+        ToolsView()
+    }
+    .preferredColorScheme(.dark)
+}
+#endif

--- a/Xomfit/Views/Workout/WorkoutView.swift
+++ b/Xomfit/Views/Workout/WorkoutView.swift
@@ -46,101 +46,11 @@ struct WorkoutView: View {
     }
 
     var body: some View {
-        NavigationStack {
-            ZStack {
-                Theme.background.ignoresSafeArea()
-
-                VStack(spacing: 0) {
-                    ScrollView {
-                        VStack(spacing: Theme.Spacing.sm) {
-                            // Start Workout CTA
-                            Button {
-                                Haptics.light()
-                                pendingWorkoutName = ""
-                                showNameEntry = true
-                            } label: {
-                                HStack(spacing: 10) {
-                                    Image(systemName: "play.fill")
-                                    Text("Start Workout")
-                                }
-                            }
-                            .buttonStyle(AccentButtonStyle())
-                            .padding(.horizontal, Theme.Spacing.md)
-                            .padding(.top, Theme.Spacing.md)
-                            .simultaneousGesture(
-                                LongPressGesture(minimumDuration: 0.6).onEnded { _ in
-                                    // Long-press resets the warmup preference so the prompt shows again.
-                                    Haptics.medium()
-                                    warmupOptIn = ""
-                                    pendingWorkoutName = ""
-                                    showNameEntry = true
-                                }
-                            )
-                            .accessibilityHint("Long press to reset warmup preference")
-
-                            // Build Workout + Log Past Workout (side-by-side)
-                            HStack(spacing: Theme.Spacing.sm) {
-                                Button {
-                                    Haptics.light()
-                                    showBuilder = true
-                                } label: {
-                                    HStack(spacing: Theme.Spacing.sm) {
-                                        Image(systemName: "hammer.fill")
-                                        Text("Build")
-                                    }
-                                }
-                                .buttonStyle(GhostButtonStyle())
-
-                                Button {
-                                    Haptics.light()
-                                    showLogPastWorkout = true
-                                } label: {
-                                    HStack(spacing: Theme.Spacing.sm) {
-                                        Image(systemName: "calendar.badge.clock")
-                                        Text("Log Past")
-                                    }
-                                }
-                                .buttonStyle(GhostButtonStyle())
-                                .accessibilityLabel("Log a past workout")
-                            }
-                            .padding(.horizontal, Theme.Spacing.md)
-
-                            // First workout guide for new users (#310).
-                            // Persist this card even after recents arrive — gate
-                            // only on whether the user has built/saved their own
-                            // template (myTemplates + savedTemplates), plus the
-                            // manual "Skip" escape hatch.
-                            if viewModel.myTemplates.isEmpty
-                                && viewModel.savedTemplates.isEmpty
-                                && !hasStartedFirstWorkout {
-                                firstWorkoutCard
-                            }
-
-                            // Category segmented nav + selected list (#338)
-                            WorkoutCategoryTabs(selection: $selectedCategory)
-                                .padding(.top, Theme.Spacing.sm)
-
-                            WorkoutCategoryListView(category: selectedCategory, viewModel: viewModel)
-                        }
-                    }
-                    // #339: lift bottom of scroll content above the floating tab
-                    // bar + resume bar so the last item isn't hidden under chrome.
-                    .safeAreaPadding(.bottom, Theme.Spacing.md)
-                }
-            }
-            .navigationTitle("Workout")
-            .navigationBarTitleDisplayMode(.large)
-            .toolbarColorScheme(.dark, for: .navigationBar)
-            .task {
-                await viewModel.load(userId: userId)
-            }
-            .onChange(of: workoutSession.isPresented) { _, isPresented in
-                if !isPresented {
-                    Task { await viewModel.load(userId: userId) }
-                }
-            }
-        }
-        .alert("Name Your Workout", isPresented: $showNameEntry) {
+        // Lives inside `MainTabView`'s NavigationStack (#372). Sheets and the
+        // warmup full-screen cover stay attached at the root of the view so
+        // they can re-present after the drawer closes.
+        workoutRoot
+            .alert("Name Your Workout", isPresented: $showNameEntry) {
             TextField("e.g. Push Day", text: $pendingWorkoutName)
             Button("Start") {
                 let name = pendingWorkoutName.isEmpty ? "Workout" : pendingWorkoutName
@@ -201,6 +111,103 @@ struct WorkoutView: View {
                     workoutSession.startFromTemplate(captured, userId: userId)
                     workoutSession.isPresented = true
                 }
+            }
+        }
+    }
+
+    // MARK: - Root
+
+    private var workoutRoot: some View {
+        ZStack {
+            Theme.background.ignoresSafeArea()
+
+            VStack(spacing: 0) {
+                ScrollView {
+                    VStack(spacing: Theme.Spacing.sm) {
+                        // Start Workout CTA
+                        Button {
+                            Haptics.light()
+                            pendingWorkoutName = ""
+                            showNameEntry = true
+                        } label: {
+                            HStack(spacing: 10) {
+                                Image(systemName: "play.fill")
+                                Text("Start Workout")
+                            }
+                        }
+                        .buttonStyle(AccentButtonStyle())
+                        .padding(.horizontal, Theme.Spacing.md)
+                        .padding(.top, Theme.Spacing.md)
+                        .simultaneousGesture(
+                            LongPressGesture(minimumDuration: 0.6).onEnded { _ in
+                                // Long-press resets the warmup preference so the prompt shows again.
+                                Haptics.medium()
+                                warmupOptIn = ""
+                                pendingWorkoutName = ""
+                                showNameEntry = true
+                            }
+                        )
+                        .accessibilityHint("Long press to reset warmup preference")
+
+                        // Build Workout + Log Past Workout (side-by-side)
+                        HStack(spacing: Theme.Spacing.sm) {
+                            Button {
+                                Haptics.light()
+                                showBuilder = true
+                            } label: {
+                                HStack(spacing: Theme.Spacing.sm) {
+                                    Image(systemName: "hammer.fill")
+                                    Text("Build")
+                                }
+                            }
+                            .buttonStyle(GhostButtonStyle())
+
+                            Button {
+                                Haptics.light()
+                                showLogPastWorkout = true
+                            } label: {
+                                HStack(spacing: Theme.Spacing.sm) {
+                                    Image(systemName: "calendar.badge.clock")
+                                    Text("Log Past")
+                                }
+                            }
+                            .buttonStyle(GhostButtonStyle())
+                            .accessibilityLabel("Log a past workout")
+                        }
+                        .padding(.horizontal, Theme.Spacing.md)
+
+                        // First workout guide for new users (#310).
+                        // Persist this card even after recents arrive — gate
+                        // only on whether the user has built/saved their own
+                        // template (myTemplates + savedTemplates), plus the
+                        // manual "Skip" escape hatch.
+                        if viewModel.myTemplates.isEmpty
+                            && viewModel.savedTemplates.isEmpty
+                            && !hasStartedFirstWorkout {
+                            firstWorkoutCard
+                        }
+
+                        // Category segmented nav + selected list (#338)
+                        WorkoutCategoryTabs(selection: $selectedCategory)
+                            .padding(.top, Theme.Spacing.sm)
+
+                        WorkoutCategoryListView(category: selectedCategory, viewModel: viewModel)
+                    }
+                }
+                // #339: lift bottom of scroll content above the resume bar so
+                // the last item isn't hidden under chrome.
+                .safeAreaPadding(.bottom, Theme.Spacing.md)
+            }
+        }
+        .navigationTitle("Workout")
+        .navigationBarTitleDisplayMode(.large)
+        .toolbarColorScheme(.dark, for: .navigationBar)
+        .task {
+            await viewModel.load(userId: userId)
+        }
+        .onChange(of: workoutSession.isPresented) { _, isPresented in
+            if !isPresented {
+                Task { await viewModel.load(userId: userId) }
             }
         }
     }


### PR DESCRIPTION
Closes #372.

- New AppDrawer with header + 7 destinations (Feed/Workout/Progress/Profile/Reports/Tools/Settings) + Sign Out
- MainTabView rewritten as a NavigationStack-rooted shell with custom top bar (avatar / title / bell)
- Inner NavigationStacks removed from Feed/Workout/Progress/Profile (shell owns the one stack)
- WorkoutResumeBar + ActiveWorkoutView cover preserved
- New Xomfit/Views/Tools/ToolsView.swift extracts Plate Calc + 1RM rows
- Tap-outside / swipe-left / X close drawer
- Reduce Motion respected
- DEBUG env vars XOMFIT_DRAWER_OPEN + XOMFIT_INITIAL_DESTINATION for agent verification
- Agent verified each destination renders with screenshots