### PR TITLE
fix(workout): list-mode top spacing + tap-to-expand minimized rest chip

### DIFF
--- a/Xomfit/ViewModels/WorkoutLoggerViewModel.swift
+++ b/Xomfit/ViewModels/WorkoutLoggerViewModel.swift
@@ -37,6 +37,11 @@ final class WorkoutLoggerViewModel {
     var restTimeRemaining: Double = 0
     var restDuration: Double = 0
     var isRestTimerActive: Bool = false
+    /// True when the focus-mode rest timer is collapsed to a banner. Lifted onto
+    /// the VM (#409) so the header chip in `ActiveWorkoutView` can tap-to-expand
+    /// the fullscreen overlay; `WorkoutFocusView` reads/writes this for its own
+    /// minimize chevron + banner background tap. In-memory only.
+    var isRestTimerMinimized: Bool = false
 
     // Pause state — freezes elapsed timer + rest countdown without ending the workout.
     // In-memory only (not persisted).
@@ -1040,6 +1045,9 @@ final class WorkoutLoggerViewModel {
         restDuration = duration
         restTimeRemaining = duration
         isRestTimerActive = true
+        // Every fresh rest period starts expanded — the user just finished a
+        // set and benefits from the full-screen countdown.
+        isRestTimerMinimized = false
         restTimerStartDate = Date()
         updateLiveActivity()
 
@@ -1069,6 +1077,8 @@ final class WorkoutLoggerViewModel {
     func skipRestTimer() {
         restTimeRemaining = 0
         isRestTimerActive = false
+        // Reset minimize state so the next rest period always starts fullscreen.
+        isRestTimerMinimized = false
         updateLiveActivity()
         // Cancel any pending local "rest done" notification (#369). Safe to call
         // when none is pending — also clears delivered notifications if the user
@@ -1406,6 +1416,7 @@ final class WorkoutLoggerViewModel {
         isPaused = false
         pausedAt = nil
         isRestTimerActive = false
+        isRestTimerMinimized = false
         restTimeRemaining = 0
         restDuration = 0
         showExerciseTransition = false

--- a/Xomfit/Views/Workout/ActiveWorkoutView.swift
+++ b/Xomfit/Views/Workout/ActiveWorkoutView.swift
@@ -383,18 +383,27 @@ struct ActiveWorkoutView: View {
     /// can't trust `safeAreaPadding` or the system inset to push content past
     /// the Dynamic Island. Instead we read the active window's top safe-area
     /// inset directly via UIKit and apply it as explicit padding (#402).
+    ///
+    /// List mode keeps the headerBar anchored tight to the Dynamic Island
+    /// (#409) — the previous +28pt breathing room only made sense in focus
+    /// mode where the rest of the screen has plenty of negative space. In
+    /// list mode the toolbar was floating ~halfway down the screen on
+    /// iPhone 17 Pro TestFlight 2.1.0, so list mode now uses a minimal
+    /// 4pt buffer below the inset. Focus mode keeps the wider buffer.
     private var headerBar: some View {
-        VStack(spacing: Theme.Spacing.xs) {
+        let topClearance: CGFloat = max(Self.topSafeAreaInset, 62)
+        let extraBuffer: CGFloat = viewModel.focusMode ? 28 : Theme.Spacing.xs
+        return VStack(spacing: Theme.Spacing.xs) {
             headerTopRow
             headerSecondRow
         }
         .padding(.horizontal, Theme.Spacing.md)
-        // Clear the Dynamic Island. iPhone 17 Pro reports a 62pt top safe-area
-        // inset but `.toolbar(.hidden)` on iOS 26 NavigationStack swallows it
-        // when SwiftUI lays out the cover — so we use the larger of the
-        // UIKit-reported inset (with a 62pt floor) plus an extra 28pt of
-        // breathing room. End result on iPhone 17 Pro: ~90pt top padding.
-        .padding(.top, max(Self.topSafeAreaInset, 62) + 28)
+        // iPhone 17 Pro reports a 62pt top safe-area inset but
+        // `.toolbar(.hidden)` on iOS 26 NavigationStack swallows it when
+        // SwiftUI lays out the cover — so we use the larger of the
+        // UIKit-reported inset (with a 62pt floor) plus a mode-dependent
+        // breathing buffer. List mode: ~66pt total. Focus mode: ~90pt total.
+        .padding(.top, topClearance + extraBuffer)
         .padding(.bottom, Theme.Spacing.sm)
         .frame(maxWidth: .infinity)
         .background(Theme.surface.ignoresSafeArea(edges: .top))
@@ -520,24 +529,7 @@ struct ActiveWorkoutView: View {
                     .foregroundStyle(Theme.accent)
 
                     if viewModel.isRestTimerActive {
-                        let isOvertime = viewModel.restTimeRemaining <= 0
-                        HStack(spacing: 3) {
-                            Image(systemName: "timer")
-                                .font(Theme.fontCaption2)
-                            Text(headerRestString)
-                                .font(Theme.fontNumberMedium)
-                                .lineLimit(1)
-                                .minimumScaleFactor(0.7)
-                                .fixedSize(horizontal: true, vertical: false)
-                        }
-                        .foregroundStyle(isOvertime ? Theme.destructive : Theme.textPrimary)
-                        .padding(.horizontal, 7)
-                        .padding(.vertical, Theme.Spacing.tighter)
-                        .background(
-                            Capsule()
-                                .fill((isOvertime ? Theme.destructive : Theme.accent).opacity(0.15))
-                        )
-                        .transition(.scale.combined(with: .opacity))
+                        restTimerChip
                     }
                 }
 
@@ -704,6 +696,76 @@ struct ActiveWorkoutView: View {
         let secs = total % 60
         let prefix = remaining < 0 ? "-" : ""
         return prefix + String(format: "%d:%02d", mins, secs)
+    }
+
+    /// Header rest-timer chip. Two rendering modes (#409):
+    ///
+    /// - Informational (default): plain capsule, no hit target. Used in list
+    ///   mode and in focus mode while the fullscreen overlay is up.
+    /// - Tappable: solid accent capsule with a chevron-up affordance + 44pt
+    ///   hit target. Only renders when focus mode + the rest overlay is
+    ///   minimized — tap re-expands the fullscreen overlay.
+    @ViewBuilder
+    private var restTimerChip: some View {
+        let isOvertime = viewModel.restTimeRemaining <= 0
+        let canExpand = viewModel.focusMode && viewModel.isRestTimerMinimized
+
+        if canExpand {
+            Button {
+                Haptics.light()
+                withAnimation(.xomChill) {
+                    viewModel.isRestTimerMinimized = false
+                }
+            } label: {
+                HStack(spacing: 3) {
+                    Image(systemName: "timer")
+                        .font(Theme.fontCaption2)
+                    Text(headerRestString)
+                        .font(Theme.fontNumberMedium)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.7)
+                        .fixedSize(horizontal: true, vertical: false)
+                    Image(systemName: "chevron.up")
+                        .font(.caption2.weight(.bold))
+                }
+                // Black text on the accent / destructive capsule so the
+                // affordance reads as a primary CTA — matches the Finish pill
+                // styling.
+                .foregroundStyle(Theme.background)
+                .padding(.horizontal, 9)
+                .padding(.vertical, 4)
+                .frame(minHeight: 28)
+                .background(
+                    Capsule()
+                        .fill(isOvertime ? Theme.destructive : Theme.accent)
+                )
+                .contentShape(Capsule())
+            }
+            .buttonStyle(.plain)
+            .frame(minHeight: 44)
+            .transition(.scale.combined(with: .opacity))
+            .accessibilityLabel("Expand rest timer")
+            .accessibilityHint("Shows the full-screen countdown")
+        } else {
+            HStack(spacing: 3) {
+                Image(systemName: "timer")
+                    .font(Theme.fontCaption2)
+                Text(headerRestString)
+                    .font(Theme.fontNumberMedium)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.7)
+                    .fixedSize(horizontal: true, vertical: false)
+            }
+            .foregroundStyle(isOvertime ? Theme.destructive : Theme.textPrimary)
+            .padding(.horizontal, 7)
+            .padding(.vertical, Theme.Spacing.tighter)
+            .background(
+                Capsule()
+                    .fill((isOvertime ? Theme.destructive : Theme.accent).opacity(0.15))
+            )
+            .transition(.scale.combined(with: .opacity))
+            .accessibilityLabel("Rest timer \(headerRestString) remaining")
+        }
     }
 
     // MARK: - Rest Timer Config

--- a/Xomfit/Views/Workout/WorkoutFocusView.swift
+++ b/Xomfit/Views/Workout/WorkoutFocusView.swift
@@ -10,15 +10,9 @@ struct WorkoutFocusView: View {
     @FocusState private var weightFieldFocused: Bool
     @FocusState private var repsFieldFocused: Bool
     @State private var showExercisePicker = false
-    @State private var isRestTimerMinimized: Bool = {
-        #if DEBUG
-        // Agent screenshot helper (#402) — start the rest timer minimized so
-        // the inline banner can be captured from a cold launch without a tap.
-        return ProcessInfo.processInfo.environment["XOMFIT_AUTO_MINIMIZE_REST"] == "1"
-        #else
-        return false
-        #endif
-    }()
+    /// Minimized rest-timer state lives on the VM (#409) so the header chip
+    /// in `ActiveWorkoutView` can tap-to-expand the fullscreen overlay. Local
+    /// `@State` is gone — read/write through `viewModel.isRestTimerMinimized`.
     @AppStorage("restTimerSound") private var restTimerSound = false
 
     /// Set pill index targeted by a long-press, used to drive the delete
@@ -121,7 +115,7 @@ struct WorkoutFocusView: View {
                     // `.safeAreaInset(.bottom)` — guarantees the middle's DONE
                     // button never gets compressed off-screen, and the banner
                     // is always reachable below the weight/reps cards.
-                    if viewModel.isRestTimerActive && isRestTimerMinimized {
+                    if viewModel.isRestTimerActive && viewModel.isRestTimerMinimized {
                         minimizedRestTimerBanner
                     } else {
                         exerciseNavigation
@@ -133,13 +127,13 @@ struct WorkoutFocusView: View {
                 .padding(.top, Theme.Spacing.sm)
                 .padding(.horizontal, Theme.Spacing.lg)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .animation(.xomChill, value: isRestTimerMinimized)
+                .animation(.xomChill, value: viewModel.isRestTimerMinimized)
                 .animation(.xomChill, value: viewModel.isRestTimerActive)
 
                 // Full-screen rest timer — only when the timer is active AND not minimized.
                 // The minimized banner is rendered via `.safeAreaInset(edge: .bottom)`
                 // below so it reserves its own row instead of shrinking the header.
-                if viewModel.isRestTimerActive && !isRestTimerMinimized {
+                if viewModel.isRestTimerActive && !viewModel.isRestTimerMinimized {
                     fullScreenRestTimer
                         .transition(.opacity)
                 }
@@ -188,9 +182,9 @@ struct WorkoutFocusView: View {
         } message: {
             Text("Removes this set from the current exercise.")
         }
-        .onChange(of: viewModel.isRestTimerActive) { _, isActive in
-            if isActive { isRestTimerMinimized = false }
-        }
+        // `WorkoutLoggerViewModel.startRestTimer` + `skipRestTimer` now own the
+        // minimize-state reset, so the previous local `onChange(isRestTimerActive)`
+        // handler is gone (#409).
     }
 
     // MARK: - Exercise Header
@@ -587,7 +581,7 @@ struct WorkoutFocusView: View {
             // Expand glyph — far left, 44pt hit target.
             Button {
                 Haptics.light()
-                withAnimation(.xomChill) { isRestTimerMinimized = false }
+                withAnimation(.xomChill) { viewModel.isRestTimerMinimized = false }
             } label: {
                 Image(systemName: "arrow.up.left.and.arrow.down.right")
                     .font(.subheadline.weight(.semibold))
@@ -637,7 +631,6 @@ struct WorkoutFocusView: View {
             Button {
                 Haptics.success()
                 viewModel.skipRestTimer()
-                isRestTimerMinimized = false
             } label: {
                 Text("Lift")
                     .font(.subheadline.weight(.black))
@@ -662,7 +655,7 @@ struct WorkoutFocusView: View {
                 .contentShape(Rectangle())
                 .onTapGesture {
                     Haptics.light()
-                    withAnimation(.xomChill) { isRestTimerMinimized = false }
+                    withAnimation(.xomChill) { viewModel.isRestTimerMinimized = false }
                 }
         )
         .overlay(
@@ -706,7 +699,7 @@ struct WorkoutFocusView: View {
                 HStack {
                     Button {
                         Haptics.light()
-                        withAnimation(.xomChill) { isRestTimerMinimized = true }
+                        withAnimation(.xomChill) { viewModel.isRestTimerMinimized = true }
                     } label: {
                         Image(systemName: "arrow.down.right.and.arrow.up.left")
                             .font(.subheadline.weight(.semibold))
@@ -790,7 +783,6 @@ struct WorkoutFocusView: View {
                 Button {
                     Haptics.success()
                     viewModel.skipRestTimer()
-                    isRestTimerMinimized = false
                 } label: {
                     Text("LIFT")
                         .font(.title.weight(.black))

--- a/Xomfit/XomfitApp.swift
+++ b/Xomfit/XomfitApp.swift
@@ -360,6 +360,13 @@ struct XomFitApp: App {
             workoutSession.startRestTimer(for: workoutSession.focusExerciseIndex)
         }
 
+        // Optionally seed the rest timer in its minimized banner state — the
+        // VM owns this flag now (#409) so both the focus view and the header
+        // chip can read/write it.
+        if env["XOMFIT_AUTO_MINIMIZE_REST"] == "1" {
+            workoutSession.isRestTimerMinimized = true
+        }
+
         // Optionally jump straight into the active runner so the cover renders.
         workoutSession.isPresented = true
     }


### PR DESCRIPTION
## Summary

Two TestFlight 2.1.0 bugs caught on device.

### 1. List view had ~half-screen of empty space at the top
The DI-clearance buffer added in #404 was applied in **both** focus and list mode. Focus mode benefits from the extra 28pt breathing room; list mode does not — it pushed the toolbar way down the screen.

Now mode-dependent:
- **Focus**: `topSafeAreaInset + 28pt` (~90pt total) — unchanged
- **List**: `topSafeAreaInset + Theme.Spacing.xs` (~66pt total) — anchored tight to the DI

### 2. No way to re-expand the rest timer when minimized in focus mode
The minimized rest chip in the header was read-only — once you collapsed the fullscreen overlay, you had to wait it out or finish the set.

Lifted `isRestTimerMinimized` from `WorkoutFocusView` local `@State` onto `WorkoutLoggerViewModel` so the header chip in `ActiveWorkoutView` can drive it. New `restTimerChip` view builder renders two modes:
- **Tappable** (focus + minimized): solid accent capsule, chevron-up affordance, 44pt hit target, accessibility labels. Tap re-expands the fullscreen overlay.
- **Informational** (everywhere else): existing translucent capsule, no tap.

VM also resets the minimize flag on `startRestTimer`, `skipRestTimer`, and `discardWorkout` so each rest period starts fullscreen.

## Verified
`BUILD SUCCEEDED` clean on iPhone 17 Debug. (Agent's screenshot loop was cancelled in the interest of shipping — reported visually-verified diff before stopping.)

## Test plan
- [ ] List view: top toolbar sits tight under the Dynamic Island, no large gap
- [ ] Focus view: still has the wider breathing room (DI clearance unchanged)
- [ ] Start rest timer → fullscreen overlay
- [ ] Tap minimize → rest chip appears as a solid accent pill with chevron-up
- [ ] Tap chip → fullscreen overlay re-expands
- [ ] Finish a set → next rest period starts fullscreen (minimize flag reset)