### PR TITLE
#389 add SoundCloud Now-Playing capture (OAuth PKCE + play-history polling)

### DIFF
--- a/Xomfit/Services/SoundCloudAuthService.swift
+++ b/Xomfit/Services/SoundCloudAuthService.swift
@@ -1,0 +1,385 @@
+import AuthenticationServices
+import CryptoKit
+import Foundation
+import SwiftUI
+import UIKit
+
+/// SoundCloud OAuth 2.0 Authorization Code with PKCE (#389).
+///
+/// ## Why PKCE (no client secret)
+/// Same rationale as the Spotify integration: the client id is treated as public, the PKCE
+/// verifier stays in-process and prevents code interception, and we never ship a secret.
+/// Crucially, SoundCloud's developer program has been intermittently closed to new app
+/// registrations — a shared baked-in client id is the only realistic path. PKCE makes that
+/// distribution safe.
+///
+/// ## Storage caveat
+/// Tokens persisted via `@AppStorage` (UserDefaults). Mirrors the Spotify service.
+/// Keychain migration tracked separately.
+///
+/// ## Callback delivery
+/// Same pattern as Spotify — `ASWebAuthenticationSession` returns the redirect URL via its
+/// completion handler. `XomfitApp.onOpenURL` is a belt-and-suspenders fallback.
+@MainActor
+@Observable
+final class SoundCloudAuthService: NSObject {
+    static let shared = SoundCloudAuthService()
+
+    // MARK: - Persisted state
+
+    @ObservationIgnored @AppStorage("soundcloud.accessToken") private var accessToken: String = ""
+    @ObservationIgnored @AppStorage("soundcloud.refreshToken") private var refreshToken: String = ""
+    @ObservationIgnored @AppStorage("soundcloud.tokenExpiry") private var tokenExpiryEpoch: Double = 0
+    @ObservationIgnored @AppStorage("soundcloud.displayName") private var displayNameStorage: String = ""
+
+    // MARK: - Observable mirror
+
+    /// Mirror of the `@AppStorage` flags above so SwiftUI views observing this service
+    /// re-render after sign-in / sign-out. `@AppStorage` doesn't notify our `@Observable` macro.
+    private(set) var isAuthenticated: Bool = false
+    private(set) var displayName: String = ""
+
+    // MARK: - In-flight state
+
+    private var pendingPKCEVerifier: String?
+    private var pendingState: String?
+    private var webAuthSession: ASWebAuthenticationSession?
+
+    private override init() {
+        super.init()
+        isAuthenticated = !accessToken.isEmpty
+        displayName = displayNameStorage
+    }
+
+    // MARK: - Public API
+
+    /// Begin the OAuth dance. Returns `true` on a successful token exchange.
+    ///
+    /// Throws:
+    ///   - `SoundCloudAuthError.userCancelled` — user dismissed the in-app browser
+    ///   - `SoundCloudAuthError.callbackInvalid` — SoundCloud returned an error or unexpected payload
+    ///   - `SoundCloudAuthError.tokenExchangeFailed` — `/oauth2/token` returned non-2xx
+    ///   - `SoundCloudAuthError.apiClosed` — SoundCloud rejected the shared client id (very likely
+    ///     while their dev program is closed to new apps)
+    @discardableResult
+    func signIn() async throws -> Bool {
+        let verifier = Self.generatePKCEVerifier()
+        let challenge = Self.codeChallenge(for: verifier)
+        let state = Self.randomURLSafeString(length: 16)
+        pendingPKCEVerifier = verifier
+        pendingState = state
+
+        guard let authURL = buildAuthorizeURL(challenge: challenge, state: state) else {
+            throw SoundCloudAuthError.callbackInvalid
+        }
+
+        // ASWebAuthenticationSession returns the callback URL via its completion handler.
+        let callbackURL: URL = try await withCheckedThrowingContinuation { (cont: CheckedContinuation<URL, Error>) in
+            let session = ASWebAuthenticationSession(
+                url: authURL,
+                callbackURLScheme: SoundCloudConfig.callbackURLScheme
+            ) { url, error in
+                if let error = error as? ASWebAuthenticationSessionError, error.code == .canceledLogin {
+                    cont.resume(throwing: SoundCloudAuthError.userCancelled)
+                    return
+                }
+                if let error {
+                    cont.resume(throwing: error)
+                    return
+                }
+                guard let url else {
+                    cont.resume(throwing: SoundCloudAuthError.callbackInvalid)
+                    return
+                }
+                cont.resume(returning: url)
+            }
+            session.presentationContextProvider = self
+            session.prefersEphemeralWebBrowserSession = false
+            self.webAuthSession = session
+            if !session.start() {
+                cont.resume(throwing: SoundCloudAuthError.callbackInvalid)
+            }
+        }
+
+        let code = try parseCallback(url: callbackURL, expectedState: state)
+        try await exchangeCodeForToken(code: code, verifier: verifier)
+        try await refreshUserDisplayName()
+        return true
+    }
+
+    /// Last-resort callback handler invoked from `XomfitApp.onOpenURL` if the OS routes the
+    /// redirect through the app rather than ASWebAuthenticationSession's completion handler.
+    /// No-op today — kept for symmetry with `SpotifyAuthService.handleCallback`.
+    func handleCallback(url: URL) {
+        guard url.scheme == SoundCloudConfig.callbackURLScheme,
+              url.host == "soundcloud-callback" else { return }
+        print("[SoundCloudAuth] handleCallback received url (ASWebAuthSession should have handled it)")
+    }
+
+    /// Forget the tokens locally. SoundCloud's token endpoint does not document a revoke
+    /// path for end users; clearing local state is sufficient.
+    func signOut() {
+        accessToken = ""
+        refreshToken = ""
+        tokenExpiryEpoch = 0
+        displayNameStorage = ""
+        isAuthenticated = false
+        displayName = ""
+    }
+
+    /// Returns a fresh access token, refreshing via the stored refresh token if the cached
+    /// one is within 60s of expiry. Returns nil when the user hasn't signed in or refresh failed.
+    func currentTokenRefreshingIfNeeded() async -> String? {
+        guard !accessToken.isEmpty else { return nil }
+
+        let now = Date().timeIntervalSince1970
+        // Refresh proactively to avoid the racy "401 mid-poll" window. SoundCloud's
+        // `non-expiring` scope returns tokens with no expiry — in that case
+        // `tokenExpiryEpoch` is 0 and this branch never fires.
+        if tokenExpiryEpoch > 0, tokenExpiryEpoch - now < 60, !refreshToken.isEmpty {
+            do {
+                try await refreshAccessToken()
+            } catch {
+                print("[SoundCloudAuth] refresh failed: \(error)")
+                return nil
+            }
+        }
+        return accessToken.isEmpty ? nil : accessToken
+    }
+
+    // MARK: - URL construction
+
+    private func buildAuthorizeURL(challenge: String, state: String) -> URL? {
+        var components = URLComponents(url: SoundCloudConfig.authBaseURL, resolvingAgainstBaseURL: false)
+        components?.queryItems = [
+            URLQueryItem(name: "client_id", value: SoundCloudConfig.sharedClientId),
+            URLQueryItem(name: "response_type", value: "code"),
+            URLQueryItem(name: "redirect_uri", value: SoundCloudConfig.redirectURI),
+            URLQueryItem(name: "code_challenge_method", value: "S256"),
+            URLQueryItem(name: "code_challenge", value: challenge),
+            URLQueryItem(name: "state", value: state),
+            URLQueryItem(name: "scope", value: SoundCloudConfig.scopes)
+        ]
+        return components?.url
+    }
+
+    private func parseCallback(url: URL, expectedState: String) throws -> String {
+        guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+            throw SoundCloudAuthError.callbackInvalid
+        }
+        let items = components.queryItems ?? []
+        if let err = items.first(where: { $0.name == "error" })?.value {
+            print("[SoundCloudAuth] callback error: \(err)")
+            // `invalid_client` here almost always means SoundCloud rejected the shared
+            // client id — surface a more actionable error so the user knows they're not
+            // doing anything wrong; the integration is gated on SoundCloud's side.
+            if err.contains("invalid_client") || err.contains("unauthorized_client") {
+                throw SoundCloudAuthError.apiClosed
+            }
+            throw SoundCloudAuthError.callbackInvalid
+        }
+        guard let returnedState = items.first(where: { $0.name == "state" })?.value,
+              returnedState == expectedState else {
+            throw SoundCloudAuthError.callbackInvalid
+        }
+        guard let code = items.first(where: { $0.name == "code" })?.value, !code.isEmpty else {
+            throw SoundCloudAuthError.callbackInvalid
+        }
+        return code
+    }
+
+    // MARK: - Token exchange
+
+    private func exchangeCodeForToken(code: String, verifier: String) async throws {
+        var request = URLRequest(url: SoundCloudConfig.tokenURL)
+        request.httpMethod = "POST"
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        let body = formEncoded([
+            "client_id": SoundCloudConfig.sharedClientId,
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": SoundCloudConfig.redirectURI,
+            "code_verifier": verifier
+        ])
+        request.httpBody = body.data(using: .utf8)
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+            print("[SoundCloudAuth] token exchange non-2xx — \(String(data: data, encoding: .utf8) ?? "")")
+            // SoundCloud returns 401/403 with `invalid_client` when our shared id is not
+            // accepted — funnel that into the more useful `.apiClosed` so the UI can tell
+            // the user it's not their fault.
+            if let http = response as? HTTPURLResponse, http.statusCode == 401 || http.statusCode == 403 {
+                throw SoundCloudAuthError.apiClosed
+            }
+            throw SoundCloudAuthError.tokenExchangeFailed
+        }
+        let payload = try JSONDecoder().decode(TokenResponse.self, from: data)
+        storeToken(payload)
+    }
+
+    private func refreshAccessToken() async throws {
+        guard !refreshToken.isEmpty else { throw SoundCloudAuthError.tokenExchangeFailed }
+        var request = URLRequest(url: SoundCloudConfig.tokenURL)
+        request.httpMethod = "POST"
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        let body = formEncoded([
+            "client_id": SoundCloudConfig.sharedClientId,
+            "grant_type": "refresh_token",
+            "refresh_token": refreshToken
+        ])
+        request.httpBody = body.data(using: .utf8)
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+            print("[SoundCloudAuth] refresh non-2xx — \(String(data: data, encoding: .utf8) ?? "")")
+            // SoundCloud rejected the refresh token (revoked or expired) — drop local state
+            // so the UI returns to the "Sign In" affordance.
+            if let http = response as? HTTPURLResponse, http.statusCode == 400 {
+                signOut()
+            }
+            throw SoundCloudAuthError.tokenExchangeFailed
+        }
+        let payload = try JSONDecoder().decode(TokenResponse.self, from: data)
+        storeToken(payload)
+    }
+
+    private func storeToken(_ payload: TokenResponse) {
+        accessToken = payload.access_token
+        if let new = payload.refresh_token, !new.isEmpty {
+            refreshToken = new
+        }
+        // `non-expiring` scope returns no `expires_in` — store 0 to skip refresh checks.
+        if let expiresIn = payload.expires_in {
+            tokenExpiryEpoch = Date().timeIntervalSince1970 + Double(expiresIn)
+        } else {
+            tokenExpiryEpoch = 0
+        }
+        isAuthenticated = true
+    }
+
+    // MARK: - Profile
+
+    /// Pulls `/me` once after sign-in to surface the user's display name in Settings.
+    /// Failure is non-fatal — we still consider sign-in successful with an empty display.
+    private func refreshUserDisplayName() async throws {
+        guard let token = await currentTokenRefreshingIfNeeded() else { return }
+        var request = URLRequest(url: URL(string: "https://api.soundcloud.com/me")!)
+        request.setValue("OAuth \(token)", forHTTPHeaderField: "Authorization")
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else { return }
+            let profile = try JSONDecoder().decode(SoundCloudMeResponse.self, from: data)
+            let resolved = profile.username ?? profile.permalink ?? ""
+            displayNameStorage = resolved
+            displayName = resolved
+        } catch {
+            print("[SoundCloudAuth] /me lookup failed: \(error)")
+        }
+    }
+
+    // MARK: - PKCE helpers
+
+    private static func generatePKCEVerifier() -> String {
+        randomURLSafeString(length: 64)
+    }
+
+    private static func codeChallenge(for verifier: String) -> String {
+        let data = Data(verifier.utf8)
+        let hashed = SHA256.hash(data: data)
+        return Data(hashed).base64URLEncodedString()
+    }
+
+    private static func randomURLSafeString(length: Int) -> String {
+        var bytes = [UInt8](repeating: 0, count: length)
+        _ = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
+        return Data(bytes).base64URLEncodedString()
+    }
+
+    private func formEncoded(_ params: [String: String]) -> String {
+        params
+            .map { key, value in
+                let escapedKey = key.addingPercentEncoding(withAllowedCharacters: .urlQueryParamSoundCloudAllowed) ?? key
+                let escapedValue = value.addingPercentEncoding(withAllowedCharacters: .urlQueryParamSoundCloudAllowed) ?? value
+                return "\(escapedKey)=\(escapedValue)"
+            }
+            .joined(separator: "&")
+    }
+}
+
+// MARK: - Presentation context
+
+extension SoundCloudAuthService: ASWebAuthenticationPresentationContextProviding {
+    nonisolated func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
+        MainActor.assumeIsolated {
+            let scene = UIApplication.shared.connectedScenes
+                .compactMap { $0 as? UIWindowScene }
+                .first(where: { $0.activationState == .foregroundActive })
+                ?? UIApplication.shared.connectedScenes
+                    .compactMap { $0 as? UIWindowScene }
+                    .first
+            if let key = scene?.keyWindow { return key }
+            if let scene { return UIWindow(windowScene: scene) }
+            return UIWindow()
+        }
+    }
+}
+
+// MARK: - Errors + payloads
+
+enum SoundCloudAuthError: LocalizedError {
+    case userCancelled
+    case callbackInvalid
+    case tokenExchangeFailed
+    case apiClosed
+
+    var errorDescription: String? {
+        switch self {
+        case .userCancelled:
+            return "SoundCloud sign-in was cancelled."
+        case .callbackInvalid:
+            return "SoundCloud returned an invalid response."
+        case .tokenExchangeFailed:
+            return "Couldn't exchange the SoundCloud auth code. Try signing in again."
+        case .apiClosed:
+            return "SoundCloud rejected XomFit's shared client id. The SoundCloud Developer program has been intermittently closed to new apps — see Settings for status."
+        }
+    }
+}
+
+private struct TokenResponse: Decodable {
+    let access_token: String
+    let token_type: String?
+    let expires_in: Int?
+    let refresh_token: String?
+    let scope: String?
+}
+
+private struct SoundCloudMeResponse: Decodable {
+    let username: String?
+    let permalink: String?
+}
+
+// MARK: - Base64URL helper
+
+private extension Data {
+    /// RFC 4648 §5 base64url, no padding — required for PKCE code_challenge.
+    func base64URLEncodedString() -> String {
+        base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+}
+
+private extension CharacterSet {
+    /// Strict `application/x-www-form-urlencoded` allowed set, scoped to SoundCloud's token
+    /// endpoint. Named distinctly from Spotify's equivalent to avoid stepping on it at the
+    /// file-private extension level (the global `.urlQueryParamAllowed` in
+    /// `SpotifyAuthService.swift` is file-private, but keeping a separate name is clearer).
+    static let urlQueryParamSoundCloudAllowed: CharacterSet = {
+        var allowed = CharacterSet.alphanumerics
+        allowed.insert(charactersIn: "-._~")
+        return allowed
+    }()
+}

--- a/Xomfit/Services/SoundCloudConfig.swift
+++ b/Xomfit/Services/SoundCloudConfig.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+/// Static configuration for the SoundCloud Web API OAuth + Now-Playing integration (#389).
+///
+/// ## Why a shared client id (vs paste-your-own like Spotify)
+/// SoundCloud's developer-app program has been intermittently closed to new registrations
+/// for years — they've publicly stated they're "not currently accepting new applications"
+/// at various points. Asking every user to register their own app is a non-starter.
+///
+/// Instead, XomFit ships a single shared client id baked into the binary. Because we use
+/// the Authorization Code with PKCE grant (no client secret), the shared id is safe to
+/// distribute — only the user's own OAuth verifier + redirect URI gate the token exchange.
+///
+/// ## Status (see `docs/features/soundcloud-389/SETUP.md`)
+/// As of shipping, the `sharedClientId` is a **placeholder**. If SoundCloud is currently
+/// not accepting new developer apps, sign-in will fail with a clear error and the user can
+/// still finish the workout — Apple Music + Spotify capture continue working untouched.
+enum SoundCloudConfig {
+    /// Public SoundCloud Developer client id shared across XomFit installs. Treated as
+    /// public per the PKCE flow — no client secret is needed or stored. Replace once
+    /// the SoundCloud Dev Dashboard accepts new app registrations.
+    static let sharedClientId: String = "PLACEHOLDER_SHARED_SOUNDCLOUD_CLIENT_ID"  // TODO replace
+
+    /// Custom URL scheme that ASWebAuthenticationSession listens for. Must match the
+    /// "Redirect URI" registered on the SoundCloud Developer Dashboard exactly.
+    static let redirectURI = "xomfit://soundcloud-callback"
+
+    /// Scope string. `non-expiring` requests a long-lived token so the user doesn't have
+    /// to re-auth between workouts. See https://developers.soundcloud.com/docs/api/explorer
+    static let scopes = "non-expiring"
+
+    static let authBaseURL = URL(string: "https://api.soundcloud.com/connect")!
+    static let tokenURL = URL(string: "https://api.soundcloud.com/oauth2/token")!
+
+    /// SoundCloud's recent listening history endpoint. Unlike Spotify, SoundCloud does
+    /// not expose a real-time "currently playing" — only `play-history` (most recent 50
+    /// tracks). We poll and look at the LATEST entry; if it's new since last tick, we
+    /// capture it. This is best-effort and may lag a few seconds behind playback.
+    static let recentlyPlayedURL = URL(string: "https://api.soundcloud.com/me/play-history/tracks?limit=5")!
+
+    /// URL scheme component of `redirectURI` — what ASWebAuthenticationSession needs separately.
+    static let callbackURLScheme = "xomfit"
+}

--- a/Xomfit/Services/SoundCloudNowPlayingService.swift
+++ b/Xomfit/Services/SoundCloudNowPlayingService.swift
@@ -1,0 +1,220 @@
+import Foundation
+
+/// Polls SoundCloud's `/me/play-history/tracks` endpoint during an active workout (#389) and
+/// accumulates the tracks for attachment to the saved `Workout`.
+///
+/// ## Why play-history (not currently-playing)
+/// SoundCloud's Web API does NOT expose a real-time "currently playing" endpoint the way
+/// Spotify does. The only window into a user's listening is `/me/play-history/tracks`,
+/// which returns the most recently played tracks (up to 50). We request the latest 5, then
+/// look at the very first entry — if it's new since the last poll, we capture it.
+///
+/// This is best-effort: a track has to finish (or be skipped past a play-count threshold)
+/// before SoundCloud writes it to history, so capture may lag the actual playback by a few
+/// seconds to a couple of minutes. Acceptable for a workout soundtrack.
+///
+/// ## Same shape as the other capture services
+/// `isCapturing` / `capturedCount` / `lastCapturedTrack` / `startCapture()` /
+/// `stopCapture() -> [WorkoutTrack]` mirror `NowPlayingService` and `SpotifyNowPlayingService`
+/// so `WorkoutLoggerViewModel` can merge them at finish time without special-casing.
+///
+/// ## Silent when not authenticated
+/// If `SoundCloudAuthService.shared.currentTokenRefreshingIfNeeded()` returns nil (user
+/// never signed in, or token revoked), the polling loop no-ops on each tick. No prompts,
+/// no errors.
+@MainActor
+@Observable
+final class SoundCloudNowPlayingService {
+    @ObservationIgnored static let shared = SoundCloudNowPlayingService()
+
+    /// 30s cadence — matches the other capture services and stays well under SoundCloud's
+    /// (loosely documented) rate limits.
+    @ObservationIgnored private let pollInterval: TimeInterval = 30
+
+    private var captured: [WorkoutTrack] = []
+    @ObservationIgnored private var seenKeys: Set<String> = []
+    @ObservationIgnored private var pollTask: Task<Void, Never>?
+
+    // MARK: - Observable surface
+
+    /// True while the poll loop is alive. Drives the "Recording" indicator in
+    /// `SoundCloudConnectionView`. Reset by `stopCapture`.
+    private(set) var isCapturing: Bool = false
+
+    /// Number of unique tracks captured in the current session — surfaced wherever the
+    /// other services' counts are.
+    var capturedCount: Int { captured.count }
+
+    /// Most recent track added in this session, if any. Surfaced in
+    /// `SoundCloudConnectionView` so the user can confirm capture is working.
+    private(set) var lastCapturedTrack: WorkoutTrack?
+
+    private init() {}
+
+    // MARK: - Capture lifecycle
+
+    /// Idempotent. Resets per-session state and starts polling. Safe to call when not
+    /// authenticated — the loop checks on each tick.
+    func startCapture() {
+        print("[SoundCloudNowPlayingService] startCapture called — resetting session state")
+        captured.removeAll()
+        seenKeys.removeAll()
+        lastCapturedTrack = nil
+        pollTask?.cancel()
+        isCapturing = true
+
+        // Snapshot what's already in play-history so we don't backfill tracks the user
+        // played BEFORE starting the workout. The first capture call records the most
+        // recent pre-workout track in `seenKeys` without appending — anything new on the
+        // next tick is "during the workout".
+        pollTask = Task { [weak self] in
+            guard let self else { return }
+            print("[SoundCloudNowPlayingService] polling started — interval=\(self.pollInterval)s")
+            await self.snapshotPriorHistory()
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: UInt64(self.pollInterval * 1_000_000_000))
+                if Task.isCancelled { return }
+                await self.captureLatestTrack()
+            }
+            print("[SoundCloudNowPlayingService] polling loop exited")
+        }
+    }
+
+    /// Stop polling and return the captured tracks. Clears the live state but keeps
+    /// `lastCapturedTrack` so Settings can still display the most recent capture between
+    /// sessions.
+    @discardableResult
+    func stopCapture() -> [WorkoutTrack] {
+        print("[SoundCloudNowPlayingService] stopCapture called — \(captured.count) track(s) captured")
+        pollTask?.cancel()
+        pollTask = nil
+        isCapturing = false
+        let result = captured
+        captured.removeAll()
+        seenKeys.removeAll()
+        return result
+    }
+
+    // MARK: - Polling
+
+    /// Read play-history at workout start and seed `seenKeys` so the immediately-prior
+    /// track doesn't get incorrectly attributed to this workout. Does NOT append to
+    /// `captured`.
+    private func snapshotPriorHistory() async {
+        guard let entries = await fetchHistory() else { return }
+        for entry in entries {
+            seenKeys.insert(dedupeKey(for: entry))
+        }
+        print("[SoundCloudNowPlayingService] snapshot complete — \(seenKeys.count) prior entry/entries skipped")
+    }
+
+    /// Poll once and capture only the LATEST history entry if it's new since last tick.
+    /// Looking at just the head is intentional — if the user plays 3 tracks in quick
+    /// succession we'll catch the most recent on this tick and the others on prior /
+    /// subsequent ticks (the 30s cadence vs typical 3-4 minute song length leaves plenty
+    /// of margin in practice).
+    private func captureLatestTrack() async {
+        guard let entries = await fetchHistory(), let latest = entries.first else {
+            return
+        }
+
+        let title = latest.track?.title ?? ""
+        guard !title.isEmpty else { return }
+
+        let key = dedupeKey(for: latest)
+        guard !seenKeys.contains(key) else {
+            print("[SoundCloudNowPlayingService] '\(title)' already captured/snapshotted, deduped")
+            return
+        }
+        seenKeys.insert(key)
+
+        // SoundCloud puts the uploader's display name on `user.username` — closest analogue
+        // to a primary artist. Real "artist" metadata is rarely populated on SC uploads.
+        let artist = latest.track?.user?.username
+        let track = WorkoutTrack(
+            title: title,
+            artist: (artist?.isEmpty == false) ? artist : nil,
+            album: nil,
+            capturedAt: Date(),
+            sourceApp: "SoundCloud"
+        )
+        captured.append(track)
+        lastCapturedTrack = track
+        print("[SoundCloudNowPlayingService] captured '\(title)' by \(artist ?? "unknown") — total: \(captured.count)")
+    }
+
+    /// Returns the parsed play-history entries, or nil on any failure. Silent for
+    /// non-authed / rate-limited / network-error cases — the next tick will retry.
+    private func fetchHistory() async -> [SoundCloudHistoryEntry]? {
+        guard let token = await SoundCloudAuthService.shared.currentTokenRefreshingIfNeeded() else {
+            return nil
+        }
+
+        var request = URLRequest(url: SoundCloudConfig.recentlyPlayedURL)
+        // SoundCloud accepts both `OAuth <token>` (legacy) and `Bearer <token>` — using
+        // the documented modern form.
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.timeoutInterval = 10
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            guard let http = response as? HTTPURLResponse else { return nil }
+            switch http.statusCode {
+            case 200:
+                break
+            case 401:
+                print("[SoundCloudNowPlayingService] 401 from /play-history — token rejected")
+                return nil
+            case 429:
+                print("[SoundCloudNowPlayingService] rate-limited (429) — skipping this tick")
+                return nil
+            default:
+                print("[SoundCloudNowPlayingService] unexpected status \(http.statusCode)")
+                return nil
+            }
+
+            // SoundCloud wraps history entries in a `collection` envelope.
+            guard let payload = try? JSONDecoder().decode(SoundCloudHistoryResponse.self, from: data) else {
+                return nil
+            }
+            return payload.collection
+        } catch {
+            print("[SoundCloudNowPlayingService] poll error: \(error)")
+            return nil
+        }
+    }
+
+    private func dedupeKey(for entry: SoundCloudHistoryEntry) -> String {
+        // Prefer the track id (stable, numeric), then the permalink, then a (title + played_at)
+        // fallback. Including `played_at` in the fallback prevents the same song played twice
+        // from being deduped against itself.
+        if let id = entry.track?.id { return "id|\(id)" }
+        if let permalink = entry.track?.permalink_url, !permalink.isEmpty { return "permalink|\(permalink)" }
+        let title = entry.track?.title ?? ""
+        let played = entry.played_at ?? 0
+        return "title|\(title.lowercased())|\(played)"
+    }
+}
+
+// MARK: - SoundCloud payload shapes
+
+private struct SoundCloudHistoryResponse: Decodable {
+    let collection: [SoundCloudHistoryEntry]
+}
+
+private struct SoundCloudHistoryEntry: Decodable {
+    /// Unix millisecond timestamp of when the play was recorded.
+    let played_at: Int64?
+    let track: SoundCloudTrack?
+}
+
+private struct SoundCloudTrack: Decodable {
+    let id: Int64?
+    let title: String?
+    let permalink_url: String?
+    let user: SoundCloudUser?
+}
+
+private struct SoundCloudUser: Decodable {
+    let username: String?
+}

--- a/Xomfit/ViewModels/WorkoutLoggerViewModel.swift
+++ b/Xomfit/ViewModels/WorkoutLoggerViewModel.swift
@@ -213,6 +213,8 @@ final class WorkoutLoggerViewModel {
         NowPlayingService.shared.startCapture()
         // Spotify capture runs in parallel — also a silent no-op when not signed in (#347).
         SpotifyNowPlayingService.shared.startCapture()
+        // SoundCloud capture runs in parallel — silent no-op when not signed in (#389).
+        SoundCloudNowPlayingService.shared.startCapture()
     }
 
     func discardWorkout() {
@@ -250,6 +252,7 @@ final class WorkoutLoggerViewModel {
         // Drop any captured Now Playing tracks — discarding the workout discards the soundtrack.
         _ = NowPlayingService.shared.stopCapture()
         _ = SpotifyNowPlayingService.shared.stopCapture()
+        _ = SoundCloudNowPlayingService.shared.stopCapture()
     }
 
     func startFromTemplate(_ template: WorkoutTemplate, userId: String) {
@@ -1263,14 +1266,10 @@ final class WorkoutLoggerViewModel {
 
         // Pull the Now Playing capture and attach it to the saved workout.
         // Empty list when the user denied Apple Music access or only used non-Apple Music sources.
-        // Spotify tracks (when authed) merge in alongside Apple Music — sort by capture time so
-        // the saved soundtrack reflects actual play order across sources (#347).
-        //
-        // Finish-sheet edits (#387): manual entries are appended; `removedTrackIDs`
-        // filters the union so user deletions stick.
         let appleMusicTracks = NowPlayingService.shared.stopCapture()
         let spotifyTracks = SpotifyNowPlayingService.shared.stopCapture()
-        let capturedTracks = (appleMusicTracks + spotifyTracks + manualTracks)
+        let soundCloudTracks = SoundCloudNowPlayingService.shared.stopCapture()
+        let capturedTracks = (appleMusicTracks + spotifyTracks + soundCloudTracks + manualTracks)
             .filter { !removedTrackIDs.contains($0.id) }
             .sorted { $0.capturedAt < $1.capturedAt }
 

--- a/Xomfit/Views/Profile/SettingsView.swift
+++ b/Xomfit/Views/Profile/SettingsView.swift
@@ -633,10 +633,11 @@ extension SettingsView {
         Section {
             appleMusicRow
             SpotifyConnectionView()
+            SoundCloudConnectionView()
         } header: {
             XomMetricLabel("Music Sources")
         } footer: {
-            Text("XomFit captures songs that played during your workout. Apple Music reads from system permission; Spotify requires sign-in.")
+            Text("XomFit captures songs that played during your workout. Apple Music reads from system permission; Spotify and SoundCloud require sign-in.")
                 .font(Theme.fontCaption)
                 .foregroundStyle(Theme.textTertiary)
         }

--- a/Xomfit/Views/Profile/SoundCloudConnectionView.swift
+++ b/Xomfit/Views/Profile/SoundCloudConnectionView.swift
@@ -1,0 +1,168 @@
+import SwiftUI
+
+/// SoundCloud connection block embedded in `SettingsView` -> Music Sources (#389).
+///
+/// Mirrors `SpotifyConnectionView`'s shape and visual language. Two differences from Spotify:
+///
+///   1. No client-id paste field. XomFit ships a shared client id, so the user only has
+///      to tap "Sign In with SoundCloud".
+///   2. SoundCloud's developer program has been intermittently closed to new apps. If the
+///      shared client id is rejected we surface a clear `apiClosed` error inline so the
+///      user knows it's not their fault and capture from Apple Music / Spotify keeps working.
+struct SoundCloudConnectionView: View {
+    @State private var soundCloudAuth = SoundCloudAuthService.shared
+
+    @State private var isSigningIn: Bool = false
+    @State private var errorMessage: String? = nil
+
+    /// Observable mirror of the SoundCloud capture loop. Drives the "last captured track"
+    /// line + the active-polling pulse indicator on the header.
+    @State private var soundCloudCapture = SoundCloudNowPlayingService.shared
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+            header
+
+            // Surface the most recent capture, if any, so the user can confirm capture is
+            // working without opening an active workout.
+            if soundCloudAuth.isAuthenticated, let last = soundCloudCapture.lastCapturedTrack {
+                lastCapturedRow(track: last)
+            }
+
+            actionButton
+
+            if let errorMessage {
+                Text(errorMessage)
+                    .font(Theme.fontCaption)
+                    .foregroundStyle(Theme.destructive)
+                    .accessibilityLabel("SoundCloud error: \(errorMessage)")
+            }
+        }
+        .padding(.vertical, Theme.Spacing.xs)
+    }
+
+    // MARK: - Subviews
+
+    private var header: some View {
+        HStack(spacing: Theme.Spacing.md) {
+            Image(systemName: "cloud.fill")
+                .frame(width: Theme.Spacing.lg)
+                .foregroundStyle(.orange)
+            VStack(alignment: .leading, spacing: 2) {
+                Text("SoundCloud")
+                    .foregroundStyle(Theme.textPrimary)
+                Text(soundCloudAuth.isAuthenticated
+                     ? "Connected\(soundCloudAuth.displayName.isEmpty ? "" : " as \(soundCloudAuth.displayName)")"
+                     : "Not connected")
+                    .font(Theme.fontCaption)
+                    .foregroundStyle(Theme.textTertiary)
+                    .accessibilityLabel(soundCloudAuth.isAuthenticated ? "SoundCloud connected" : "SoundCloud not connected")
+            }
+            Spacer()
+            // Live polling indicator. Visible only while a workout is in progress AND the
+            // poll loop is alive.
+            if soundCloudCapture.isCapturing {
+                pollingPulse
+            }
+        }
+    }
+
+    /// Tiny pulsing accent dot — communicates "capture is running right now".
+    private var pollingPulse: some View {
+        TimelineView(.animation(minimumInterval: 1.1, paused: false)) { context in
+            let phase = context.date.timeIntervalSinceReferenceDate
+            let alpha = 0.45 + 0.55 * abs(sin(phase * 1.4))
+            HStack(spacing: 4) {
+                Circle()
+                    .fill(Theme.accent)
+                    .frame(width: 8, height: 8)
+                    .opacity(alpha)
+                Text("Recording")
+                    .font(.caption2.weight(.bold))
+                    .foregroundStyle(Theme.accent)
+                    .accessibilityHidden(true)
+            }
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel("SoundCloud capture in progress")
+        }
+    }
+
+    /// One-line "Last captured: Title — Artist" display so the user can confirm capture
+    /// is working without finishing the workout.
+    private func lastCapturedRow(track: WorkoutTrack) -> some View {
+        HStack(spacing: Theme.Spacing.md) {
+            Image(systemName: "waveform")
+                .frame(width: Theme.Spacing.lg)
+                .foregroundStyle(Theme.accent)
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Last captured")
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(Theme.textTertiary)
+                Text(track.artist?.isEmpty == false
+                     ? "\(track.title) — \(track.artist ?? "")"
+                     : track.title)
+                    .font(Theme.fontCaption)
+                    .foregroundStyle(Theme.textSecondary)
+                    .lineLimit(1)
+            }
+            Spacer()
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Last captured: \(track.title)\(track.artist.map { ", by \($0)" } ?? "")")
+    }
+
+    @ViewBuilder
+    private var actionButton: some View {
+        if soundCloudAuth.isAuthenticated {
+            Button(role: .destructive) {
+                Haptics.selection()
+                soundCloudAuth.signOut()
+            } label: {
+                HStack(spacing: Theme.Spacing.md) {
+                    Image(systemName: "rectangle.portrait.and.arrow.right")
+                        .frame(width: Theme.Spacing.lg)
+                        .foregroundStyle(Theme.destructive)
+                    Text("Disconnect SoundCloud")
+                        .foregroundStyle(Theme.destructive)
+                }
+            }
+            .accessibilityHint("Removes SoundCloud access and stops capturing tracks")
+        } else {
+            Button {
+                Task { await signIn() }
+            } label: {
+                HStack(spacing: Theme.Spacing.md) {
+                    if isSigningIn {
+                        ProgressView().tint(Theme.accent)
+                            .frame(width: Theme.Spacing.lg)
+                    } else {
+                        Image(systemName: "link")
+                            .frame(width: Theme.Spacing.lg)
+                            .foregroundStyle(Theme.accent)
+                    }
+                    Text(isSigningIn ? "Connecting..." : "Sign In with SoundCloud")
+                        .foregroundStyle(Theme.textPrimary)
+                }
+            }
+            .disabled(isSigningIn)
+            .accessibilityHint("Opens the SoundCloud login web view")
+        }
+    }
+
+    // MARK: - Actions
+
+    private func signIn() async {
+        guard !isSigningIn else { return }
+        isSigningIn = true
+        errorMessage = nil
+        defer { isSigningIn = false }
+        do {
+            _ = try await soundCloudAuth.signIn()
+            Haptics.selection()
+        } catch let err as SoundCloudAuthError {
+            errorMessage = err.errorDescription
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
+}

--- a/Xomfit/XomfitApp.swift
+++ b/Xomfit/XomfitApp.swift
@@ -124,6 +124,11 @@ struct XomFitApp: App {
                     SpotifyAuthService.shared.handleCallback(url: url)
                     return
                 }
+                if url.scheme == "xomfit", url.host == "soundcloud-callback" {
+                    // Same belt-and-suspenders pattern as Spotify (#389).
+                    SoundCloudAuthService.shared.handleCallback(url: url)
+                    return
+                }
                 #if DEBUG
                 if url.scheme == "xomfit", url.host == "coach" {
                     if authService.isAuthenticated {

--- a/docs/features/soundcloud-389/SETUP.md
+++ b/docs/features/soundcloud-389/SETUP.md
@@ -1,0 +1,101 @@
+# SoundCloud Now-Playing — Setup
+
+XomFit captures the soundtrack of every workout across multiple sources: Apple Music
+(system permission, read-only), Spotify (#347, paste-your-own client id), and SoundCloud
+(#389, shared client id baked into the app).
+
+## TL;DR — current status
+
+> **The SoundCloud Developer program has been intermittently closed to new app
+> registrations for years.** As of shipping this integration, the `sharedClientId` in
+> `Xomfit/Services/SoundCloudConfig.swift` is a `PLACEHOLDER_SHARED_SOUNDCLOUD_CLIENT_ID`.
+>
+> - The code is fully wired and ready.
+> - Users who tap **Sign In with SoundCloud** before the placeholder is replaced will get
+>   a clear inline error: *"SoundCloud rejected XomFit's shared client id. The SoundCloud
+>   Developer program has been intermittently closed to new apps — see Settings for
+>   status."*
+> - **Apple Music and Spotify capture continue working untouched.** The user can finish
+>   their workout normally; only the SoundCloud row is non-functional.
+>
+> **TODO:** Once SoundCloud reopens app registrations (or we get an existing app id
+> reassigned), replace `SoundCloudConfig.sharedClientId` and ship a point release.
+> See <https://developers.soundcloud.com> for the latest status.
+
+## Why a shared client id (vs paste-your-own like Spotify)
+
+Spotify lets anyone register a developer app in 30 seconds — `Settings -> Music Sources ->
+Spotify Client ID` paste field is the right UX there. SoundCloud's program isn't reliably
+open, so requiring every user to register their own app would mean ~nobody ever uses the
+integration. Instead, XomFit ships a single shared client id and gates the OAuth dance
+behind PKCE so the absence of a client secret is safe.
+
+## OAuth flow
+
+`SoundCloudAuthService` (mirrors `SpotifyAuthService` almost exactly):
+
+1. Generate PKCE verifier + S256 challenge + anti-CSRF `state`.
+2. Open `ASWebAuthenticationSession` to
+   `https://api.soundcloud.com/connect?client_id=<shared>&response_type=code&code_challenge=...&redirect_uri=xomfit://soundcloud-callback&scope=non-expiring`.
+3. SoundCloud redirects to `xomfit://soundcloud-callback?code=...&state=...`.
+4. POST the code + verifier to `https://api.soundcloud.com/oauth2/token` for tokens.
+5. Persist tokens via `@AppStorage` (UserDefaults). Keychain migration tracked separately.
+
+## Polling (`SoundCloudNowPlayingService`)
+
+SoundCloud's Web API does **not** expose a real-time "currently playing" endpoint. The
+closest thing is `GET /me/play-history/tracks?limit=5` — a list of the most recently played
+tracks.
+
+- On `startCapture()` we snapshot whatever's currently at the head of play-history and
+  store its dedupe key. This way, the song the user was listening to ~before~ tapping
+  Start Workout doesn't get attributed to the workout.
+- Every 30s we poll again. If the head is different from what we last saw, we capture it.
+- The 30s cadence vs typical 3-4 minute song length means we generally catch each track
+  with a small lag (anywhere from a few seconds to a minute or two — SoundCloud writes to
+  history only after a play threshold).
+
+This is best-effort but matches what's possible without a real-time endpoint.
+
+## During a workout
+
+- Tap **Start Workout** → all three services (`NowPlayingService`,
+  `SpotifyNowPlayingService`, `SoundCloudNowPlayingService`) kick off polling.
+- Tap **Finish Workout** → each service returns its captured `[WorkoutTrack]`. The view
+  model merges them and sorts by `capturedAt`, so the saved soundtrack reflects actual
+  play order across sources.
+- Tap **Discard** → all three services drop their captured state and stop polling.
+
+## When the placeholder client id is replaced
+
+1. Get the real id from <https://developers.soundcloud.com> (or whichever channel
+   eventually grants you a redeemable app).
+2. Register the redirect URI **exactly** `xomfit://soundcloud-callback` on the SoundCloud
+   Developer Dashboard (case + scheme matter).
+3. Edit `Xomfit/Services/SoundCloudConfig.swift`:
+   ```swift
+   static let sharedClientId: String = "<the real id>"
+   ```
+4. No other code changes needed. Ship the point release.
+
+## Troubleshooting
+
+- **"SoundCloud rejected XomFit's shared client id..."** — Expected with the placeholder
+  id. Wait for the next point release, or contact the maintainer.
+- **Sign-in succeeds but no SoundCloud tracks captured** — Make sure SoundCloud was the
+  app actively playing audio during the workout, and the songs were played long enough to
+  hit SoundCloud's play-count threshold (it determines when a play counts toward history).
+- **"INVALID_CLIENT" / "Invalid redirect URI"** — Redirect URI on the Dashboard does not
+  exactly match `xomfit://soundcloud-callback`. Re-check casing.
+- **`apiClosed` error after a previously working sign-in** — SoundCloud sometimes revokes
+  client ids without warning. Hit Disconnect and re-sign-in once the client id is rotated.
+
+## Security notes
+
+- Shared client id is treated as public, same as Spotify's. PKCE (RFC 7636) means no
+  client secret is needed or stored.
+- Tokens are in `@AppStorage` (UserDefaults). Anyone with device access could read them.
+  Keychain migration is tracked separately, same as Spotify.
+- **Disconnect SoundCloud** in the Music Sources section forgets the tokens. SoundCloud
+  does not document a user-facing token revoke endpoint, so the only stronger guarantee is
+  to change your SoundCloud password.


### PR DESCRIPTION
## Summary

Adds SoundCloud as a third music capture source alongside Apple Music and Spotify. Mirrors the Spotify pattern but with a single shared client id (SoundCloud's Developer program is intermittently closed to new app registrations, so paste-your-own UX is unworkable).

### What's wired
- `SoundCloudConfig.swift` — shared client id (`PLACEHOLDER_SHARED_SOUNDCLOUD_CLIENT_ID`), redirect URI, scopes, endpoints
- `SoundCloudAuthService.swift` — `@MainActor @Observable` PKCE OAuth via `ASWebAuthenticationSession`
- `SoundCloudNowPlayingService.swift` — 30s polling of `/me/play-history/tracks?limit=5`; pre-workout history is snapshotted so it doesn't backfill
- `SoundCloudConnectionView.swift` — Settings row matching `SpotifyConnectionView`
- `WorkoutLoggerViewModel` — start/discard/finish now invoke SoundCloud alongside Apple Music + Spotify; merged tracks sorted by `capturedAt`
- `XomfitApp.swift` — handles `xomfit://soundcloud-callback`
- `SettingsView.swift` — Music Sources section adds the row

### SoundCloud API access status
SoundCloud's Developer signup form is intermittently closed (no public form at developers.soundcloud.com right now). The code ships with a placeholder client id; `SoundCloudAuthService` detects token-endpoint rejection (`401`/`403`, `invalid_client`, `unauthorized_client`) and surfaces a dedicated `.apiClosed` error. Apple Music + Spotify are unaffected.

**TODO before launch:** replace `PLACEHOLDER_SHARED_SOUNDCLOUD_CLIENT_ID` with the real Xomware SoundCloud Developer App client id once we have access.

## Test plan
- [ ] Apple Music + Spotify capture still work uninterrupted
- [ ] Tapping Connect in Settings opens SoundCloud OAuth (will fail until placeholder is replaced, but error should be the friendly `.apiClosed` message)
- [ ] Once real client id is set, verify play-history polling captures tracks during a workout