### PR TITLE
#390 ship shared Spotify Client ID (placeholder); override moved to Advanced

### DIFF
--- a/Xomfit/Services/SpotifyAuthService.swift
+++ b/Xomfit/Services/SpotifyAuthService.swift
@@ -26,7 +26,11 @@ final class SpotifyAuthService: NSObject {
 
     // MARK: - Persisted state
 
-    @ObservationIgnored @AppStorage("spotifyClientId") private var clientIdSetting: String = ""
+    // Note: the per-user Client ID override is owned by `SpotifyConnectionView` via
+    // `@AppStorage("spotifyClientId")`. Reads inside this service always go through
+    // `SpotifyConfig.resolvedClientId()` so we honor the override first and fall back to the
+    // shared id baked into the app (#390). No local `@AppStorage` mirror needed here.
+
     @ObservationIgnored @AppStorage("spotify.accessToken") private var accessToken: String = ""
     @ObservationIgnored @AppStorage("spotify.refreshToken") private var refreshToken: String = ""
     @ObservationIgnored @AppStorage("spotify.tokenExpiry") private var tokenExpiryEpoch: Double = 0
@@ -65,7 +69,12 @@ final class SpotifyAuthService: NSObject {
     ///   - `SpotifyAuthError.tokenExchangeFailed` — `/api/token` returned non-2xx
     @discardableResult
     func signIn() async throws -> Bool {
-        guard !clientIdSetting.trimmingCharacters(in: .whitespaces).isEmpty else {
+        // Resolve the Client ID through SpotifyConfig so we honor the user override first and
+        // fall back to the shared id baked into the app (#390). `resolvedClientId()` also emits a
+        // console warning when the shared id is still the unreplaced placeholder.
+        let resolvedClientId = SpotifyConfig.resolvedClientId()
+        guard !resolvedClientId.isEmpty,
+              resolvedClientId != "PLACEHOLDER_SHARED_SPOTIFY_CLIENT_ID" else {
             throw SpotifyAuthError.missingClientId
         }
 
@@ -76,7 +85,7 @@ final class SpotifyAuthService: NSObject {
         pendingPKCEVerifier = verifier
         pendingState = state
 
-        guard let authURL = buildAuthorizeURL(challenge: challenge, state: state) else {
+        guard let authURL = buildAuthorizeURL(clientId: resolvedClientId, challenge: challenge, state: state) else {
             throw SpotifyAuthError.callbackInvalid
         }
 
@@ -109,7 +118,7 @@ final class SpotifyAuthService: NSObject {
         }
 
         let code = try parseCallback(url: callbackURL, expectedState: state)
-        try await exchangeCodeForToken(code: code, verifier: verifier)
+        try await exchangeCodeForToken(clientId: resolvedClientId, code: code, verifier: verifier)
         try await refreshUserDisplayName()
         return true
     }
@@ -157,10 +166,10 @@ final class SpotifyAuthService: NSObject {
 
     // MARK: - URL construction
 
-    private func buildAuthorizeURL(challenge: String, state: String) -> URL? {
+    private func buildAuthorizeURL(clientId: String, challenge: String, state: String) -> URL? {
         var components = URLComponents(url: SpotifyConfig.authBaseURL, resolvingAgainstBaseURL: false)
         components?.queryItems = [
-            URLQueryItem(name: "client_id", value: clientIdSetting),
+            URLQueryItem(name: "client_id", value: clientId),
             URLQueryItem(name: "response_type", value: "code"),
             URLQueryItem(name: "redirect_uri", value: SpotifyConfig.redirectURI),
             URLQueryItem(name: "code_challenge_method", value: "S256"),
@@ -192,12 +201,12 @@ final class SpotifyAuthService: NSObject {
 
     // MARK: - Token exchange
 
-    private func exchangeCodeForToken(code: String, verifier: String) async throws {
+    private func exchangeCodeForToken(clientId: String, code: String, verifier: String) async throws {
         var request = URLRequest(url: SpotifyConfig.tokenURL)
         request.httpMethod = "POST"
         request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
         let body = formEncoded([
-            "client_id": clientIdSetting,
+            "client_id": clientId,
             "grant_type": "authorization_code",
             "code": code,
             "redirect_uri": SpotifyConfig.redirectURI,
@@ -216,11 +225,14 @@ final class SpotifyAuthService: NSObject {
 
     private func refreshAccessToken() async throws {
         guard !refreshToken.isEmpty else { throw SpotifyAuthError.tokenExchangeFailed }
+        // Resolve the Client ID again here so a paste-in (or revert) of an override since the
+        // original sign-in is honored on the next refresh tick (#390).
+        let clientId = SpotifyConfig.resolvedClientId()
         var request = URLRequest(url: SpotifyConfig.tokenURL)
         request.httpMethod = "POST"
         request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
         let body = formEncoded([
-            "client_id": clientIdSetting,
+            "client_id": clientId,
             "grant_type": "refresh_token",
             "refresh_token": refreshToken
         ])
@@ -334,7 +346,11 @@ enum SpotifyAuthError: LocalizedError {
     var errorDescription: String? {
         switch self {
         case .missingClientId:
-            return "Paste your Spotify Client ID in Settings -> Music Sources before signing in."
+            // After #390 this surface is only hit when the shared Client ID is still the
+            // unreplaced placeholder, which is a project-owner config problem, not a user
+            // problem. We still offer the Advanced override as an escape hatch.
+            return "Spotify isn't configured yet. Try again later, or paste your own Spotify " +
+                   "Client ID under Settings -> Music Sources -> Spotify -> Advanced."
         case .userCancelled:
             return "Spotify sign-in was cancelled."
         case .callbackInvalid:

--- a/Xomfit/Services/SpotifyConfig.swift
+++ b/Xomfit/Services/SpotifyConfig.swift
@@ -1,20 +1,63 @@
 import Foundation
 
-/// Static configuration for the Spotify Web API OAuth + Now-Playing integration (#347).
+/// Static configuration for the Spotify Web API OAuth + Now-Playing integration (#347, #390).
 ///
-/// We use the Authorization Code with PKCE grant — no client secret required, which is
-/// exactly why the `clientId` can ship empty here and be pasted in by the user via
-/// `Settings -> Music Sources -> Spotify Client ID` (read off `@AppStorage("spotifyClientId")`).
-/// Spotify treats the client id as public; only the redirect URI + PKCE verifier protect
-/// the code exchange.
+/// We use the Authorization Code with PKCE grant — no client secret required. Spotify treats the
+/// client id as a public identifier; only the redirect URI + PKCE verifier protect the code
+/// exchange.
 ///
-/// See `docs/features/spotify-347/SETUP.md` for the full Developer App walkthrough.
+/// ## Shared Client ID (#390)
+/// XomFit now ships a *shared* Spotify Developer App Client ID baked into the app so end users
+/// don't have to register their own Developer App just to record their workout soundtrack. The
+/// owner of the shared Spotify Developer App **must** have `xomfit://spotify-callback` registered
+/// as a Redirect URI for sign-in to succeed.
+///
+/// Power users can still override the shared id by pasting their own value into Settings ->
+/// Music Sources -> Spotify -> Advanced. The override is persisted under
+/// `@AppStorage("spotifyClientId")` and takes precedence over `sharedClientId` on the very next
+/// sign-in attempt without an app restart.
+///
+/// See `docs/features/spotify-347/SETUP.md` for the user-facing guide.
 enum SpotifyConfig {
-    /// Public Spotify Developer client id. Empty by default — the user pastes their
-    /// own value via Settings, persisted under `@AppStorage("spotifyClientId")`. Reading
-    /// the live value is the responsibility of `SpotifyAuthService` so a paste-in takes
-    /// effect on the very next sign-in attempt without an app restart.
-    static let clientId = ""
+    /// Shared Spotify Developer App Client ID baked into the app (#390). When the user has not
+    /// supplied their own override, this is what `resolvedClientId()` returns.
+    ///
+    /// TODO(#390): replace this placeholder with the real shared Spotify Developer App Client ID
+    /// from the Xomware Spotify Developer Dashboard before shipping. The matching Developer App
+    /// must have `xomfit://spotify-callback` registered under "Redirect URIs" or sign-in will
+    /// fail with `INVALID_CLIENT: Invalid redirect URI`.
+    static let sharedClientId: String = "PLACEHOLDER_SHARED_SPOTIFY_CLIENT_ID"
+
+    /// `@AppStorage` key the legacy per-user override is persisted under. Kept as a named
+    /// constant so the View, the AuthService, and the static resolver can't drift apart.
+    static let clientIdOverrideKey = "spotifyClientId"
+
+    /// Returns the Client ID we should hand to Spotify for the next OAuth call.
+    ///
+    /// Resolution order:
+    ///   1. Per-user override stored under `@AppStorage("spotifyClientId")` — for power users
+    ///      bringing their own Spotify Developer App.
+    ///   2. `sharedClientId` baked into the app.
+    ///
+    /// We read the override straight out of `UserDefaults.standard` rather than through
+    /// `@AppStorage` so this stays callable from anywhere — `@AppStorage` is a SwiftUI property
+    /// wrapper and would force `SpotifyConfig` to become a view-bound type. The on-disk storage
+    /// is identical (`UserDefaults.standard`), so the resolver sees a paste-in immediately.
+    ///
+    /// Emits a one-line console warning if the resolved value is still the unreplaced
+    /// `sharedClientId` placeholder — sign-in will fail until the project owner ships a real id.
+    static func resolvedClientId() -> String {
+        let override = (UserDefaults.standard.string(forKey: clientIdOverrideKey) ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let resolved = override.isEmpty ? sharedClientId : override
+
+        if resolved == sharedClientId, sharedClientId == "PLACEHOLDER_SHARED_SPOTIFY_CLIENT_ID" {
+            print("[SpotifyConfig] WARNING: shared Spotify Client ID is still the placeholder — " +
+                  "sign-in will fail until SpotifyConfig.sharedClientId is replaced with the " +
+                  "real Xomware Spotify Developer App Client ID (#390).")
+        }
+        return resolved
+    }
 
     /// Custom URL scheme that ASWebAuthenticationSession listens for. Must match the
     /// "Redirect URI" registered on the Spotify Developer Dashboard exactly.

--- a/Xomfit/Views/Profile/SpotifyConnectionView.swift
+++ b/Xomfit/Views/Profile/SpotifyConnectionView.swift
@@ -1,16 +1,27 @@
 import SwiftUI
 
-/// Spotify connection block embedded in `SettingsView` -> Music Sources (#347).
+/// Spotify connection block embedded in `SettingsView` -> Music Sources (#347, #390).
 ///
 /// Renders one of two modes:
-///   - Signed out: client-id paste field + "Sign In with Spotify" button
-///   - Signed in: connected display name + Sign Out button (paste field still visible so the
-///     user can swap accounts without leaving Settings)
+///   - Signed out: a single "Sign In with Spotify" CTA — the Client ID is shipped with the app
+///     so most users never need to think about it (#390).
+///   - Signed in: connected display name + Disconnect button.
+///
+/// Power users can still bring their own Spotify Developer App by expanding the
+/// "Advanced (override Client ID)" disclosure at the bottom.
 ///
 /// Kept as its own view so `SettingsView` doesn't grow another 80 lines of music-source logic.
 struct SpotifyConnectionView: View {
     @State private var spotifyAuth = SpotifyAuthService.shared
-    @AppStorage("spotifyClientId") private var clientId: String = ""
+
+    /// Per-user override for the shared Client ID baked into `SpotifyConfig.sharedClientId`. The
+    /// resolution rule lives in `SpotifyConfig.resolvedClientId()`; this binding only owns the
+    /// text-field state. Most users leave this empty and it stays out of sight under Advanced.
+    @AppStorage("spotifyClientId") private var clientIdOverride: String = ""
+
+    /// Local UI state — whether the Advanced disclosure is expanded. Defaults to collapsed so the
+    /// signed-out view stays a single-CTA experience.
+    @State private var showAdvanced: Bool = false
 
     @State private var isSigningIn: Bool = false
     @State private var errorMessage: String? = nil
@@ -22,8 +33,6 @@ struct SpotifyConnectionView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
             header
-
-            clientIdField
 
             // Surface the most recent capture, if any, so the user can confirm capture is
             // working without opening an active workout (Spotify capture polish).
@@ -39,6 +48,10 @@ struct SpotifyConnectionView: View {
                     .foregroundStyle(Theme.destructive)
                     .accessibilityLabel("Spotify error: \(errorMessage)")
             }
+
+            // Advanced override lives at the bottom, collapsed by default. Keeps the main row a
+            // single Sign In CTA for the 99% case (#390).
+            advancedDisclosure
         }
         .padding(.vertical, Theme.Spacing.xs)
     }
@@ -113,19 +126,40 @@ struct SpotifyConnectionView: View {
         .accessibilityLabel("Last captured: \(track.title)\(track.artist.map { ", by \($0)" } ?? "")")
     }
 
-    private var clientIdField: some View {
-        HStack(spacing: Theme.Spacing.md) {
-            Image(systemName: "key.fill")
-                .frame(width: Theme.Spacing.lg)
-                .foregroundStyle(Theme.accent)
-            SecureField("Spotify Client ID", text: $clientId)
-                .foregroundStyle(Theme.textPrimary)
-                .font(Theme.fontBody)
-                .textInputAutocapitalization(.never)
-                .autocorrectionDisabled()
-                .accessibilityLabel("Spotify Client ID")
-                .accessibilityHint("Paste the client id from your Spotify Developer Dashboard")
+    /// Advanced (override Client ID) — collapsed by default. Power users who want to swap in
+    /// their own Spotify Developer App can paste a Client ID here; an empty value falls back to
+    /// the shared id baked into the app via `SpotifyConfig.resolvedClientId()` (#390).
+    private var advancedDisclosure: some View {
+        DisclosureGroup(isExpanded: $showAdvanced) {
+            VStack(alignment: .leading, spacing: Theme.Spacing.xs) {
+                HStack(spacing: Theme.Spacing.md) {
+                    Image(systemName: "key.fill")
+                        .frame(width: Theme.Spacing.lg)
+                        .foregroundStyle(Theme.accent)
+                    SecureField("Override Spotify Client ID", text: $clientIdOverride)
+                        .foregroundStyle(Theme.textPrimary)
+                        .font(Theme.fontBody)
+                        .textInputAutocapitalization(.never)
+                        .autocorrectionDisabled()
+                        .accessibilityLabel("Spotify Client ID override")
+                        .accessibilityHint("Optional. Paste a Spotify Developer App client id to override the one shipped with XomFit.")
+                }
+                Text("Leave empty to use the Spotify app shipped with XomFit. Paste your own Client ID here to point sign-in at your personal Spotify Developer App.")
+                    .font(Theme.fontCaption)
+                    .foregroundStyle(Theme.textTertiary)
+            }
+            .padding(.top, Theme.Spacing.xs)
+        } label: {
+            HStack(spacing: Theme.Spacing.md) {
+                Image(systemName: "wrench.adjustable")
+                    .frame(width: Theme.Spacing.lg)
+                    .foregroundStyle(Theme.textTertiary)
+                Text("Advanced (override Client ID)")
+                    .font(Theme.fontCaption)
+                    .foregroundStyle(Theme.textSecondary)
+            }
         }
+        .accessibilityHint("Power users only. Override the Spotify Client ID that ships with XomFit.")
     }
 
     @ViewBuilder
@@ -145,6 +179,9 @@ struct SpotifyConnectionView: View {
             }
             .accessibilityHint("Removes Spotify access and stops capturing tracks")
         } else {
+            // Primary CTA. Always enabled after #390 — the shared Client ID is baked into the
+            // app so sign-in works out of the box; the override field (under Advanced) is
+            // purely optional.
             Button {
                 Task { await signIn() }
             } label: {
@@ -158,13 +195,11 @@ struct SpotifyConnectionView: View {
                             .foregroundStyle(Theme.accent)
                     }
                     Text(isSigningIn ? "Connecting..." : "Sign In with Spotify")
-                        .foregroundStyle(clientId.trimmingCharacters(in: .whitespaces).isEmpty ? Theme.textTertiary : Theme.textPrimary)
+                        .foregroundStyle(Theme.textPrimary)
                 }
             }
-            .disabled(isSigningIn || clientId.trimmingCharacters(in: .whitespaces).isEmpty)
-            .accessibilityHint(clientId.isEmpty
-                               ? "Paste a Spotify client id above first"
-                               : "Opens the Spotify login web view")
+            .disabled(isSigningIn)
+            .accessibilityHint("Opens the Spotify login web view")
         }
     }
 

--- a/docs/features/spotify-347/SETUP.md
+++ b/docs/features/spotify-347/SETUP.md
@@ -1,13 +1,69 @@
 # Spotify Now-Playing — Setup
 
-XomFit captures the soundtrack of every workout. Apple Music works out of the box via
-system permission. Spotify needs an explicit OAuth sign-in because iOS does not expose
-other apps' Now Playing metadata to third-party apps — we have to ask Spotify directly.
+XomFit captures the soundtrack of every workout. Apple Music works out of the box via the
+system Now-Playing permission. Spotify needs an explicit OAuth sign-in because iOS does not
+expose other apps' Now-Playing metadata to third-party apps — we have to ask Spotify directly.
 
-This guide walks you through creating a Spotify Developer App, copying the public client
-id into XomFit, and signing in.
+As of #390, XomFit ships with a shared Spotify Developer App baked in. **Most users just need
+to sign in.**
 
-## 1. Create a Spotify Developer App
+## Connect Spotify
+
+1. Open XomFit -> **Profile tab** -> **Settings** -> **Music Sources**.
+2. Tap **Sign In with Spotify**.
+3. A web sheet opens at `accounts.spotify.com`. Log in (if you aren't already) and approve the
+   requested scopes:
+   - `user-read-currently-playing` — what XomFit polls during a workout
+   - `user-read-playback-state` — reserved for future "what device is playing" UI
+4. You'll be bounced back to XomFit. The Music Sources row now shows
+   **Connected as `<your Spotify display name>`**.
+
+That's it. Start a workout — XomFit will pick up whatever you're playing on Spotify and merge
+it with any Apple Music captures into one chronological soundtrack on Finish.
+
+## How it works during a workout
+
+- When you tap **Start Workout**, XomFit kicks off a 30s polling task against
+  `https://api.spotify.com/v1/me/player/currently-playing`.
+- Each new track is deduped by URI and appended to the workout's captured tracks.
+- On **Finish Workout**, Apple Music + Spotify captures are merged and sorted by capture time
+  — one chronological soundtrack regardless of which app you used.
+- If nothing is playing on Spotify (or you're paused), the endpoint returns 204 and the
+  polling tick is a no-op. No empty entries, no crashes.
+
+## Troubleshooting
+
+- **"Spotify isn't configured yet."** — the shared Client ID hasn't been replaced in this
+  build. Wait for an updated build, or use the Advanced override below with your own Spotify
+  Developer App.
+- **Spotify says "INVALID_CLIENT: Invalid redirect URI"** — the redirect URI on the shared
+  Spotify Developer App must be exactly `xomfit://spotify-callback`. If you're overriding the
+  Client ID with your own Developer App, you have to register that URI yourself.
+- **Sign-in succeeds but the workout has no Spotify tracks** — make sure Spotify is actively
+  playing (not paused) on at least one device during the workout. The Web API only reports
+  active playback.
+- **"User not registered in the Developer Dashboard"** — the shared Developer App is in
+  Development Mode and you aren't on the allow-list. Either wait for the app to move to
+  Extended Quota Mode, or use the Advanced override with your own Developer App.
+
+## Security notes
+
+- The Spotify Client ID is a **public** identifier — Spotify treats it that way, and so do we.
+- XomFit uses **PKCE** (RFC 7636), so the client secret is never needed nor stored.
+- Tokens are persisted via `@AppStorage` (UserDefaults) for v1. Anyone with device access
+  could read them. Migrating to Keychain is tracked separately.
+- Tap **Disconnect Spotify** in the same section to forget the tokens. You can also revoke
+  XomFit's access from your Spotify account page at any time.
+
+---
+
+## Power users: use your own Client ID
+
+If you'd rather point sign-in at your own Spotify Developer App (e.g. you've already hit the
+shared app's user quota, or you want to test against your own account), XomFit honors a
+per-user override.
+
+### 1. Create a Spotify Developer App
 
 1. Go to <https://developer.spotify.com/dashboard> and log in with your Spotify account.
 2. Click **Create app**.
@@ -19,64 +75,26 @@ id into XomFit, and signing in.
    - **APIs used:** check **Web API**
 4. Agree to the developer terms and click **Save**.
 
-## 2. Copy your Client ID
+### 2. Copy your Client ID
 
 1. On the new app's dashboard, click **Settings** (top-right).
-2. Copy the value labelled **Client ID**.
-   - It looks like `9a1b2c3d4e5f6789...` — 32 hex chars.
+2. Copy the value labelled **Client ID** (a 32-char hex string).
    - You do NOT need the Client Secret. XomFit uses PKCE so the secret stays unused.
 
-## 3. Paste it into XomFit
+### 3. Paste it into XomFit
 
 1. Open XomFit -> **Profile tab** -> **Settings** -> **Music Sources**.
-2. Tap into the **Spotify Client ID** field and paste your client id.
-3. Tap **Sign In with Spotify**.
-4. A web sheet opens at `accounts.spotify.com`. Log in (if you aren't already) and
-   approve the requested scopes:
-   - `user-read-currently-playing` — what XomFit polls during a workout
-   - `user-read-playback-state` — reserved for future "what device is playing" UI
-5. You'll be bounced back to XomFit. The Music Sources row now shows
-   **Connected as `<your Spotify display name>`**.
+2. Expand the **Advanced (override Client ID)** disclosure at the bottom of the Spotify block.
+3. Paste your Client ID into the **Override Spotify Client ID** field.
+4. Tap **Sign In with Spotify**. Sign-in will now use *your* Developer App instead of the
+   shared one. Clearing the override field reverts to the shared id.
 
-## 4. (Optional) Add yourself as a tester
+### 4. (Optional) Add yourself as a tester
 
-Spotify apps start in *Development Mode*, which limits sign-in to users you explicitly
-allow.
+Spotify apps start in *Development Mode*, which limits sign-in to users you explicitly allow.
 
 1. Dashboard -> your app -> **Settings** -> **User Management**.
-2. Click **Add New User**, enter your Spotify display name and the email tied to the
-   account.
+2. Click **Add New User**, enter your Spotify display name and the email tied to the account.
 
-If you skip this you'll still see the Spotify login screen — but the consent step will
-fail with a `User not registered in the Developer Dashboard` message.
-
-## How it works during a workout
-
-- When you tap **Start Workout**, XomFit kicks off a 30s polling task against
-  `https://api.spotify.com/v1/me/player/currently-playing`.
-- Each new track is deduped by URI and appended to the workout's captured tracks.
-- On **Finish Workout**, Apple Music + Spotify captures are merged and sorted by capture
-  time — you get one chronological soundtrack regardless of which app you used.
-- If nothing is playing on Spotify (or you're paused), the endpoint returns 204 and the
-  polling tick is a no-op. No empty entries, no crashes.
-
-## Troubleshooting
-
-- **"Paste your Spotify Client ID in Settings before signing in"** — you tapped Sign In
-  before pasting the id. Drop it in the field above and retry.
-- **Spotify says "INVALID_CLIENT: Invalid redirect URI"** — the redirect URI on the
-  Dashboard does not exactly match `xomfit://spotify-callback`. Re-check casing.
-- **Sign-in succeeds but the workout has no Spotify tracks** — make sure Spotify is
-  actively playing (not paused) on at least one device during the workout. The Web API
-  only reports active playback.
-- **"User not registered in the Developer Dashboard"** — add yourself as a tester
-  (step 4 above) or move the app to Extended Quota Mode via Spotify's review process.
-
-## Security notes
-
-- The client id is a **public** identifier — Spotify treats it that way, and so do we.
-- XomFit uses **PKCE** (RFC 7636), so the client secret is never needed nor stored.
-- Tokens are persisted via `@AppStorage` (UserDefaults) for v1. Anyone with device
-  access could read them. Migrating to Keychain is tracked separately.
-- Tap **Disconnect Spotify** in the same section to forget the tokens. You can also
-  revoke XomFit's access from your Spotify account page at any time.
+If you skip this you'll still see the Spotify login screen — but the consent step will fail
+with a `User not registered in the Developer Dashboard` message.


### PR DESCRIPTION
Closes #390. SpotifyConfig.sharedClientId (PLACEHOLDER constant) baked in; resolvedClientId() reads UserDefaults override first, falls back to shared. SpotifyConnectionView no longer shows the Client ID field prominently — moved under 'Advanced (override Client ID)' DisclosureGroup. SETUP.md rewritten as 1-tap Sign In. **TODO for owner**: replace PLACEHOLDER_SHARED_SPOTIFY_CLIENT_ID with the real Xomware Spotify Developer App Client ID + ensure xomfit://spotify-callback is registered as a redirect URI.