### PR TITLE
feat(music): live capture indicator + resume-bar count + Spotify connection polish

### DIFF
--- a/Xomfit/Services/NowPlayingService.swift
+++ b/Xomfit/Services/NowPlayingService.swift
@@ -16,17 +16,35 @@ import MediaPlayer
 /// the only workarounds are (a) being the audio app yourself, or (b) private API
 /// (rejected at App Review). v1 ships the Apple Music capture only.
 @MainActor
+@Observable
 final class NowPlayingService {
-    static let shared = NowPlayingService()
+    @ObservationIgnored static let shared = NowPlayingService()
 
     /// 30s polling cadence — frequent enough to catch song changes, cheap enough to avoid wakelock pressure.
-    private let pollInterval: TimeInterval = 30
+    @ObservationIgnored private let pollInterval: TimeInterval = 30
 
     /// Accumulated tracks for the current capture session, deduped by `dedupeKey`.
     private var captured: [WorkoutTrack] = []
-    private var seenKeys: Set<String> = []
-    private var pollTask: Task<Void, Never>?
-    private var isAuthorized: Bool = false
+    @ObservationIgnored private var seenKeys: Set<String> = []
+    @ObservationIgnored private var pollTask: Task<Void, Never>?
+    @ObservationIgnored private var isAuthorized: Bool = false
+
+    /// Becomes true after the user explicitly denies Apple Music access. Used to suppress
+    /// repeated `MPMediaLibrary.requestAuthorization` traffic and noisy logs across multiple
+    /// `startCapture()` invocations within the same app launch — see `ensureAuthorization`.
+    @ObservationIgnored private var deniedNoticed: Bool = false
+
+    // MARK: - Observable surface (Spotify capture polish)
+
+    /// True while the poll loop is alive AND auth is granted. Drives the active-workout
+    /// "Recording soundtrack" pill. Reset by `stopCapture`.
+    private(set) var isCapturing: Bool = false
+
+    /// Number of unique tracks captured in the current session.
+    var capturedCount: Int { captured.count }
+
+    /// Most recent track captured this session (or the last completed session).
+    private(set) var lastCapturedTrack: WorkoutTrack?
 
     private init() {}
 
@@ -34,13 +52,19 @@ final class NowPlayingService {
 
     /// Triggers the system Apple Music auth prompt the first time. Subsequent calls
     /// are cheap — they just refresh the cached `isAuthorized` flag.
+    ///
+    /// When the user has previously denied access, this is a silent no-op after the first
+    /// observation: we log once via `deniedNoticed` and never re-poke the system. The
+    /// Soundtrack section on `WorkoutDetailView` already explains the limitation + steers
+    /// the user toward Spotify as the alternative.
     func ensureAuthorization() async {
         let status = MPMediaLibrary.authorizationStatus()
-        print("[NowPlayingService] authorizationStatus = \(status.rawValue)")
         switch status {
         case .authorized:
+            if !isAuthorized {
+                print("[NowPlayingService] authorized — polling will run")
+            }
             isAuthorized = true
-            print("[NowPlayingService] authorized — polling will run")
         case .notDetermined:
             print("[NowPlayingService] not determined — requesting authorization")
             let result = await withCheckedContinuation { (continuation: CheckedContinuation<MPMediaLibraryAuthorizationStatus, Never>) in
@@ -50,12 +74,23 @@ final class NowPlayingService {
             }
             isAuthorized = (result == .authorized)
             print("[NowPlayingService] authorization result: \(result.rawValue), isAuthorized=\(isAuthorized)")
+            if result == .denied {
+                // Mark deniedNoticed so subsequent startCapture invocations skip the noisy
+                // "denied/restricted" branch logging without us re-prompting the system.
+                deniedNoticed = true
+            }
         case .denied, .restricted:
             isAuthorized = false
-            print("[NowPlayingService] access denied/restricted — no track capture will occur")
+            if !deniedNoticed {
+                print("[NowPlayingService] access denied/restricted — Apple Music capture disabled for this session; Spotify capture (if connected) still runs")
+                deniedNoticed = true
+            }
         @unknown default:
             isAuthorized = false
-            print("[NowPlayingService] unknown auth status \(status.rawValue) — defaulting to denied")
+            if !deniedNoticed {
+                print("[NowPlayingService] unknown auth status \(status.rawValue) — defaulting to denied")
+                deniedNoticed = true
+            }
         }
     }
 
@@ -67,6 +102,7 @@ final class NowPlayingService {
         // Reset session state up-front so a back-to-back start clears prior captures
         captured.removeAll()
         seenKeys.removeAll()
+        lastCapturedTrack = nil
         pollTask?.cancel()
 
         // Kick off auth check + first poll. If auth lands on denied, the polling loop
@@ -75,9 +111,11 @@ final class NowPlayingService {
             guard let self else { return }
             await self.ensureAuthorization()
             guard self.isAuthorized else {
-                print("[NowPlayingService] startCapture: not authorized, polling will not run")
+                // Silent skip — deniedNoticed gates repeat logging in `ensureAuthorization`.
+                self.isCapturing = false
                 return
             }
+            self.isCapturing = true
             print("[NowPlayingService] polling started — interval=\(self.pollInterval)s")
             // Capture immediately so a song already playing at workout start is recorded.
             self.captureCurrentTrack()
@@ -91,13 +129,15 @@ final class NowPlayingService {
         }
     }
 
-    /// Stops polling and returns the captured list. Clears internal state so the next
-    /// `startCapture()` begins fresh.
+    /// Stops polling and returns the captured list. Clears in-flight state so the next
+    /// `startCapture()` begins fresh. `lastCapturedTrack` is retained across stop/start so
+    /// Settings can still show the most recent capture between sessions.
     @discardableResult
     func stopCapture() -> [WorkoutTrack] {
         print("[NowPlayingService] stopCapture called — \(captured.count) track(s) captured")
         pollTask?.cancel()
         pollTask = nil
+        isCapturing = false
         let result = captured
         captured.removeAll()
         seenKeys.removeAll()
@@ -139,6 +179,7 @@ final class NowPlayingService {
             sourceApp: "Apple Music"
         )
         captured.append(track)
+        lastCapturedTrack = track
         print("[NowPlayingService] captured '\(title)' by \(item.artist ?? "unknown") — total: \(captured.count)")
     }
 

--- a/Xomfit/Services/SpotifyNowPlayingService.swift
+++ b/Xomfit/Services/SpotifyNowPlayingService.swift
@@ -13,15 +13,30 @@ import Foundation
 /// If `SpotifyAuthService.shared.currentTokenRefreshingIfNeeded()` returns nil (user never signed
 /// in, or token revoked) the polling loop simply no-ops on each tick. No prompts, no errors.
 @MainActor
+@Observable
 final class SpotifyNowPlayingService {
-    static let shared = SpotifyNowPlayingService()
+    @ObservationIgnored static let shared = SpotifyNowPlayingService()
 
     /// 30s cadence — matches `NowPlayingService` and stays well under Spotify's rate limit.
-    private let pollInterval: TimeInterval = 30
+    @ObservationIgnored private let pollInterval: TimeInterval = 30
 
     private var captured: [WorkoutTrack] = []
-    private var seenKeys: Set<String> = []
-    private var pollTask: Task<Void, Never>?
+    @ObservationIgnored private var seenKeys: Set<String> = []
+    @ObservationIgnored private var pollTask: Task<Void, Never>?
+
+    // MARK: - Observable surface (Spotify capture polish)
+
+    /// True while the poll loop is alive. Drives the "Recording soundtrack" pill + the
+    /// Settings pulse indicator. Reset by `stopCapture`.
+    private(set) var isCapturing: Bool = false
+
+    /// Number of unique tracks captured in the current session — surfaced in the resume bar
+    /// and the active-workout popover. Stays in sync with `captured.count`.
+    var capturedCount: Int { captured.count }
+
+    /// Most recent track added in this session, if any. Surfaced in `SpotifyConnectionView` so
+    /// the user can confirm capture is working without opening an active workout.
+    private(set) var lastCapturedTrack: WorkoutTrack?
 
     private init() {}
 
@@ -33,7 +48,9 @@ final class SpotifyNowPlayingService {
         print("[SpotifyNowPlayingService] startCapture called — resetting session state")
         captured.removeAll()
         seenKeys.removeAll()
+        lastCapturedTrack = nil
         pollTask?.cancel()
+        isCapturing = true
 
         pollTask = Task { [weak self] in
             guard let self else { return }
@@ -49,12 +66,15 @@ final class SpotifyNowPlayingService {
         }
     }
 
-    /// Stop polling and return the captured tracks. Clears state for the next session.
+    /// Stop polling and return the captured tracks. Clears the live state but keeps
+    /// `lastCapturedTrack` so Settings can still display the most recent capture between
+    /// sessions.
     @discardableResult
     func stopCapture() -> [WorkoutTrack] {
         print("[SpotifyNowPlayingService] stopCapture called — \(captured.count) track(s) captured")
         pollTask?.cancel()
         pollTask = nil
+        isCapturing = false
         let result = captured
         captured.removeAll()
         seenKeys.removeAll()
@@ -122,6 +142,7 @@ final class SpotifyNowPlayingService {
                 sourceApp: "Spotify"
             )
             captured.append(track)
+            lastCapturedTrack = track
             print("[SpotifyNowPlayingService] captured '\(title)' by \(artist ?? "unknown") — total: \(captured.count)")
         } catch {
             // Network blips happen — log and continue. Polling will retry on the next tick.

--- a/Xomfit/Views/MainTabView.swift
+++ b/Xomfit/Views/MainTabView.swift
@@ -65,6 +65,12 @@ struct MainTabView: View {
 
     private let resumeTimer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
 
+    /// Observable mirrors of the Now Playing capture services. Used by the resume bar to
+    /// show a live track count while the active-workout cover is dismissed. Reading these
+    /// here subscribes the shell to capture-state changes via the `@Observable` macro.
+    @State private var spotifyCapture = SpotifyNowPlayingService.shared
+    @State private var appleMusicCapture = NowPlayingService.shared
+
     /// Default drawer width: ~78% of the screen, clamped so it doesn't grow
     /// absurd on iPad widths. iOS resolves this via GeometryReader below.
     private let drawerMaxWidth: CGFloat = 320
@@ -135,6 +141,10 @@ struct MainTabView: View {
                     durationString: workoutSession.durationString,
                     isPaused: workoutSession.isPaused,
                     tickId: tickId,
+                    // Live-updating via `@Observable` on the singletons (Spotify capture
+                    // polish). When the workout is active and tracks have been captured,
+                    // the resume bar surfaces a subtle "💿 N tracks" label.
+                    capturedTrackCount: spotifyCapture.capturedCount + appleMusicCapture.capturedCount,
                     onTap: {
                         withAnimation(.spring(response: 0.35, dampingFraction: 0.82)) {
                             workoutSession.isPresented = true
@@ -407,6 +417,9 @@ private struct WorkoutResumeBar: View {
     let isPaused: Bool
     /// Drives re-render of the duration string every second. Owner updates this.
     let tickId: UUID
+    /// Live track count from `SpotifyNowPlayingService` + `NowPlayingService`. Rendered
+    /// as a subtle disc label when > 0 (Spotify capture polish).
+    let capturedTrackCount: Int
     let onTap: () -> Void
 
     var body: some View {
@@ -427,16 +440,28 @@ private struct WorkoutResumeBar: View {
                         .font(.subheadline.weight(.semibold))
                         .foregroundStyle(Theme.textPrimary)
                         .lineLimit(1)
-                    if isPaused {
-                        Text("Paused")
-                            .font(.caption.weight(.semibold))
-                            .foregroundStyle(Theme.textSecondary)
-                    } else {
-                        Text(durationString)
-                            .font(.caption.weight(.medium))
-                            .foregroundStyle(Theme.textSecondary)
-                            .monospacedDigit()
-                            .id(tickId)
+                    HStack(spacing: Theme.Spacing.xs) {
+                        if isPaused {
+                            Text("Paused")
+                                .font(.caption.weight(.semibold))
+                                .foregroundStyle(Theme.textSecondary)
+                        } else {
+                            Text(durationString)
+                                .font(.caption.weight(.medium))
+                                .foregroundStyle(Theme.textSecondary)
+                                .monospacedDigit()
+                                .id(tickId)
+                        }
+                        if capturedTrackCount > 0 {
+                            HStack(spacing: 3) {
+                                Image(systemName: "opticaldisc.fill")
+                                    .font(.caption2)
+                                Text("\(capturedTrackCount) track\(capturedTrackCount == 1 ? "" : "s")")
+                                    .font(.caption.weight(.medium).monospacedDigit())
+                            }
+                            .foregroundStyle(Theme.accent)
+                            .accessibilityLabel("\(capturedTrackCount) track\(capturedTrackCount == 1 ? "" : "s") captured")
+                        }
                     }
                 }
 

--- a/Xomfit/Views/Profile/SpotifyConnectionView.swift
+++ b/Xomfit/Views/Profile/SpotifyConnectionView.swift
@@ -15,11 +15,21 @@ struct SpotifyConnectionView: View {
     @State private var isSigningIn: Bool = false
     @State private var errorMessage: String? = nil
 
+    /// Observable mirror of the Spotify capture loop. Drives the "last captured track"
+    /// line + the active-polling pulse indicator on the header (Spotify capture polish).
+    @State private var spotifyCapture = SpotifyNowPlayingService.shared
+
     var body: some View {
         VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
             header
 
             clientIdField
+
+            // Surface the most recent capture, if any, so the user can confirm capture is
+            // working without opening an active workout (Spotify capture polish).
+            if spotifyAuth.isAuthenticated, let last = spotifyCapture.lastCapturedTrack {
+                lastCapturedRow(track: last)
+            }
 
             actionButton
 
@@ -51,7 +61,56 @@ struct SpotifyConnectionView: View {
                     .accessibilityLabel(spotifyAuth.isAuthenticated ? "Spotify connected" : "Spotify not connected")
             }
             Spacer()
+            // Live polling indicator (Spotify capture polish). Visible only while a
+            // workout is in progress AND the Spotify poll loop is alive.
+            if spotifyCapture.isCapturing {
+                pollingPulse
+            }
         }
+    }
+
+    /// Tiny pulsing accent dot — communicates "capture is running right now".
+    private var pollingPulse: some View {
+        TimelineView(.animation(minimumInterval: 1.1, paused: false)) { context in
+            let phase = context.date.timeIntervalSinceReferenceDate
+            let alpha = 0.45 + 0.55 * abs(sin(phase * 1.4))
+            HStack(spacing: 4) {
+                Circle()
+                    .fill(Theme.accent)
+                    .frame(width: 8, height: 8)
+                    .opacity(alpha)
+                Text("Recording")
+                    .font(.caption2.weight(.bold))
+                    .foregroundStyle(Theme.accent)
+                    .accessibilityHidden(true)
+            }
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel("Spotify capture in progress")
+        }
+    }
+
+    /// One-line "Last captured: Title — Artist" display so the user can confirm capture
+    /// is working without finishing the workout.
+    private func lastCapturedRow(track: WorkoutTrack) -> some View {
+        HStack(spacing: Theme.Spacing.md) {
+            Image(systemName: "waveform")
+                .frame(width: Theme.Spacing.lg)
+                .foregroundStyle(Theme.accent)
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Last captured")
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(Theme.textTertiary)
+                Text(track.artist?.isEmpty == false
+                     ? "\(track.title) — \(track.artist ?? "")"
+                     : track.title)
+                    .font(Theme.fontCaption)
+                    .foregroundStyle(Theme.textSecondary)
+                    .lineLimit(1)
+            }
+            Spacer()
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Last captured: \(track.title)\(track.artist.map { ", by \($0)" } ?? "")")
     }
 
     private var clientIdField: some View {

--- a/Xomfit/Views/Workout/ActiveWorkoutView.swift
+++ b/Xomfit/Views/Workout/ActiveWorkoutView.swift
@@ -23,6 +23,15 @@ struct ActiveWorkoutView: View {
     /// to scroll to the picked card, then cleared.
     @State private var pendingScrollIndex: Int?
 
+    // Soundtrack-capture popover (Spotify capture polish). Tapping the
+    // "Recording soundtrack" pill in the footer opens a small disclosure with
+    // the captured-tracks-so-far count + most recently captured track per source.
+    @State private var showSoundtrackPopover = false
+    /// Live mirrors of the singleton capture services. Used purely to subscribe to
+    /// `@Observable` changes — calls still go through `.shared`.
+    @State private var spotifyCapture = SpotifyNowPlayingService.shared
+    @State private var appleMusicCapture = NowPlayingService.shared
+
     // First-run polish (#310)
     /// Persisted flag — once dismissed, the active-workout tutorial overlay never re-shows.
     @AppStorage("xomfit_first_workout_tutorial_seen") private var firstTutorialSeen = false
@@ -139,8 +148,16 @@ struct ActiveWorkoutView: View {
                 // The scrollview above reserves bottom inset via
                 // `.contentMargins` so this FAB never sits on top of set rows.
                 if !viewModel.focusMode {
-                    VStack {
+                    VStack(spacing: Theme.Spacing.xs) {
                         Spacer()
+
+                        // Soundtrack capture pill (Spotify capture polish). Visible
+                        // only while at least one capture loop is alive. Tap opens
+                        // the captured-tracks-so-far popover.
+                        if spotifyCapture.isCapturing || appleMusicCapture.isCapturing {
+                            soundtrackCapturePill
+                        }
+
                         XomButton("Add Exercise", variant: .primary, icon: "plus") {
                             showExercisePicker = true
                         }
@@ -608,6 +625,130 @@ struct ActiveWorkoutView: View {
         }
         .padding(.horizontal, Theme.Spacing.md)
         .padding(.vertical, Theme.Spacing.sm)
+    }
+
+    // MARK: - Soundtrack Capture Pill (Spotify capture polish)
+
+    /// Compact, accent-tinted pill telling the user that workout music capture is running.
+    /// One pill total — sources are summarized in the label and the popover. Hidden when
+    /// neither service is actively polling.
+    private var soundtrackCapturePill: some View {
+        Button {
+            Haptics.light()
+            showSoundtrackPopover = true
+        } label: {
+            HStack(spacing: Theme.Spacing.xs) {
+                Image(systemName: "music.note")
+                    .font(.caption.weight(.bold))
+                Text(soundtrackPillLabel)
+                    .font(.caption.weight(.semibold))
+                    .lineLimit(1)
+                if totalCapturedCount > 0 {
+                    Text("\(totalCapturedCount)")
+                        .font(.caption2.weight(.heavy).monospacedDigit())
+                        .foregroundStyle(Theme.accent)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 1)
+                        .background(Theme.accent.opacity(0.22), in: Capsule())
+                }
+            }
+            .foregroundStyle(Theme.accent)
+            .padding(.horizontal, Theme.Spacing.sm)
+            .padding(.vertical, 6)
+            .frame(minHeight: 32)
+            .background(Theme.accent.opacity(0.12), in: Capsule())
+            .overlay(Capsule().stroke(Theme.accent.opacity(0.35), lineWidth: 0.5))
+            .contentShape(Capsule())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(soundtrackPillAccessibilityLabel)
+        .accessibilityHint("Shows the songs captured so far for this workout's soundtrack")
+        .popover(isPresented: $showSoundtrackPopover, attachmentAnchor: .point(.top)) {
+            soundtrackPopoverContent
+                .presentationCompactAdaptation(.popover)
+        }
+    }
+
+    /// Pill label — composes from whichever services are currently capturing.
+    private var soundtrackPillLabel: String {
+        switch (spotifyCapture.isCapturing, appleMusicCapture.isCapturing) {
+        case (true, true):  return "Recording soundtrack"
+        case (true, false): return "Recording soundtrack via Spotify"
+        case (false, true): return "Recording soundtrack via Apple Music"
+        case (false, false): return "Recording soundtrack" // unreachable — pill is hidden
+        }
+    }
+
+    private var soundtrackPillAccessibilityLabel: String {
+        let count = totalCapturedCount
+        let countSuffix = count == 0
+            ? "no tracks yet"
+            : "\(count) track\(count == 1 ? "" : "s") captured"
+        return "\(soundtrackPillLabel), \(countSuffix)"
+    }
+
+    private var totalCapturedCount: Int {
+        spotifyCapture.capturedCount + appleMusicCapture.capturedCount
+    }
+
+    /// Popover content surfacing per-source counts + last captured track so the user can
+    /// confirm capture is working without finishing the workout.
+    private var soundtrackPopoverContent: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.md) {
+            HStack(spacing: Theme.Spacing.sm) {
+                Image(systemName: "music.note.list")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(Theme.accent)
+                Text("Soundtrack capture")
+                    .font(.subheadline.weight(.bold))
+                    .foregroundStyle(Theme.textPrimary)
+            }
+
+            if spotifyCapture.isCapturing {
+                soundtrackPopoverSource(
+                    name: "Spotify",
+                    count: spotifyCapture.capturedCount,
+                    last: spotifyCapture.lastCapturedTrack
+                )
+            }
+            if appleMusicCapture.isCapturing {
+                soundtrackPopoverSource(
+                    name: "Apple Music",
+                    count: appleMusicCapture.capturedCount,
+                    last: appleMusicCapture.lastCapturedTrack
+                )
+            }
+
+            if totalCapturedCount == 0 {
+                Text("Nothing captured yet — start playing music and we'll log it.")
+                    .font(Theme.fontCaption)
+                    .foregroundStyle(Theme.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .padding(Theme.Spacing.md)
+        .frame(minWidth: 240, maxWidth: 300)
+    }
+
+    private func soundtrackPopoverSource(name: String, count: Int, last: WorkoutTrack?) -> some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.tighter) {
+            HStack {
+                Text(name)
+                    .font(.caption.weight(.bold))
+                    .foregroundStyle(Theme.textPrimary)
+                Spacer()
+                Text("\(count) track\(count == 1 ? "" : "s")")
+                    .font(.caption.weight(.semibold).monospacedDigit())
+                    .foregroundStyle(Theme.textSecondary)
+            }
+            if let last {
+                Text("Last: \(last.title)\(last.artist.map { " — \($0)" } ?? "")")
+                    .font(Theme.fontSmall)
+                    .foregroundStyle(Theme.textSecondary)
+                    .lineLimit(2)
+            }
+        }
+        .accessibilityElement(children: .combine)
     }
 
     // MARK: - Empty State

--- a/Xomfit/Views/Workout/WorkoutDetailView.swift
+++ b/Xomfit/Views/Workout/WorkoutDetailView.swift
@@ -446,11 +446,11 @@ struct WorkoutDetailView: View {
             }
 
             if workout.tracks.isEmpty {
-                Text("No tracks captured. Tip: Now Playing capture works with Apple Music.")
+                Text("No tracks captured. iOS only exposes Apple Music's Now Playing to third-party apps — connect Spotify in Settings to capture from there too.")
                     .font(Theme.fontSmall)
                     .foregroundStyle(Theme.textSecondary)
                     .fixedSize(horizontal: false, vertical: true)
-                    .accessibilityLabel("No tracks captured during this workout")
+                    .accessibilityLabel("No tracks captured during this workout. Connect Spotify in Settings to capture from Spotify too.")
             } else {
                 VStack(spacing: 0) {
                     ForEach(Array(workout.tracks.enumerated()), id: \.element.id) { index, track in


### PR DESCRIPTION
NowPlayingService and SpotifyNowPlayingService are now @Observable with isCapturing / capturedCount / lastCapturedTrack. ActiveWorkoutView shows a 'Recording soundtrack' pill (popover with per-source counts + last track). WorkoutResumeBar shows '💿 N tracks' when capture is active. SpotifyConnectionView shows 'Last captured: Track — Artist' + pulse indicator while polling. WorkoutDetailView empty-state mentions Spotify as alternative. AppleMusic denial logs once + silently no-ops.