### PR TITLE
feat: SoundCloud sign-in via shared Xomcloud app + xomfit-state bridge

### DIFF
--- a/Xomfit/Services/SoundCloudAuthService.swift
+++ b/Xomfit/Services/SoundCloudAuthService.swift
@@ -65,7 +65,11 @@ final class SoundCloudAuthService: NSObject {
     func signIn() async throws -> Bool {
         let verifier = Self.generatePKCEVerifier()
         let challenge = Self.codeChallenge(for: verifier)
-        let state = Self.randomURLSafeString(length: 16)
+        // Prefix the OAuth `state` so the shared xomcloud.xomware.com/callback
+        // bridge can recognize XomFit-initiated auth and bounce back to the
+        // `xomfit://soundcloud-callback` deep link instead of completing the
+        // Xomcloud web flow. See xomcloud-frontend `callback.component.ts`.
+        let state = "xomfit-" + Self.randomURLSafeString(length: 16)
         pendingPKCEVerifier = verifier
         pendingState = state
 

--- a/Xomfit/Services/SoundCloudConfig.swift
+++ b/Xomfit/Services/SoundCloudConfig.swift
@@ -16,14 +16,17 @@ import Foundation
 /// not accepting new developer apps, sign-in will fail with a clear error and the user can
 /// still finish the workout — Apple Music + Spotify capture continue working untouched.
 enum SoundCloudConfig {
-    /// Public SoundCloud Developer client id shared across XomFit installs. Treated as
-    /// public per the PKCE flow — no client secret is needed or stored. Replace once
-    /// the SoundCloud Dev Dashboard accepts new app registrations.
-    static let sharedClientId: String = "PLACEHOLDER_SHARED_SOUNDCLOUD_CLIENT_ID"  // TODO replace
+    /// Public Xomcloud SoundCloud Developer App client id, shared across XomFit installs.
+    /// Treated as public per the PKCE flow — no client secret is needed or stored.
+    static let sharedClientId: String = "FdZcMJaQOlOuQVK54FFgoR2L8CMmQvfF"
 
-    /// Custom URL scheme that ASWebAuthenticationSession listens for. Must match the
-    /// "Redirect URI" registered on the SoundCloud Developer Dashboard exactly.
-    static let redirectURI = "xomfit://soundcloud-callback"
+    /// SoundCloud only allows one redirect URI per app, and the Xomcloud web app already
+    /// owns this one. The xomcloud-frontend `CallbackComponent` inspects the OAuth `state`
+    /// query param — when it starts with `xomfit-` it JS-redirects to
+    /// `xomfit://soundcloud-callback?<original params>`, which `ASWebAuthenticationSession`
+    /// then intercepts via `callbackURLScheme = "xomfit"`. SoundCloud verifies this URI
+    /// during the code → token exchange, so it MUST match the dashboard value exactly.
+    static let redirectURI = "https://xomcloud.xomware.com/callback"
 
     /// SoundCloud rejects `non-expiring` for newly-registered shared apps with
     /// `403 — "Requesting non-expiring tokens is not allowed. Set scope=''."`


### PR DESCRIPTION
## Summary

Wires SoundCloud sign-in to the **shared Xomcloud SoundCloud Developer App** since SoundCloud only allows one redirect URI per app and Xomcloud already owns `https://xomcloud.xomware.com/callback`.

### Changes
- **`SoundCloudConfig.sharedClientId`** — real Xomcloud client id (`FdZcMJaQOlOuQVK54FFgoR2L8CMmQvfF`, public per PKCE)
- **`SoundCloudConfig.redirectURI`** — `https://xomcloud.xomware.com/callback` (matches dashboard)
- **`SoundCloudAuthService`** — prefixes OAuth `state` with `xomfit-` so the shared callback page can route back to `xomfit://soundcloud-callback`

### How the round-trip works
1. iOS app starts auth with `state = "xomfit-<random>"`
2. SoundCloud redirects to `https://xomcloud.xomware.com/callback?code=...&state=xomfit-...`
3. xomcloud-frontend `CallbackComponent` (xomcloud-frontend#36) sees the prefix and `window.location.replace`s to `xomfit://soundcloud-callback?<query>`
4. `ASWebAuthenticationSession` (`callbackURLScheme = "xomfit"`) intercepts and completes the PKCE token exchange — never goes back to mobile Safari

### Dependency
This PR depends on Xomware/xomcloud-frontend#36 being merged + deployed. iOS sign-in will fail with the callback hanging on the Xomcloud loader until that ships.

## Test plan
- [ ] After xomcloud-frontend#36 ships: tap "Connect SoundCloud" in XomFit Settings → web auth completes → app receives token
- [ ] Xomcloud's own SoundCloud sign-in is unaffected (no `xomfit-` prefix on its state, falls through to existing handler)