### PR TITLE
#402 active workout: rebuild safe-area layout + add-exercise top bar + superset overflow + minimize/pause hardening

### DIFF
--- a/Xomfit/ViewModels/WorkoutLoggerViewModel.swift
+++ b/Xomfit/ViewModels/WorkoutLoggerViewModel.swift
@@ -888,9 +888,22 @@ final class WorkoutLoggerViewModel {
     }
 
     /// Complete the focused set and auto-advance.
+    ///
+    /// `completeSet` may have already redirected focus to a superset sibling
+    /// (the alternate exercise in an A/B group). When that happened we MUST NOT
+    /// also call `focusAdvance()` — that would push the set index forward on
+    /// the sibling, skipping the set the user is supposed to lift next (#402).
     func completeFocusedSet() {
+        let priorEx = focusExerciseIndex
+        let priorSet = focusSetIndex
         completeSet(exerciseIndex: focusExerciseIndex, setIndex: focusSetIndex)
-        focusAdvance()
+
+        // Did the superset auto-advance inside `completeSet` move us elsewhere?
+        let supersetAdvanced =
+            focusExerciseIndex != priorEx || focusSetIndex != priorSet
+        if !supersetAdvanced {
+            focusAdvance()
+        }
     }
 
     /// Watch-triggered "Done Set". Marks the currently focused set complete
@@ -912,8 +925,15 @@ final class WorkoutLoggerViewModel {
         guard ex.sets[focusSetIndex].completedAt == Date.distantPast else { return }
 
         Haptics.success()
+        let priorEx = focusExerciseIndex
+        let priorSet = focusSetIndex
         completeSet(exerciseIndex: focusExerciseIndex, setIndex: focusSetIndex)
-        focusAdvance()
+        // Same superset-aware guard as `completeFocusedSet()` (#402).
+        let supersetAdvanced =
+            focusExerciseIndex != priorEx || focusSetIndex != priorSet
+        if !supersetAdvanced {
+            focusAdvance()
+        }
     }
 
     // MARK: - Exercise Transition Actions

--- a/Xomfit/Views/Workout/ActiveWorkoutView.swift
+++ b/Xomfit/Views/Workout/ActiveWorkoutView.swift
@@ -64,7 +64,8 @@ struct ActiveWorkoutView: View {
                 Theme.background.ignoresSafeArea()
 
                 VStack(spacing: 0) {
-                    // Header bar
+                    // Header bar — sits BELOW the Dynamic Island via explicit
+                    // safe-area padding inside the header itself (#402).
                     headerBar
 
                     // Persistent current-exercise pill (#253). Sits below the header so it
@@ -115,13 +116,12 @@ struct ActiveWorkoutView: View {
                                     }
                                     .padding(Theme.Spacing.md)
                                 }
-                                // Reserve scroll real estate for the sticky
-                                // Add Exercise FAB so the last set rows are
-                                // never covered by the floating control (#344-B).
-                                // Using `.contentMargins` keeps the FAB rendered
-                                // unconditionally (also on the empty state) while
-                                // still letting the list scroll cleanly past it.
-                                .contentMargins(.bottom, 88, for: .scrollContent)
+                                // Bottom inset that just clears the soundtrack
+                                // capture pill (when visible) — the Add Exercise
+                                // FAB is gone (#402); add-exercise lives in the
+                                // top header now. Keeping a generous 24pt so the
+                                // last set rows don't kiss the home indicator.
+                                .contentMargins(.bottom, Theme.Spacing.lg, for: .scrollContent)
                                 .onTapGesture {
                                     UIApplication.shared.sendAction(
                                         #selector(UIResponder.resignFirstResponder),
@@ -144,30 +144,12 @@ struct ActiveWorkoutView: View {
                 .animation(.xomChill, value: viewModel.showExerciseTransition)
                 .animation(.xomChill, value: viewModel.focusMode)
 
-                // Floating Add Exercise button (hidden in focus mode).
-                // The scrollview above reserves bottom inset via
-                // `.contentMargins` so this FAB never sits on top of set rows.
-                if !viewModel.focusMode {
-                    VStack(spacing: Theme.Spacing.xs) {
-                        Spacer()
-
-                        // Soundtrack capture pill (Spotify capture polish). Visible
-                        // only while at least one capture loop is alive. Tap opens
-                        // the captured-tracks-so-far popover.
-                        if spotifyCapture.isCapturing || appleMusicCapture.isCapturing {
-                            soundtrackCapturePill
-                        }
-
-                        XomButton("Add Exercise", variant: .primary, icon: "plus") {
-                            showExercisePicker = true
-                        }
-                        .padding(.horizontal, Theme.Spacing.xl)
-                        .padding(.vertical, Theme.Spacing.sm)
-                        .background(.ultraThinMaterial)
-                        .clipShape(.rect(cornerRadius: Theme.Radius.xl))
-                        .padding(.bottom, Theme.Spacing.md)
-                    }
-                }
+                // Soundtrack capture pill (Spotify capture polish). Visible only
+                // while at least one capture loop is alive. The Add Exercise FAB
+                // moved to the top header (#402) — remove it from the bottom
+                // entirely. The soundtrack pill rides above the home indicator
+                // via `.safeAreaInset(.bottom)` further down so it never overlaps
+                // set rows OR a fullscreen rest timer's LIFT button.
 
                 // PR Celebration Banner
                 if viewModel.showPRCelebration, let pr = viewModel.newPR {
@@ -216,6 +198,20 @@ struct ActiveWorkoutView: View {
                     .animation(.xomConfident, value: viewModel.showExerciseTransition)
                 }
             }
+            // Bottom safe-area inset (#402). When music capture is running,
+            // surface the soundtrack pill anchored above the home indicator —
+            // never floating over set rows or a fullscreen rest timer's LIFT
+            // button. Otherwise just a hair of padding so the last row clears
+            // the OS gesture area.
+            .safeAreaInset(edge: .bottom, spacing: 0) {
+                if !viewModel.focusMode &&
+                    (spotifyCapture.isCapturing || appleMusicCapture.isCapturing) {
+                    soundtrackCapturePill
+                        .padding(.bottom, Theme.Spacing.xs)
+                } else {
+                    Color.clear.frame(height: Theme.Spacing.xs)
+                }
+            }
             .toolbar(.hidden, for: .navigationBar)
             .toolbar {
                 ToolbarItemGroup(placement: .keyboard) {
@@ -225,19 +221,6 @@ struct ActiveWorkoutView: View {
                     }
                     .foregroundStyle(Theme.accent)
                 }
-            }
-            // Push the header below any active Dynamic Island (#289/#399). With the
-            // new two-row layout the top row only carries corner controls (Discard /
-            // Minimize / Finish) and the second row carries the timer, so even an
-            // active island can't occlude the elapsed-time string. Keep an extra
-            // 8pt of breathing room above the natural top safe area.
-            .safeAreaInset(edge: .top, spacing: 0) {
-                Color.clear.frame(height: Theme.Spacing.sm)
-            }
-            // Reserve a hair above the home indicator so the floating Add Exercise
-            // pill / rest timer card never clip into the OS gesture area (#399).
-            .safeAreaInset(edge: .bottom, spacing: 0) {
-                Color.clear.frame(height: Theme.Spacing.xs)
             }
         }
         .onReceive(timer) { _ in
@@ -395,20 +378,51 @@ struct ActiveWorkoutView: View {
     // one row, which on iPhone 14/15/16/17 Pro models collided with the
     // Dynamic Island and clipped the duration timer.
 
+    /// Header bar. `.toolbar(.hidden, for: .navigationBar)` + NavigationStack
+    /// on iOS 26 zeroes the implicit top safe-area for descendants, so we
+    /// can't trust `safeAreaPadding` or the system inset to push content past
+    /// the Dynamic Island. Instead we read the active window's top safe-area
+    /// inset directly via UIKit and apply it as explicit padding (#402).
     private var headerBar: some View {
         VStack(spacing: Theme.Spacing.xs) {
             headerTopRow
             headerSecondRow
         }
         .padding(.horizontal, Theme.Spacing.md)
-        .padding(.top, Theme.Spacing.sm)
+        // Clear the Dynamic Island. iPhone 17 Pro reports a 62pt top safe-area
+        // inset but `.toolbar(.hidden)` on iOS 26 NavigationStack swallows it
+        // when SwiftUI lays out the cover — so we use the larger of the
+        // UIKit-reported inset (with a 62pt floor) plus an extra 28pt of
+        // breathing room. End result on iPhone 17 Pro: ~90pt top padding.
+        .padding(.top, max(Self.topSafeAreaInset, 62) + 28)
         .padding(.bottom, Theme.Spacing.sm)
-        .background(Theme.surface)
+        .frame(maxWidth: .infinity)
+        .background(Theme.surface.ignoresSafeArea(edges: .top))
+    }
+
+    /// UIKit-derived top safe-area inset — used because `.toolbar(.hidden)` on
+    /// iOS 26 NavigationStack collapses SwiftUI's implicit top inset. Computed
+    /// per-access (not cached) so a cold launch where the scene's window isn't
+    /// fully laid out yet still gets the right value on the next render pass.
+    ///
+    /// Falls back to 59pt — iPhone Pro top safe-area inset — when no window
+    /// is available. That's enough to clear the Dynamic Island even on the
+    /// largest Pro Max device.
+    private static var topSafeAreaInset: CGFloat {
+        let scene = UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .first { $0.activationState == .foregroundActive }
+            ?? UIApplication.shared.connectedScenes
+                .compactMap { $0 as? UIWindowScene }
+                .first
+        let inset = scene?.windows.first?.safeAreaInsets.top ?? 0
+        return max(inset, 59)
     }
 
     /// Row 1 — corner controls only. Discard sits on the leading edge; Minimize
-    /// + Finish sit on the trailing edge. The center is intentionally empty so
-    /// the Dynamic Island can render without clipping anything.
+    /// + Finish sit on the trailing edge. The center reserves a 130pt-wide gap
+    /// so the Dynamic Island (≈125pt × 37pt on iPhone Pro models) never clips
+    /// any interactive content (#402).
     private var headerTopRow: some View {
         HStack(spacing: Theme.Spacing.xs) {
             // Discard button — leading corner.
@@ -426,6 +440,14 @@ struct ActiveWorkoutView: View {
             }
             .accessibilityLabel("Discard workout")
             .accessibilityHint("Ends and deletes the in-progress workout without saving")
+
+            // Hard-reserved center gap for the Dynamic Island. 130pt is wider
+            // than the island's pill (~125pt) so corner controls can never be
+            // covered (#402). Using a fixed-width Color.clear instead of a
+            // Spacer guarantees the gap even when leading content grows.
+            Color.clear
+                .frame(width: 130, height: 1)
+                .accessibilityHidden(true)
 
             Spacer(minLength: 0)
 
@@ -478,9 +500,9 @@ struct ActiveWorkoutView: View {
         }
     }
 
-    /// Row 2 — timer + name on the leading edge, pause + focus toggle on the
-    /// trailing edge. Lives below the Dynamic Island so the duration string is
-    /// never clipped.
+    /// Row 2 — timer + name on the leading edge, pause + focus toggle + add
+    /// exercise on the trailing edge. Lives below the Dynamic Island so the
+    /// duration string is never clipped (#402).
     private var headerSecondRow: some View {
         HStack(spacing: Theme.Spacing.sm) {
             // Timer cluster — total time prominent + rest timer chip when active.
@@ -576,6 +598,24 @@ struct ActiveWorkoutView: View {
                     .contentShape(Rectangle())
             }
             .accessibilityLabel(viewModel.focusMode ? "Switch to list view" : "Switch to focus view")
+
+            // Add Exercise — promoted from a bottom FAB to a top-bar control
+            // (#402). Lives in row 2 so it sits well below the Dynamic Island.
+            Button {
+                Haptics.selection()
+                showExercisePicker = true
+            } label: {
+                Image(systemName: "plus")
+                    .font(.subheadline.weight(.bold))
+                    .foregroundStyle(Theme.accent)
+                    .frame(width: Theme.Spacing.xl, height: Theme.Spacing.xl)
+                    .background(Theme.accent.opacity(0.15))
+                    .clipShape(Circle())
+                    .frame(width: 44, height: 44)
+                    .contentShape(Rectangle())
+            }
+            .accessibilityLabel("Add exercise")
+            .accessibilityHint("Opens the exercise picker to add a new exercise to this workout")
         }
     }
 
@@ -974,20 +1014,28 @@ private struct ExerciseCard: View {
             // Exercise header
             HStack {
                 VStack(alignment: .leading, spacing: 3) {
+                    // Superset pill — moved to its OWN row so the title gets
+                    // the full card width. Previously sat to the left of the
+                    // title and shrunk it to ~2 chars per line on supersetted
+                    // exercises with long names (#402).
+                    if let letter = supersetLetter {
+                        Text("Superset \(letter)")
+                            .font(.caption2.weight(.black))
+                            .foregroundStyle(.black)
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, Theme.Spacing.tighter)
+                            .background(Theme.accent)
+                            .clipShape(.capsule)
+                            .accessibilityLabel("Superset \(letter)")
+                    }
                     HStack(spacing: 6) {
-                        if let letter = supersetLetter {
-                            Text("Superset \(letter)")
-                                .font(.caption2.weight(.black))
-                                .foregroundStyle(.black)
-                                .padding(.horizontal, 6)
-                                .padding(.vertical, Theme.Spacing.tighter)
-                                .background(Theme.accent)
-                                .clipShape(.capsule)
-                                .accessibilityLabel("Superset \(letter)")
-                        }
                         Text(exercise.exercise.name)
                             .font(.body.weight(.bold))
                             .foregroundStyle(Theme.textPrimary)
+                            .lineLimit(2)
+                            .minimumScaleFactor(0.7)
+                            .multilineTextAlignment(.leading)
+                            .fixedSize(horizontal: false, vertical: true)
                     }
                     HStack(spacing: Theme.Spacing.tight) {
                         ForEach(exercise.exercise.muscleGroups.prefix(2), id: \.self) { mg in

--- a/Xomfit/Views/Workout/WorkoutFocusView.swift
+++ b/Xomfit/Views/Workout/WorkoutFocusView.swift
@@ -10,7 +10,15 @@ struct WorkoutFocusView: View {
     @FocusState private var weightFieldFocused: Bool
     @FocusState private var repsFieldFocused: Bool
     @State private var showExercisePicker = false
-    @State private var isRestTimerMinimized = false
+    @State private var isRestTimerMinimized: Bool = {
+        #if DEBUG
+        // Agent screenshot helper (#402) — start the rest timer minimized so
+        // the inline banner can be captured from a cold launch without a tap.
+        return ProcessInfo.processInfo.environment["XOMFIT_AUTO_MINIMIZE_REST"] == "1"
+        #else
+        return false
+        #endif
+    }()
     @AppStorage("restTimerSound") private var restTimerSound = false
 
     /// Set pill index targeted by a long-press, used to drive the delete
@@ -69,9 +77,9 @@ struct WorkoutFocusView: View {
                 // exerciseNavigation — never the minimized rest banner. The banner
                 // is rendered via `.safeAreaInset(edge: .bottom)` so it reserves its
                 // own real estate and does not steal vertical space from the header.
-                VStack(spacing: Theme.Spacing.lg) {
+                VStack(spacing: Theme.Spacing.md) {
                     // TOP — exercise header + config + set indicator
-                    VStack(spacing: Theme.Spacing.lg) {
+                    VStack(spacing: Theme.Spacing.md) {
                         exerciseHeader(exercise: exercise)
 
                         // Variant config (grip, attachment, position, laterality) + per-session extras
@@ -94,7 +102,7 @@ struct WorkoutFocusView: View {
                     // MIDDLE — weight / reps / done. Absorbs slack so the top
                     // header stays pinned under the Dynamic Island regardless of
                     // whether the minimized rest banner is showing (#344-A).
-                    VStack(spacing: Theme.Spacing.lg) {
+                    VStack(spacing: Theme.Spacing.md) {
                         weightDisplay(currentSet: currentSet)
                         repsDisplay(currentSet: currentSet)
                         // Drop-set capsule sits on its own row directly under
@@ -107,7 +115,17 @@ struct WorkoutFocusView: View {
                     .frame(maxHeight: .infinity)
 
                     // BOTTOM — exercise navigation (prev/next/add + rest config).
-                    exerciseNavigation
+                    // While the rest timer is minimized we show the rest-timer
+                    // banner here INSTEAD of exerciseNavigation (#402). Putting
+                    // it in the bottom slot — rather than as a sibling via
+                    // `.safeAreaInset(.bottom)` — guarantees the middle's DONE
+                    // button never gets compressed off-screen, and the banner
+                    // is always reachable below the weight/reps cards.
+                    if viewModel.isRestTimerActive && isRestTimerMinimized {
+                        minimizedRestTimerBanner
+                    } else {
+                        exerciseNavigation
+                    }
                 }
                 .id(viewModel.focusExerciseIndex)
                 .transition(.push(from: .trailing))
@@ -129,20 +147,13 @@ struct WorkoutFocusView: View {
                 emptyFocusState
             }
         }
-        // Push content below any active Dynamic Island (#289). Bumps content
-        // down deterministically when an island (e.g. music app) is present.
+        // Push content below any active Dynamic Island (#289/#402). Bumps
+        // content down deterministically when an island is present. The
+        // minimized rest banner is rendered inline in the bottom slot of the
+        // main VStack (replacing `exerciseNavigation` while active) so it
+        // never steals vertical real estate from the DONE button.
         .safeAreaInset(edge: .top, spacing: 0) {
             Color.clear.frame(height: Theme.Spacing.sm)
-        }
-        // Reserve a dedicated bottom row for the minimized rest banner so it
-        // never compresses the top header under the Dynamic Island (#344-A).
-        .safeAreaInset(edge: .bottom, spacing: 0) {
-            if viewModel.isRestTimerActive && isRestTimerMinimized {
-                minimizedRestTimerBanner
-                    .padding(.horizontal, Theme.Spacing.lg)
-                    .padding(.bottom, Theme.Spacing.sm)
-                    .transition(.move(edge: .bottom).combined(with: .opacity))
-            }
         }
         .sheet(isPresented: $showExercisePicker) {
             ExercisePickerView { exercise in
@@ -408,7 +419,7 @@ struct WorkoutFocusView: View {
             }
         }
         .frame(maxWidth: .infinity)
-        .padding(.vertical, Theme.Spacing.md)
+        .padding(.vertical, Theme.Spacing.sm)
         .background(Theme.surface)
         .clipShape(.rect(cornerRadius: Theme.cornerRadius))
     }
@@ -454,7 +465,7 @@ struct WorkoutFocusView: View {
             }
         }
         .frame(maxWidth: .infinity)
-        .padding(.vertical, Theme.Spacing.md)
+        .padding(.vertical, Theme.Spacing.sm)
         .background(Theme.surface)
         .clipShape(.rect(cornerRadius: Theme.cornerRadius))
     }
@@ -473,7 +484,7 @@ struct WorkoutFocusView: View {
                 .font(.title3.weight(.black))
                 .foregroundStyle(isCompleted ? Theme.textSecondary : .black)
                 .frame(maxWidth: .infinity)
-                .padding(.vertical, 18)
+                .padding(.vertical, 14)
                 .background(isCompleted ? Theme.surface : Theme.accent)
                 .clipShape(.rect(cornerRadius: Theme.cornerRadius))
         }
@@ -677,30 +688,43 @@ struct WorkoutFocusView: View {
         return String(format: "%d:%02d", total / 60, total % 60)
     }
 
+    /// Fullscreen rest-timer overlay. Layout reimagined in #402: minimize
+    /// chevron pinned to the TOP-LEFT corner; LIFT button pinned to the
+    /// BOTTOM with explicit bottom padding that always clears the home
+    /// indicator. The middle (ring + NEXT UP + +30s) sits inside a
+    /// Spacer-padded VStack so it centers between the two anchored slots.
+    ///
+    /// Uses inline layout (NOT `.safeAreaInset`) because the overlay is
+    /// already a sibling inside the focus view's ZStack — adding additional
+    /// safe-area insets there would push the button below the visible bounds.
     private var fullScreenRestTimer: some View {
         ZStack {
             Color.black.opacity(0.92).ignoresSafeArea()
 
-            VStack(spacing: Theme.Spacing.xl) {
-                // Minimize button
+            VStack(spacing: 0) {
+                // TOP — minimize chevron on the left.
                 HStack {
-                    Spacer()
                     Button {
+                        Haptics.light()
                         withAnimation(.xomChill) { isRestTimerMinimized = true }
                     } label: {
                         Image(systemName: "arrow.down.right.and.arrow.up.left")
-                            .font(Theme.fontBodyEmphasized)
-                            .foregroundStyle(Theme.textSecondary)
+                            .font(.subheadline.weight(.semibold))
+                            .foregroundStyle(Theme.textPrimary)
                             .frame(width: 44, height: 44)
-                            .background(Theme.surface.opacity(0.3))
+                            .background(Theme.surface.opacity(0.6))
                             .clipShape(Circle())
+                            .contentShape(Rectangle())
                     }
                     .accessibilityLabel("Minimize rest timer")
+                    .accessibilityHint("Collapses the rest timer to a banner so you can see the next set")
+
+                    Spacer()
                 }
                 .padding(.horizontal, Theme.Spacing.lg)
-                .padding(.top, Theme.Spacing.md)
+                .padding(.top, Theme.Spacing.xs)
 
-                Spacer()
+                Spacer(minLength: Theme.Spacing.md)
 
                 // Large circular ring
                 ZStack {
@@ -723,7 +747,8 @@ struct WorkoutFocusView: View {
                             .foregroundStyle(restIsOvertime ? Theme.destructive : .white)
                     }
                 }
-                .frame(width: 240, height: 240)
+                .frame(width: 200, height: 200)
+                .padding(.vertical, Theme.Spacing.md)
 
                 // Next exercise hint
                 if let nextEx = viewModel.upcomingExercise {
@@ -735,6 +760,7 @@ struct WorkoutFocusView: View {
                             .font(.subheadline.weight(.semibold))
                             .foregroundStyle(Theme.textPrimary)
                     }
+                    .padding(.bottom, Theme.Spacing.sm)
                 }
 
                 // +30s button
@@ -749,12 +775,18 @@ struct WorkoutFocusView: View {
                         .padding(.vertical, 10)
                         .background(Theme.accent.opacity(0.15))
                         .clipShape(.capsule)
+                        .frame(minHeight: 44)
                 }
                 .accessibilityLabel("Add 30 seconds to rest timer")
 
-                Spacer()
+                Spacer(minLength: Theme.Spacing.sm)
 
-                // LIFT button
+                // LIFT — anchored to the bottom of the VStack with a 100pt
+                // bottom Spacer separating it from the screen edge. The
+                // parent ZStack `.ignoresSafeArea()` lets the black backdrop
+                // run to the screen edges, but the VStack's bottom isn't
+                // automatically pulled up to the safe-area boundary — we have
+                // to do that ourselves (#402).
                 Button {
                     Haptics.success()
                     viewModel.skipRestTimer()
@@ -767,11 +799,19 @@ struct WorkoutFocusView: View {
                         .padding(.vertical, 22)
                         .background(Theme.accent)
                         .clipShape(.rect(cornerRadius: Theme.cornerRadius))
+                        .contentShape(Rectangle())
                 }
                 .padding(.horizontal, Theme.Spacing.lg)
-                .padding(.bottom, Theme.Spacing.xl)
-                .accessibilityLabel("Skip rest timer and return to sets")
+                .accessibilityLabel("Skip rest timer and start the next set")
+                .accessibilityHint("Ends the rest timer immediately and returns to the lift")
+
+                // Hard bottom clearance: home indicator (~34pt) + soundtrack
+                // pill slot reserved by ActiveWorkoutView's bottom safeArea
+                // inset (~50pt when active, ~4pt otherwise) + breathing room.
+                // Sized to clear the largest reasonable bottom inset.
+                Color.clear.frame(height: 80)
             }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
     }
 

--- a/Xomfit/XomfitApp.swift
+++ b/Xomfit/XomfitApp.swift
@@ -258,9 +258,28 @@ struct XomFitApp: App {
     }
 
     #if DEBUG
-    /// Seed an in-progress workout for agent screenshot flows (#387). Adds two
-    /// real exercises and (optionally) completes the first or pops the finish
+    /// Seed an in-progress workout for agent screenshot flows (#387/#402).
+    /// Adds real exercises and (optionally) completes the first, pairs them as
+    /// a superset, enters focus mode, fires the rest timer, or pops the finish
     /// sheet so the new UI surfaces from a cold launch.
+    ///
+    /// Env vars:
+    ///   XOMFIT_AUTO_START_WORKOUT=1     → start workout, two exercises seeded
+    ///   XOMFIT_AUTO_COMPLETE_FIRST=1    → also complete every set on the first
+    ///                                     exercise so the transition card shows
+    ///   XOMFIT_AUTO_PRESENT_FINISH=1    → also present the finish sheet
+    ///   XOMFIT_AUTO_SEED_TRACKS=1       → add demo soundtrack tracks
+    ///   XOMFIT_AUTO_LONG_NAME=1         → swap second exercise for one with a
+    ///                                     long name so the superset-list card
+    ///                                     overflow fix can be verified (#402)
+    ///   XOMFIT_AUTO_GROUP_SUPERSET=1    → group the two seeded exercises into
+    ///                                     a superset so the "Superset A/B"
+    ///                                     badges + alternation logic render
+    ///   XOMFIT_AUTO_ENTER_FOCUS=1       → flip into focus mode on launch
+    ///   XOMFIT_AUTO_START_REST_TIMER=1  → fire the rest timer immediately so
+    ///                                     the fullscreen overlay renders
+    ///   XOMFIT_AUTO_MINIMIZE_REST=1     → start the rest timer in its minimized
+    ///                                     banner state (read by WorkoutFocusView)
     @MainActor
     private func seedDebugActiveWorkout() {
         let env = ProcessInfo.processInfo.environment
@@ -272,11 +291,23 @@ struct XomFitApp: App {
         }
 
         let userId = authService.currentUser?.id.uuidString.lowercased() ?? ""
-        workoutSession.startWorkout(name: "Screenshot Workout", userId: userId)
+        // Long workout name so the row-2 truncation behavior can be observed.
+        let name = env["XOMFIT_AUTO_LONG_NAME"] == "1"
+            ? "(s)arms" : "Screenshot Workout"
+        workoutSession.startWorkout(name: name, userId: userId)
 
-        // Two safe exercises from ExerciseDatabase. Picked deterministically by
+        // Two exercises from ExerciseDatabase. Picked deterministically by
         // id so the seeded workout looks consistent across screenshot runs.
-        let preferredIds = ["ex-bench-flat", "ex-lat-pulldown"]
+        // When XOMFIT_AUTO_LONG_NAME=1 we swap in the longest-named tricep
+        // exercise so the superset list-card overflow is reproducible.
+        let preferredIds: [String]
+        if env["XOMFIT_AUTO_LONG_NAME"] == "1" {
+            // Long-named exercise FIRST so the list-card overflow fix can be
+            // captured at the top of the scroll view (#402).
+            preferredIds = ["ex-cable-overhead-tri-ext", "ex-tricep-pushdown"]
+        } else {
+            preferredIds = ["ex-bench-flat", "ex-lat-pulldown"]
+        }
         var chosen: [Exercise] = []
         for id in preferredIds {
             if let match = ExerciseDatabase.all.first(where: { $0.id == id }) {
@@ -288,6 +319,14 @@ struct XomFitApp: App {
         }
         for ex in chosen {
             workoutSession.addExercise(ex)
+        }
+
+        // Group the two seeded exercises as a superset so the list-card layout,
+        // the focus-mode badge, and the alternation logic can all be exercised
+        // from a cold launch (#402).
+        if env["XOMFIT_AUTO_GROUP_SUPERSET"] == "1",
+           workoutSession.exercises.count >= 2 {
+            workoutSession.toggleSuperset(exerciseIndices: [0, 1])
         }
 
         // Optionally complete the first exercise so the transition card shows
@@ -305,6 +344,20 @@ struct XomFitApp: App {
         if env["XOMFIT_AUTO_SEED_TRACKS"] == "1" {
             workoutSession.addManualTrack(title: "Pump Anthem", artist: "Demo Artist")
             workoutSession.addManualTrack(title: "Heavy Lift", artist: "Squat Crew")
+        }
+
+        // Flip into focus mode so the gym-floor layout is the first thing the
+        // user / agent sees (#402).
+        if env["XOMFIT_AUTO_ENTER_FOCUS"] == "1" {
+            workoutSession.focusMode = true
+            workoutSession.syncFocusToCurrentExercise()
+        }
+
+        // Fire the rest timer immediately. Useful for screenshotting both the
+        // fullscreen rest timer overlay (focus mode) and the inline rest timer
+        // card (list mode) from a cold launch (#402).
+        if env["XOMFIT_AUTO_START_REST_TIMER"] == "1" {
+            workoutSession.startRestTimer(for: workoutSession.focusExerciseIndex)
         }
 
         // Optionally jump straight into the active runner so the cover renders.


### PR DESCRIPTION
## Summary

Third attempt at the active workout layout — this time grounded in the actual Dynamic Island geometry and explicit safe-area zones for every interactive element.

### Top safe area (Dynamic Island clearance)
- 130pt center gap reserved in Row 1 — no content threads through the DI
- Row 1: Discard (left cluster) | DI gap | Minimize chevron + Finish (right cluster)
- Row 2 (below DI): 0:00 timer + workout name (left) | pause + focus + Add Exercise + (right)
- All controls remain visible regardless of workout name length

### Bottom safe area (LIFT/DONE button)
- Rest timer fullscreen overlay: 80pt bottom Spacer + split `ignoresSafeArea` so the LIFT button is **always** anchored above the home indicator
- Minimized rest banner moved INTO the bottom slot of the focus VStack (was `.safeAreaInset(.bottom)`) so the DONE button is never squeezed off-screen
- Soundtrack pill moved to `.safeAreaInset(.bottom)` of the list view

### Add Exercise relocated
- Removed the bottom floating "+ Add Exercise" CTA
- Green `+` lives in Row 2 of the top bar (next to pause + focus icons)

### Superset card title overflow
- "Superset A" pill moved ABOVE the title (full-width row) instead of stealing the title's left edge
- Title now gets `.lineLimit(2)` + `.minimumScaleFactor(0.7)` and the full card width

### Superset alternation bug
`completeFocusedSet()` and `completeFocusedSetFromWatch()` previously double-advanced focus: `completeSet` redirected to the superset sibling, then `focusAdvance()` pushed it forward a set. Now we capture focus indices before/after and skip `focusAdvance` when `completeSet` already moved focus.

### DEBUG screenshot seeds
New env vars for agent UI verification: `XOMFIT_AUTO_LONG_NAME`, `XOMFIT_AUTO_GROUP_SUPERSET`, `XOMFIT_AUTO_ENTER_FOCUS`, `XOMFIT_AUTO_START_REST_TIMER`, `XOMFIT_AUTO_MINIMIZE_REST`.

## Verified (5 screenshots on iPhone 17, XOMFIT_AUTH_BYPASS=1)
1. Focus, no rest — Discard/chevron/Finish + Row 2 all below DI, DONE visible
2. Focus, rest fullscreen — minimize chevron top-left, LIFT button huge at the bottom (not clipped)
3. Focus, rest minimized — banner at bottom of focus VStack, DONE still visible above it
4. List, with superset — "Superset A" pill above the title row, title wraps on 2 lines, NO bottom FAB
5. List, no superset — sanity check

## Test plan
- [ ] On iPhone 17 sim: start workout → all 4 controls + Row 2 visible, no DI overlap
- [ ] Enter focus, start rest timer fullscreen → LIFT button visible at bottom
- [ ] Minimize the rest timer → DONE button visible above the banner
- [ ] Superset workout in list mode → title not squashed, no bottom Add Exercise button
- [ ] Complete a set on Superset A1 → focus advances to A2, not to A1 set 2
- [ ] Top-bar `+` opens add-exercise sheet
- [ ] Pause button toggles freezes timer
- [ ] Minimize chevron dismisses sheet; Workout Resume Bar appears