### PR TITLE
feat(watch): wire DoneSet → completeSet + connection status indicator

### DIFF
--- a/Xomfit/Services/WatchSyncService.swift
+++ b/Xomfit/Services/WatchSyncService.swift
@@ -10,6 +10,9 @@
 //    WorkoutLoggerViewModel.updateLiveActivity() {
 //        WatchSyncService.shared.send(state: snapshot)
 //    }
+//    WatchSyncService.shared.onDoneSetReceived = { [weak vm] in
+//        vm?.completeFocusedSetFromWatch()
+//    }
 //
 //  This file MUST compile against the iOS target alone — it does NOT depend
 //  on any watchOS-only API. Receive callbacks are routed through a nonisolated
@@ -17,6 +20,7 @@
 //
 
 import Foundation
+import Observation
 import WatchConnectivity
 
 /// Singleton iOS->watch broadcaster.
@@ -25,8 +29,23 @@ import WatchConnectivity
 /// - Otherwise falls back to `updateApplicationContext` so the watch can pick
 ///   up the latest state on cold launch / wake.
 @MainActor
+@Observable
 final class WatchSyncService {
     static let shared = WatchSyncService()
+
+    /// True when a watch is paired AND the companion watch app is installed.
+    /// Observable so the iOS UI can render a "watch connected" indicator
+    /// (see `WorkoutResumeBar` + `ActiveWorkoutView.headerBar`). Refreshed on
+    /// activation and whenever the WCSessionDelegate reports a watch state
+    /// change.
+    private(set) var isWatchAvailable: Bool = false
+
+    /// Closure invoked when the watch sends `["doneSet": true]`. Wired by the
+    /// view model so the watch's "Done Set" button can complete the focused
+    /// set on iOS. See `WorkoutLoggerViewModel.completeFocusedSetFromWatch()`
+    /// for idempotency guarantees — multiple inbound events within a short
+    /// window collapse into a single completion.
+    var onDoneSetReceived: (@MainActor () -> Void)?
 
     private let delegateShim = WatchSyncDelegate()
     private var didActivate = false
@@ -43,12 +62,14 @@ final class WatchSyncService {
         let session = WCSession.default
         session.delegate = delegateShim
         session.activate()
+        // `isPaired` / `isWatchAppInstalled` aren't valid until activation
+        // completes — the delegate refreshes `isWatchAvailable` for us.
     }
 
     /// Push a state snapshot to the watch.
     ///
     /// Strategy:
-    ///  1. If the session is activated AND the watch is reachable → `sendMessage`
+    ///  1. If the session is activated AND the watch is reachable -> `sendMessage`
     ///     (low-latency, in-memory only).
     ///  2. Always also stash the latest state in `applicationContext` so the
     ///     watch picks it up on cold launch / re-wake.
@@ -80,14 +101,39 @@ final class WatchSyncService {
 
     // MARK: - Inbound (watch -> iOS)
 
-    /// Closure invoked when the watch sends `["doneSet": true]`. Wired by the
-    /// view model so the watch's "Done Set" button can complete the focused set.
-    var onDoneSetReceived: (@MainActor () -> Void)?
+    /// Minimum gap between two accepted `doneSet` events. WCSession will
+    /// occasionally deliver the same message twice (once via `sendMessage`
+    /// and once via `transferUserInfo` fallback) — without dedup we'd
+    /// toggle the set OFF on the second event.
+    private static let doneSetDebounceInterval: TimeInterval = 0.75
+    private var lastDoneSetAt: Date?
 
     fileprivate func handle(message: [String: Any]) {
         if let done = message["doneSet"] as? Bool, done {
+            let now = Date()
+            if let last = lastDoneSetAt,
+               now.timeIntervalSince(last) < Self.doneSetDebounceInterval {
+                #if DEBUG
+                print("[WatchSync] doneSet ignored (debounced)")
+                #endif
+                return
+            }
+            lastDoneSetAt = now
             onDoneSetReceived?()
         }
+    }
+
+    fileprivate func refreshWatchAvailability() {
+        guard WCSession.isSupported() else {
+            isWatchAvailable = false
+            return
+        }
+        let session = WCSession.default
+        guard session.activationState == .activated else {
+            isWatchAvailable = false
+            return
+        }
+        isWatchAvailable = session.isPaired && session.isWatchAppInstalled
     }
 
     // MARK: - Helpers
@@ -113,6 +159,9 @@ private final class WatchSyncDelegate: NSObject, WCSessionDelegate, @unchecked S
             print("[WatchSync] activation state: \(activationState.rawValue)")
         }
         #endif
+        Task { @MainActor in
+            WatchSyncService.shared.refreshWatchAvailability()
+        }
     }
 
     // iOS-only WCSessionDelegate stubs — must be implemented to satisfy the
@@ -122,6 +171,21 @@ private final class WatchSyncDelegate: NSObject, WCSessionDelegate, @unchecked S
     func sessionDidDeactivate(_ session: WCSession) {
         // Reactivate so we can pair with a different watch if the user switches.
         session.activate()
+    }
+
+    // iOS-only WCSessionDelegate callbacks for watch-state changes. Each
+    // refresh the observable availability flag so the UI indicator stays
+    // in sync when the user unpairs or removes the watch app.
+    func sessionWatchStateDidChange(_ session: WCSession) {
+        Task { @MainActor in
+            WatchSyncService.shared.refreshWatchAvailability()
+        }
+    }
+
+    func sessionReachabilityDidChange(_ session: WCSession) {
+        Task { @MainActor in
+            WatchSyncService.shared.refreshWatchAvailability()
+        }
     }
 
     func session(_ session: WCSession, didReceiveMessage message: [String: Any]) {
@@ -142,6 +206,15 @@ private final class WatchSyncDelegate: NSObject, WCSessionDelegate, @unchecked S
     func session(_ session: WCSession, didReceiveApplicationContext applicationContext: [String: Any]) {
         Task { @MainActor in
             WatchSyncService.shared.handle(message: applicationContext)
+        }
+    }
+
+    func session(_ session: WCSession, didReceiveUserInfo userInfo: [String: Any] = [:]) {
+        // `transferUserInfo` is the watch-side fallback when the iPhone isn't
+        // reachable. Route it through the same handler so a queued "Done Set"
+        // doesn't get dropped.
+        Task { @MainActor in
+            WatchSyncService.shared.handle(message: userInfo)
         }
     }
 }

--- a/Xomfit/ViewModels/WorkoutLoggerViewModel.swift
+++ b/Xomfit/ViewModels/WorkoutLoggerViewModel.swift
@@ -841,6 +841,29 @@ final class WorkoutLoggerViewModel {
         focusAdvance()
     }
 
+    /// Watch-triggered "Done Set". Marks the currently focused set complete
+    /// **idempotently** — if the set is already complete (e.g. WCSession
+    /// delivered the same message twice via both `sendMessage` and the
+    /// `transferUserInfo` fallback), this is a no-op. Without this guard,
+    /// `completeSet` would toggle the set OFF on the duplicate event.
+    ///
+    /// Wired from `WatchSyncService.onDoneSetReceived` in `XomFitApp`.
+    func completeFocusedSetFromWatch() {
+        // Bail when no active session or focus is out of bounds — the watch
+        // can race ahead of iOS state on cold launch.
+        guard isActive else { return }
+        guard exercises.indices.contains(focusExerciseIndex) else { return }
+        let ex = exercises[focusExerciseIndex]
+        guard ex.sets.indices.contains(focusSetIndex) else { return }
+
+        // Idempotent: only complete if currently incomplete. Skip toggle-off.
+        guard ex.sets[focusSetIndex].completedAt == Date.distantPast else { return }
+
+        Haptics.success()
+        completeSet(exerciseIndex: focusExerciseIndex, setIndex: focusSetIndex)
+        focusAdvance()
+    }
+
     // MARK: - Exercise Transition Actions
 
     func addAnotherSet() {

--- a/Xomfit/Views/MainTabView.swift
+++ b/Xomfit/Views/MainTabView.swift
@@ -134,6 +134,7 @@ struct MainTabView: View {
                     workoutName: workoutSession.workoutName,
                     durationString: workoutSession.durationString,
                     isPaused: workoutSession.isPaused,
+                    isWatchConnected: WatchSyncService.shared.isWatchAvailable,
                     tickId: tickId,
                     onTap: {
                         withAnimation(.spring(response: 0.35, dampingFraction: 0.82)) {
@@ -405,6 +406,10 @@ private struct WorkoutResumeBar: View {
     let workoutName: String
     let durationString: String
     let isPaused: Bool
+    /// True when a watch is paired AND the watch companion app is installed.
+    /// Renders an `applewatch` glyph in subtle accent so the user knows the
+    /// "Done Set" button on their watch is live (#256 follow-up).
+    let isWatchConnected: Bool
     /// Drives re-render of the duration string every second. Owner updates this.
     let tickId: UUID
     let onTap: () -> Void
@@ -441,6 +446,13 @@ private struct WorkoutResumeBar: View {
                 }
 
                 Spacer(minLength: 0)
+
+                if isWatchConnected {
+                    Image(systemName: "applewatch")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(Theme.accent.opacity(0.85))
+                        .accessibilityLabel("Apple Watch connected")
+                }
 
                 Image(systemName: "chevron.up")
                     .font(.caption.weight(.bold))

--- a/Xomfit/Views/Workout/ActiveWorkoutView.swift
+++ b/Xomfit/Views/Workout/ActiveWorkoutView.swift
@@ -406,10 +406,22 @@ struct ActiveWorkoutView: View {
                     }
                 }
 
-                Text(viewModel.workoutName)
-                    .font(.caption2.weight(.semibold))
-                    .foregroundStyle(Theme.textTertiary)
-                    .lineLimit(1)
+                HStack(spacing: 4) {
+                    // Subtle "Apple Watch connected" cue (#256 follow-up).
+                    // Rendered next to the workout name so users know the
+                    // watch's Done Set button is live without taking extra
+                    // header space.
+                    if WatchSyncService.shared.isWatchAvailable {
+                        Image(systemName: "applewatch")
+                            .font(.caption2.weight(.semibold))
+                            .foregroundStyle(Theme.accent.opacity(0.8))
+                            .accessibilityLabel("Apple Watch connected")
+                    }
+                    Text(viewModel.workoutName)
+                        .font(.caption2.weight(.semibold))
+                        .foregroundStyle(Theme.textTertiary)
+                        .lineLimit(1)
+                }
             }
             .animation(.xomChill, value: viewModel.isRestTimerActive)
 

--- a/Xomfit/XomfitApp.swift
+++ b/Xomfit/XomfitApp.swift
@@ -47,6 +47,13 @@ struct XomFitApp: App {
                             await NotificationService.shared.requestPermission()
                             #endif
                             WatchSyncService.shared.activate()
+                            // Route the watch's "Done Set" button into the
+                            // active workout session. Uses weak capture so
+                            // the closure can't keep the view model alive
+                            // past app teardown.
+                            WatchSyncService.shared.onDoneSetReceived = { [weak workoutSession] in
+                                workoutSession?.completeFocusedSetFromWatch()
+                            }
                             evaluateFitnessQuestionnaireGate()
                         }
                         .sheet(isPresented: Bindable(authService).needsProfileCompletion) {

--- a/docs/features/apple-watch-256/SETUP.md
+++ b/docs/features/apple-watch-256/SETUP.md
@@ -62,8 +62,43 @@ This PR ships everything except the watchOS App **target** itself. Adding a targ
 3. On the Watch: workout name + elapsed time should update; rest ring should appear; "Paused" pill should show when paired iPhone is paused.
 4. Tap **Done Set** on the Watch — the iPhone should mark the focused set complete.
 
+### Testing the Done Set button (follow-up wiring)
+
+The watch → iOS "Done Set" path is wired through:
+
+```
+Watch "Done Set" button
+  → WatchSessionStore.sendDoneSet()         [XomfitWatch/]
+  → WCSession.sendMessage(["doneSet": true]) (or transferUserInfo fallback)
+  → WatchSyncService.handle(message:)        [Xomfit/Services/]
+  → WatchSyncService.onDoneSetReceived       (closure installed in XomFitApp)
+  → WorkoutLoggerViewModel.completeFocusedSetFromWatch()
+  → completeSet(exerciseIndex: focusExerciseIndex, setIndex: focusSetIndex)
+  → focusAdvance()
+```
+
+To verify after adding the target:
+
+1. Start a multi-set workout on the iPhone (e.g. 3 sets of bench).
+2. On the watch, confirm "Set 1 / 3" + the workout name render.
+3. Tap **Done Set**. Watch the iPhone:
+   - The focused set's checkmark fills.
+   - Rest timer starts (assuming not a drop-set / superset round).
+   - Focus advances to the next set or exercise.
+4. **Double-tap idempotency check**: tap **Done Set** twice in quick succession. Only the first tap should complete the set — the second is debounced (`doneSetDebounceInterval = 0.75s` in `WatchSyncService`). Without this guard, `completeSet` would toggle the set off because it's defined as a toggle.
+5. **Cold-launch check**: kill the iPhone app, wake the watch app, tap **Done Set**. The message is queued via `transferUserInfo`; once the iPhone app relaunches and the active workout cover restores, the queued event delivers and completes the focused set.
+
+### Connection status indicator
+
+When `WCSession.default.isPaired && session.isWatchAppInstalled` is true after activation, a small `applewatch` SF Symbol renders:
+
+- In the `WorkoutResumeBar` (between the duration label and the chevron).
+- In the `ActiveWorkoutView` header bar (inline with the workout name).
+
+The flag is observable on `WatchSyncService.shared.isWatchAvailable` and refreshes on `sessionWatchStateDidChange` / `sessionReachabilityDidChange` callbacks.
+
 ## How the wiring works
 
 - **iOS → Watch**: `WatchSyncService` (in `Xomfit/Services/`) wraps `WCSession`. It runs every time `WorkoutLoggerViewModel.updateLiveActivity()` ticks. Uses `sendMessage` when reachable, `updateApplicationContext` as a cold-launch fallback.
-- **Watch → iOS**: `WatchSessionStore` (in `XomfitWatch/`) decodes inbound `WatchWorkoutState` snapshots. Its "Done Set" button posts `["doneSet": true]` back. The iOS service's `onDoneSetReceived` closure is the hook to wire that into `WorkoutLoggerViewModel.completeSet(...)` in a follow-up.
+- **Watch → iOS**: `WatchSessionStore` (in `XomfitWatch/`) decodes inbound `WatchWorkoutState` snapshots. Its "Done Set" button posts `["doneSet": true]` back. The iOS service's `onDoneSetReceived` closure is installed in `XomFitApp` and routes into `WorkoutLoggerViewModel.completeFocusedSetFromWatch()` (idempotent — won't toggle an already-completed set off on duplicate WCSession delivery).
 - **Shared shape**: `WatchWorkoutState` is duplicated in `Xomfit/Models/` and `XomfitWatch/` — same trick as `XomfitWidgetAttributes.swift`. Keep both copies byte-identical or messages will silently drop on decode.


### PR DESCRIPTION
Follow-up to #256.
- WatchSyncService.onDoneSetReceived → WorkoutLoggerViewModel.completeFocusedSetFromWatch (idempotent, debounced 0.75s)
- isWatchAvailable @Observable mirrors WCSession.isReachable
- applewatch glyph in ActiveWorkoutView headerBar + WorkoutResumeBar when connected
- transferUserInfo fallback handler so queued messages reach the same dispatch
- SETUP.md updated with Done Set + connection-status sections