### PR TITLE
#398 stretches polish: live activity + reorder/edit + negative countdown

### DIFF
--- a/Xomfit/Models/XomfitWidgetAttributes.swift
+++ b/Xomfit/Models/XomfitWidgetAttributes.swift
@@ -10,7 +10,16 @@ import ActivityKit
 import Foundation
 
 struct XomfitWidgetAttributes: ActivityAttributes {
+    /// Which Live Activity flow this payload drives. Older payloads omit
+    /// `mode` and decode as `.workout` so the existing workout Live Activity
+    /// keeps rendering unchanged (#398).
+    public enum Mode: String, Codable, Hashable {
+        case workout
+        case stretch
+    }
+
     public struct ContentState: Codable, Hashable {
+        // MARK: - Workout fields
         var elapsedSeconds: Int
         var completedSets: Int
         var totalSets: Int
@@ -21,6 +30,21 @@ struct XomfitWidgetAttributes: ActivityAttributes {
         var restEndDate: Date? = nil
         var isOvertime: Bool = false
         var isPaused: Bool = false
+
+        // MARK: - Stretch sequence fields (#398)
+        /// Which Live Activity flow this is. Defaults to `.workout` so old
+        /// payloads decode cleanly.
+        var mode: Mode = .workout
+        /// Name of the stretch currently being held. Only meaningful when
+        /// `mode == .stretch`.
+        var stretchName: String = ""
+        /// Seconds remaining on the current stretch. Allowed to go negative
+        /// once the user holds past the recommended time.
+        var stretchSecondsRemaining: Int = 0
+        /// 1-based index of the current stretch in the sequence.
+        var stretchIndex: Int = 0
+        /// Total stretches in the sequence.
+        var stretchTotal: Int = 0
     }
 
     var workoutName: String

--- a/Xomfit/ViewModels/GuidedStretchRunnerViewModel.swift
+++ b/Xomfit/ViewModels/GuidedStretchRunnerViewModel.swift
@@ -1,15 +1,19 @@
+import ActivityKit
 import Foundation
 import SwiftUI
 
-/// Drives the guided stretch sequence runner (#388).
+/// Drives the guided stretch sequence runner (#388 / polished in #398).
 ///
 /// Wraps a list of `Stretch`es with:
-/// - a per-stretch countdown that auto-advances on hitting 0
-/// - skip / back controls
-/// - "finished" state once the last stretch wraps up
+/// - a per-stretch countdown that keeps ticking past 0 into negative territory
+///   so the user can hold longer than the recommended time (#398)
+/// - skip / back / pause controls
+/// - "finished" state once the user moves past the last stretch
+/// - an ActivityKit Live Activity that mirrors the workout one, surfacing the
+///   current stretch + countdown in the Dynamic Island / lock screen
 ///
-/// MVVM: this is the only place the timer lives. The view binds to
-/// `currentIndex` / `secondsRemaining` / `isFinished` for display.
+/// MVVM: this is the only place the timer + Live Activity live. The view binds
+/// to `currentIndex` / `secondsRemaining` / `isFinished` for display.
 @MainActor
 @Observable
 final class GuidedStretchRunnerViewModel {
@@ -17,13 +21,17 @@ final class GuidedStretchRunnerViewModel {
 
     /// Resolved stretches the runner walks through. Empty arrays short-circuit
     /// straight to `isFinished` so the view can show its end card.
-    let stretches: [Stretch]
-    /// Friendly name surfaced on the end screen ("Nice — done with X").
+    private(set) var stretches: [Stretch]
+    /// Friendly name surfaced on the end screen ("Nice — done with X") and on
+    /// the Live Activity.
     let templateName: String
 
     // MARK: - State
 
     private(set) var currentIndex: Int = 0
+    /// Seconds remaining on the current stretch. Goes negative once the user
+    /// holds past the recommended time — the UI flips to red and the user
+    /// stays in manual control (no auto-advance) until they tap Skip / Done.
     private(set) var secondsRemaining: Int
     private(set) var isFinished: Bool = false
     /// True while the timer is actively ticking. `pause()` flips it false.
@@ -34,6 +42,7 @@ final class GuidedStretchRunnerViewModel {
     private(set) var elapsedSeconds: Int = 0
 
     private var timer: Timer?
+    private var liveActivity: Activity<XomfitWidgetAttributes>?
 
     // MARK: - Init
 
@@ -62,10 +71,19 @@ final class GuidedStretchRunnerViewModel {
 
     var totalCount: Int { stretches.count }
 
-    /// 0...1 — fraction of the current hold elapsed. Used to drive the ring.
+    /// 0...1 — fraction of the current hold elapsed. Clamped at 1 once the
+    /// countdown hits zero so the ring stays full when the user holds longer
+    /// than the recommended time instead of looping back around (#398).
     var stretchProgress: Double {
         guard let stretch = currentStretch, stretch.durationSeconds > 0 else { return 0 }
-        return 1 - (Double(secondsRemaining) / Double(stretch.durationSeconds))
+        let raw = 1 - (Double(secondsRemaining) / Double(stretch.durationSeconds))
+        return min(1, max(0, raw))
+    }
+
+    /// True once the user is holding past the recommended hold time. Drives
+    /// the red "overtime" styling in the runner and Live Activity (#398).
+    var isOvertime: Bool {
+        secondsRemaining < 0
     }
 
     /// 0...1 — fraction of the sequence completed (by stretch count). Used by
@@ -95,12 +113,15 @@ final class GuidedStretchRunnerViewModel {
                 self?.tick()
             }
         }
+        startLiveActivityIfNeeded()
+        updateLiveActivity()
     }
 
     func pause() {
         isRunning = false
         timer?.invalidate()
         timer = nil
+        updateLiveActivity()
     }
 
     func togglePause() {
@@ -130,12 +151,50 @@ final class GuidedStretchRunnerViewModel {
             isFinished = false
             start()
         }
+        updateLiveActivity()
     }
 
     func finishEarly() {
         pause()
         isFinished = true
         Haptics.success()
+        endLiveActivity()
+    }
+
+    /// Called by the view when the user dismisses the runner (close / Done on
+    /// the end card). Tears the timer and Live Activity down.
+    func teardown() {
+        pause()
+        endLiveActivity()
+    }
+
+    #if DEBUG
+    /// Forces a single tick of the runner without going through the timer.
+    /// Used only by agent screenshot flows to push the countdown into the
+    /// overtime state without waiting in real time. Compiles out of Release.
+    func debugTickForOvertimeScreenshot() {
+        guard !isFinished else { return }
+        elapsedSeconds += 1
+        secondsRemaining -= 1
+        updateLiveActivity()
+    }
+    #endif
+
+    // MARK: - Editing (#398)
+
+    /// Replace the current session's stretch list. Used by the detail view's
+    /// edit mode to apply reorders / deletes before starting. Resets the
+    /// position to the first stretch and pauses so the user can hit Play.
+    func replaceStretches(_ next: [Stretch]) {
+        timer?.invalidate()
+        timer = nil
+        isRunning = false
+        stretches = next
+        currentIndex = 0
+        secondsRemaining = next.first?.durationSeconds ?? 0
+        isFinished = next.isEmpty
+        elapsedSeconds = 0
+        updateLiveActivity()
     }
 
     // MARK: - Private
@@ -144,12 +203,12 @@ final class GuidedStretchRunnerViewModel {
     private func tick() {
         guard !isFinished else { return }
         elapsedSeconds += 1
-        if secondsRemaining > 0 {
-            secondsRemaining -= 1
-        }
-        if secondsRemaining <= 0 {
-            advance()
-        }
+        // Per #398: keep counting past zero. The runner does NOT auto-advance
+        // — the user controls Skip / Done themselves.
+        secondsRemaining -= 1
+        // Push a Live Activity update every tick so the Dynamic Island
+        // countdown stays in sync. Cheap because the payload is tiny.
+        updateLiveActivity()
     }
 
     private func advance() {
@@ -158,10 +217,85 @@ final class GuidedStretchRunnerViewModel {
             isFinished = true
             pause()
             Haptics.success()
+            endLiveActivity()
             return
         }
         currentIndex = next
         secondsRemaining = stretches[next].durationSeconds
         Haptics.selection()
+        updateLiveActivity()
+    }
+
+    // MARK: - Live Activity
+
+    private func startLiveActivityIfNeeded() {
+        guard liveActivity == nil else { return }
+        guard ActivityAuthorizationInfo().areActivitiesEnabled else { return }
+
+        // End any stale stretch activities to prevent stacking. Workout
+        // activities are managed by `WorkoutLoggerViewModel` — we only clean
+        // up ones tagged with our stretch mode here.
+        for activity in Activity<XomfitWidgetAttributes>.activities where activity.content.state.mode == .stretch {
+            let finalState = activity.content.state
+            Task {
+                await activity.end(.init(state: finalState, staleDate: nil), dismissalPolicy: .immediate)
+            }
+        }
+
+        let attributes = XomfitWidgetAttributes(
+            workoutName: templateName,
+            startTime: Date()
+        )
+        let state = currentLiveState()
+
+        do {
+            liveActivity = try Activity.request(
+                attributes: attributes,
+                content: .init(state: state, staleDate: nil),
+                pushType: nil
+            )
+        } catch {
+            print("[StretchLiveActivity] Failed to start: \(error)")
+        }
+    }
+
+    private func updateLiveActivity() {
+        guard let activity = liveActivity else { return }
+        let state = currentLiveState()
+        Task {
+            await activity.update(.init(state: state, staleDate: nil))
+        }
+    }
+
+    private func endLiveActivity() {
+        guard let activity = liveActivity else { return }
+        let finalState = currentLiveState()
+        Task {
+            await activity.end(.init(state: finalState, staleDate: nil), dismissalPolicy: .immediate)
+        }
+        liveActivity = nil
+    }
+
+    /// Snapshot of the runner state translated into the shared
+    /// `ContentState`. Only the stretch-mode fields carry meaning; workout
+    /// fields stay at their defaults.
+    private func currentLiveState() -> XomfitWidgetAttributes.ContentState {
+        XomfitWidgetAttributes.ContentState(
+            elapsedSeconds: elapsedSeconds,
+            completedSets: 0,
+            totalSets: 0,
+            currentExercise: "",
+            totalExercises: 0,
+            isResting: false,
+            restTimeRemaining: 0,
+            restEndDate: nil,
+            isOvertime: false,
+            isPaused: !isRunning,
+            mode: .stretch,
+            stretchName: currentStretch?.name ?? "",
+            stretchSecondsRemaining: secondsRemaining,
+            stretchIndex: min(currentIndex + 1, max(totalCount, 1)),
+            stretchTotal: totalCount
+        )
     }
 }

--- a/Xomfit/Views/Stretches/GuidedStretchRunnerView.swift
+++ b/Xomfit/Views/Stretches/GuidedStretchRunnerView.swift
@@ -2,10 +2,13 @@ import SwiftUI
 
 // MARK: - GuidedStretchRunnerView
 //
-// Full-screen guided stretching session for a curated template (#388).
-// Shows the current stretch, a per-stretch countdown ring, a top progress
-// bar, and skip/back/pause controls. Auto-advances when the timer hits 0;
-// finishes with a celebratory end card summarizing total time.
+// Full-screen guided stretching session for a curated template (#388, polished
+// in #398). Shows the current stretch, a per-stretch countdown ring, a top
+// progress bar, and skip/back/pause controls. The countdown keeps going past
+// zero into negative territory so the user can hold a stretch as long as they
+// want — the runner does NOT auto-advance; Skip / Done are manual. Mirrors
+// the workout Live Activity via `XomfitWidgetAttributes` so the current
+// stretch + countdown surface in the Dynamic Island / on the lock screen.
 
 struct GuidedStretchRunnerView: View {
     let stretches: [Stretch]
@@ -43,17 +46,37 @@ struct GuidedStretchRunnerView: View {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Close") {
                         Haptics.light()
-                        viewModel.pause()
+                        viewModel.teardown()
                         dismiss()
                     }
                     .foregroundStyle(Theme.textSecondary)
+                    .accessibilityLabel("Close stretching sequence")
                 }
             }
             .onAppear {
                 viewModel.start()
+                #if DEBUG
+                // Agent screenshot helper: jump-start the runner into the
+                // negative-countdown ("overtime") state so the red styling can
+                // be captured from a cold launch.
+                let env = ProcessInfo.processInfo.environment
+                if let raw = env["XOMFIT_STRETCH_FORCE_OVERTIME"], let secs = Int(raw) {
+                    Task { @MainActor in
+                        try? await Task.sleep(for: .milliseconds(400))
+                        // Tick the runner forward enough to push `secondsRemaining`
+                        // to roughly `-secs`. The view model owns the timer so
+                        // we use its public skip path to enter overtime.
+                        let target = viewModel.currentStretch?.durationSeconds ?? 0
+                        let tickCount = target + secs
+                        for _ in 0..<tickCount {
+                            viewModel.debugTickForOvertimeScreenshot()
+                        }
+                    }
+                }
+                #endif
             }
             .onDisappear {
-                viewModel.pause()
+                viewModel.teardown()
             }
         }
     }
@@ -131,20 +154,30 @@ struct GuidedStretchRunnerView: View {
                     .accessibilityAddTraits(.isHeader)
 
                 ZStack {
-                    RestTimerRingView(progress: viewModel.stretchProgress, color: Theme.accent, lineWidth: 10)
+                    // Ring color also flips red once the user holds past the
+                    // recommended time (#398). Progress stays clamped at 1.
+                    RestTimerRingView(
+                        progress: viewModel.stretchProgress,
+                        color: viewModel.isOvertime ? Theme.destructive : Theme.accent,
+                        lineWidth: 10
+                    )
                     VStack(spacing: 2) {
                         Text("\(viewModel.secondsRemaining)")
                             .font(.system(size: 56, weight: .heavy, design: .rounded))
                             .monospacedDigit()
-                            .foregroundStyle(Theme.textPrimary)
-                        Text("seconds")
+                            .foregroundStyle(viewModel.isOvertime ? Theme.destructive : Theme.textPrimary)
+                        Text(viewModel.isOvertime ? "over · tap skip" : "seconds")
                             .font(Theme.fontCaption)
-                            .foregroundStyle(Theme.textSecondary)
+                            .foregroundStyle(viewModel.isOvertime ? Theme.destructive : Theme.textSecondary)
                     }
                 }
                 .frame(width: 200, height: 200)
                 .accessibilityElement(children: .ignore)
-                .accessibilityLabel("\(viewModel.secondsRemaining) seconds remaining on \(stretch.name)")
+                .accessibilityLabel(
+                    viewModel.isOvertime
+                        ? "\(abs(viewModel.secondsRemaining)) seconds past target on \(stretch.name). Tap skip when ready."
+                        : "\(viewModel.secondsRemaining) seconds remaining on \(stretch.name)"
+                )
             }
         }
         .padding(Theme.Spacing.md)
@@ -317,6 +350,7 @@ struct GuidedStretchRunnerView: View {
 
             Button {
                 Haptics.medium()
+                viewModel.teardown()
                 dismiss()
             } label: {
                 Text("Done")

--- a/Xomfit/Views/Stretches/StretchTemplateDetailView.swift
+++ b/Xomfit/Views/Stretches/StretchTemplateDetailView.swift
@@ -1,17 +1,23 @@
 import SwiftUI
 
-/// Detail view for a curated `StretchTemplate` (#388).
+/// Detail view for a curated `StretchTemplate` (#388, edit mode added in #398).
 ///
 /// Shows the template's stretches in order with a "Start Stretching" CTA that
-/// presents the guided runner as a full-screen cover. Tapping a row opens the
-/// existing `StretchDetailSheet` so the user can read the long description.
+/// presents the guided runner as a full-screen cover. The user can flip into
+/// edit mode (pencil button) to reorder + delete stretches before starting;
+/// edits affect only the current session and never mutate
+/// `StretchTemplate.curated`. Tapping a row out of edit mode opens the
+/// existing `StretchDetailSheet`.
 struct StretchTemplateDetailView: View {
     let template: StretchTemplate
 
     @State private var stretchForDetail: Stretch?
     @State private var showRunner = false
-
-    private var stretches: [Stretch] { template.stretches }
+    /// Per-session, editable copy of the template's stretches. Initialized
+    /// from `template.stretches` and reset back to it via the "Reset" button.
+    @State private var sessionStretches: [Stretch] = []
+    /// Drives the swipe / drag affordances on the in-sequence list.
+    @State private var editMode: EditMode = .inactive
 
     var body: some View {
         ZStack {
@@ -33,12 +39,39 @@ struct StretchTemplateDetailView: View {
         .navigationTitle(template.name)
         .navigationBarTitleDisplayMode(.inline)
         .toolbarColorScheme(.dark, for: .navigationBar)
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                editToolbarContent
+            }
+        }
+        .environment(\.editMode, $editMode)
+        .onAppear {
+            // Seed the editable copy lazily so we don't trample mid-session
+            // edits when the view re-renders from a state change.
+            if sessionStretches.isEmpty {
+                sessionStretches = template.stretches
+            }
+            #if DEBUG
+            // Agent screenshot helper: when XOMFIT_STRETCH_EDIT_MODE=1 is set,
+            // auto-flip into edit mode shortly after first render so the
+            // verification script can capture the drag/swipe affordances
+            // without scripted taps.
+            if ProcessInfo.processInfo.environment["XOMFIT_STRETCH_EDIT_MODE"] == "1" {
+                Task { @MainActor in
+                    try? await Task.sleep(for: .milliseconds(400))
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        editMode = .active
+                    }
+                }
+            }
+            #endif
+        }
         .sheet(item: $stretchForDetail) { stretch in
             StretchDetailSheet(stretch: stretch)
         }
         .fullScreenCover(isPresented: $showRunner) {
             GuidedStretchRunnerView(
-                stretches: stretches,
+                stretches: sessionStretches,
                 templateName: template.name
             )
         }
@@ -73,8 +106,8 @@ struct StretchTemplateDetailView: View {
                 .fixedSize(horizontal: false, vertical: true)
 
             HStack(spacing: Theme.Spacing.md) {
-                metric(icon: "clock.fill", label: template.totalDurationLabel)
-                metric(icon: "list.bullet", label: "\(stretches.count) stretches")
+                metric(icon: "clock.fill", label: totalDurationLabel)
+                metric(icon: "list.bullet", label: "\(sessionStretches.count) stretches")
             }
             .accessibilityElement(children: .combine)
         }
@@ -98,26 +131,128 @@ struct StretchTemplateDetailView: View {
         .clipShape(.rect(cornerRadius: Theme.Radius.xs))
     }
 
+    private var totalDurationLabel: String {
+        let secs = sessionStretches.reduce(0) { $0 + $1.durationSeconds }
+        if secs < 60 { return "\(secs) sec" }
+        let mins = (secs + 30) / 60
+        return "\(mins) min"
+    }
+
+    // MARK: - Toolbar
+
+    @ViewBuilder
+    private var editToolbarContent: some View {
+        if editMode == .active {
+            HStack(spacing: Theme.Spacing.md) {
+                Button {
+                    Haptics.light()
+                    sessionStretches = template.stretches
+                } label: {
+                    Text("Reset")
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(Theme.alert)
+                }
+                .disabled(sessionStretches.map(\.id) == template.stretchIds)
+                .accessibilityLabel("Reset stretches to template order")
+
+                Button {
+                    Haptics.light()
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        editMode = .inactive
+                    }
+                } label: {
+                    Text("Done")
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(Theme.accent)
+                }
+                .accessibilityLabel("Finish editing stretches")
+            }
+        } else {
+            Button {
+                Haptics.light()
+                withAnimation(.easeInOut(duration: 0.2)) {
+                    editMode = .active
+                }
+            } label: {
+                Image(systemName: "pencil")
+                    .font(.body.weight(.semibold))
+                    .foregroundStyle(Theme.accent)
+            }
+            .disabled(sessionStretches.isEmpty)
+            .accessibilityLabel("Edit stretches")
+            .accessibilityHint("Reorder or remove stretches before starting")
+        }
+    }
+
     // MARK: - Stretch List
 
     private var listSection: some View {
         VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
-            XomMetricLabel("In This Sequence")
-
-            VStack(spacing: Theme.Spacing.xs) {
-                ForEach(Array(stretches.enumerated()), id: \.element.id) { index, stretch in
-                    Button {
-                        Haptics.selection()
-                        stretchForDetail = stretch
-                    } label: {
-                        row(index: index, stretch: stretch)
-                    }
-                    .buttonStyle(PressableCardStyle())
-                    .accessibilityLabel("Stretch \(index + 1): \(stretch.name), \(stretch.durationSeconds) seconds")
-                    .accessibilityHint("Opens stretch details")
+            HStack(alignment: .firstTextBaseline) {
+                XomMetricLabel("In This Sequence")
+                Spacer()
+                if editMode == .active {
+                    Text("Drag to reorder · swipe to remove")
+                        .font(.caption2.weight(.medium))
+                        .foregroundStyle(Theme.textTertiary)
                 }
             }
+
+            if editMode == .active {
+                editableList
+            } else {
+                staticList
+            }
         }
+    }
+
+    /// Read-only list used out of edit mode. Each row stays tappable so the
+    /// user can pop the detail sheet without entering edit mode.
+    private var staticList: some View {
+        VStack(spacing: Theme.Spacing.xs) {
+            ForEach(Array(sessionStretches.enumerated()), id: \.element.id) { index, stretch in
+                Button {
+                    Haptics.selection()
+                    stretchForDetail = stretch
+                } label: {
+                    row(index: index, stretch: stretch)
+                }
+                .buttonStyle(PressableCardStyle())
+                .accessibilityLabel("Stretch \(index + 1): \(stretch.name), \(stretch.durationSeconds) seconds")
+                .accessibilityHint("Opens stretch details")
+            }
+        }
+    }
+
+    /// Edit-mode list. Uses SwiftUI `List` so we get drag handles + swipe to
+    /// delete for free. The fixed-height frame caps the visual size to match
+    /// the static list — it grows as needed because we set `.scrollDisabled`.
+    private var editableList: some View {
+        List {
+            ForEach(Array(sessionStretches.enumerated()), id: \.element.id) { index, stretch in
+                row(index: index, stretch: stretch)
+                    .listRowBackground(Color.clear)
+                    .listRowInsets(EdgeInsets(top: 4, leading: 0, bottom: 4, trailing: 0))
+                    .listRowSeparator(.hidden)
+                    .accessibilityLabel("Stretch \(index + 1): \(stretch.name), \(stretch.durationSeconds) seconds")
+            }
+            .onMove(perform: moveStretch)
+            .onDelete(perform: deleteStretch)
+        }
+        .listStyle(.plain)
+        .scrollContentBackground(.hidden)
+        .scrollDisabled(true)
+        .frame(minHeight: CGFloat(sessionStretches.count) * 84)
+    }
+
+    private func moveStretch(from source: IndexSet, to destination: Int) {
+        Haptics.selection()
+        sessionStretches.move(fromOffsets: source, toOffset: destination)
+    }
+
+    private func deleteStretch(at offsets: IndexSet) {
+        Haptics.light()
+        sessionStretches.remove(atOffsets: offsets)
     }
 
     private func row(index: Int, stretch: Stretch) -> some View {
@@ -160,6 +295,9 @@ struct StretchTemplateDetailView: View {
         VStack(spacing: 0) {
             Button {
                 Haptics.medium()
+                // Leave edit mode before starting so the runner doesn't render
+                // behind a stale edit affordance.
+                if editMode == .active { editMode = .inactive }
                 showRunner = true
             } label: {
                 HStack(spacing: 10) {
@@ -168,9 +306,10 @@ struct StretchTemplateDetailView: View {
                 }
             }
             .buttonStyle(AccentButtonStyle())
+            .disabled(sessionStretches.isEmpty)
             .padding(.horizontal, Theme.Spacing.md)
             .padding(.bottom, Theme.Spacing.md)
-            .accessibilityLabel("Start guided stretching sequence")
+            .accessibilityLabel("Start guided stretching sequence with \(sessionStretches.count) stretches")
         }
         .background(
             LinearGradient(

--- a/XomfitWidget/XomfitWidgetAttributes.swift
+++ b/XomfitWidget/XomfitWidgetAttributes.swift
@@ -11,7 +11,16 @@ import ActivityKit
 import Foundation
 
 struct XomfitWidgetAttributes: ActivityAttributes {
+    /// Which Live Activity flow this payload drives. Older payloads omit
+    /// `mode` and decode as `.workout` so the existing workout Live Activity
+    /// keeps rendering unchanged (#398).
+    public enum Mode: String, Codable, Hashable {
+        case workout
+        case stretch
+    }
+
     public struct ContentState: Codable, Hashable {
+        // MARK: - Workout fields
         var elapsedSeconds: Int
         var completedSets: Int
         var totalSets: Int
@@ -22,6 +31,21 @@ struct XomfitWidgetAttributes: ActivityAttributes {
         var restEndDate: Date? = nil
         var isOvertime: Bool = false
         var isPaused: Bool = false
+
+        // MARK: - Stretch sequence fields (#398)
+        /// Which Live Activity flow this is. Defaults to `.workout` so old
+        /// payloads decode cleanly.
+        var mode: Mode = .workout
+        /// Name of the stretch currently being held. Only meaningful when
+        /// `mode == .stretch`.
+        var stretchName: String = ""
+        /// Seconds remaining on the current stretch. Allowed to go negative
+        /// once the user holds past the recommended time.
+        var stretchSecondsRemaining: Int = 0
+        /// 1-based index of the current stretch in the sequence.
+        var stretchIndex: Int = 0
+        /// Total stretches in the sequence.
+        var stretchTotal: Int = 0
     }
 
     var workoutName: String

--- a/XomfitWidget/XomfitWidgetLiveActivity.swift
+++ b/XomfitWidget/XomfitWidgetLiveActivity.swift
@@ -50,12 +50,30 @@ struct XomfitWidgetLiveActivity: Widget {
         .foregroundStyle(.white.opacity(0.85))
     }
 
+    /// Color used for the per-stretch countdown. Goes red once the user holds
+    /// past the recommended time (#398).
+    private func stretchColor(_ state: XomfitWidgetAttributes.ContentState) -> Color {
+        state.stretchSecondsRemaining < 0 ? .red : Self.accentGreen
+    }
+
+    /// Per-stretch countdown text (e.g. "12s", "-5s"). The negative `Int`
+    /// renders its own minus sign for the overtime case.
+    private func stretchCountdownText(_ state: XomfitWidgetAttributes.ContentState) -> String {
+        "\(state.stretchSecondsRemaining)s"
+    }
+
     var body: some WidgetConfiguration {
         ActivityConfiguration(for: XomfitWidgetAttributes.self) { context in
             // Lock screen / banner UI
-            lockScreenView(context: context)
-                .activityBackgroundTint(Self.darkBackground)
-                .activitySystemActionForegroundColor(.white)
+            Group {
+                if context.state.mode == .stretch {
+                    stretchLockScreenView(context: context)
+                } else {
+                    lockScreenView(context: context)
+                }
+            }
+            .activityBackgroundTint(Self.darkBackground)
+            .activitySystemActionForegroundColor(.white)
         } dynamicIsland: { context in
             DynamicIsland {
                 DynamicIslandExpandedRegion(.leading) {
@@ -65,7 +83,13 @@ struct XomfitWidgetLiveActivity: Widget {
                         .lineLimit(1)
                 }
                 DynamicIslandExpandedRegion(.trailing) {
-                    if context.state.isPaused {
+                    if context.state.mode == .stretch {
+                        Text(stretchCountdownText(context.state))
+                            .font(.system(size: 14, weight: .semibold, design: .monospaced))
+                            .foregroundStyle(stretchColor(context.state))
+                            .monospacedDigit()
+                            .multilineTextAlignment(.trailing)
+                    } else if context.state.isPaused {
                         pausedLabel(font: .system(size: 14, weight: .semibold))
                     } else {
                         Text(context.attributes.startTime, style: .timer)
@@ -81,14 +105,30 @@ struct XomfitWidgetLiveActivity: Widget {
                         .lineLimit(1)
                 }
                 DynamicIslandExpandedRegion(.bottom) {
-                    expandedBottomView(state: context.state)
+                    if context.state.mode == .stretch {
+                        stretchExpandedBottom(state: context.state)
+                    } else {
+                        expandedBottomView(state: context.state)
+                    }
                 }
             } compactLeading: {
-                Image(systemName: "dumbbell.fill")
-                    .font(.system(size: 12))
-                    .foregroundStyle(Self.accentGreen)
+                if context.state.mode == .stretch {
+                    Image(systemName: "figure.flexibility")
+                        .font(.system(size: 12))
+                        .foregroundStyle(Self.accentGreen)
+                } else {
+                    Image(systemName: "dumbbell.fill")
+                        .font(.system(size: 12))
+                        .foregroundStyle(Self.accentGreen)
+                }
             } compactTrailing: {
-                if context.state.isPaused {
+                if context.state.mode == .stretch {
+                    Text(stretchCountdownText(context.state))
+                        .font(.system(size: 12, weight: .semibold, design: .monospaced))
+                        .foregroundStyle(stretchColor(context.state))
+                        .multilineTextAlignment(.trailing)
+                        .monospacedDigit()
+                } else if context.state.isPaused {
                     pausedLabel(font: .system(size: 12, weight: .semibold))
                 } else if context.state.isResting, let endDate = context.state.restEndDate {
                     restTimerCountdown(endDate: endDate, isOvertime: context.state.isOvertime)
@@ -103,7 +143,13 @@ struct XomfitWidgetLiveActivity: Widget {
                         .multilineTextAlignment(.trailing)
                 }
             } minimal: {
-                if context.state.isPaused {
+                if context.state.mode == .stretch {
+                    Text(stretchCountdownText(context.state))
+                        .font(.system(size: 11, weight: .semibold, design: .monospaced))
+                        .foregroundStyle(stretchColor(context.state))
+                        .multilineTextAlignment(.center)
+                        .monospacedDigit()
+                } else if context.state.isPaused {
                     Image(systemName: "pause.fill")
                         .font(.system(size: 11, weight: .semibold))
                         .foregroundStyle(.white.opacity(0.85))
@@ -121,8 +167,8 @@ struct XomfitWidgetLiveActivity: Widget {
                         .monospacedDigit()
                 }
             }
-            .widgetURL(URL(string: "xomfit://workout"))
-            .keylineTint(restColor(context.state))
+            .widgetURL(URL(string: context.state.mode == .stretch ? "xomfit://stretch" : "xomfit://workout"))
+            .keylineTint(context.state.mode == .stretch ? stretchColor(context.state) : restColor(context.state))
         }
     }
 
@@ -270,9 +316,114 @@ struct XomfitWidgetLiveActivity: Widget {
         }
     }
 
+    // MARK: - Stretch Live Activity (#398)
+
+    /// Lock-screen card for the guided stretch sequence. Mirrors the workout
+    /// lock-screen layout (top row, middle row, progress bar) but swaps the
+    /// content for the active stretch + countdown.
+    @ViewBuilder
+    private func stretchLockScreenView(context: ActivityViewContext<XomfitWidgetAttributes>) -> some View {
+        let state = context.state
+        let progress: Double = state.stretchTotal > 0
+            ? min(1, max(0, Double(state.stretchIndex) / Double(state.stretchTotal)))
+            : 0
+
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                HStack(spacing: 6) {
+                    Image(systemName: "figure.flexibility")
+                        .font(.system(size: 14))
+                        .foregroundStyle(Self.accentGreen)
+                    Text(context.attributes.workoutName)
+                        .font(.system(size: 15, weight: .bold))
+                        .foregroundStyle(.white)
+                        .lineLimit(1)
+                }
+
+                Spacer()
+
+                Text(stretchCountdownText(state))
+                    .font(.system(size: 15, weight: .semibold, design: .monospaced))
+                    .foregroundStyle(stretchColor(state))
+                    .multilineTextAlignment(.trailing)
+                    .monospacedDigit()
+            }
+
+            HStack(spacing: 0) {
+                Text(state.stretchName.isEmpty ? " " : state.stretchName)
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(.white.opacity(0.85))
+                    .lineLimit(1)
+
+                Text("  \u{2022}  ")
+                    .foregroundStyle(.white.opacity(0.4))
+
+                Text("\(state.stretchIndex)/\(state.stretchTotal)")
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(.white.opacity(0.7))
+            }
+
+            GeometryReader { geo in
+                ZStack(alignment: .leading) {
+                    RoundedRectangle(cornerRadius: 3)
+                        .fill(.white.opacity(0.15))
+                        .frame(height: 6)
+                    RoundedRectangle(cornerRadius: 3)
+                        .fill(Self.accentGreen)
+                        .frame(width: max(0, geo.size.width * progress), height: 6)
+                }
+            }
+            .frame(height: 6)
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 14)
+    }
+
+    /// Bottom region for the expanded Dynamic Island when in stretch mode.
+    /// Shows current stretch name, sequence progress, and a small label that
+    /// flips red when the user is past the recommended hold time.
+    @ViewBuilder
+    private func stretchExpandedBottom(state: XomfitWidgetAttributes.ContentState) -> some View {
+        let progress: Double = state.stretchTotal > 0
+            ? min(1, max(0, Double(state.stretchIndex) / Double(state.stretchTotal)))
+            : 0
+
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 0) {
+                Text(state.stretchName.isEmpty ? " " : state.stretchName)
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(.white.opacity(0.85))
+                    .lineLimit(1)
+
+                Spacer()
+
+                Text("\(state.stretchIndex)/\(state.stretchTotal)")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(.white.opacity(0.7))
+            }
+
+            if state.stretchSecondsRemaining < 0 {
+                HStack(spacing: 4) {
+                    Image(systemName: "exclamationmark.circle.fill")
+                        .font(.system(size: 11))
+                    Text("Holding past target")
+                        .font(.system(size: 12, weight: .semibold))
+                }
+                .foregroundStyle(.red)
+            }
+
+            ProgressView(value: progress)
+                .tint(Self.accentGreen)
+                .scaleEffect(y: 1.5, anchor: .center)
+        }
+    }
+
     // MARK: - Helpers
 
     private func centerText(for state: XomfitWidgetAttributes.ContentState) -> String {
+        if state.mode == .stretch {
+            return state.stretchName.isEmpty ? "Stretching" : state.stretchName
+        }
         if state.isPaused { return "Paused" }
         if state.isResting { return "Resting" }
         return state.currentExercise
@@ -325,6 +476,36 @@ extension XomfitWidgetAttributes.ContentState {
             totalExercises: 6
         )
     }
+
+    fileprivate static var stretchMid: XomfitWidgetAttributes.ContentState {
+        XomfitWidgetAttributes.ContentState(
+            elapsedSeconds: 120,
+            completedSets: 0,
+            totalSets: 0,
+            currentExercise: "",
+            totalExercises: 0,
+            mode: .stretch,
+            stretchName: "Pigeon Pose",
+            stretchSecondsRemaining: 18,
+            stretchIndex: 3,
+            stretchTotal: 6
+        )
+    }
+
+    fileprivate static var stretchOvertime: XomfitWidgetAttributes.ContentState {
+        XomfitWidgetAttributes.ContentState(
+            elapsedSeconds: 220,
+            completedSets: 0,
+            totalSets: 0,
+            currentExercise: "",
+            totalExercises: 0,
+            mode: .stretch,
+            stretchName: "Couch Stretch",
+            stretchSecondsRemaining: -7,
+            stretchIndex: 4,
+            stretchTotal: 6
+        )
+    }
 }
 
 #Preview("Notification", as: .content, using: XomfitWidgetAttributes.preview) {
@@ -332,4 +513,6 @@ extension XomfitWidgetAttributes.ContentState {
 } contentStates: {
     XomfitWidgetAttributes.ContentState.midWorkout
     XomfitWidgetAttributes.ContentState.nearEnd
+    XomfitWidgetAttributes.ContentState.stretchMid
+    XomfitWidgetAttributes.ContentState.stretchOvertime
 }


### PR DESCRIPTION
## Summary

Three bugs in the stretches feature from #388.

### Bug 1 — No Live Activity / Dynamic Island during stretching
Extended `XomfitWidgetAttributes.ContentState` with a `mode` enum (`.workout` / `.stretch`) and stretch-specific fields. Compact leading icon = `figure.flexibility`; compact trailing shows the countdown (`30s`, `-5s`, etc.) and flips to red when negative. Lock-screen + expanded regions render stretch-mode rows. `GuidedStretchRunnerViewModel` drives the Activity lifecycle (`startLiveActivityIfNeeded` / `updateLiveActivity` / `endLiveActivity` / `teardown`).

### Bug 2 — Couldn't edit template stretches before starting
`StretchTemplateDetailView` now has a pencil toolbar button that toggles SwiftUI `EditMode`. In edit mode the list supports `onMove` (drag-to-reorder) and `onDelete` (swipe). A Reset button restores the template's original order. Edits are session-local — `StretchTemplate.curated` is never mutated; the edited sequence is passed into the runner via `replaceStretches(_:)`.

### Bug 3 — Countdown stopped at 0 instead of going negative red
- Timer continues past zero into negative territory (`-3s`, `-149s` — no cap).
- Removed auto-advance at 0; user controls Skip/Done.
- `stretchProgress` clamps at `[0, 1]` so the ring stays full at 100% during overtime.
- New `isOvertime` derived flag — when true, the ring + number + subtitle flip to `Theme.destructive` red.
- Accessibility label switches to "X seconds past target on Y, tap skip when ready".

### Drive-by
- Two DEBUG-only env hooks for agent screenshots: `XOMFIT_STRETCH_EDIT_MODE=1` and `XOMFIT_STRETCH_FORCE_OVERTIME=<N>` — same pattern as #353/#372/#388.

## Test plan
- [ ] Open Stretches → tap a template → pencil button visible top-right
- [ ] Tap pencil → drag handles + swipe-to-delete; Reset disabled when at original order
- [ ] Start Stretching → Dynamic Island shows stretch name + green countdown
- [ ] Let timer hit 0 then keep waiting → countdown goes `-1s`, `-2s`, ... in red; DI flips red; no auto-advance
- [ ] Tap Skip → advances; tap Close → Live Activity ends cleanly