### PR TITLE
fix: silence Swift 6 strict-concurrency warnings blocking TestFlight archive

### DIFF
--- a/Xomfit/Views/Onboarding/OnboardingFriendsScreen.swift
+++ b/Xomfit/Views/Onboarding/OnboardingFriendsScreen.swift
@@ -313,13 +313,13 @@ struct OnboardingFriendsScreen: View {
 
     private func cancelRequest(targetId: String, friendshipId: String) {
         guard friendshipId != "pending" else {
-            relations[targetId] = .none
+            relations[targetId] = FriendshipRelation.none
             return
         }
         Task {
             do {
                 try await FriendsService.shared.cancelFriendRequest(friendshipId: friendshipId)
-                relations[targetId] = .none
+                relations[targetId] = FriendshipRelation.none
             } catch {
                 errorMessage = error.localizedDescription
             }
@@ -341,7 +341,7 @@ struct OnboardingFriendsScreen: View {
         Task {
             do {
                 try await FriendsService.shared.declineFriendRequest(friendshipId: friendshipId)
-                relations[targetId] = .none
+                relations[targetId] = FriendshipRelation.none
             } catch {
                 errorMessage = error.localizedDescription
             }

--- a/Xomfit/Views/Workout/LogPastWorkoutView.swift
+++ b/Xomfit/Views/Workout/LogPastWorkoutView.swift
@@ -487,6 +487,7 @@ struct LogPastWorkoutView: View {
                 }
             }
 
+            let pickerLabel = viewModel.photoImages.isEmpty ? "Add Photos" : "Change Photos"
             PhotosPicker(
                 selection: $viewModel.selectedPhotos,
                 maxSelectionCount: 4,
@@ -494,7 +495,7 @@ struct LogPastWorkoutView: View {
             ) {
                 HStack(spacing: 6) {
                     Image(systemName: "photo.on.rectangle.angled")
-                    Text(viewModel.photoImages.isEmpty ? "Add Photos" : "Change Photos")
+                    Text(pickerLabel)
                         .font(.subheadline.weight(.medium))
                 }
                 .foregroundStyle(Theme.accent)


### PR DESCRIPTION
## Summary

The most recent TestFlight archive failed at `CompileSwift` (exit 65) on two warnings that the Xcode 26 / Swift 6 toolchain promotes to errors during Release builds:

1. `OnboardingFriendsScreen.swift` — `relations[targetId] = .none` was ambiguous between `Optional.none` and `FriendshipRelation.none`. Made all three call sites explicit.
2. `LogPastWorkoutView.swift:497` — `viewModel.photoImages.isEmpty` was read inside the `PhotosPicker` label closure, which doesn't inherit `@MainActor` in Swift 6. Hoisted to a `let` in the parent body (which is `@MainActor`).

## Test plan
- [ ] CI archive succeeds