### PR TITLE
fix: SoundCloud OAuth scope = '' to fix 403 non-expiring rejection

### DIFF
--- a/Xomfit/Services/SoundCloudConfig.swift
+++ b/Xomfit/Services/SoundCloudConfig.swift
@@ -25,9 +25,11 @@ enum SoundCloudConfig {
     /// "Redirect URI" registered on the SoundCloud Developer Dashboard exactly.
     static let redirectURI = "xomfit://soundcloud-callback"
 
-    /// Scope string. `non-expiring` requests a long-lived token so the user doesn't have
-    /// to re-auth between workouts. See https://developers.soundcloud.com/docs/api/explorer
-    static let scopes = "non-expiring"
+    /// SoundCloud rejects `non-expiring` for newly-registered shared apps with
+    /// `403 — "Requesting non-expiring tokens is not allowed. Set scope=''."`
+    /// An empty scope yields a standard expiring access token + refresh token,
+    /// which `SoundCloudAuthService` already knows how to refresh.
+    static let scopes = ""
 
     static let authBaseURL = URL(string: "https://api.soundcloud.com/connect")!
     static let tokenURL = URL(string: "https://api.soundcloud.com/oauth2/token")!


### PR DESCRIPTION
SoundCloud's API explorer returned `403 — "Requesting non-expiring tokens is not allowed. Set scope=''."` when the user tried to sign in. Newly registered shared apps can't request non-expiring tokens.

Changed `SoundCloudConfig.scopes` from `"non-expiring"` to `""`. We get a standard expiring access token + refresh token, which `SoundCloudAuthService` already knows how to refresh.

## Still TODO (yours)
- Replace `PLACEHOLDER_SHARED_SOUNDCLOUD_CLIENT_ID` in `SoundCloudConfig.swift` with a real client id once SoundCloud's Developer registration reopens
- Replace `PLACEHOLDER_SHARED_SPOTIFY_CLIENT_ID` in `SpotifyConfig.swift` with the real Xomware Spotify Developer App client id; **also** add `xomfit://spotify-callback` to that Spotify Developer App's "Redirect URIs" list — the user reported "Spotify failed bc of redirect uri" which is almost certainly the dashboard config, not the iOS code (which sends `xomfit://spotify-callback`)