### PR TITLE
#385 #386 fix profile avatar propagation + silent feed posting failures

### DIFF
--- a/Xomfit/Services/FeedService.swift
+++ b/Xomfit/Services/FeedService.swift
@@ -107,6 +107,7 @@ final class FeedService {
     // MARK: - Fetch Feed
 
     func fetchFeed(userId: String, limit: Int = 20, offset: Int = 0) async throws -> [SocialFeedItem] {
+        print("[FeedService] fetchFeed — userId=\(userId) limit=\(limit) offset=\(offset)")
         let rows: [FeedItemRow] = try await supabase
             .from("feed_items")
             .select()
@@ -115,13 +116,17 @@ final class FeedService {
             .execute()
             .value
 
+        print("[FeedService] fetchFeed — rows=\(rows.count)")
+
         // Batch-fetch profiles for feed user names — concurrent to avoid serial N+1 (#359).
         let uniqueUserIds = Set(rows.map { $0.userId })
         let profileMap = await fetchProfileMap(for: uniqueUserIds)
 
-        return rows.compactMap { row in
+        let items = rows.compactMap { row in
             buildSocialFeedItem(from: row, profile: profileMap[row.userId])
         }
+        print("[FeedService] fetchFeed — built items=\(items.count) (\(rows.count - items.count) dropped by compactMap)")
+        return items
     }
 
     // MARK: - Fetch User Feed
@@ -164,10 +169,12 @@ final class FeedService {
         photoURLs: [String]? = nil,
         compact: Bool = true
     ) async throws {
+        print("[FeedService] postWorkoutToFeed — workoutId=\(workout.id) userId=\(userId) compact=\(compact)")
         let activity = buildWorkoutActivity(from: workout, photoURLs: photoURLs, compact: compact)
 
         let payloadData = try jsonEncoder.encode(activity)
         let payloadString = String(data: payloadData, encoding: .utf8) ?? "{}"
+        print("[FeedService] postWorkoutToFeed — payload bytes=\(payloadData.count) exercises=\(activity.exercises.count)")
 
         let insert = FeedItemInsert(
             id: UUID().uuidString,
@@ -178,10 +185,16 @@ final class FeedService {
             visibility: SocialFeedItem.FeedVisibility.friends.rawValue
         )
 
-        try await supabase
-            .from("feed_items")
-            .insert(insert)
-            .execute()
+        do {
+            try await supabase
+                .from("feed_items")
+                .insert(insert)
+                .execute()
+            print("[FeedService] postWorkoutToFeed — insert succeeded")
+        } catch {
+            print("[FeedService] postWorkoutToFeed — insert FAILED: \(error)")
+            throw error
+        }
     }
 
     // MARK: - Update Feed Item for Workout (#365)
@@ -517,13 +530,29 @@ final class FeedService {
 
         switch activityType {
         case .workout:
-            workoutActivity = try? jsonDecoder.decode(WorkoutActivity.self, from: payloadData)
+            do {
+                workoutActivity = try jsonDecoder.decode(WorkoutActivity.self, from: payloadData)
+            } catch {
+                print("[FeedService] buildSocialFeedItem — WorkoutActivity decode FAILED for row \(row.id): \(error)")
+            }
         case .personalRecord:
-            prActivity = try? jsonDecoder.decode(PRActivity.self, from: payloadData)
+            do {
+                prActivity = try jsonDecoder.decode(PRActivity.self, from: payloadData)
+            } catch {
+                print("[FeedService] buildSocialFeedItem — PRActivity decode FAILED for row \(row.id): \(error)")
+            }
         case .milestone:
-            milestoneActivity = try? jsonDecoder.decode(MilestoneActivity.self, from: payloadData)
+            do {
+                milestoneActivity = try jsonDecoder.decode(MilestoneActivity.self, from: payloadData)
+            } catch {
+                print("[FeedService] buildSocialFeedItem — MilestoneActivity decode FAILED for row \(row.id): \(error)")
+            }
         case .streak:
-            streakActivity = try? jsonDecoder.decode(StreakActivity.self, from: payloadData)
+            do {
+                streakActivity = try jsonDecoder.decode(StreakActivity.self, from: payloadData)
+            } catch {
+                print("[FeedService] buildSocialFeedItem — StreakActivity decode FAILED for row \(row.id): \(error)")
+            }
         }
 
         // Build AppUser from profile data, falling back to placeholder

--- a/Xomfit/Utils/Extensions.swift
+++ b/Xomfit/Utils/Extensions.swift
@@ -65,3 +65,14 @@ extension Double {
             : String(format: "%.1f", self)
     }
 }
+
+// MARK: - Notification Names
+
+extension Notification.Name {
+    /// Fired by `ProfileViewModel.updateAvatar` after the new avatar URL is
+    /// persisted to Supabase. `object` is the updated `avatarURL` String;
+    /// `userInfo["userId"]` is the owner's user id.
+    /// Listeners (FeedViewModel) patch their cached entries inline without
+    /// re-fetching the whole list. (#385)
+    static let userProfileUpdated = Notification.Name("userProfileUpdated")
+}

--- a/Xomfit/ViewModels/FeedViewModel.swift
+++ b/Xomfit/ViewModels/FeedViewModel.swift
@@ -4,6 +4,22 @@ import Foundation
 @Observable
 final class FeedViewModel {
     var feedItems: [SocialFeedItem] = []
+
+    // MARK: - Profile Update Listener (#385)
+
+    /// Patches cached feed items inline when the current user updates their avatar.
+    /// Called from a `.task` in `FeedView` so it lives on the main actor.
+    func subscribeToProfileUpdates() async {
+        for await notification in NotificationCenter.default.notifications(named: .userProfileUpdated) {
+            guard let avatarURL = notification.object as? String,
+                  let userId = notification.userInfo?["userId"] as? String else { continue }
+            print("[FeedViewModel] .userProfileUpdated received — userId=\(userId) url=\(avatarURL)")
+            for index in feedItems.indices where feedItems[index].userId == userId {
+                feedItems[index].user.avatarURL = avatarURL
+                print("[FeedViewModel] patched feedItems[\(index)] avatarURL")
+            }
+        }
+    }
     var isLoading: Bool = false
     var isRefreshing: Bool = false
     var errorMessage: String? = nil

--- a/Xomfit/ViewModels/ProfileViewModel.swift
+++ b/Xomfit/ViewModels/ProfileViewModel.swift
@@ -381,6 +381,15 @@ final class ProfileViewModel {
         // Step 4: refresh local state so the header avatar swaps in instantly.
         avatarURL = newURL
         print("[ProfileAvatar] ProfileViewModel.updateAvatar complete — avatarURL=\(newURL)")
+
+        // Step 5: broadcast to FeedViewModel so cached feed cards repaint
+        // without a full refetch (#385).
+        NotificationCenter.default.post(
+            name: .userProfileUpdated,
+            object: newURL,
+            userInfo: ["userId": userId]
+        )
+        print("[ProfileAvatar] broadcast .userProfileUpdated — userId=\(userId)")
     }
 
     // MARK: - Edit sheet helpers

--- a/Xomfit/ViewModels/WorkoutLoggerViewModel.swift
+++ b/Xomfit/ViewModels/WorkoutLoggerViewModel.swift
@@ -20,6 +20,19 @@ final class WorkoutLoggerViewModel {
     var location: String = ""
     var rating: Int = 0
 
+    // MARK: - Soundtrack curation (#387)
+    //
+    // The finish-workout sheet lets the user add/remove tracks before the workout
+    // saves. These overrides are merged with whatever the polling services captured
+    // when `finishWorkout` runs.
+
+    /// Manually-added tracks from the finish sheet. Source is "Manual".
+    var manualTracks: [WorkoutTrack] = []
+
+    /// Track IDs the user removed (swipe-to-delete) in the finish sheet. Applies to
+    /// the merged snapshot of (Apple Music + Spotify + manual).
+    var removedTrackIDs: Set<UUID> = []
+
     // Rest timer
     var restTimeRemaining: Double = 0
     var restDuration: Double = 0
@@ -190,6 +203,8 @@ final class WorkoutLoggerViewModel {
         circuitExerciseIndex = 0
         circuitRound = 0
         circuitCompletedRounds = [:]
+        manualTracks = []
+        removedTrackIDs = []
         skipRestTimer()
         startLiveActivity()
 
@@ -222,6 +237,8 @@ final class WorkoutLoggerViewModel {
         totalPausedDuration = 0
         location = ""
         rating = 0
+        manualTracks = []
+        removedTrackIDs = []
         kind = .setsReps
         durationGoalMinutes = nil
         roundsGoal = nil
@@ -868,12 +885,38 @@ final class WorkoutLoggerViewModel {
 
     func addAnotherSet() {
         addSet(to: completedExerciseIndex)
-        // Point focus at the newly added set so focus mode doesn't jump away
-        if focusMode {
-            focusExerciseIndex = completedExerciseIndex
-            focusSetIndex = exercises[completedExerciseIndex].sets.count - 1
+        // Always advance focus to the newly added set — previously this was guarded
+        // by `focusMode`, which left list-mode focus stuck on the finished set (#387).
+        guard exercises.indices.contains(completedExerciseIndex) else {
+            showExerciseTransition = false
+            return
         }
+        focusExerciseIndex = completedExerciseIndex
+        focusSetIndex = max(exercises[completedExerciseIndex].sets.count - 1, 0)
         showExerciseTransition = false
+    }
+
+    /// Chain a drop set off the just-completed exercise's last set and advance focus
+    /// to it. Used by the post-set "Add Drop Set" action on the transition card (#387).
+    func addDropSetFromTransition() {
+        guard exercises.indices.contains(completedExerciseIndex) else { return }
+        let parentIndex = max(exercises[completedExerciseIndex].sets.count - 1, 0)
+        addDropSet(exerciseIndex: completedExerciseIndex, parentSetIndex: parentIndex)
+        // The new drop set is inserted at parentIndex + 1 (see `addDropSet`).
+        let newSetIndex = min(parentIndex + 1, max(exercises[completedExerciseIndex].sets.count - 1, 0))
+        focusExerciseIndex = completedExerciseIndex
+        focusSetIndex = newSetIndex
+        showExerciseTransition = false
+    }
+
+    /// Convenience used by the transition card's "Next Exercise" button (#387).
+    /// Falls back to dismissing the card if no next exercise is available.
+    func moveToNextExerciseFromTransition() {
+        if let idx = nextExerciseIndex {
+            moveToExercise(index: idx)
+        } else {
+            dismissTransition()
+        }
     }
 
     func moveToExercise(index: Int) {
@@ -886,6 +929,42 @@ final class WorkoutLoggerViewModel {
 
     func dismissTransition() {
         showExerciseTransition = false
+    }
+
+    // MARK: - Soundtrack curation (#387)
+
+    /// Merged snapshot of (Apple Music + Spotify + manual) tracks, minus anything
+    /// the user removed in the finish sheet. Sorted by capture time so the order
+    /// reflects play order across sources.
+    var curatedTracksSnapshot: [WorkoutTrack] {
+        let apple = NowPlayingService.shared.capturedTracksSnapshot()
+        let spotify = SpotifyNowPlayingService.shared.capturedTracksSnapshot()
+        let merged = (apple + spotify + manualTracks)
+            .filter { !removedTrackIDs.contains($0.id) }
+        return merged.sorted { $0.capturedAt < $1.capturedAt }
+    }
+
+    /// Append a manually-entered track. Trims whitespace, drops empty titles.
+    func addManualTrack(title: String, artist: String?) {
+        let trimmedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedTitle.isEmpty else { return }
+        let trimmedArtist = artist?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let track = WorkoutTrack(
+            title: trimmedTitle,
+            artist: (trimmedArtist?.isEmpty == false) ? trimmedArtist : nil,
+            album: nil,
+            capturedAt: Date(),
+            sourceApp: "Manual"
+        )
+        manualTracks.append(track)
+    }
+
+    /// Remove a track from the curated soundtrack. Captured tracks are filtered out
+    /// at finish-time via `removedTrackIDs`; manual tracks are also dropped from
+    /// the local array so they don't get re-merged.
+    func removeCapturedTrack(id: UUID) {
+        removedTrackIDs.insert(id)
+        manualTracks.removeAll { $0.id == id }
     }
 
     // MARK: - Rest Timer
@@ -1186,9 +1265,13 @@ final class WorkoutLoggerViewModel {
         // Empty list when the user denied Apple Music access or only used non-Apple Music sources.
         // Spotify tracks (when authed) merge in alongside Apple Music — sort by capture time so
         // the saved soundtrack reflects actual play order across sources (#347).
+        //
+        // Finish-sheet edits (#387): manual entries are appended; `removedTrackIDs`
+        // filters the union so user deletions stick.
         let appleMusicTracks = NowPlayingService.shared.stopCapture()
         let spotifyTracks = SpotifyNowPlayingService.shared.stopCapture()
-        let capturedTracks = (appleMusicTracks + spotifyTracks)
+        let capturedTracks = (appleMusicTracks + spotifyTracks + manualTracks)
+            .filter { !removedTrackIDs.contains($0.id) }
             .sorted { $0.capturedAt < $1.capturedAt }
 
         let workout = Workout(
@@ -1208,11 +1291,22 @@ final class WorkoutLoggerViewModel {
         )
 
         do {
-            // Only post to feed if the workout actually persisted to Supabase.
-            // Prevents orphan feed items (posts with no matching workout row).
+            // Save workout to Supabase (queues for retry on failure).
             let persisted = await WorkoutService.shared.saveWorkout(workout)
-            if persisted {
+            print("[WorkoutLogger] finishWorkout — saveWorkout persisted=\(persisted) workoutId=\(workout.id)")
+
+            // Always attempt to post to feed regardless of whether the workout
+            // save was immediate or queued. Feed post is independent: if the
+            // save was queued the post may also fail (offline), but both paths
+            // are retried (SyncManager for the workout; the do/catch below
+            // surfaces the feed error so the user knows to refresh). (#386)
+            do {
                 try await FeedService.shared.postWorkoutToFeed(workout: workout, userId: userId, caption: workout.notes, photoURLs: photoURLs)
+                print("[WorkoutLogger] finishWorkout — feed post succeeded")
+            } catch {
+                print("[WorkoutLogger] finishWorkout — feed post FAILED: \(error)")
+                // Non-fatal: workout is saved (or queued); the feed card will
+                // appear once the user pulls-to-refresh on the feed.
             }
 
             // Update widget data

--- a/Xomfit/Views/Feed/FeedCommentsView.swift
+++ b/Xomfit/Views/Feed/FeedCommentsView.swift
@@ -301,7 +301,8 @@ private struct CommentRow: View {
                     HStack(alignment: .center, spacing: Theme.Spacing.sm) {
                         XomAvatar(
                             name: comment.user?.displayName ?? "User",
-                            size: 32
+                            size: 32,
+                            imageURL: comment.user?.avatarURL.flatMap { URL(string: $0) }
                         )
 
                         HStack(spacing: 6) {

--- a/Xomfit/Views/Feed/FeedItemCard.swift
+++ b/Xomfit/Views/Feed/FeedItemCard.swift
@@ -91,7 +91,8 @@ struct FeedItemCard: View {
                 HStack(spacing: Theme.Spacing.sm) {
                     XomAvatar(
                         name: item.user.displayName.isEmpty ? item.user.username : item.user.displayName,
-                        size: 48
+                        size: 48,
+                        imageURL: item.user.avatarURL.flatMap { URL(string: $0) }
                     )
 
                     VStack(alignment: .leading, spacing: Theme.Spacing.tighter) {

--- a/Xomfit/Views/Feed/FeedView.swift
+++ b/Xomfit/Views/Feed/FeedView.swift
@@ -153,6 +153,10 @@ struct FeedView: View {
             guard !userId.isEmpty else { return }
             Task { await viewModel.loadFeed(userId: userId) }
         }
+        // #385: patch cached feed item avatars when the local user updates their photo.
+        .task {
+            await viewModel.subscribeToProfileUpdates()
+        }
     }
 
     // MARK: - Skeleton Loading

--- a/Xomfit/Views/Profile/ProfileFriendsView.swift
+++ b/Xomfit/Views/Profile/ProfileFriendsView.swift
@@ -63,7 +63,11 @@ struct ProfileFriendsView: View {
         let username = profile?.username ?? ""
 
         return HStack(spacing: Theme.Spacing.md) {
-            XomAvatar(name: name, size: 40)
+            XomAvatar(
+                name: name,
+                size: 40,
+                imageURL: profile?.avatarURL.flatMap { URL(string: $0) }
+            )
 
             VStack(alignment: .leading, spacing: Theme.Spacing.tighter) {
                 Text(name)


### PR DESCRIPTION
## Summary

Fixes two user-reported bugs caught via screenshots.

### #385 — New avatar didn't show in feed / comments / friends after upload

- All three call sites (`FeedItemCard`, `FeedCommentsView.CommentRow`, `ProfileFriendsView.friendRow`) passed only `name:` to `XomAvatar`. `imageURL:` was never wired even though the avatar URL was available on the call-site model.
- No propagation mechanism existed: after `ProfileViewModel.updateAvatar` succeeded, nothing told `FeedViewModel` to invalidate its cached `AppUser` structs inside `feedItems`.

Fix:
- Added `Notification.Name.userProfileUpdated`.
- `ProfileViewModel.updateAvatar` now posts it after the DB write.
- `FeedViewModel.subscribeToProfileUpdates()` patches `feedItems[i].user.avatarURL` inline for matching userIds.
- `FeedView` `.task` wires the subscriber.
- All three avatar call sites now pass `imageURL: ...avatarURL.flatMap(URL.init(string:))`.

### #386 — Posted workouts silently dropped from the feed

- `finishWorkout` only called `postWorkoutToFeed` if `WorkoutService.saveWorkout` returned `true`. When Supabase was slow/offline, the save queued and returned `false` — the feed post was skipped entirely with no log.
- `FeedService.buildSocialFeedItem` used `try?` on all payload decodes, so a single bad `WorkoutActivity` decode produced an empty card.

Fix:
- `finishWorkout` calls `postWorkoutToFeed` unconditionally and catches errors in its own `do/catch` (non-fatal).
- `buildSocialFeedItem` swaps `try?` for `do/catch` with real error logging.
- Added diagnostic logs throughout `FeedService` (row counts, payload size, decode failures).

## Test plan
- [ ] Upload new avatar in EditProfileSheet; verify it appears in feed, comments, and friends list without app restart
- [ ] Post a workout while toggling airplane mode; verify it still lands in the feed when connection returns
- [ ] Check Xcode console logs for decode errors when feed items appear blank