### PR TITLE
fix(feed): swallow cancellation errors so pull-to-refresh stops blowing away the feed

### DIFF
--- a/Xomfit/ViewModels/FeedViewModel.swift
+++ b/Xomfit/ViewModels/FeedViewModel.swift
@@ -77,6 +77,15 @@ final class FeedViewModel {
             feedItems = items
             offset = items.count
             hasMore = items.count == pageSize
+        } catch is CancellationError {
+            // A newer pull-to-refresh / view re-render replaced this task — leave
+            // the existing feed in place rather than blowing it away with a
+            // "cancelled" toast.
+            isLoading = false
+            return
+        } catch let urlError as URLError where urlError.code == .cancelled {
+            isLoading = false
+            return
         } catch {
             errorMessage = error.localizedDescription
         }
@@ -111,6 +120,10 @@ final class FeedViewModel {
             feedItems.append(contentsOf: items)
             offset += items.count
             hasMore = items.count == pageSize
+        } catch is CancellationError {
+            return
+        } catch let urlError as URLError where urlError.code == .cancelled {
+            return
         } catch {
             // #311: keep `hasMore` true so the user can retry, and surface
             // a retry banner at the bottom of the feed instead of silently


### PR DESCRIPTION
User screenshot showed "Failed to load feed — cancelled" after a swipe-down. That's URLError code -999, fired when a previous URLSession task is cancelled (pull-to-refresh racing the initial fetch, view re-render replacing the .task, etc.). Both `loadFeed` and `loadMore` now early-return on `CancellationError` + `URLError.cancelled` instead of populating `errorMessage` / `loadMoreError`.