### PR TITLE
fix: route SoundCloud token exchange through xomcloud-backend proxy

### DIFF
--- a/Xomfit/Services/SoundCloudAuthService.swift
+++ b/Xomfit/Services/SoundCloudAuthService.swift
@@ -191,24 +191,28 @@ final class SoundCloudAuthService: NSObject {
     // MARK: - Token exchange
 
     private func exchangeCodeForToken(code: String, verifier: String) async throws {
-        var request = URLRequest(url: SoundCloudConfig.tokenURL)
+        // SoundCloud's `/oauth2/token` now demands `client_secret`, which we refuse to bake
+        // into the IPA. We POST to xomcloud-backend's auth proxy instead — it reads the
+        // secret from SSM and forwards to SoundCloud, returning the same JSON shape.
+        SoundCloudConfig.warnIfAuthProxyIsPlaceholder()
+
+        var request = URLRequest(url: SoundCloudConfig.authProxyTokenURL)
         request.httpMethod = "POST"
-        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
-        let body = formEncoded([
-            "client_id": SoundCloudConfig.sharedClientId,
-            "grant_type": "authorization_code",
-            "code": code,
-            "redirect_uri": SoundCloudConfig.redirectURI,
-            "code_verifier": verifier
-        ])
-        request.httpBody = body.data(using: .utf8)
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        let body = TokenExchangeRequest(
+            code: code,
+            code_verifier: verifier,
+            redirect_uri: SoundCloudConfig.redirectURI
+        )
+        request.httpBody = try JSONEncoder().encode(body)
 
         let (data, response) = try await URLSession.shared.data(for: request)
         guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
             print("[SoundCloudAuth] token exchange non-2xx — \(String(data: data, encoding: .utf8) ?? "")")
-            // SoundCloud returns 401/403 with `invalid_client` when our shared id is not
-            // accepted — funnel that into the more useful `.apiClosed` so the UI can tell
-            // the user it's not their fault.
+            // 401/403 from the proxy almost always means SoundCloud rejected the upstream
+            // (either the shared client id or a quota issue) — funnel that into
+            // `.apiClosed` so the UI can tell the user it's not their fault.
             if let http = response as? HTTPURLResponse, http.statusCode == 401 || http.statusCode == 403 {
                 throw SoundCloudAuthError.apiClosed
             }
@@ -220,15 +224,16 @@ final class SoundCloudAuthService: NSObject {
 
     private func refreshAccessToken() async throws {
         guard !refreshToken.isEmpty else { throw SoundCloudAuthError.tokenExchangeFailed }
-        var request = URLRequest(url: SoundCloudConfig.tokenURL)
+        // See `exchangeCodeForToken` — refresh goes through the same xomcloud-backend
+        // proxy (`/auth/refresh`) so the client_secret never leaves the server.
+        SoundCloudConfig.warnIfAuthProxyIsPlaceholder()
+
+        var request = URLRequest(url: SoundCloudConfig.authProxyRefreshURL)
         request.httpMethod = "POST"
-        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
-        let body = formEncoded([
-            "client_id": SoundCloudConfig.sharedClientId,
-            "grant_type": "refresh_token",
-            "refresh_token": refreshToken
-        ])
-        request.httpBody = body.data(using: .utf8)
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        let body = RefreshRequest(refresh_token: refreshToken)
+        request.httpBody = try JSONEncoder().encode(body)
 
         let (data, response) = try await URLSession.shared.data(for: request)
         guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
@@ -295,16 +300,6 @@ final class SoundCloudAuthService: NSObject {
         _ = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
         return Data(bytes).base64URLEncodedString()
     }
-
-    private func formEncoded(_ params: [String: String]) -> String {
-        params
-            .map { key, value in
-                let escapedKey = key.addingPercentEncoding(withAllowedCharacters: .urlQueryParamSoundCloudAllowed) ?? key
-                let escapedValue = value.addingPercentEncoding(withAllowedCharacters: .urlQueryParamSoundCloudAllowed) ?? value
-                return "\(escapedKey)=\(escapedValue)"
-            }
-            .joined(separator: "&")
-    }
 }
 
 // MARK: - Presentation context
@@ -355,6 +350,21 @@ private struct TokenResponse: Decodable {
     let scope: String?
 }
 
+/// Request body for `POST <authProxyBaseURL>/token`. The backend forwards `code`,
+/// `code_verifier`, and `redirect_uri` to SoundCloud's `/oauth2/token` after attaching
+/// `client_id` and `client_secret` from SSM.
+private struct TokenExchangeRequest: Encodable {
+    let code: String
+    let code_verifier: String
+    let redirect_uri: String
+}
+
+/// Request body for `POST <authProxyBaseURL>/refresh`. The backend forwards
+/// `refresh_token` to SoundCloud after attaching `client_id` + `client_secret`.
+private struct RefreshRequest: Encodable {
+    let refresh_token: String
+}
+
 private struct SoundCloudMeResponse: Decodable {
     let username: String?
     let permalink: String?
@@ -370,16 +380,4 @@ private extension Data {
             .replacingOccurrences(of: "/", with: "_")
             .replacingOccurrences(of: "=", with: "")
     }
-}
-
-private extension CharacterSet {
-    /// Strict `application/x-www-form-urlencoded` allowed set, scoped to SoundCloud's token
-    /// endpoint. Named distinctly from Spotify's equivalent to avoid stepping on it at the
-    /// file-private extension level (the global `.urlQueryParamAllowed` in
-    /// `SpotifyAuthService.swift` is file-private, but keeping a separate name is clearer).
-    static let urlQueryParamSoundCloudAllowed: CharacterSet = {
-        var allowed = CharacterSet.alphanumerics
-        allowed.insert(charactersIn: "-._~")
-        return allowed
-    }()
 }

--- a/Xomfit/Services/SoundCloudConfig.swift
+++ b/Xomfit/Services/SoundCloudConfig.swift
@@ -42,4 +42,50 @@ enum SoundCloudConfig {
 
     /// URL scheme component of `redirectURI` — what ASWebAuthenticationSession needs separately.
     static let callbackURLScheme = "xomfit"
+
+    // MARK: - xomcloud-backend Auth Proxy
+    //
+    // SoundCloud's token endpoint now requires `client_secret`, which we refuse to ship in
+    // the IPA. Instead, we POST to a tiny proxy on xomcloud-backend (`/auth/token` and
+    // `/auth/refresh`) that reads the secret out of SSM and forwards to SoundCloud. The
+    // proxy returns SoundCloud's JSON response unchanged.
+
+    /// Base URL of the xomcloud-backend SoundCloud auth proxy.
+    ///
+    /// Resolves to `https://api.xomcloud.xomware.com/auth` — the API Gateway custom domain
+    /// configured in `xomcloud-infrastructure/terraform/locals.tf` (`api_domain_name =
+    /// "api.${app_name}${domain_suffix}"` = `api.xomcloud.xomware.com`). The `/auth` prefix
+    /// matches the API Gateway resource path the backend agent is wiring up.
+    ///
+    /// TODO: if the backend's path prefix lands as something other than `/auth` (e.g.
+    /// `/soundcloud/auth`), update this constant before merging the corresponding backend PR.
+    static let authProxyBaseURL = URL(string: "https://api.xomcloud.xomware.com/auth")!
+
+    /// `true` while `authProxyBaseURL` still points at the placeholder host. Mirrors the
+    /// resolver pattern in `SpotifyConfig.resolvedClientId()` so failed proxy calls log a
+    /// clearly-labeled warning instead of failing silently.
+    static var authProxyIsPlaceholder: Bool {
+        // The URL is hard-coded above. As soon as someone replaces the host with the
+        // real custom-domain or `<apiId>.execute-api.us-east-1.amazonaws.com/dev` URL,
+        // this returns false. The check is intentionally string-based so we don't need
+        // to plumb a separate "isPlaceholder" flag through Config.swift.
+        let host = authProxyBaseURL.host ?? ""
+        return host.contains("PLACEHOLDER") || host.isEmpty
+    }
+
+    /// Token-exchange endpoint on the xomcloud-backend proxy (`POST /auth/token`).
+    static var authProxyTokenURL: URL { authProxyBaseURL.appendingPathComponent("token") }
+
+    /// Refresh endpoint on the xomcloud-backend proxy (`POST /auth/refresh`).
+    static var authProxyRefreshURL: URL { authProxyBaseURL.appendingPathComponent("refresh") }
+
+    /// Logs a one-shot console warning when the proxy base URL is still the placeholder.
+    /// Call sites: `exchangeCodeForToken` and `refreshAccessToken` — mirror the
+    /// `SpotifyConfig.resolvedClientId()` pattern.
+    static func warnIfAuthProxyIsPlaceholder() {
+        guard authProxyIsPlaceholder else { return }
+        print("[SoundCloudConfig] WARNING: SoundCloud auth proxy base URL is still a " +
+              "placeholder — token exchange will fail until SoundCloudConfig.authProxyBaseURL " +
+              "is replaced with the real xomcloud-backend custom domain.")
+    }
 }


### PR DESCRIPTION
## Summary

SoundCloud now requires \`client_secret\` at \`/oauth/token\` even with PKCE. Rather than embedding the secret in the IPA, XomFit now hits the new xomcloud-backend auth proxy.

### Changes
- \`SoundCloudConfig\` — added \`authProxyBaseURL\` (\`https://api.xomcloud.xomware.com/auth\`), derived \`authProxyTokenURL\` / \`authProxyRefreshURL\`, and \`warnIfAuthProxyIsPlaceholder()\` helper
- \`SoundCloudAuthService.exchangeCodeForToken\` → \`POST <proxy>/token\` with JSON \`{ code, code_verifier, redirect_uri }\`
- \`SoundCloudAuthService.refreshAccessToken\` → \`POST <proxy>/refresh\` with JSON \`{ refresh_token }\`
- Drops \`client_id\` + \`grant_type\` + form-encoding from request bodies (backend supplies these)
- \`TokenResponse\` decoder unchanged — proxy passes SoundCloud JSON through verbatim
- 401/403 → \`.apiClosed\`, 400 on refresh → \`signOut()\` — error mapping preserved
- Authorize URL, PKCE, ASWebAuthenticationSession, \`xomfit-\` state bridge — untouched

### Dependency
Backend (xomcloud-backend#26) + infra (xomcloud-infrastructure#52) must be deployed for sign-in to work. Both are merging now; first bootstrap is 2-cycle (ECR repo → image → Lambda).

## Test plan
- [ ] After backend + infra fully deployed: tap "Connect SoundCloud" in Settings → web auth completes → token persisted
- [ ] Refresh flow on stale token uses the new endpoint
- [ ] Build clean (verified: \`BUILD SUCCEEDED\` on iPhone 17, no new warnings)