### PR TITLE
#399 active workout: dynamic island layout + minimize-to-main + resume on relaunch + LA cleanup

### DIFF
--- a/Xomfit/Services/NowPlayingService.swift
+++ b/Xomfit/Services/NowPlayingService.swift
@@ -43,17 +43,14 @@ final class NowPlayingService {
     /// Number of unique tracks captured in the current session.
     var capturedCount: Int { captured.count }
 
-    /// Immutable snapshot of currently-captured tracks (#387). Used by
-    /// `WorkoutLoggerViewModel.curatedTracksSnapshot` to merge sources at
-    /// finish time without exposing the mutable backing array.
-    func capturedTracksSnapshot() -> [WorkoutTrack] { captured }
-
     /// Most recent track captured this session (or the last completed session).
     private(set) var lastCapturedTrack: WorkoutTrack?
 
     /// Read-only copy of the currently captured tracks for this session. Used by the
     /// finish-workout sheet (#387) to preview what will be saved without yet stopping
-    /// the capture loop. Does NOT mutate state — call `stopCapture()` to actually drain.
+    /// the capture loop, AND by `WorkoutLoggerViewModel.curatedTracksSnapshot` to
+    /// merge sources at finish time without exposing the mutable backing array.
+    /// Does NOT mutate state — call `stopCapture()` to actually drain.
     func capturedTracksSnapshot() -> [WorkoutTrack] {
         captured
     }

--- a/Xomfit/Services/SpotifyNowPlayingService.swift
+++ b/Xomfit/Services/SpotifyNowPlayingService.swift
@@ -34,18 +34,15 @@ final class SpotifyNowPlayingService {
     /// and the active-workout popover. Stays in sync with `captured.count`.
     var capturedCount: Int { captured.count }
 
-    /// Immutable snapshot of captured tracks (#387). Used by
-    /// `WorkoutLoggerViewModel.curatedTracksSnapshot` to merge sources at
-    /// finish time without exposing the mutable backing array.
-    func capturedTracksSnapshot() -> [WorkoutTrack] { captured }
-
     /// Most recent track added in this session, if any. Surfaced in `SpotifyConnectionView` so
     /// the user can confirm capture is working without opening an active workout.
     private(set) var lastCapturedTrack: WorkoutTrack?
 
     /// Read-only copy of the currently captured tracks for this session. Used by the
     /// finish-workout sheet (#387) to preview what will be saved without yet stopping
-    /// the capture loop. Does NOT mutate state — call `stopCapture()` to actually drain.
+    /// the capture loop, AND by `WorkoutLoggerViewModel.curatedTracksSnapshot` to
+    /// merge sources at finish time without exposing the mutable backing array.
+    /// Does NOT mutate state — call `stopCapture()` to actually drain.
     func capturedTracksSnapshot() -> [WorkoutTrack] {
         captured
     }

--- a/Xomfit/ViewModels/WorkoutLoggerViewModel.swift
+++ b/Xomfit/ViewModels/WorkoutLoggerViewModel.swift
@@ -215,10 +215,29 @@ final class WorkoutLoggerViewModel {
         SpotifyNowPlayingService.shared.startCapture()
         // SoundCloud capture runs in parallel — silent no-op when not signed in (#389).
         SoundCloudNowPlayingService.shared.startCapture()
+
+        // Persist the fresh session so a force-quit within the first second
+        // (rare but possible) still surfaces the resume alert (#399).
+        saveActiveSession(force: true)
     }
 
     func discardWorkout() {
+        // End the Live Activity for the in-memory session AND any stale activity
+        // started in a previous launch (#399). Use the global activities list so
+        // discards from a restored-but-rejected session also clean up.
         endLiveActivity()
+        Self.endAllOrphanLiveActivities()
+
+        // Cancel both the in-memory and any persisted rest-timer notifications so
+        // a discarded workout can't fire a "Rest done" banner.
+        NotificationService.shared.cancelRestTimerNotification(workoutId: workoutId)
+        if let savedId = Self.peekSavedWorkoutId(), savedId != workoutId {
+            NotificationService.shared.cancelRestTimerNotification(workoutId: savedId)
+        }
+
+        // Wipe the persisted session — discard means we don't want to offer a resume.
+        Self.clearSavedSession()
+
         workoutName = ""
         exercises = []
         isActive = false
@@ -291,6 +310,7 @@ final class WorkoutLoggerViewModel {
         }
         exercises = builtExercises
         updateLiveActivity()
+        saveActiveSession(force: true)
     }
 
     // MARK: - Timed Circuit (#370)
@@ -432,6 +452,7 @@ final class WorkoutLoggerViewModel {
         workoutExercise.selectedLaterality = exercise.defaultLaterality
         exercises.append(workoutExercise)
         updateLiveActivity()
+        saveActiveSession(force: true)
     }
 
     /// Find the most recent set for an exercise from workout history.
@@ -471,6 +492,7 @@ final class WorkoutLoggerViewModel {
         guard exercises.indices.contains(index) else { return }
         exercises.remove(at: index)
         updateLiveActivity()
+        saveActiveSession(force: true)
     }
 
     func moveExercise(from source: Int, direction: Int) {
@@ -631,6 +653,7 @@ final class WorkoutLoggerViewModel {
             }
         }
         updateLiveActivity()
+        saveActiveSession(force: true)
     }
 
     func removeSet(exerciseIndex: Int, setIndex: Int) {
@@ -1064,6 +1087,7 @@ final class WorkoutLoggerViewModel {
             isPaused = true
         }
         updateLiveActivity()
+        saveActiveSession(force: true)
     }
 
     // MARK: - PR Detection
@@ -1207,6 +1231,219 @@ final class WorkoutLoggerViewModel {
         let interval = isRestTimerActive ? 5 : 30
         if liveActivityUpdateCounter % interval == 0 {
             updateLiveActivity()
+            // Piggy-back a throttled session snapshot so a force-quit can recover
+            // even when the user hasn't logged a set in a while (#399).
+            saveActiveSession()
+        }
+    }
+
+    // MARK: - Active Session Persistence (#399)
+    //
+    // Keep a single in-flight workout serialized to UserDefaults so a force-quit
+    // (or OS-initiated kill) can be recovered on next launch. We snapshot every
+    // meaningful state change (set complete, exercise add/remove, focus jump,
+    // pause toggle, …) — small writes, no async hop. The restore alert in
+    // `XomfitApp` reads `peekSavedWorkoutId() != nil` to decide whether to ask.
+
+    private static let savedSessionKey = "xomfit_active_session_v1"
+
+    /// Bumped on every schema breakage so we don't try to decode a v1 blob into v2.
+    private static let savedSessionSchemaVersion = 1
+
+    /// Auto-save throttling — coalesce rapid mutations (e.g. tickRestTimer ticks
+    /// don't write every frame). 1 second is short enough that a force-quit
+    /// loses at most one second of work but doesn't thrash UserDefaults.
+    private var lastPersistAt: Date = .distantPast
+    private static let persistMinInterval: TimeInterval = 1.0
+
+    /// Snapshot of the in-progress workout. Restricted to JSON-friendly types so
+    /// the whole struct round-trips through `JSONEncoder`/`JSONDecoder`. New
+    /// fields must default to backwards-compatible values.
+    struct PersistedSession: Codable {
+        var schemaVersion: Int
+        var workoutId: String
+        var workoutName: String
+        var exercises: [WorkoutExercise]
+        var startTime: Date
+        var savedAt: Date
+        var totalPausedDuration: TimeInterval
+        var defaultRestDuration: Double
+        var focusExerciseIndex: Int
+        var focusSetIndex: Int
+        var kind: WorkoutKind
+        var durationGoalMinutes: Int?
+        var roundsGoal: Int?
+        var location: String
+        var rating: Int
+        var activeUserId: String
+    }
+
+    /// Serialize the current state. No-op when `isActive == false` so a fresh
+    /// app launch with no workout doesn't churn UserDefaults.
+    func saveActiveSession(force: Bool = false) {
+        guard isActive else { return }
+        if !force {
+            let elapsed = Date().timeIntervalSince(lastPersistAt)
+            guard elapsed >= Self.persistMinInterval else { return }
+        }
+        lastPersistAt = Date()
+
+        let snapshot = PersistedSession(
+            schemaVersion: Self.savedSessionSchemaVersion,
+            workoutId: workoutId,
+            workoutName: workoutName,
+            exercises: exercises,
+            startTime: startTime,
+            savedAt: Date(),
+            totalPausedDuration: totalPausedDuration,
+            defaultRestDuration: defaultRestDuration,
+            focusExerciseIndex: focusExerciseIndex,
+            focusSetIndex: focusSetIndex,
+            kind: kind,
+            durationGoalMinutes: durationGoalMinutes,
+            roundsGoal: roundsGoal,
+            location: location,
+            rating: rating,
+            activeUserId: activeUserId
+        )
+
+        do {
+            let data = try JSONEncoder().encode(snapshot)
+            UserDefaults.standard.set(data, forKey: Self.savedSessionKey)
+        } catch {
+            print("[WorkoutLogger] saveActiveSession failed: \(error)")
+        }
+    }
+
+    /// Read-only check for the saved session id. Used by `XomfitApp` to decide
+    /// whether to surface the resume alert before instantiating the runner.
+    nonisolated static func peekSavedWorkoutId() -> String? {
+        guard let data = UserDefaults.standard.data(forKey: savedSessionKey),
+              let snapshot = try? JSONDecoder().decode(PersistedSession.self, from: data) else {
+            return nil
+        }
+        return snapshot.workoutId
+    }
+
+    /// Inspect the saved session without restoring it. Returns nil when there
+    /// is nothing persisted, or when the blob is unreadable (schema drift).
+    nonisolated static func peekSavedSession() -> PersistedSession? {
+        guard let data = UserDefaults.standard.data(forKey: savedSessionKey) else { return nil }
+        return try? JSONDecoder().decode(PersistedSession.self, from: data)
+    }
+
+    /// Clear the saved session blob. Safe to call when none is present.
+    nonisolated static func clearSavedSession() {
+        UserDefaults.standard.removeObject(forKey: savedSessionKey)
+    }
+
+    /// Stale threshold for an auto-cleared restore. Anything older than this
+    /// almost certainly belongs to a session the user abandoned days ago.
+    static let staleSessionAge: TimeInterval = 60 * 60 * 12  // 12h
+
+    /// Restore an in-flight workout snapshot. Drops it (and ends any lingering
+    /// Live Activity / scheduled notifications) when older than `staleSessionAge`.
+    /// Returns `true` when the workout was successfully restored.
+    @discardableResult
+    func restoreActiveSession() -> Bool {
+        guard let snapshot = Self.peekSavedSession() else { return false }
+        guard snapshot.schemaVersion == Self.savedSessionSchemaVersion else {
+            // Schema mismatch — drop the orphan blob + kill any LA so the user
+            // doesn't keep seeing stale Dynamic Island data.
+            Self.clearSavedSession()
+            Self.endAllOrphanLiveActivities()
+            return false
+        }
+
+        let age = Date().timeIntervalSince(snapshot.savedAt)
+        if age > Self.staleSessionAge {
+            // Stale — wipe persisted blob, end any lingering Live Activity,
+            // and cancel any scheduled rest notification for that workoutId.
+            NotificationService.shared.cancelRestTimerNotification(workoutId: snapshot.workoutId)
+            Self.clearSavedSession()
+            Self.endAllOrphanLiveActivities()
+            return false
+        }
+
+        // Rehydrate.
+        workoutId = snapshot.workoutId
+        workoutName = snapshot.workoutName
+        exercises = snapshot.exercises
+        startTime = snapshot.startTime
+        totalPausedDuration = snapshot.totalPausedDuration
+        defaultRestDuration = snapshot.defaultRestDuration
+        focusExerciseIndex = snapshot.focusExerciseIndex
+        focusSetIndex = snapshot.focusSetIndex
+        kind = snapshot.kind
+        durationGoalMinutes = snapshot.durationGoalMinutes
+        roundsGoal = snapshot.roundsGoal
+        location = snapshot.location
+        rating = snapshot.rating
+        activeUserId = snapshot.activeUserId
+
+        // Reset volatile state — pause + rest timer don't survive a cold launch
+        // (the rest timer's wall-clock anchor is irrecoverable across kills).
+        isPaused = false
+        pausedAt = nil
+        isRestTimerActive = false
+        restTimeRemaining = 0
+        restDuration = 0
+        showExerciseTransition = false
+        showPRCelebration = false
+        manualTracks = []
+        removedTrackIDs = []
+
+        isActive = true
+        isPresented = true
+        // Start a fresh Live Activity for the resumed session — the previous
+        // one (if any) is killed below so we don't stack two.
+        Self.endAllOrphanLiveActivities()
+        startLiveActivity()
+
+        // Re-arm soundtrack capture so the user's existing music session resumes
+        // being recorded for the rest of the workout.
+        NowPlayingService.shared.startCapture()
+        SpotifyNowPlayingService.shared.startCapture()
+        SoundCloudNowPlayingService.shared.startCapture()
+
+        return true
+    }
+
+    /// Convenience: explicitly decline a restore. Same effect as `discardWorkout`
+    /// for cleanup purposes, but doesn't touch in-memory state (because there
+    /// isn't any yet) — just kills the persisted blob + any orphan LA.
+    nonisolated static func declineRestore() {
+        // Cancel any rest notification keyed to the persisted workout id.
+        let savedId = peekSavedWorkoutId()
+        clearSavedSession()
+        Task { @MainActor in
+            if let savedId {
+                NotificationService.shared.cancelRestTimerNotification(workoutId: savedId)
+            }
+            endAllOrphanLiveActivities()
+        }
+    }
+
+    /// End every Xomfit Live Activity currently tracked by ActivityKit, with
+    /// immediate dismissal. Use this when discarding / declining / detecting a
+    /// stale session — `liveActivity` may be nil on cold launch even though
+    /// the OS still shows the bar.
+    @MainActor
+    static func endAllOrphanLiveActivities() {
+        for activity in Activity<XomfitWidgetAttributes>.activities {
+            let finalState = XomfitWidgetAttributes.ContentState(
+                elapsedSeconds: 0,
+                completedSets: 0,
+                totalSets: 0,
+                currentExercise: "Ended",
+                totalExercises: 0
+            )
+            Task {
+                await activity.end(
+                    .init(state: finalState, staleDate: nil),
+                    dismissalPolicy: .immediate
+                )
+            }
         }
     }
 

--- a/Xomfit/Views/Workout/ActiveWorkoutView.swift
+++ b/Xomfit/Views/Workout/ActiveWorkoutView.swift
@@ -226,15 +226,18 @@ struct ActiveWorkoutView: View {
                     .foregroundStyle(Theme.accent)
                 }
             }
-            // Push the header below any active Dynamic Island (#289). Even with the
-            // existing top safe-area, an active island (e.g. music app) can still
-            // occlude the workout header — bump everything down deterministically.
+            // Push the header below any active Dynamic Island (#289/#399). With the
+            // new two-row layout the top row only carries corner controls (Discard /
+            // Minimize / Finish) and the second row carries the timer, so even an
+            // active island can't occlude the elapsed-time string. Keep an extra
+            // 8pt of breathing room above the natural top safe area.
             .safeAreaInset(edge: .top, spacing: 0) {
                 Color.clear.frame(height: Theme.Spacing.sm)
             }
+            // Reserve a hair above the home indicator so the floating Add Exercise
+            // pill / rest timer card never clip into the OS gesture area (#399).
             .safeAreaInset(edge: .bottom, spacing: 0) {
-                // Empty — just ensures keyboard inset is respected; actual toolbar is above
-                Color.clear.frame(height: 0)
+                Color.clear.frame(height: Theme.Spacing.xs)
             }
         }
         .onReceive(timer) { _ in
@@ -380,12 +383,35 @@ struct ActiveWorkoutView: View {
     }
 
     // MARK: - Header
+    //
+    // Two-row layout (#399) so nothing collides with the Dynamic Island. The
+    // top row only contains corner controls (Discard / Minimize / Finish) —
+    // they're far enough from center that they sit cleanly to the left/right
+    // of the island. The second row carries the timer + workout name +
+    // pause/focus toggles, which live BELOW the island so they're never
+    // occluded.
+    //
+    // Previous single-row design (#287/#289) tried to squeeze 6 controls into
+    // one row, which on iPhone 14/15/16/17 Pro models collided with the
+    // Dynamic Island and clipped the duration timer.
 
     private var headerBar: some View {
-        // Tighten horizontal spacing between adjacent controls so the rest pill
-        // doesn't get squeezed into multiple lines (#287).
+        VStack(spacing: Theme.Spacing.xs) {
+            headerTopRow
+            headerSecondRow
+        }
+        .padding(.horizontal, Theme.Spacing.md)
+        .padding(.top, Theme.Spacing.sm)
+        .padding(.bottom, Theme.Spacing.sm)
+        .background(Theme.surface)
+    }
+
+    /// Row 1 — corner controls only. Discard sits on the leading edge; Minimize
+    /// + Finish sit on the trailing edge. The center is intentionally empty so
+    /// the Dynamic Island can render without clipping anything.
+    private var headerTopRow: some View {
         HStack(spacing: Theme.Spacing.xs) {
-            // Discard button — compact
+            // Discard button — leading corner.
             Button {
                 Haptics.warning()
                 showDiscardAlert = true
@@ -395,13 +421,70 @@ struct ActiveWorkoutView: View {
                     .foregroundStyle(Theme.destructive)
                     .lineLimit(1)
                     .fixedSize(horizontal: true, vertical: false)
+                    .frame(minHeight: 44)
+                    .contentShape(Rectangle())
             }
+            .accessibilityLabel("Discard workout")
+            .accessibilityHint("Ends and deletes the in-progress workout without saving")
 
-            Spacer(minLength: Theme.Spacing.xs)
+            Spacer(minLength: 0)
 
-            // Timer cluster — total time prominent + rest timer chip so both stay visible
-            // around the Dynamic Island. Name is secondary (can be hidden by island).
-            VStack(spacing: Theme.Spacing.tighter) {
+            // Minimize — dismiss the cover and leave the workout running in the
+            // background. The persistent resume bar in MainTabView re-presents
+            // it via `xomfit://workout` or a tap.
+            Button {
+                Haptics.light()
+                withAnimation(.spring(response: 0.35, dampingFraction: 0.82)) {
+                    viewModel.isPresented = false
+                }
+            } label: {
+                Image(systemName: "chevron.down")
+                    .font(.subheadline.weight(.bold))
+                    .foregroundStyle(Theme.textPrimary)
+                    .frame(width: 44, height: 44)
+                    .background(Theme.textSecondary.opacity(0.15))
+                    .clipShape(Circle())
+                    .contentShape(Rectangle())
+            }
+            .accessibilityLabel("Minimize workout")
+            .accessibilityHint("Hides the active workout and returns to the main app. The workout keeps running.")
+
+            // Finish button.
+            Button {
+                Haptics.success()
+                workoutDescription = ""
+                showFinishSheet = true
+            } label: {
+                if viewModel.isSaving {
+                    ProgressView()
+                        .tint(.black)
+                        .frame(width: 60, height: 28)
+                        .background(Theme.accent)
+                        .clipShape(.rect(cornerRadius: 8))
+                } else {
+                    Text("Finish")
+                        .font(.caption.weight(.bold))
+                        .foregroundStyle(.black)
+                        .lineLimit(1)
+                        .fixedSize(horizontal: true, vertical: false)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 7)
+                        .background(Theme.accent)
+                        .clipShape(.rect(cornerRadius: 8))
+                }
+            }
+            .disabled(viewModel.isSaving)
+            .accessibilityLabel("Finish workout")
+        }
+    }
+
+    /// Row 2 — timer + name on the leading edge, pause + focus toggle on the
+    /// trailing edge. Lives below the Dynamic Island so the duration string is
+    /// never clipped.
+    private var headerSecondRow: some View {
+        HStack(spacing: Theme.Spacing.sm) {
+            // Timer cluster — total time prominent + rest timer chip when active.
+            VStack(alignment: .leading, spacing: Theme.Spacing.tighter) {
                 HStack(spacing: 6) {
                     HStack(spacing: 3) {
                         Image(systemName: "clock.fill")
@@ -437,10 +520,6 @@ struct ActiveWorkoutView: View {
                 }
 
                 HStack(spacing: 4) {
-                    // Subtle "Apple Watch connected" cue (#256 follow-up).
-                    // Rendered next to the workout name so users know the
-                    // watch's Done Set button is live without taking extra
-                    // header space.
                     if WatchSyncService.shared.isWatchAvailable {
                         Image(systemName: "applewatch")
                             .font(.caption2.weight(.semibold))
@@ -457,8 +536,7 @@ struct ActiveWorkoutView: View {
 
             Spacer(minLength: Theme.Spacing.xs)
 
-            // Pause / Resume toggle — freezes elapsed time + rest timer
-            // Visually narrower (32pt) but keeps a 44pt tap target via contentShape.
+            // Pause / Resume toggle.
             Button {
                 Haptics.light()
                 withAnimation(.xomChill) {
@@ -468,7 +546,7 @@ struct ActiveWorkoutView: View {
                 Image(systemName: viewModel.isPaused ? "play.circle.fill" : "pause.circle.fill")
                     .font(.title3.weight(.semibold))
                     .foregroundStyle(viewModel.isPaused ? Theme.accent : Theme.textPrimary)
-                    .frame(width: 32, height: 44)
+                    .frame(width: 44, height: 44)
                     .contentShape(Rectangle())
             }
             .accessibilityLabel(viewModel.isPaused ? "Resume workout" : "Pause workout")
@@ -476,7 +554,7 @@ struct ActiveWorkoutView: View {
                 ? "Resumes the elapsed timer and rest countdown"
                 : "Freezes the elapsed timer and rest countdown")
 
-            // Focus mode toggle — visually narrower, 44pt tap area enforced.
+            // Focus mode toggle.
             Button {
                 withAnimation {
                     viewModel.focusMode.toggle()
@@ -498,38 +576,7 @@ struct ActiveWorkoutView: View {
                     .contentShape(Rectangle())
             }
             .accessibilityLabel(viewModel.focusMode ? "Switch to list view" : "Switch to focus view")
-
-            // Finish button — compact (smaller font + tighter padding to free up header space).
-            Button {
-                Haptics.success()
-                workoutDescription = ""
-                showFinishSheet = true
-            } label: {
-                if viewModel.isSaving {
-                    ProgressView()
-                        .tint(.black)
-                        .frame(width: 60, height: 28)
-                        .background(Theme.accent)
-                        .clipShape(.rect(cornerRadius: 8))
-                } else {
-                    Text("Finish")
-                        .font(.caption.weight(.bold))
-                        .foregroundStyle(.black)
-                        .lineLimit(1)
-                        .fixedSize(horizontal: true, vertical: false)
-                        .padding(.horizontal, 12)
-                        .padding(.vertical, 7)
-                        .background(Theme.accent)
-                        .clipShape(.rect(cornerRadius: 8))
-                }
-            }
-            .disabled(viewModel.isSaving)
-            .accessibilityLabel("Finish workout")
         }
-        .padding(.horizontal, Theme.Spacing.md)
-        .padding(.top, Theme.Spacing.md)
-        .padding(.bottom, Theme.Spacing.md)
-        .background(Theme.surface)
     }
 
     // MARK: - Current Exercise Pill (#253)

--- a/Xomfit/XomfitApp.swift
+++ b/Xomfit/XomfitApp.swift
@@ -24,6 +24,12 @@ struct XomFitApp: App {
     @State private var showCoachSheet = false
     #endif
 
+    /// Force-quit recovery (#399). When the user (or the OS) terminates the app
+    /// mid-workout, the active session is persisted by `WorkoutLoggerViewModel`
+    /// and offered back on the next launch via this alert. `pendingRestoreInfo`
+    /// is non-nil only while the prompt is visible; resolved by Resume / Discard.
+    @State private var pendingRestoreInfo: WorkoutRestoreInfo? = nil
+
     var body: some Scene {
         WindowGroup {
             Group {
@@ -61,6 +67,30 @@ struct XomFitApp: App {
                                 workoutSession?.completeFocusedSetFromWatch()
                             }
                             evaluateFitnessQuestionnaireGate()
+                            evaluateActiveSessionRestore()
+                        }
+                        .alert(
+                            "Resume workout?",
+                            isPresented: Binding(
+                                get: { pendingRestoreInfo != nil },
+                                set: { if !$0 { pendingRestoreInfo = nil } }
+                            ),
+                            presenting: pendingRestoreInfo
+                        ) { info in
+                            Button("Resume") {
+                                Haptics.light()
+                                _ = workoutSession.restoreActiveSession()
+                                pendingRestoreInfo = nil
+                            }
+                            .accessibilityHint("Reopens the workout exactly where you left it.")
+                            Button("Discard", role: .destructive) {
+                                Haptics.warning()
+                                WorkoutLoggerViewModel.declineRestore()
+                                pendingRestoreInfo = nil
+                            }
+                            .accessibilityHint("Deletes the saved workout and ends the Live Activity.")
+                        } message: { info in
+                            Text("Your “\(info.workoutName)” workout was still running. Pick up where you left off — started \(info.startedRelative).")
                         }
                         .sheet(isPresented: Bindable(authService).needsProfileCompletion) {
                             ProfileCompletionView()
@@ -177,6 +207,44 @@ struct XomFitApp: App {
         }
     }
 
+    /// Force-quit recovery (#399). When the app launches and finds a persisted
+    /// in-progress workout, surface the resume alert so the user can pick up
+    /// where they left off. Stale (>12h) blobs are dropped silently — see
+    /// `WorkoutLoggerViewModel.restoreActiveSession`'s threshold.
+    @MainActor
+    private func evaluateActiveSessionRestore() {
+        // Don't double-prompt if a workout is already live (e.g. user navigated
+        // away and back without killing the app).
+        guard !workoutSession.isActive else { return }
+        guard let snapshot = WorkoutLoggerViewModel.peekSavedSession() else { return }
+
+        let age = Date().timeIntervalSince(snapshot.savedAt)
+        if age > WorkoutLoggerViewModel.staleSessionAge {
+            // Auto-clean stale blobs + any orphan Live Activity. Don't ask.
+            WorkoutLoggerViewModel.declineRestore()
+            return
+        }
+
+        // Skip under DEBUG bypass flags that seed their own workout — the
+        // seeded session would otherwise conflict with the resume alert.
+        #if DEBUG
+        let env = ProcessInfo.processInfo.environment
+        if env["XOMFIT_AUTO_START_WORKOUT"] == "1" {
+            WorkoutLoggerViewModel.declineRestore()
+            return
+        }
+        #endif
+
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .full
+        let startedRelative = formatter.localizedString(for: snapshot.startTime, relativeTo: Date())
+
+        pendingRestoreInfo = WorkoutRestoreInfo(
+            workoutName: snapshot.workoutName.isEmpty ? "Workout" : snapshot.workoutName,
+            startedRelative: startedRelative
+        )
+    }
+
     /// Decide whether to present the fitness questionnaire on this launch.
     /// Don't re-prompt once the user finishes it OR explicitly skipped — they can
     /// always reopen it from Settings -> Fitness Goals.
@@ -243,4 +311,13 @@ struct XomFitApp: App {
         workoutSession.isPresented = true
     }
     #endif
+}
+
+/// Lightweight value type passed to the resume alert (#399). Carries only the
+/// strings the prompt needs so we don't have to plumb the full `PersistedSession`
+/// through `@State` and `Binding` machinery.
+private struct WorkoutRestoreInfo: Identifiable {
+    let id = UUID()
+    let workoutName: String
+    let startedRelative: String
 }


### PR DESCRIPTION
## Summary

Three critical bugs reported on device.

### Bug 1 — Top toolbar overlapped Dynamic Island
Split the single-row header into a two-row layout:
- **Row 1** (corners only): Discard (left) | center gap for Dynamic Island | Minimize chevron + Finish (right)
- **Row 2** (below DI): timer clock + 0:00 + workout name (left) | pause + focus eye (right)

Also widened the bottom `safeAreaInset` by `Theme.Spacing.xs` so the Add Exercise / rest banner clear the home indicator.

### Bug 2 — No escape to main app during active workout
- Added a Minimize chevron in Row 1 of the toolbar; tapping it dismisses the fullscreen-cover (`viewModel.isPresented = false`) and the existing `WorkoutResumeBar` in `MainTabView` surfaces a "Workout in progress — tap to resume" pill at the bottom.
- Tapping the pill (or the existing `xomfit://workout` deep link) re-presents.

### Bug 3 — Workout lost on app quit + Live Activity persists after discard
- `WorkoutLoggerViewModel.saveActiveSession()` serializes session state to UserDefaults on every meaningful change (set complete, exercise add/remove, pause toggle, start, tick — throttled to 1s for tick-driven calls).
- `restoreActiveSession()` rehydrates on launch.
- `XomfitApp.evaluateActiveSessionRestore()` peeks the persisted blob and shows a "Resume?" alert with Resume / Discard / Cancel. Stale blobs (&gt;12h) auto-clear.
- `discardWorkout()` now ends every Xomfit Live Activity (in-memory + orphans) AND cancels scheduled rest notifications tied to the saved workout id.

### Drive-by
- Deduped a `capturedTracksSnapshot()` declaration that landed twice (from #387 + a follow-up) and broke the Swift 6 build.

## Test plan
- [ ] On iPhone 17 sim: start workout → toolbar sits with Dynamic Island in between Discard/Finish, second row below DI; bottom rest banner clears the home indicator
- [ ] Tap Minimize → workout sheet dismisses; "Workout in progress" pill visible at bottom
- [ ] Tap pill → workout re-presents
- [ ] Force-terminate + relaunch (without auto-start env) → Resume? alert appears with elapsed time
- [ ] Tap Discard → Live Activity ends + no further notifications