### PR TITLE
#387 finish flow: per-exercise prompt + soundtrack preview/edit + location field

### DIFF
--- a/Xomfit/Services/NowPlayingService.swift
+++ b/Xomfit/Services/NowPlayingService.swift
@@ -46,6 +46,13 @@ final class NowPlayingService {
     /// Most recent track captured this session (or the last completed session).
     private(set) var lastCapturedTrack: WorkoutTrack?
 
+    /// Read-only copy of the currently captured tracks for this session. Used by the
+    /// finish-workout sheet (#387) to preview what will be saved without yet stopping
+    /// the capture loop. Does NOT mutate state — call `stopCapture()` to actually drain.
+    func capturedTracksSnapshot() -> [WorkoutTrack] {
+        captured
+    }
+
     private init() {}
 
     // MARK: - Authorization
@@ -104,6 +111,16 @@ final class NowPlayingService {
         seenKeys.removeAll()
         lastCapturedTrack = nil
         pollTask?.cancel()
+
+        #if DEBUG
+        // Agent screenshot bypass — skip the Apple Music auth prompt entirely so
+        // the active-workout cover renders without a modal in screenshots (#387).
+        if ProcessInfo.processInfo.environment["XOMFIT_AUTH_BYPASS"] == "1" {
+            print("[NowPlayingService] bypass active — capture is a no-op")
+            isCapturing = false
+            return
+        }
+        #endif
 
         // Kick off auth check + first poll. If auth lands on denied, the polling loop
         // will simply observe the auth flag and exit — no nag, no UI.

--- a/Xomfit/Services/SoundCloudNowPlayingService.swift
+++ b/Xomfit/Services/SoundCloudNowPlayingService.swift
@@ -49,6 +49,13 @@ final class SoundCloudNowPlayingService {
     /// `SoundCloudConnectionView` so the user can confirm capture is working.
     private(set) var lastCapturedTrack: WorkoutTrack?
 
+    /// Read-only copy of the currently captured tracks for this session. Used by the
+    /// finish-workout sheet (#387) to preview what will be saved without yet stopping
+    /// the capture loop. Does NOT mutate state — call `stopCapture()` to actually drain.
+    func capturedTracksSnapshot() -> [WorkoutTrack] {
+        captured
+    }
+
     private init() {}
 
     // MARK: - Capture lifecycle
@@ -61,6 +68,16 @@ final class SoundCloudNowPlayingService {
         seenKeys.removeAll()
         lastCapturedTrack = nil
         pollTask?.cancel()
+
+        #if DEBUG
+        // Agent screenshot bypass — skip the poll loop so the active-workout
+        // cover renders cleanly in screenshots (#387).
+        if ProcessInfo.processInfo.environment["XOMFIT_AUTH_BYPASS"] == "1" {
+            isCapturing = false
+            return
+        }
+        #endif
+
         isCapturing = true
 
         // Snapshot what's already in play-history so we don't backfill tracks the user

--- a/Xomfit/Services/SpotifyNowPlayingService.swift
+++ b/Xomfit/Services/SpotifyNowPlayingService.swift
@@ -38,6 +38,13 @@ final class SpotifyNowPlayingService {
     /// the user can confirm capture is working without opening an active workout.
     private(set) var lastCapturedTrack: WorkoutTrack?
 
+    /// Read-only copy of the currently captured tracks for this session. Used by the
+    /// finish-workout sheet (#387) to preview what will be saved without yet stopping
+    /// the capture loop. Does NOT mutate state — call `stopCapture()` to actually drain.
+    func capturedTracksSnapshot() -> [WorkoutTrack] {
+        captured
+    }
+
     private init() {}
 
     // MARK: - Capture lifecycle
@@ -50,6 +57,16 @@ final class SpotifyNowPlayingService {
         seenKeys.removeAll()
         lastCapturedTrack = nil
         pollTask?.cancel()
+
+        #if DEBUG
+        // Agent screenshot bypass — skip the poll loop so the active-workout
+        // cover renders cleanly in screenshots (#387).
+        if ProcessInfo.processInfo.environment["XOMFIT_AUTH_BYPASS"] == "1" {
+            isCapturing = false
+            return
+        }
+        #endif
+
         isCapturing = true
 
         pollTask = Task { [weak self] in

--- a/Xomfit/ViewModels/WorkoutLoggerViewModel.swift
+++ b/Xomfit/ViewModels/WorkoutLoggerViewModel.swift
@@ -614,9 +614,18 @@ final class WorkoutLoggerViewModel {
                     return RemainingExercise(index: idx, name: ex.exercise.name)
                 }
 
-                // Suppress the transition card while still mid-superset round — the focus
-                // already advanced to the next member, so no card needed.
-                if !inSupersetRound {
+                // Suppress the transition card in these cases:
+                //   1. Mid-superset round — focus already advanced to the next
+                //      member, so no card needed.
+                //   2. Timed-circuit workouts — they have their own loop UI
+                //      (`TimedCircuitView`), no per-exercise transition (#387).
+                //   3. Final exercise of the session — when no other exercise
+                //      has incomplete sets left, the user is done and we want
+                //      them to head straight to the Finish flow without an
+                //      extra modal (#387). The existing "all complete" cue in
+                //      the persistent pill / footer is enough.
+                let isFinalExercise = nextExerciseIndex == nil
+                if !inSupersetRound && kind != .timedCircuit && !isFinalExercise {
                     showExerciseTransition = true
                 }
             }
@@ -936,13 +945,14 @@ final class WorkoutLoggerViewModel {
 
     // MARK: - Soundtrack curation (#387)
 
-    /// Merged snapshot of (Apple Music + Spotify + manual) tracks, minus anything
-    /// the user removed in the finish sheet. Sorted by capture time so the order
-    /// reflects play order across sources.
+    /// Merged snapshot of (Apple Music + Spotify + SoundCloud + manual) tracks,
+    /// minus anything the user removed in the finish sheet. Sorted by capture time
+    /// so the order reflects play order across sources.
     var curatedTracksSnapshot: [WorkoutTrack] {
         let apple = NowPlayingService.shared.capturedTracksSnapshot()
         let spotify = SpotifyNowPlayingService.shared.capturedTracksSnapshot()
-        let merged = (apple + spotify + manualTracks)
+        let soundCloud = SoundCloudNowPlayingService.shared.capturedTracksSnapshot()
+        let merged = (apple + spotify + soundCloud + manualTracks)
             .filter { !removedTrackIDs.contains($0.id) }
         return merged.sorted { $0.capturedAt < $1.capturedAt }
     }

--- a/Xomfit/Views/Workout/ActiveWorkoutView.swift
+++ b/Xomfit/Views/Workout/ActiveWorkoutView.swift
@@ -283,6 +283,7 @@ struct ActiveWorkoutView: View {
         }
         .sheet(isPresented: $showFinishSheet) {
             FinishWorkoutSheet(
+                viewModel: viewModel,
                 description: $workoutDescription,
                 location: $viewModel.location,
                 rating: $viewModel.rating,
@@ -363,6 +364,18 @@ struct ActiveWorkoutView: View {
                     }
                 }
             }
+
+            #if DEBUG
+            // Agent screenshot helper for #387 — auto-present the finish sheet so
+            // the new soundtrack / location UI surfaces from a cold launch.
+            if ProcessInfo.processInfo.environment["XOMFIT_AUTO_PRESENT_FINISH"] == "1" {
+                Task { @MainActor in
+                    try? await Task.sleep(for: .milliseconds(600))
+                    workoutDescription = ""
+                    showFinishSheet = true
+                }
+            }
+            #endif
         }
     }
 
@@ -1435,6 +1448,11 @@ private struct ExerciseTransitionCard: View {
 // MARK: - Finish Workout Sheet
 
 private struct FinishWorkoutSheet: View {
+    /// Passed in so the sheet can render the captured-soundtrack section and
+    /// accept manual track additions / removals (#387). Plain `let` — we only
+    /// call methods + read computed properties; `@Observable` already invalidates
+    /// the body on mutations to those properties.
+    let viewModel: WorkoutLoggerViewModel
     @Binding var description: String
     @Binding var location: String
     @Binding var rating: Int
@@ -1443,6 +1461,9 @@ private struct FinishWorkoutSheet: View {
     @Binding var photoImages: [UIImage]
     let isSaving: Bool
     let onFinish: () -> Void
+
+    /// Drives the manual-track entry sub-sheet (#387).
+    @State private var showManualTrackSheet = false
 
     var body: some View {
         NavigationStack {
@@ -1474,7 +1495,10 @@ private struct FinishWorkoutSheet: View {
                             }
                         }
 
-                        // Location
+                        // Location (#387.3) — single-line free-text input above
+                        // the soundtrack section. Placeholder steers the user to
+                        // any short label (gym, home, park...). Trimming happens
+                        // in the save path on the view model.
                         VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
                             Text("Location")
                                 .font(.subheadline.weight(.semibold))
@@ -1483,9 +1507,11 @@ private struct FinishWorkoutSheet: View {
                                 Image(systemName: "location.fill")
                                     .font(Theme.fontCaption)
                                     .foregroundStyle(Theme.textSecondary)
-                                TextField("Gym name", text: $location)
+                                TextField("Where? (gym, home, park...)", text: $location)
                                     .font(Theme.fontBody)
                                     .foregroundStyle(Theme.textPrimary)
+                                    .accessibilityLabel("Workout location")
+                                    .accessibilityHint("Optional. Where you did this workout — gym, home, park, etc.")
                             }
                             .padding(Theme.Spacing.sm)
                             .background(Theme.surface)
@@ -1495,6 +1521,12 @@ private struct FinishWorkoutSheet: View {
                                     .stroke(Theme.textSecondary.opacity(0.2), lineWidth: 1)
                             )
                         }
+
+                        // Soundtrack (#387.2) — captured Now Playing tracks plus
+                        // any manual additions, with per-row remove. Sits above
+                        // the caption so the user reviews their soundtrack right
+                        // after rating/location.
+                        soundtrackSection
 
                         // Description
                         VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
@@ -1645,5 +1677,260 @@ private struct FinishWorkoutSheet: View {
             .navigationBarTitleDisplayMode(.inline)
             .toolbarColorScheme(.dark, for: .navigationBar)
         }
+        .sheet(isPresented: $showManualTrackSheet) {
+            ManualTrackSheet { title, artist in
+                viewModel.addManualTrack(title: title, artist: artist)
+            }
+            .presentationDetents([.medium])
+        }
+    }
+
+    // MARK: - Soundtrack section (#387.2)
+
+    @ViewBuilder
+    private var soundtrackSection: some View {
+        let tracks = viewModel.curatedTracksSnapshot
+        VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+            HStack(spacing: Theme.Spacing.sm) {
+                Text("Soundtrack")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(Theme.textPrimary)
+                if !tracks.isEmpty {
+                    Text("\(tracks.count)")
+                        .font(.caption.weight(.bold).monospacedDigit())
+                        .foregroundStyle(Theme.accent)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 1)
+                        .background(Theme.accent.opacity(0.15), in: Capsule())
+                }
+                Spacer()
+            }
+
+            if tracks.isEmpty {
+                Text("No songs captured. Add one manually or play music during your next workout.")
+                    .font(Theme.fontCaption)
+                    .foregroundStyle(Theme.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            } else {
+                VStack(spacing: 0) {
+                    ForEach(tracks) { track in
+                        SoundtrackRow(track: track) {
+                            withAnimation(.xomChill) {
+                                viewModel.removeCapturedTrack(id: track.id)
+                            }
+                        }
+                        if track.id != tracks.last?.id {
+                            Divider()
+                                .background(Theme.textSecondary.opacity(0.15))
+                                .padding(.leading, Theme.Spacing.md)
+                        }
+                    }
+                }
+                .background(Theme.surface)
+                .clipShape(.rect(cornerRadius: Theme.cornerRadiusSmall))
+                .overlay(
+                    RoundedRectangle(cornerRadius: Theme.cornerRadiusSmall)
+                        .stroke(Theme.textSecondary.opacity(0.2), lineWidth: 1)
+                )
+            }
+
+            Button {
+                Haptics.selection()
+                showManualTrackSheet = true
+            } label: {
+                HStack(spacing: 6) {
+                    Image(systemName: "plus")
+                    Text("Add manual track")
+                        .font(.subheadline.weight(.medium))
+                }
+                .foregroundStyle(Theme.accent)
+                .padding(.horizontal, 12)
+                .padding(.vertical, Theme.Spacing.sm)
+                .frame(minHeight: 44)
+                .background(Theme.accent.opacity(0.12))
+                .clipShape(.rect(cornerRadius: Theme.cornerRadiusSmall))
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Add a track manually")
+            .accessibilityHint("Opens a form to enter a song title and artist")
+        }
+    }
+}
+
+// MARK: - Soundtrack Row (#387.2)
+
+/// Single captured-track row used by the finish sheet. Renders an icon + title
+/// + artist + source pill with a trailing trash button. Hit target on the trash
+/// is sized to 44pt per HIG.
+private struct SoundtrackRow: View {
+    let track: WorkoutTrack
+    let onRemove: () -> Void
+
+    var body: some View {
+        HStack(spacing: Theme.Spacing.sm) {
+            Image(systemName: sourceIcon)
+                .font(.subheadline.weight(.semibold))
+                .foregroundStyle(Theme.accent)
+                .frame(width: 24)
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(track.title)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(Theme.textPrimary)
+                    .lineLimit(1)
+                HStack(spacing: 6) {
+                    if let artist = track.artist, !artist.isEmpty {
+                        Text(artist)
+                            .font(Theme.fontCaption)
+                            .foregroundStyle(Theme.textSecondary)
+                            .lineLimit(1)
+                        Text("\u{2022}")
+                            .font(.caption2.weight(.bold))
+                            .foregroundStyle(Theme.textTertiary)
+                            .accessibilityHidden(true)
+                    }
+                    Text(track.sourceApp)
+                        .font(Theme.fontSmall)
+                        .foregroundStyle(Theme.textTertiary)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 1)
+                        .background(Theme.textTertiary.opacity(0.15), in: Capsule())
+                }
+            }
+            Spacer()
+
+            Button {
+                Haptics.light()
+                onRemove()
+            } label: {
+                Image(systemName: "trash")
+                    .font(Theme.fontCaption)
+                    .foregroundStyle(Theme.destructive.opacity(0.85))
+                    .frame(width: 44, height: 44)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Remove \(track.title) from soundtrack")
+        }
+        .padding(.horizontal, Theme.Spacing.md)
+        .padding(.vertical, 8)
+        .contentShape(Rectangle())
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(track.title)\(track.artist.map { ", \($0)" } ?? "") from \(track.sourceApp)")
+    }
+
+    private var sourceIcon: String {
+        switch track.sourceApp.lowercased() {
+        case "manual": return "pencil"
+        case "spotify": return "music.note"
+        case "soundcloud": return "waveform"
+        case "apple music": return "music.note"
+        default: return "music.note"
+        }
+    }
+}
+
+// MARK: - Manual Track Sheet (#387.2)
+
+/// Compact title + artist entry sheet for adding a song the auto-capture missed.
+/// Source is hard-coded to "Manual" by `WorkoutLoggerViewModel.addManualTrack`.
+private struct ManualTrackSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    @State private var title: String = ""
+    @State private var artist: String = ""
+    @FocusState private var focusedField: Field?
+
+    enum Field { case title, artist }
+
+    let onAdd: (String, String?) -> Void
+
+    private var canAdd: Bool {
+        !title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Theme.background.ignoresSafeArea()
+                ScrollView {
+                    VStack(alignment: .leading, spacing: Theme.Spacing.md) {
+                        VStack(alignment: .leading, spacing: Theme.Spacing.tighter) {
+                            Text("Title")
+                                .font(.caption.weight(.semibold))
+                                .foregroundStyle(Theme.textSecondary)
+                            TextField("Song title", text: $title)
+                                .font(Theme.fontBody)
+                                .foregroundStyle(Theme.textPrimary)
+                                .focused($focusedField, equals: .title)
+                                .submitLabel(.next)
+                                .onSubmit { focusedField = .artist }
+                                .padding(Theme.Spacing.sm)
+                                .background(Theme.surface)
+                                .clipShape(.rect(cornerRadius: Theme.cornerRadiusSmall))
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: Theme.cornerRadiusSmall)
+                                        .stroke(Theme.textSecondary.opacity(0.2), lineWidth: 1)
+                                )
+                                .accessibilityLabel("Song title")
+                        }
+
+                        VStack(alignment: .leading, spacing: Theme.Spacing.tighter) {
+                            Text("Artist")
+                                .font(.caption.weight(.semibold))
+                                .foregroundStyle(Theme.textSecondary)
+                            TextField("Artist (optional)", text: $artist)
+                                .font(Theme.fontBody)
+                                .foregroundStyle(Theme.textPrimary)
+                                .focused($focusedField, equals: .artist)
+                                .submitLabel(.done)
+                                .onSubmit { if canAdd { commit() } }
+                                .padding(Theme.Spacing.sm)
+                                .background(Theme.surface)
+                                .clipShape(.rect(cornerRadius: Theme.cornerRadiusSmall))
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: Theme.cornerRadiusSmall)
+                                        .stroke(Theme.textSecondary.opacity(0.2), lineWidth: 1)
+                                )
+                                .accessibilityLabel("Artist (optional)")
+                        }
+
+                        Button {
+                            commit()
+                        } label: {
+                            Text("Add Track")
+                                .font(.body.weight(.bold))
+                                .foregroundStyle(.black)
+                                .frame(maxWidth: .infinity)
+                                .padding(.vertical, 14)
+                                .background(canAdd ? Theme.accent : Theme.accent.opacity(0.4))
+                                .clipShape(.rect(cornerRadius: Theme.cornerRadius))
+                        }
+                        .buttonStyle(.plain)
+                        .disabled(!canAdd)
+                        .accessibilityLabel("Add track")
+                    }
+                    .padding(Theme.Spacing.md)
+                }
+            }
+            .navigationTitle("Add Track")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+            }
+        }
+        .onAppear { focusedField = .title }
+    }
+
+    private func commit() {
+        let trimmedTitle = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedTitle.isEmpty else { return }
+        Haptics.success()
+        let trimmedArtist = artist.trimmingCharacters(in: .whitespacesAndNewlines)
+        onAdd(trimmedTitle, trimmedArtist.isEmpty ? nil : trimmedArtist)
+        dismiss()
     }
 }

--- a/Xomfit/XomfitApp.swift
+++ b/Xomfit/XomfitApp.swift
@@ -103,6 +103,23 @@ struct XomFitApp: App {
                             if ProcessInfo.processInfo.environment["XOMFIT_OPEN_COACH"] == "1" {
                                 showCoachSheet = true
                             }
+
+                            // Agent screenshot helper for #387 finish-flow polish:
+                            // seed an in-progress workout with two exercises so the
+                            // active runner + transition card + finish sheet can be
+                            // screenshotted from a cold launch without taps.
+                            //
+                            //   XOMFIT_AUTO_START_WORKOUT=1  → start workout, two exercises seeded
+                            //   XOMFIT_AUTO_COMPLETE_FIRST=1 → also complete every set on the first
+                            //                                  exercise so the transition card shows
+                            //   XOMFIT_AUTO_PRESENT_FINISH=1 → also present the finish sheet
+                            if ProcessInfo.processInfo.environment["XOMFIT_AUTO_START_WORKOUT"] == "1" {
+                                // Small delay so MainTabView's `.fullScreenCover`
+                                // is fully mounted before we flip its binding —
+                                // SwiftUI can otherwise race-reset it to false.
+                                try? await Task.sleep(for: .milliseconds(500))
+                                seedDebugActiveWorkout()
+                            }
                         }
                         #endif
                 } else {
@@ -171,4 +188,59 @@ struct XomFitApp: App {
         guard !onboardingSkipped else { return }
         showFitnessQuestionnaire = true
     }
+
+    #if DEBUG
+    /// Seed an in-progress workout for agent screenshot flows (#387). Adds two
+    /// real exercises and (optionally) completes the first or pops the finish
+    /// sheet so the new UI surfaces from a cold launch.
+    @MainActor
+    private func seedDebugActiveWorkout() {
+        let env = ProcessInfo.processInfo.environment
+
+        // Always clear any in-memory workout state so the seeded one is
+        // deterministic across re-launches in the same simulator session.
+        if workoutSession.isActive {
+            workoutSession.discardWorkout()
+        }
+
+        let userId = authService.currentUser?.id.uuidString.lowercased() ?? ""
+        workoutSession.startWorkout(name: "Screenshot Workout", userId: userId)
+
+        // Two safe exercises from ExerciseDatabase. Picked deterministically by
+        // id so the seeded workout looks consistent across screenshot runs.
+        let preferredIds = ["ex-bench-flat", "ex-lat-pulldown"]
+        var chosen: [Exercise] = []
+        for id in preferredIds {
+            if let match = ExerciseDatabase.all.first(where: { $0.id == id }) {
+                chosen.append(match)
+            }
+        }
+        if chosen.isEmpty {
+            chosen = Array(ExerciseDatabase.all.prefix(2))
+        }
+        for ex in chosen {
+            workoutSession.addExercise(ex)
+        }
+
+        // Optionally complete the first exercise so the transition card shows
+        // immediately on launch.
+        if env["XOMFIT_AUTO_COMPLETE_FIRST"] == "1",
+           let first = workoutSession.exercises.first {
+            for setIdx in 0..<first.sets.count {
+                workoutSession.completeSet(exerciseIndex: 0, setIndex: setIdx)
+            }
+        }
+
+        // Seed two demo soundtrack tracks so the finish-sheet section renders
+        // populated for screenshots. Skip when running under the soundtrack
+        // capture bypass already (we want a deterministic preview).
+        if env["XOMFIT_AUTO_SEED_TRACKS"] == "1" {
+            workoutSession.addManualTrack(title: "Pump Anthem", artist: "Demo Artist")
+            workoutSession.addManualTrack(title: "Heavy Lift", artist: "Squat Crew")
+        }
+
+        // Optionally jump straight into the active runner so the cover renders.
+        workoutSession.isPresented = true
+    }
+    #endif
 }


### PR DESCRIPTION
## Summary

Polishes the finish-workout flow with three additions:

### #387.1 — per-exercise "moving on" prompt
When the user completes the last planned set on an exercise (and it's not the final exercise of the session, and the kind isn't `.timedCircuit`), a transition card appears with two CTAs:
- **Do Another Set** — appends an empty set to the current exercise
- **Move to [next exercise]** — advances normally

### #387.2 — soundtrack preview + edit on finish sheet
Adds a Soundtrack section to the finish sheet showing the union of:
- `appleMusicTracks + spotifyTracks + soundCloudTracks + manualTracks` — minus anything in `removedTrackIDs`

Each row shows title, artist, and a source pill (Apple Music / Spotify / SoundCloud / Manual) with a trailing trash button. "Add manual track" CTA opens a small form for free-text entries.

`capturedTracksSnapshot()` was added on all three Now-Playing services for non-destructive preview.

### #387.3 — location field
Single-line text field bound to `WorkoutLoggerViewModel.location` with placeholder `"Where? (gym, home, park...)"`. Trim handled in the save path.

### Bonus — DEBUG env hooks for agent screenshots
`XOMFIT_AUTO_START_WORKOUT`, `XOMFIT_AUTO_SEED_TRACKS`, `XOMFIT_AUTO_PRESENT_FINISH` — only compile in DEBUG builds, used to drive screenshot flows.

## Verified
3 screenshots captured under `XOMFIT_AUTH_BYPASS=1`:
1. Active runner with seeded exercises
2. Transition card after last set of an exercise
3. Finish sheet with location field + Soundtrack section showing manual track rows + "Add manual track" CTA

## Test plan
- [ ] Start a workout, complete the last planned set of a non-final exercise → transition card appears
- [ ] Tap "Do Another Set" → empty set added; complete it; tap "Move to next" → advances
- [ ] On `.timedCircuit` kind → no transition card (loop runs as before)
- [ ] On the final exercise → no transition card (just stays on focus screen)
- [ ] Open finish sheet → Soundtrack section lists captured tracks with source pills
- [ ] Tap trash on a track → it disappears from the saved workout
- [ ] Tap "Add manual track" → fill title + artist → it appears with Manual pill
- [ ] Location field accepts text and persists into the saved workout's `location`