### PR TITLE
fix(ci): make TestFlight build number unique to avoid ITMS-90189

### DIFF
--- a/.github/workflows/testflight-deploy.yml
+++ b/.github/workflows/testflight-deploy.yml
@@ -74,7 +74,10 @@ jobs:
         run: |
           MARKETING_VERSION=$(git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//')
           MARKETING_VERSION=${MARKETING_VERSION:-2.0.0}
-          BUILD_NUMBER=$(date +%Y%m%d%H%M)
+          # Build number must be strictly monotonic and unique across uploads
+          # (ITMS-90189 fires on collisions). Combine UTC seconds with the
+          # GitHub run id so two near-simultaneous workflows can't collide.
+          BUILD_NUMBER="$(date -u +%Y%m%d%H%M%S)${GITHUB_RUN_ID: -3}"
           echo "marketing=$MARKETING_VERSION" >> "$GITHUB_OUTPUT"
           echo "build=$BUILD_NUMBER" >> "$GITHUB_OUTPUT"
           echo "Marketing version: $MARKETING_VERSION"

--- a/Xomfit/Views/Onboarding/OnboardingFriendsScreen.swift
+++ b/Xomfit/Views/Onboarding/OnboardingFriendsScreen.swift
@@ -313,13 +313,13 @@ struct OnboardingFriendsScreen: View {
 
     private func cancelRequest(targetId: String, friendshipId: String) {
         guard friendshipId != "pending" else {
-            relations[targetId] = .none
+            relations[targetId] = FriendshipRelation.none
             return
         }
         Task {
             do {
                 try await FriendsService.shared.cancelFriendRequest(friendshipId: friendshipId)
-                relations[targetId] = .none
+                relations[targetId] = FriendshipRelation.none
             } catch {
                 errorMessage = error.localizedDescription
             }
@@ -341,7 +341,7 @@ struct OnboardingFriendsScreen: View {
         Task {
             do {
                 try await FriendsService.shared.declineFriendRequest(friendshipId: friendshipId)
-                relations[targetId] = .none
+                relations[targetId] = FriendshipRelation.none
             } catch {
                 errorMessage = error.localizedDescription
             }

--- a/Xomfit/Views/Workout/LogPastWorkoutView.swift
+++ b/Xomfit/Views/Workout/LogPastWorkoutView.swift
@@ -487,6 +487,7 @@ struct LogPastWorkoutView: View {
                 }
             }
 
+            let pickerLabel = viewModel.photoImages.isEmpty ? "Add Photos" : "Change Photos"
             PhotosPicker(
                 selection: $viewModel.selectedPhotos,
                 maxSelectionCount: 4,
@@ -494,7 +495,7 @@ struct LogPastWorkoutView: View {
             ) {
                 HStack(spacing: 6) {
                     Image(systemName: "photo.on.rectangle.angled")
-                    Text(viewModel.photoImages.isEmpty ? "Add Photos" : "Change Photos")
+                    Text(pickerLabel)
                         .font(.subheadline.weight(.medium))
                 }
                 .foregroundStyle(Theme.accent)


### PR DESCRIPTION
## Summary

Apple rejected the most recent upload with `ITMS-90189: Redundant Binary Upload — You've already uploaded a build with build number '202605182327' for version number '2.0.0'`.

Root cause: `date +%Y%m%d%H%M` only has minute precision, so two workflow runs in the same minute generate identical build numbers.

Fix: append UTC seconds + last 3 digits of `GITHUB_RUN_ID` so back-to-back deploys can't collide.

## Test plan
- [ ] Next TestFlight deploy succeeds with a unique build number