### PR TITLE
#371 ai coach: recent workout context + regenerate + model picker + better chips + cost meter

### DIFF
--- a/Xomfit/Services/AICoachService.swift
+++ b/Xomfit/Services/AICoachService.swift
@@ -39,8 +39,45 @@ enum AICoachStreamEvent {
     /// A `build_workout` tool call resolved to a parseable payload.
     /// Attach it to the assistant message so the chat can render the action card.
     case toolUse(WorkoutBuildPayload)
+    /// Token usage for this exchange. Emitted once after `message_delta`
+    /// finalizes Anthropic's usage block (#371).
+    case usage(inputTokens: Int, outputTokens: Int)
     /// Stream finished cleanly (`message_stop`).
     case done
+}
+
+// MARK: - Model selection (#371)
+
+/// User-selectable Anthropic models. Persisted via `@AppStorage("aiCoach.model")`.
+/// Source of truth for both the picker label and the API model id.
+enum AICoachModel: String, CaseIterable, Identifiable {
+    case sonnet45 = "claude-sonnet-4-6"
+    case haiku45 = "claude-haiku-4-5"
+
+    var id: String { rawValue }
+
+    /// Display name used in Settings → AI Coach → Model.
+    var displayName: String {
+        switch self {
+        case .sonnet45: return "Sonnet 4.6 (smarter)"
+        case .haiku45: return "Haiku 4.5 (faster + cheaper)"
+        }
+    }
+
+    /// Resolve a stored `@AppStorage` rawValue (possibly empty/stale) into a
+    /// valid model. Defaults to Sonnet.
+    static func resolve(rawValue: String) -> AICoachModel {
+        AICoachModel(rawValue: rawValue) ?? .sonnet45
+    }
+
+    /// Anthropic public pricing in USD per million tokens (approximate, used
+    /// for the cost meter — best-effort). Update when pricing changes.
+    var pricing: (inputPerMillion: Double, outputPerMillion: Double) {
+        switch self {
+        case .sonnet45: return (3.0, 15.0)
+        case .haiku45: return (1.0, 5.0)
+        }
+    }
 }
 
 // MARK: - Service
@@ -112,10 +149,18 @@ final class AICoachService {
 
     // MARK: - System prompt builder
 
-    /// Builds the system prompt by prepending the user's fitness profile (if any)
-    /// and appending a compressed exercise-catalog hint so the model can pick
-    /// valid `exerciseId`s for `build_workout` calls.
-    static func systemPrompt(profile: UserFitnessProfile) -> String {
+    /// Builds the system prompt by prepending the user's fitness profile (if any),
+    /// optionally appending a compressed recent-history + PR summary, and
+    /// finally appending the exercise-catalog hint so the model can pick valid
+    /// `exerciseId`s for `build_workout` calls.
+    ///
+    /// `workoutContext` is built on the @MainActor side (see
+    /// `AICoachViewModel.buildWorkoutContext`) and capped at ~3000 chars by the
+    /// caller. Passed in as a plain string so the service stays actor-agnostic.
+    static func systemPrompt(
+        profile: UserFitnessProfile,
+        workoutContext: String? = nil
+    ) -> String {
         var prompt = baseSystemPrompt
 
         if profile.isComplete {
@@ -139,6 +184,10 @@ final class AICoachService {
             if lines.count > 1 {
                 prompt = lines.joined(separator: "\n") + "\n\n" + prompt
             }
+        }
+
+        if let workoutContext, !workoutContext.isEmpty {
+            prompt += "\n\n" + workoutContext
         }
 
         let catalog = exerciseCatalogHint()
@@ -181,6 +230,7 @@ final class AICoachService {
     func sendMessageStream(
         messages: [AICoachMessage],
         profile: UserFitnessProfile = .current,
+        workoutContext: String? = nil,
         apiKeyOverride: String? = nil,
         model: String = AICoachService.defaultModel,
         maxTokens: Int = AICoachService.defaultMaxTokens
@@ -191,6 +241,7 @@ final class AICoachService {
                     try await self.runStream(
                         messages: messages,
                         profile: profile,
+                        workoutContext: workoutContext,
                         apiKeyOverride: apiKeyOverride,
                         model: model,
                         maxTokens: maxTokens,
@@ -208,6 +259,7 @@ final class AICoachService {
     private func runStream(
         messages: [AICoachMessage],
         profile: UserFitnessProfile,
+        workoutContext: String?,
         apiKeyOverride: String?,
         model: String,
         maxTokens: Int,
@@ -220,7 +272,7 @@ final class AICoachService {
         let body = AnthropicRequest(
             model: model,
             maxTokens: maxTokens,
-            system: Self.systemPrompt(profile: profile),
+            system: Self.systemPrompt(profile: profile, workoutContext: workoutContext),
             messages: messages.map { AnthropicMessage(role: $0.role.rawValue, content: $0.text) },
             stream: true,
             tools: [Self.buildWorkoutTool]
@@ -264,6 +316,11 @@ final class AICoachService {
         // input_json_delta partials until content_block_stop fires.
         var pendingToolJSON = ""
         var inToolBlock = false
+        // Token usage accumulators (#371). `message_start` carries input_tokens
+        // in `message.usage`; `message_delta` carries final output_tokens in
+        // the top-level `usage` field.
+        var inputTokens: Int = 0
+        var outputTokens: Int = 0
 
         for try await line in bytes.lines {
             if Task.isCancelled { return }
@@ -287,6 +344,14 @@ final class AICoachService {
             }
 
             switch envelope.type {
+            case "message_start":
+                // Anthropic puts input_tokens in message.usage on the start
+                // event. Output_tokens here is usually 0 / non-final.
+                if let usage = envelope.message?.usage {
+                    if let input = usage.input_tokens { inputTokens = input }
+                    if let output = usage.output_tokens { outputTokens = output }
+                }
+
             case "content_block_start":
                 if let block = envelope.content_block {
                     if block.type == "tool_use" {
@@ -314,7 +379,17 @@ final class AICoachService {
                     pendingToolJSON = ""
                 }
 
+            case "message_delta":
+                // Final output_tokens lands here on the top-level usage field.
+                if let usage = envelope.usage {
+                    if let output = usage.output_tokens { outputTokens = output }
+                    if let input = usage.input_tokens { inputTokens = input }
+                }
+
             case "message_stop":
+                if inputTokens > 0 || outputTokens > 0 {
+                    continuation.yield(.usage(inputTokens: inputTokens, outputTokens: outputTokens))
+                }
                 continuation.yield(.done)
                 return
 
@@ -479,6 +554,8 @@ private struct SSEEnvelope: Decodable {
     let index: Int?
     let content_block: ContentBlock?
     let delta: Delta?
+    let message: MessageEnvelope?
+    let usage: Usage?
 
     struct ContentBlock: Decodable {
         let type: String
@@ -490,5 +567,17 @@ private struct SSEEnvelope: Decodable {
         let type: String?
         let text: String?
         let partial_json: String?
+    }
+
+    /// `message_start` shape: { type: "message_start", message: { ..., usage: { input_tokens, output_tokens } } }
+    struct MessageEnvelope: Decodable {
+        let usage: Usage?
+    }
+
+    /// Token usage block. Appears in `message.usage` on `message_start` and at
+    /// the top level on `message_delta`.
+    struct Usage: Decodable {
+        let input_tokens: Int?
+        let output_tokens: Int?
     }
 }

--- a/Xomfit/ViewModels/AICoachViewModel.swift
+++ b/Xomfit/ViewModels/AICoachViewModel.swift
@@ -23,12 +23,23 @@ final class AICoachViewModel {
     /// Latest user-visible error message. Cleared automatically on next send.
     var errorMessage: String?
 
-    /// Suggested prompts shown when the conversation is empty.
+    /// Accumulated input tokens across this conversation. Reset on clear (#371).
+    var totalInputTokens: Int = 0
+    /// Accumulated output tokens across this conversation. Reset on clear (#371).
+    var totalOutputTokens: Int = 0
+    /// Cost meter uses the current model's pricing when computing the display
+    /// string. Persisted across sends in the same convo via the running totals.
+    var lastModel: AICoachModel = .sonnet45
+
+    /// Suggested prompts shown when the conversation is empty (#371).
+    /// Horizontally scrollable in the view — keep these short.
     let suggestionChips: [String] = [
         "Build me today's workout",
+        "Plan my week",
+        "Critique my last workout",
+        "What should I focus on this week?",
         "Build me a 10-minute ab circuit",
-        "Suggest a 4-day split",
-        "Help me hit a 225 bench"
+        "Suggest a 4-day split"
     ]
 
     // MARK: - Persistence
@@ -57,17 +68,45 @@ final class AICoachViewModel {
         !isSending && !draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
+    /// True when the last turn is a `[user, assistant (done)]` pair and we
+    /// aren't currently streaming. Drives the regenerate button visibility (#371).
+    var canRegenerateLast: Bool {
+        guard !isSending else { return false }
+        guard
+            let lastAssistantIndex = messages.lastIndex(where: { $0.role == .assistant }),
+            !messages[lastAssistantIndex].isStreaming,
+            lastAssistantIndex >= 1,
+            messages[lastAssistantIndex - 1].role == .user
+        else { return false }
+        return true
+    }
+
+    /// The id of the last assistant message in the transcript, or nil when none
+    /// exists. Used by the view to attach the regenerate action to the right bubble.
+    var lastAssistantMessageId: UUID? {
+        messages.last(where: { $0.role == .assistant })?.id
+    }
+
     // MARK: - Actions
 
     /// Append a chip's text to the draft and immediately send it.
-    func sendSuggestion(_ text: String, apiKeyOverride: String?) async {
+    func sendSuggestion(
+        _ text: String,
+        apiKeyOverride: String?,
+        model: AICoachModel = .sonnet45,
+        userId: String? = nil
+    ) async {
         draft = text
-        await send(apiKeyOverride: apiKeyOverride)
+        await send(apiKeyOverride: apiKeyOverride, model: model, userId: userId)
     }
 
     /// Send the current draft. No-op when nothing to send.
     /// Streams the response and updates the placeholder bubble in place.
-    func send(apiKeyOverride: String?) async {
+    func send(
+        apiKeyOverride: String?,
+        model: AICoachModel = .sonnet45,
+        userId: String? = nil
+    ) async {
         let trimmed = draft.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty, !isSending else { return }
 
@@ -76,6 +115,7 @@ final class AICoachViewModel {
         messages.append(userMessage)
         draft = ""
         isSending = true
+        lastModel = model
 
         // Insert a placeholder assistant bubble that we'll stream into.
         let placeholderId = UUID()
@@ -87,9 +127,12 @@ final class AICoachViewModel {
         do {
             // Send everything except the placeholder (last entry).
             let history = Array(messages.dropLast())
+            let workoutContext = buildWorkoutContext(userId: userId)
             let stream = service.sendMessageStream(
                 messages: history,
-                apiKeyOverride: apiKeyOverride
+                workoutContext: workoutContext,
+                apiKeyOverride: apiKeyOverride,
+                model: model.rawValue
             )
 
             for try await event in stream {
@@ -98,6 +141,9 @@ final class AICoachViewModel {
                     appendText(chunk, to: placeholderId)
                 case .toolUse(let payload):
                     attachWorkoutPayload(payload, to: placeholderId)
+                case .usage(let input, let output):
+                    totalInputTokens += input
+                    totalOutputTokens += output
                 case .done:
                     finishStreaming(id: placeholderId)
                 }
@@ -113,6 +159,165 @@ final class AICoachViewModel {
         }
 
         isSending = false
+    }
+
+    /// Drop the last assistant turn and re-send the user message that preceded
+    /// it, streaming a fresh reply (#371). No-op while streaming.
+    ///
+    /// Pre-condition: the conversation ends with `[user, assistant]`. We use
+    /// `lastIndex(where: .assistant)` so an intermediate user message after the
+    /// last assistant (rare race) doesn't get clobbered.
+    func regenerateLast(
+        apiKeyOverride: String?,
+        model: AICoachModel = .sonnet45,
+        userId: String? = nil
+    ) async {
+        guard !isSending else { return }
+        guard
+            let lastAssistantIndex = messages.lastIndex(where: { $0.role == .assistant }),
+            lastAssistantIndex >= 1,
+            messages[lastAssistantIndex - 1].role == .user
+        else { return }
+
+        let userText = messages[lastAssistantIndex - 1].text
+        // Drop the user → assistant pair; the user message gets re-issued via
+        // the normal send path so streaming, persistence, and error handling
+        // all stay uniform.
+        messages.removeSubrange((lastAssistantIndex - 1)...lastAssistantIndex)
+        persist()
+
+        draft = userText
+        await send(apiKeyOverride: apiKeyOverride, model: model, userId: userId)
+    }
+
+    // MARK: - Workout context (#371)
+
+    /// Builds a compressed summary of recent workouts and PRs to seed the
+    /// system prompt. Cached-only — never hits the network. Returns nil when
+    /// there's nothing useful to surface.
+    ///
+    /// Format (truncated at ~3000 chars):
+    /// ```
+    /// Recent workout history (most recent first):
+    /// - 2026-05-08 Push Day · 12,500 lb · Bench Press best 225x4 · Overhead Press best 135x6
+    /// ...
+    ///
+    /// Lifetime PRs (top 5 by est. 1RM):
+    /// - Deadlift 405x1 (Epley 1RM ~405)
+    /// ...
+    /// ```
+    func buildWorkoutContext(userId: String?, maxChars: Int = 3000) -> String? {
+        guard let userId, !userId.isEmpty else { return nil }
+        let workouts = WorkoutService.shared.fetchWorkoutsFromCache(userId: userId)
+        guard !workouts.isEmpty else { return nil }
+
+        var sections: [String] = []
+
+        // --- Last 10 workouts
+        let dateFormatter = ISO8601DateFormatter()
+        dateFormatter.formatOptions = [.withFullDate]
+        let recent = Array(workouts.prefix(10))
+        var lines: [String] = ["Recent workout history (most recent first):"]
+        for w in recent {
+            let date = dateFormatter.string(from: w.startTime)
+            let volume = Self.formatVolume(w.totalVolume)
+            // Top 2 exercises by volume, with best set summary.
+            let topExercises = w.exercises
+                .sorted { $0.totalVolume > $1.totalVolume }
+                .prefix(2)
+            let exerciseLines: [String] = topExercises.compactMap { we in
+                guard let best = we.bestSet else { return nil }
+                return "\(we.exercise.name) best \(Self.formatWeightInt(best.weight))x\(best.reps)"
+            }
+            var line = "- \(date) \(w.name) · \(volume) lb"
+            if !exerciseLines.isEmpty {
+                line += " · " + exerciseLines.joined(separator: " · ")
+            }
+            lines.append(line)
+        }
+        sections.append(lines.joined(separator: "\n"))
+
+        // --- Top 5 PRs computed from cached workouts (PRService has no cache;
+        // we treat the best (weight, reps) per exercise across all cached
+        // workouts as the lifetime PR for prompt-priming purposes).
+        var bestByExercise: [String: (name: String, weight: Double, reps: Int, oneRM: Double)] = [:]
+        for w in workouts {
+            for we in w.exercises {
+                for set in we.sets {
+                    let oneRM = set.estimated1RM
+                    if let existing = bestByExercise[we.exercise.id] {
+                        if oneRM > existing.oneRM {
+                            bestByExercise[we.exercise.id] = (we.exercise.name, set.weight, set.reps, oneRM)
+                        }
+                    } else if set.weight > 0 && set.reps > 0 {
+                        bestByExercise[we.exercise.id] = (we.exercise.name, set.weight, set.reps, oneRM)
+                    }
+                }
+            }
+        }
+        let topPRs = bestByExercise.values
+            .sorted { $0.oneRM > $1.oneRM }
+            .prefix(5)
+        if !topPRs.isEmpty {
+            var prLines: [String] = ["Lifetime PRs (top 5 by est. 1RM):"]
+            for pr in topPRs {
+                let oneRM = Self.formatWeightInt(pr.oneRM)
+                prLines.append("- \(pr.name) \(Self.formatWeightInt(pr.weight))x\(pr.reps) (Epley 1RM ~\(oneRM))")
+            }
+            sections.append(prLines.joined(separator: "\n"))
+        }
+
+        var combined = sections.joined(separator: "\n\n")
+        if combined.count > maxChars {
+            // Truncate at the last newline boundary that fits so we don't
+            // slice a row mid-line.
+            let cut = combined.prefix(maxChars)
+            if let lastNewline = cut.lastIndex(of: "\n") {
+                combined = String(cut[..<lastNewline]) + "\n…"
+            } else {
+                combined = String(cut)
+            }
+        }
+        return combined
+    }
+
+    // MARK: - Cost meter (#371)
+
+    /// Estimated USD cost across the running input + output tokens. Uses the
+    /// last model's pricing; if mid-convo the user switches models this is a
+    /// rough mix but still informative.
+    var estimatedCostUSD: Double {
+        let pricing = lastModel.pricing
+        let input = Double(totalInputTokens) / 1_000_000 * pricing.inputPerMillion
+        let output = Double(totalOutputTokens) / 1_000_000 * pricing.outputPerMillion
+        return input + output
+    }
+
+    /// "≈ $0.03 spent on this convo" style footer, or nil when we don't yet
+    /// have token usage data.
+    var costMeterText: String? {
+        guard totalInputTokens > 0 || totalOutputTokens > 0 else { return nil }
+        let cost = estimatedCostUSD
+        let formatted: String
+        if cost < 0.01 {
+            formatted = String(format: "$%.4f", cost)
+        } else {
+            formatted = String(format: "$%.2f", cost)
+        }
+        return "≈ \(formatted) spent on this convo"
+    }
+
+    /// Compact integer weight: "225" not "225.0".
+    private static func formatWeightInt(_ value: Double) -> String {
+        String(Int(value.rounded()))
+    }
+
+    /// Volume formatter: "12.5k" for >=1000, integer otherwise.
+    private static func formatVolume(_ value: Double) -> String {
+        if value >= 1000 {
+            return String(format: "%.1fk", value / 1000)
+        }
+        return String(Int(value))
     }
 
     // MARK: - Error mapping (#311)
@@ -170,6 +375,8 @@ final class AICoachViewModel {
         draft = ""
         errorMessage = nil
         isSending = false
+        totalInputTokens = 0
+        totalOutputTokens = 0
         persist()
     }
 

--- a/Xomfit/Views/AICoach/AICoachView.swift
+++ b/Xomfit/Views/AICoach/AICoachView.swift
@@ -24,6 +24,26 @@ struct AICoachView: View {
     /// Stored in `@AppStorage` for v1 — TODO Keychain.
     @AppStorage("aiCoach.anthropicAPIKey") private var apiKeyOverride: String = ""
 
+    /// User-selected Anthropic model. Persisted in Settings → AI Coach (#371).
+    @AppStorage("aiCoach.model") private var modelRawValue: String = AICoachModel.sonnet45.rawValue
+
+    /// Whether to show the past-conversations stub sheet (#371).
+    @State private var showHistoryStub = false
+
+    /// Resolved model from the persisted raw value, with fallback to Sonnet.
+    private var selectedModel: AICoachModel {
+        AICoachModel.resolve(rawValue: modelRawValue)
+    }
+
+    /// Current user id for the prompt-priming workout context. Lowercased
+    /// UUID string to match the caching key.
+    private var userId: String? {
+        guard let raw = authService?.currentUser?.id.uuidString.lowercased(),
+              !raw.isEmpty
+        else { return nil }
+        return raw
+    }
+
     var body: some View {
         ZStack {
             Theme.background.ignoresSafeArea()
@@ -39,6 +59,10 @@ struct AICoachView: View {
                     errorBanner(error)
                 }
 
+                if let cost = viewModel.costMeterText {
+                    costFooter(cost)
+                }
+
                 composer
             }
         }
@@ -47,17 +71,31 @@ struct AICoachView: View {
         .toolbarColorScheme(.dark, for: .navigationBar)
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
-                if !viewModel.isEmpty {
-                    Button(role: .destructive) {
+                HStack(spacing: Theme.Spacing.sm) {
+                    Button {
                         Haptics.light()
-                        showClearConfirm = true
+                        showHistoryStub = true
                     } label: {
-                        Image(systemName: "trash")
+                        Image(systemName: "clock.arrow.circlepath")
                             .foregroundStyle(Theme.textPrimary)
                     }
-                    .accessibilityLabel("Clear conversation")
+                    .accessibilityLabel("Past conversations")
+
+                    if !viewModel.isEmpty {
+                        Button(role: .destructive) {
+                            Haptics.light()
+                            showClearConfirm = true
+                        } label: {
+                            Image(systemName: "trash")
+                                .foregroundStyle(Theme.textPrimary)
+                        }
+                        .accessibilityLabel("Clear conversation")
+                    }
                 }
             }
+        }
+        .sheet(isPresented: $showHistoryStub) {
+            pastConversationsStub
         }
         .confirmationDialog(
             "Clear conversation?",
@@ -91,12 +129,15 @@ struct AICoachView: View {
                     XomMetricLabel("Try Asking")
                         .padding(.horizontal, Theme.Spacing.md)
 
-                    VStack(spacing: Theme.Spacing.sm) {
-                        ForEach(viewModel.suggestionChips, id: \.self) { chip in
-                            suggestionChip(chip)
+                    // Horizontally scrollable chip rail (#371).
+                    ScrollView(.horizontal, showsIndicators: false) {
+                        HStack(spacing: Theme.Spacing.sm) {
+                            ForEach(viewModel.suggestionChips, id: \.self) { chip in
+                                suggestionChip(chip)
+                            }
                         }
+                        .padding(.horizontal, Theme.Spacing.md)
                     }
-                    .padding(.horizontal, Theme.Spacing.md)
                 }
             }
             .padding(.vertical, Theme.Spacing.lg)
@@ -106,7 +147,14 @@ struct AICoachView: View {
     private func suggestionChip(_ text: String) -> some View {
         Button {
             Haptics.light()
-            Task { await viewModel.sendSuggestion(text, apiKeyOverride: apiKeyOverride) }
+            Task {
+                await viewModel.sendSuggestion(
+                    text,
+                    apiKeyOverride: apiKeyOverride,
+                    model: selectedModel,
+                    userId: userId
+                )
+            }
         } label: {
             HStack(spacing: Theme.Spacing.sm) {
                 Image(systemName: "sparkle")
@@ -114,19 +162,15 @@ struct AICoachView: View {
                 Text(text)
                     .font(Theme.fontBody)
                     .foregroundStyle(Theme.textPrimary)
-                    .multilineTextAlignment(.leading)
-                Spacer(minLength: 0)
-                Image(systemName: "arrow.up.right")
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(Theme.textTertiary)
+                    .lineLimit(1)
             }
-            .padding(Theme.Spacing.md)
-            .frame(minHeight: 52)
+            .padding(.horizontal, Theme.Spacing.md)
+            .frame(height: 44)
             .background(
-                RoundedRectangle(cornerRadius: Theme.Radius.md)
+                Capsule()
                     .fill(Theme.surface)
                     .overlay(
-                        RoundedRectangle(cornerRadius: Theme.Radius.md)
+                        Capsule()
                             .strokeBorder(Theme.hairline, lineWidth: 0.5)
                     )
             )
@@ -155,6 +199,14 @@ struct AICoachView: View {
                                 )
                                 .padding(.leading, 40) // align with bubble (past avatar)
                             }
+                            // Regenerate action only on the latest assistant
+                            // bubble when the convo is at rest (#371).
+                            if message.role == .assistant,
+                               message.id == viewModel.lastAssistantMessageId,
+                               viewModel.canRegenerateLast {
+                                regenerateButton
+                                    .padding(.leading, 40)
+                            }
                         }
                         .id(message.id)
                     }
@@ -169,6 +221,35 @@ struct AICoachView: View {
                 scrollToBottom(proxy: proxy)
             }
         }
+    }
+
+    private var regenerateButton: some View {
+        Button {
+            Haptics.light()
+            Task {
+                await viewModel.regenerateLast(
+                    apiKeyOverride: apiKeyOverride,
+                    model: selectedModel,
+                    userId: userId
+                )
+            }
+        } label: {
+            HStack(spacing: Theme.Spacing.tight) {
+                Image(systemName: "arrow.clockwise")
+                Text("Regenerate")
+            }
+            .font(Theme.fontCaption.weight(.medium))
+            .foregroundStyle(Theme.textSecondary)
+            .padding(.horizontal, Theme.Spacing.sm)
+            .frame(minHeight: 32)
+            .background(
+                Capsule().strokeBorder(Theme.hairline, lineWidth: 0.5)
+            )
+        }
+        .buttonStyle(.plain)
+        .disabled(viewModel.isSending)
+        .accessibilityLabel("Regenerate last reply")
+        .accessibilityHint("Discards the last reply and asks again")
     }
 
     private func scrollToBottom(proxy: ScrollViewProxy) {
@@ -287,7 +368,64 @@ struct AICoachView: View {
     private func triggerSend() {
         guard viewModel.canSend else { return }
         Haptics.light()
-        Task { await viewModel.send(apiKeyOverride: apiKeyOverride) }
+        Task {
+            await viewModel.send(
+                apiKeyOverride: apiKeyOverride,
+                model: selectedModel,
+                userId: userId
+            )
+        }
+    }
+
+    // MARK: - Cost meter footer (#371)
+
+    private func costFooter(_ text: String) -> some View {
+        HStack(spacing: 4) {
+            Image(systemName: "dollarsign.circle")
+                .font(.caption2)
+                .foregroundStyle(Theme.textTertiary)
+            Text(text)
+                .font(.caption2)
+                .foregroundStyle(Theme.textTertiary)
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, Theme.Spacing.md)
+        .padding(.bottom, 2)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(text)
+    }
+
+    // MARK: - Past conversations stub (#371)
+
+    private var pastConversationsStub: some View {
+        NavigationStack {
+            ZStack {
+                Theme.background.ignoresSafeArea()
+                VStack(spacing: Theme.Spacing.md) {
+                    Image(systemName: "bubble.left.and.bubble.right")
+                        .font(.system(size: 48))
+                        .foregroundStyle(Theme.accent)
+                    Text("Multi-thread chats coming soon")
+                        .font(Theme.fontBody.weight(.semibold))
+                        .foregroundStyle(Theme.textPrimary)
+                    Text("For now your AI Coach is one rolling conversation. We'll add per-topic threads in a future update.")
+                        .font(Theme.fontCaption)
+                        .foregroundStyle(Theme.textSecondary)
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, Theme.Spacing.lg)
+                }
+            }
+            .navigationTitle("Past Conversations")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Done") { showHistoryStub = false }
+                        .foregroundStyle(Theme.accent)
+                }
+            }
+        }
+        .presentationDetents([.medium])
+        .preferredColorScheme(.dark)
     }
 }
 

--- a/Xomfit/Views/Profile/SettingsView.swift
+++ b/Xomfit/Views/Profile/SettingsView.swift
@@ -17,6 +17,9 @@ struct SettingsView: View {
     /// not secure. TODO: migrate to Keychain.
     @AppStorage("aiCoach.anthropicAPIKey") private var anthropicAPIKey: String = ""
 
+    /// User-selected Anthropic model for the AI Coach (#371). Default Sonnet.
+    @AppStorage("aiCoach.model") private var aiCoachModelRaw: String = AICoachModel.sonnet45.rawValue
+
     // MARK: - App Preferences (#312)
 
     @AppStorage("weightUnit") private var weightUnitRaw: String = WeightUnit.lbs.rawValue
@@ -324,6 +327,26 @@ struct SettingsView: View {
                     .autocorrectionDisabled()
                     .accessibilityLabel("Anthropic API Key")
                     .accessibilityHint("Stored on this device only")
+            }
+
+            // Model picker (#371). Stored as raw string so @AppStorage can use
+            // the lightweight `String` overload; AICoachView resolves it to
+            // `AICoachModel`.
+            HStack(spacing: Theme.Spacing.md) {
+                Image(systemName: "brain.head.profile")
+                    .frame(width: Theme.Spacing.lg)
+                    .foregroundStyle(Theme.accent)
+                Picker(selection: $aiCoachModelRaw) {
+                    ForEach(AICoachModel.allCases) { model in
+                        Text(model.displayName).tag(model.rawValue)
+                    }
+                } label: {
+                    Text("Model")
+                        .foregroundStyle(Theme.textPrimary)
+                }
+                .tint(Theme.accent)
+                .accessibilityLabel("AI Coach model")
+                .accessibilityHint("Pick which Anthropic model the coach uses")
             }
         } header: {
             XomMetricLabel("AI Coach")

--- a/Xomfit/XomfitApp.swift
+++ b/Xomfit/XomfitApp.swift
@@ -18,6 +18,12 @@ struct XomFitApp: App {
     @State private var pendingReportId: String? = nil
     @State private var showReportsSheet = false
 
+    /// DEBUG-only: `xomfit://coach` opens AI Coach in a sheet so agents can
+    /// screenshot it without navigating the drawer (#371).
+    #if DEBUG
+    @State private var showCoachSheet = false
+    #endif
+
     var body: some Scene {
         WindowGroup {
             Group {
@@ -73,6 +79,25 @@ struct XomFitApp: App {
                             }
                             .preferredColorScheme(.dark)
                         }
+                        #if DEBUG
+                        .sheet(isPresented: $showCoachSheet) {
+                            NavigationStack {
+                                AICoachView()
+                            }
+                            .environment(authService)
+                            .environment(workoutSession)
+                            .preferredColorScheme(.dark)
+                        }
+                        .task {
+                            // Agent screenshot helper: auto-open Coach sheet
+                            // when `XOMFIT_OPEN_COACH=1`. Combine with
+                            // XOMFIT_AUTH_BYPASS=1 to land directly on the
+                            // Coach empty-state from a cold launch (#371).
+                            if ProcessInfo.processInfo.environment["XOMFIT_OPEN_COACH"] == "1" {
+                                showCoachSheet = true
+                            }
+                        }
+                        #endif
                 } else {
                     LoginView()
                         .environment(authService)
@@ -92,6 +117,14 @@ struct XomFitApp: App {
                     SpotifyAuthService.shared.handleCallback(url: url)
                     return
                 }
+                #if DEBUG
+                if url.scheme == "xomfit", url.host == "coach" {
+                    if authService.isAuthenticated {
+                        showCoachSheet = true
+                    }
+                    return
+                }
+                #endif
                 if url.scheme == "xomfit", url.host == "report" {
                     // `xomfit://report/<id>` — first path component is the id.
                     let id = url.pathComponents


### PR DESCRIPTION
Closes #371. All 6 scoped features shipped:
1. System prompt now includes last 10 workouts + top 5 PRs (derived from cached workouts via est. 1RM)
2. Regenerate pill under the latest assistant bubble
3. Model picker (Sonnet 4.6 / Haiku 4.5) in Settings → AI Coach
4. 6 horizontal-scrollable empty-state chips
5. Past Conversations stub sheet
6. Token / cost meter footer parsed from SSE usage events

Plus DEBUG-only XOMFIT_OPEN_COACH=1 + xomfit://coach deep link for agent screenshot flows.