### PR TITLE
fix(workout): list-mode gap + inline Lift + minimized banner consistency + set indicators + remove-from-focus + keyboard collapse

### DIFF
--- a/Xomfit/Views/Workout/ActiveWorkoutView.swift
+++ b/Xomfit/Views/Workout/ActiveWorkoutView.swift
@@ -378,54 +378,33 @@ struct ActiveWorkoutView: View {
     // one row, which on iPhone 14/15/16/17 Pro models collided with the
     // Dynamic Island and clipped the duration timer.
 
-    /// Header bar. `.toolbar(.hidden, for: .navigationBar)` + NavigationStack
-    /// on iOS 26 zeroes the implicit top safe-area for descendants, so we
-    /// can't trust `safeAreaPadding` or the system inset to push content past
-    /// the Dynamic Island. Instead we read the active window's top safe-area
-    /// inset directly via UIKit and apply it as explicit padding (#402).
+    /// Header bar. The parent `ZStack` already respects the top safe-area
+    /// inset (only `Theme.background.ignoresSafeArea()` extends the BG to the
+    /// screen edge — content lives inside the inset). So the VStack content
+    /// already starts below the Dynamic Island; previous revisions stacked an
+    /// additional ~62pt manual inset on top, which doubled the offset and
+    /// floated the toolbar ~128pt down on iPhone 17 Pro (TestFlight 2.1.0 +
+    /// 2.1.1, #409 → #411).
     ///
-    /// List mode keeps the headerBar anchored tight to the Dynamic Island
-    /// (#409) — the previous +28pt breathing room only made sense in focus
-    /// mode where the rest of the screen has plenty of negative space. In
-    /// list mode the toolbar was floating ~halfway down the screen on
-    /// iPhone 17 Pro TestFlight 2.1.0, so list mode now uses a minimal
-    /// 4pt buffer below the inset. Focus mode keeps the wider buffer.
+    /// We now apply ONLY a small breathing buffer:
+    ///   - List mode: `Theme.Spacing.xs` (4pt) — anchor tight to the island.
+    ///   - Focus mode: `Theme.Spacing.lg` (24pt) — wider buffer keeps the
+    ///     gym-floor layout from feeling cramped under the island.
+    ///
+    /// The header background still extends past the safe area via
+    /// `.ignoresSafeArea(edges: .top)` so the status bar / island sit on the
+    /// surface color rather than the workout background.
     private var headerBar: some View {
-        let topClearance: CGFloat = max(Self.topSafeAreaInset, 62)
-        let extraBuffer: CGFloat = viewModel.focusMode ? 28 : Theme.Spacing.xs
+        let extraBuffer: CGFloat = viewModel.focusMode ? Theme.Spacing.lg : Theme.Spacing.xs
         return VStack(spacing: Theme.Spacing.xs) {
             headerTopRow
             headerSecondRow
         }
         .padding(.horizontal, Theme.Spacing.md)
-        // iPhone 17 Pro reports a 62pt top safe-area inset but
-        // `.toolbar(.hidden)` on iOS 26 NavigationStack swallows it when
-        // SwiftUI lays out the cover — so we use the larger of the
-        // UIKit-reported inset (with a 62pt floor) plus a mode-dependent
-        // breathing buffer. List mode: ~66pt total. Focus mode: ~90pt total.
-        .padding(.top, topClearance + extraBuffer)
+        .padding(.top, extraBuffer)
         .padding(.bottom, Theme.Spacing.sm)
         .frame(maxWidth: .infinity)
         .background(Theme.surface.ignoresSafeArea(edges: .top))
-    }
-
-    /// UIKit-derived top safe-area inset — used because `.toolbar(.hidden)` on
-    /// iOS 26 NavigationStack collapses SwiftUI's implicit top inset. Computed
-    /// per-access (not cached) so a cold launch where the scene's window isn't
-    /// fully laid out yet still gets the right value on the next render pass.
-    ///
-    /// Falls back to 59pt — iPhone Pro top safe-area inset — when no window
-    /// is available. That's enough to clear the Dynamic Island even on the
-    /// largest Pro Max device.
-    private static var topSafeAreaInset: CGFloat {
-        let scene = UIApplication.shared.connectedScenes
-            .compactMap { $0 as? UIWindowScene }
-            .first { $0.activationState == .foregroundActive }
-            ?? UIApplication.shared.connectedScenes
-                .compactMap { $0 as? UIWindowScene }
-                .first
-        let inset = scene?.windows.first?.safeAreaInsets.top ?? 0
-        return max(inset, 59)
     }
 
     /// Row 1 — corner controls only. Discard sits on the leading edge; Minimize
@@ -698,74 +677,35 @@ struct ActiveWorkoutView: View {
         return prefix + String(format: "%d:%02d", mins, secs)
     }
 
-    /// Header rest-timer chip. Two rendering modes (#409):
-    ///
-    /// - Informational (default): plain capsule, no hit target. Used in list
-    ///   mode and in focus mode while the fullscreen overlay is up.
-    /// - Tappable: solid accent capsule with a chevron-up affordance + 44pt
-    ///   hit target. Only renders when focus mode + the rest overlay is
-    ///   minimized — tap re-expands the fullscreen overlay.
-    @ViewBuilder
+    /// Header rest-timer chip. Single informational rendering across both
+    /// list and focus modes (#411 bug 3) — the previous tap-to-expand variant
+    /// (#409) created inconsistent visuals between list and focus mode and
+    /// duplicated the expand affordance already provided by the focus-mode
+    /// minimized banner. The chip is now a passive readout in both modes.
     private var restTimerChip: some View {
         let isOvertime = viewModel.restTimeRemaining <= 0
-        let canExpand = viewModel.focusMode && viewModel.isRestTimerMinimized
-
-        if canExpand {
-            Button {
-                Haptics.light()
-                withAnimation(.xomChill) {
-                    viewModel.isRestTimerMinimized = false
-                }
-            } label: {
-                HStack(spacing: 3) {
-                    Image(systemName: "timer")
-                        .font(Theme.fontCaption2)
-                    Text(headerRestString)
-                        .font(Theme.fontNumberMedium)
-                        .lineLimit(1)
-                        .minimumScaleFactor(0.7)
-                        .fixedSize(horizontal: true, vertical: false)
-                    Image(systemName: "chevron.up")
-                        .font(.caption2.weight(.bold))
-                }
-                // Black text on the accent / destructive capsule so the
-                // affordance reads as a primary CTA — matches the Finish pill
-                // styling.
-                .foregroundStyle(Theme.background)
-                .padding(.horizontal, 9)
-                .padding(.vertical, 4)
-                .frame(minHeight: 28)
-                .background(
-                    Capsule()
-                        .fill(isOvertime ? Theme.destructive : Theme.accent)
-                )
-                .contentShape(Capsule())
-            }
-            .buttonStyle(.plain)
-            .frame(minHeight: 44)
-            .transition(.scale.combined(with: .opacity))
-            .accessibilityLabel("Expand rest timer")
-            .accessibilityHint("Shows the full-screen countdown")
-        } else {
-            HStack(spacing: 3) {
-                Image(systemName: "timer")
-                    .font(Theme.fontCaption2)
-                Text(headerRestString)
-                    .font(Theme.fontNumberMedium)
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.7)
-                    .fixedSize(horizontal: true, vertical: false)
-            }
-            .foregroundStyle(isOvertime ? Theme.destructive : Theme.textPrimary)
-            .padding(.horizontal, 7)
-            .padding(.vertical, Theme.Spacing.tighter)
-            .background(
-                Capsule()
-                    .fill((isOvertime ? Theme.destructive : Theme.accent).opacity(0.15))
-            )
-            .transition(.scale.combined(with: .opacity))
-            .accessibilityLabel("Rest timer \(headerRestString) remaining")
+        return HStack(spacing: 3) {
+            Image(systemName: "timer")
+                .font(Theme.fontCaption2)
+            Text(headerRestString)
+                .font(Theme.fontNumberMedium)
+                .lineLimit(1)
+                .minimumScaleFactor(0.7)
+                .fixedSize(horizontal: true, vertical: false)
         }
+        .foregroundStyle(isOvertime ? Theme.destructive : Theme.textPrimary)
+        .padding(.horizontal, 7)
+        .padding(.vertical, Theme.Spacing.tighter)
+        .background(
+            Capsule()
+                .fill((isOvertime ? Theme.destructive : Theme.accent).opacity(0.15))
+        )
+        .overlay(
+            Capsule()
+                .strokeBorder((isOvertime ? Theme.destructive : Theme.accent).opacity(0.35), lineWidth: 0.5)
+        )
+        .transition(.scale.combined(with: .opacity))
+        .accessibilityLabel("Rest timer \(headerRestString) remaining")
     }
 
     // MARK: - Rest Timer Config
@@ -1246,6 +1186,17 @@ private struct ExerciseCard: View {
                 .padding(.horizontal, Theme.Spacing.md)
             }
 
+            // Per-exercise current set index — first incomplete row, or the
+            // last row if all sets are complete. Drives the accent border +
+            // tint on the SetRowView so the lifter always knows where they
+            // are in list mode (#411 bug 4).
+            let currentSetIdx: Int? = {
+                if let firstIncomplete = exercise.sets.firstIndex(where: { $0.completedAt == Date.distantPast }) {
+                    return firstIncomplete
+                }
+                return exercise.sets.indices.last
+            }()
+
             // Sets — use stable element IDs to prevent state loss on expand/collapse
             ForEach(Array(exercise.sets.enumerated()), id: \.element.id) { setIdx, workoutSet in
                 SetRowView(
@@ -1281,7 +1232,8 @@ private struct ExerciseCard: View {
                     },
                     lateralityLabel: exercise.selectedLaterality != .bilateral ? (exercise.exercise.muscleGroups.contains(where: { [.quads, .hamstrings, .glutes, .calves].contains($0) }) ? "/leg" : "/arm") : nil,
                     lastSet: viewModel.lastSetForExercise(exercise.exercise.id),
-                    personalRecord: viewModel.personalRecordForExercise(exercise.exercise.id)
+                    personalRecord: viewModel.personalRecordForExercise(exercise.exercise.id),
+                    isCurrentSet: setIdx == currentSetIdx
                 )
             }
 

--- a/Xomfit/Views/Workout/RestTimerView.swift
+++ b/Xomfit/Views/Workout/RestTimerView.swift
@@ -80,11 +80,13 @@ struct RestTimerView: View {
                             .foregroundStyle(Theme.textPrimary)
                             .padding(.horizontal, 14)
                             .padding(.vertical, 7)
+                            .frame(minHeight: 44)
                             .background(Theme.surfaceElevated)
                             .clipShape(.capsule)
                             .overlay(
                                 Capsule().strokeBorder(Theme.hairline, lineWidth: 0.5)
                             )
+                            .contentShape(.capsule)
                     }
                     .buttonStyle(.plain)
                     .accessibilityLabel("Skip rest timer")
@@ -98,11 +100,35 @@ struct RestTimerView: View {
                             .foregroundStyle(Theme.accent)
                             .padding(.horizontal, 14)
                             .padding(.vertical, 7)
+                            .frame(minHeight: 44)
                             .background(Theme.accentMuted)
                             .clipShape(.capsule)
+                            .contentShape(.capsule)
                     }
                     .buttonStyle(.plain)
                     .accessibilityLabel("Add 30 seconds to rest timer")
+
+                    // Lift — primary CTA. Same action as Skip (end rest +
+                    // advance to next set), but visually distinct as the
+                    // primary "I'm ready" affordance. Mirrors the focus-mode
+                    // minimized banner's Lift button (#411 bug 2).
+                    Button {
+                        Haptics.success()
+                        onSkip()
+                    } label: {
+                        Text("Lift")
+                            .font(.caption.weight(.black))
+                            .foregroundStyle(.black)
+                            .padding(.horizontal, 14)
+                            .padding(.vertical, 7)
+                            .frame(minHeight: 44)
+                            .background(Theme.accent)
+                            .clipShape(.capsule)
+                            .contentShape(.capsule)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Lift — end rest and start next set")
+                    .accessibilityHint("Ends the rest timer immediately so you can begin the next set")
                 }
             }
 

--- a/Xomfit/Views/Workout/SetRowView.swift
+++ b/Xomfit/Views/Workout/SetRowView.swift
@@ -16,6 +16,11 @@ struct SetRowView: View {
     /// Heaviest set the user has ever logged for this exercise (history only).
     /// Drives the "PR: 145×6" hint and the inline "NEW PR" badge when beat.
     var personalRecord: WorkoutSet? = nil
+    /// True when this row is the user's *active* set in the parent exercise —
+    /// the first incomplete set (or the last set if everything is complete).
+    /// Drives the accent border + tint so the lifter always knows where they
+    /// are in list mode (#411 bug 4).
+    var isCurrentSet: Bool = false
 
     @State private var weightText: String
     @State private var repsText: String
@@ -58,6 +63,15 @@ struct SetRowView: View {
         lastSet != nil || personalRecord != nil
     }
 
+    /// Background tint based on row state. Completed > current > default.
+    /// The current-set tint is a low-alpha accent fill so the row is
+    /// unmistakable even when surrounded by similar rows (#411 bug 4).
+    private var rowBackground: Color {
+        if isCompleted { return Theme.accent.opacity(0.08) }
+        if isCurrentSet { return Theme.accent.opacity(0.12) }
+        return .clear
+    }
+
     init(
         setNumber: Int,
         workoutSet: WorkoutSet,
@@ -69,7 +83,8 @@ struct SetRowView: View {
         onAddDropSet: (() -> Void)? = nil,
         lateralityLabel: String? = nil,
         lastSet: WorkoutSet? = nil,
-        personalRecord: WorkoutSet? = nil
+        personalRecord: WorkoutSet? = nil,
+        isCurrentSet: Bool = false
     ) {
         self.setNumber = setNumber
         self.workoutSet = workoutSet
@@ -82,6 +97,7 @@ struct SetRowView: View {
         self.lateralityLabel = lateralityLabel
         self.lastSet = lastSet
         self.personalRecord = personalRecord
+        self.isCurrentSet = isCurrentSet
 
         let w = workoutSet.weight
         let r = workoutSet.reps
@@ -101,8 +117,19 @@ struct SetRowView: View {
         }
         .padding(.leading, isDropSet ? Theme.Spacing.lg : 0)
         .frame(minHeight: isDropSet ? 44 : 52)
-        .background(isCompleted ? Theme.accent.opacity(0.08) : Color.clear)
+        .background(rowBackground)
         .clipShape(.rect(cornerRadius: Theme.cornerRadiusSmall))
+        .overlay(
+            // Accent border around the active set so the lifter can see which
+            // set they're on at a glance in list mode (#411 bug 4). Only
+            // applied to incomplete sets — once completed, the green tint
+            // already disambiguates it.
+            RoundedRectangle(cornerRadius: Theme.cornerRadiusSmall)
+                .strokeBorder(
+                    isCurrentSet && !isCompleted ? Theme.accent : Color.clear,
+                    lineWidth: 1.5
+                )
+        )
         .animation(nil, value: workoutSet.completedAt)
         .onChange(of: workoutSet.weight) { _, newWeight in
             let formatted = newWeight > 0 ? newWeight.formattedWeight : ""

--- a/Xomfit/Views/Workout/WorkoutFocusView.swift
+++ b/Xomfit/Views/Workout/WorkoutFocusView.swift
@@ -21,6 +21,13 @@ struct WorkoutFocusView: View {
     @State private var pendingDeleteSetIndex: Int?
     @State private var showDeleteSetConfirm = false
 
+    /// True when EITHER the weight or reps numeric field has the keyboard.
+    /// Drives the compact-mode collapse of the header + nav rows so the
+    /// keyboard never overlaps the active input (#411 bug 6).
+    private var keyboardCompactMode: Bool {
+        weightFieldFocused || repsFieldFocused
+    }
+
     private var exercise: WorkoutExercise? { viewModel.focusExercise }
     private var currentSet: WorkoutSet? { viewModel.focusSet }
 
@@ -64,33 +71,50 @@ struct WorkoutFocusView: View {
 
             if let exercise, let currentSet {
                 // Pinned top + flexible middle + pinned bottom (#344-A).
-                // The top header (exerciseHeader + config + set indicator) is anchored
-                // to the top so it respects the Dynamic Island via `.safeAreaInset`,
-                // the middle (weight/reps/done) absorbs slack via
-                // `.frame(maxHeight: .infinity)`, and the bottom slot holds
-                // exerciseNavigation — never the minimized rest banner. The banner
-                // is rendered via `.safeAreaInset(edge: .bottom)` so it reserves its
-                // own real estate and does not steal vertical space from the header.
+                // The top header (exerciseHeader + config + set indicator)
+                // collapses when a text field is focused so the keyboard
+                // never overlaps the active input (#411 bug 6). The middle
+                // (weight/reps/done) absorbs slack via `.frame(maxHeight:
+                // .infinity)`. The bottom slot is exerciseNavigation; the
+                // minimized rest banner now lives in a sibling `.safeAreaInset`
+                // (#411 bug 3) so it never steals vertical space from DONE.
                 VStack(spacing: Theme.Spacing.md) {
-                    // TOP — exercise header + config + set indicator
-                    VStack(spacing: Theme.Spacing.md) {
-                        exerciseHeader(exercise: exercise)
+                    // TOP — exercise header + config + set indicator.
+                    // Hidden while a numeric field is focused so the keyboard
+                    // can never overlap the active input (#411 bug 6).
+                    if !keyboardCompactMode {
+                        VStack(spacing: Theme.Spacing.md) {
+                            exerciseHeader(exercise: exercise)
 
-                        // Variant config (grip, attachment, position, laterality) + per-session extras
-                        // (notes / rest override). Shown unconditionally so the extras pills are
-                        // always reachable from focus mode.
-                        ExerciseConfigRow(
-                            exercise: exercise,
-                            onGripChanged: { grip in viewModel.setGrip(exerciseIndex: viewModel.focusExerciseIndex, grip: grip) },
-                            onAttachmentChanged: { att in viewModel.setAttachment(exerciseIndex: viewModel.focusExerciseIndex, attachment: att) },
-                            onPositionChanged: { pos in viewModel.setPosition(exerciseIndex: viewModel.focusExerciseIndex, position: pos) },
-                            onLateralityChanged: { lat in viewModel.setLaterality(exerciseIndex: viewModel.focusExerciseIndex, laterality: lat) },
-                            onNotesChanged: { notes in viewModel.setNotes(exerciseIndex: viewModel.focusExerciseIndex, notes: notes) },
-                            onRestSecondsChanged: { secs in viewModel.setRestSeconds(exerciseIndex: viewModel.focusExerciseIndex, seconds: secs) },
-                            defaultRestSeconds: Int(viewModel.defaultRestDuration)
-                        )
+                            // Variant config (grip, attachment, position, laterality) + per-session extras
+                            // (notes / rest override). Shown unconditionally so the extras pills are
+                            // always reachable from focus mode.
+                            ExerciseConfigRow(
+                                exercise: exercise,
+                                onGripChanged: { grip in viewModel.setGrip(exerciseIndex: viewModel.focusExerciseIndex, grip: grip) },
+                                onAttachmentChanged: { att in viewModel.setAttachment(exerciseIndex: viewModel.focusExerciseIndex, attachment: att) },
+                                onPositionChanged: { pos in viewModel.setPosition(exerciseIndex: viewModel.focusExerciseIndex, position: pos) },
+                                onLateralityChanged: { lat in viewModel.setLaterality(exerciseIndex: viewModel.focusExerciseIndex, laterality: lat) },
+                                onNotesChanged: { notes in viewModel.setNotes(exerciseIndex: viewModel.focusExerciseIndex, notes: notes) },
+                                onRestSecondsChanged: { secs in viewModel.setRestSeconds(exerciseIndex: viewModel.focusExerciseIndex, seconds: secs) },
+                                defaultRestSeconds: Int(viewModel.defaultRestDuration)
+                            )
 
-                        setIndicator(exercise: exercise)
+                            setIndicator(exercise: exercise)
+                        }
+                        .transition(.opacity.combined(with: .move(edge: .top)))
+                    } else {
+                        // Compact-mode marker: just the exercise name so the
+                        // user still knows what they're logging. No config
+                        // row, no set chips — keyboard has full vertical real
+                        // estate.
+                        Text(exercise.exercise.name)
+                            .font(.headline.weight(.bold))
+                            .foregroundStyle(Theme.textPrimary)
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.7)
+                            .frame(maxWidth: .infinity)
+                            .transition(.opacity)
                     }
 
                     // MIDDLE — weight / reps / done. Absorbs slack so the top
@@ -102,23 +126,23 @@ struct WorkoutFocusView: View {
                         // Drop-set capsule sits on its own row directly under
                         // the reps card so the horizontal pill ScrollView stays
                         // tight (#384 A). Only renders when a non-drop set has
-                        // been completed in this exercise.
-                        dropSetCapsuleRow(exercise: exercise)
+                        // been completed in this exercise. Hidden in compact
+                        // keyboard mode.
+                        if !keyboardCompactMode {
+                            dropSetCapsuleRow(exercise: exercise)
+                        }
                         doneButton(currentSet: currentSet)
                     }
                     .frame(maxHeight: .infinity)
 
                     // BOTTOM — exercise navigation (prev/next/add + rest config).
-                    // While the rest timer is minimized we show the rest-timer
-                    // banner here INSTEAD of exerciseNavigation (#402). Putting
-                    // it in the bottom slot — rather than as a sibling via
-                    // `.safeAreaInset(.bottom)` — guarantees the middle's DONE
-                    // button never gets compressed off-screen, and the banner
-                    // is always reachable below the weight/reps cards.
-                    if viewModel.isRestTimerActive && viewModel.isRestTimerMinimized {
-                        minimizedRestTimerBanner
-                    } else {
+                    // The minimized rest banner used to live here (#402) but is
+                    // now rendered via `.safeAreaInset(edge: .bottom)` below
+                    // (#411 bug 3) so DONE always has guaranteed bottom
+                    // clearance. Bottom nav is hidden in compact keyboard mode.
+                    if !keyboardCompactMode {
                         exerciseNavigation
+                            .transition(.opacity)
                     }
                 }
                 .id(viewModel.focusExerciseIndex)
@@ -129,6 +153,7 @@ struct WorkoutFocusView: View {
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .animation(.xomChill, value: viewModel.isRestTimerMinimized)
                 .animation(.xomChill, value: viewModel.isRestTimerActive)
+                .animation(.xomChill, value: keyboardCompactMode)
 
                 // Full-screen rest timer — only when the timer is active AND not minimized.
                 // The minimized banner is rendered via `.safeAreaInset(edge: .bottom)`
@@ -142,12 +167,28 @@ struct WorkoutFocusView: View {
             }
         }
         // Push content below any active Dynamic Island (#289/#402). Bumps
-        // content down deterministically when an island is present. The
-        // minimized rest banner is rendered inline in the bottom slot of the
-        // main VStack (replacing `exerciseNavigation` while active) so it
-        // never steals vertical real estate from the DONE button.
+        // content down deterministically when an island is present.
         .safeAreaInset(edge: .top, spacing: 0) {
             Color.clear.frame(height: Theme.Spacing.sm)
+        }
+        // Minimized rest banner — rendered as a bottom safe-area inset so it
+        // reserves its own layout row OUTSIDE the main VStack (#411 bug 3).
+        // This guarantees DONE never gets visually overlapped by the banner.
+        // Adds Theme.Spacing.sm of bottom padding so the banner sits above
+        // the home indicator with breathing room.
+        .safeAreaInset(edge: .bottom, spacing: 0) {
+            if viewModel.isRestTimerActive
+                && viewModel.isRestTimerMinimized
+                && !keyboardCompactMode {
+                minimizedRestTimerBanner
+                    .padding(.horizontal, Theme.Spacing.lg)
+                    .padding(.top, Theme.Spacing.sm)
+                    .padding(.bottom, Theme.Spacing.xs)
+                    .transition(.move(edge: .bottom).combined(with: .opacity))
+                    .animation(.xomChill, value: viewModel.isRestTimerMinimized)
+            } else {
+                Color.clear.frame(height: 0)
+            }
         }
         .sheet(isPresented: $showExercisePicker) {
             ExercisePickerView { exercise in
@@ -185,6 +226,25 @@ struct WorkoutFocusView: View {
         // `WorkoutLoggerViewModel.startRestTimer` + `skipRestTimer` now own the
         // minimize-state reset, so the previous local `onChange(isRestTimerActive)`
         // handler is gone (#409).
+        #if DEBUG
+        .onAppear {
+            // Agent screenshot helper (#411 bug 6): auto-focus the weight
+            // field so the keyboard pops and the compact-mode collapse can
+            // be captured from a cold launch.
+            if ProcessInfo.processInfo.environment["XOMFIT_AUTO_FOCUS_WEIGHT"] == "1" {
+                Task { @MainActor in
+                    try? await Task.sleep(for: .milliseconds(600))
+                    let w = viewModel.focusSet?.weight ?? 0
+                    weightText = w > 0 ? w.formattedWeight : ""
+                    isEditingWeight = true
+                    // Defer the focus assignment one frame so the TextField
+                    // is in the view hierarchy before @FocusState binds.
+                    try? await Task.sleep(for: .milliseconds(200))
+                    weightFieldFocused = true
+                }
+            }
+        }
+        #endif
     }
 
     // MARK: - Exercise Header
@@ -259,18 +319,34 @@ struct WorkoutFocusView: View {
                         viewModel.focusSetIndex = idx
                     } label: {
                         ZStack {
+                            // Outer pulse ring for the currently-focused
+                            // incomplete set — makes the active set
+                            // unmistakable on the gym floor (#411 bug 4).
+                            if isFocused && !isCompleted {
+                                Circle()
+                                    .stroke(Theme.accent.opacity(0.35), lineWidth: 4)
+                                    .frame(width: 46, height: 46)
+                            }
                             Circle()
-                                .fill(isCompleted ? Theme.accent : Color.clear)
+                                .fill(isCompleted
+                                      ? Theme.accent
+                                      : (isFocused ? Theme.accent.opacity(0.22) : Color.clear))
                                 .frame(width: 36, height: 36)
                             if !isCompleted {
                                 Circle()
-                                    .stroke(isFocused ? Theme.accent : Theme.textSecondary.opacity(0.5), lineWidth: isFocused ? 2 : 1.5)
+                                    .stroke(isFocused ? Theme.accent : Theme.textSecondary.opacity(0.5),
+                                            lineWidth: isFocused ? 2.5 : 1.5)
                                     .frame(width: 36, height: 36)
                             }
                             Text("\(idx + 1)")
                                 .font(.subheadline.weight(.bold))
                                 .foregroundStyle(isCompleted ? .black : (isFocused ? Theme.accent : Theme.textSecondary))
                         }
+                        // Scale the active chip up so it pops above its
+                        // siblings — `.animation(.xomChill)` smooths the
+                        // transition as the user advances sets.
+                        .scaleEffect(isFocused && !isCompleted ? 1.1 : 1.0)
+                        .animation(.xomChill, value: isFocused)
                         // Ensure 44pt min touch target around the 36pt visual
                         .frame(minWidth: 44, minHeight: 44)
                         .contentShape(Rectangle())
@@ -278,16 +354,29 @@ struct WorkoutFocusView: View {
                     .buttonStyle(.plain)
                     // Long-press to delete (#344 C). Guarded so the last
                     // remaining set is never deletable — every exercise needs
-                    // at least one set in focus mode.
+                    // at least one set in focus mode. Surfaced as both
+                    // long-press AND a context menu so the affordance is
+                    // discoverable (#411 bug 5).
                     .onLongPressGesture(minimumDuration: 0.5) {
                         guard canDelete else { return }
                         Haptics.selection()
                         pendingDeleteSetIndex = idx
                         showDeleteSetConfirm = true
                     }
+                    .contextMenu {
+                        if canDelete {
+                            Button(role: .destructive) {
+                                Haptics.warning()
+                                pendingDeleteSetIndex = idx
+                                showDeleteSetConfirm = true
+                            } label: {
+                                Label("Remove set", systemImage: "trash")
+                            }
+                        }
+                    }
                     .accessibilityLabel("Set \(idx + 1)\(isCompleted ? ", completed" : "")\(isFocused ? ", current" : "")")
                     .accessibilityHint(canDelete
-                        ? "Long press to delete"
+                        ? "Long press or use the context menu to delete this set"
                         : "Add another set before this one can be deleted")
                 }
 

--- a/Xomfit/XomfitApp.swift
+++ b/Xomfit/XomfitApp.swift
@@ -280,6 +280,10 @@ struct XomFitApp: App {
     ///                                     the fullscreen overlay renders
     ///   XOMFIT_AUTO_MINIMIZE_REST=1     → start the rest timer in its minimized
     ///                                     banner state (read by WorkoutFocusView)
+    ///   XOMFIT_AUTO_FOCUS_WEIGHT=1      → auto-focus the weight TextField in
+    ///                                     focus mode so the keyboard-collapse
+    ///                                     compact mode (#411 bug 6) renders.
+    ///                                     Read by WorkoutFocusView's onAppear.
     @MainActor
     private func seedDebugActiveWorkout() {
         let env = ProcessInfo.processInfo.environment


### PR DESCRIPTION
## Summary

Six bugs on TestFlight 2.1.1, all in active workout list + focus views.

### Bug 1 — list-mode top gap STILL there (4th attempt)
Root cause: **double-applied safe-area inset**. The parent ZStack already respects safe area, then `headerBar` was adding another `max(UIKit_inset, 62)pt` on top → ~120pt of empty space. Removed the UIKit-derived padding entirely; `headerBar` now just adds `Theme.Spacing.xs` (4pt) in list mode and `Theme.Spacing.lg` (24pt) in focus mode on top of the natural inset. Background still uses `.ignoresSafeArea(edges: .top)` so the surface color extends behind the status bar.

### Bug 2 — list-mode rest timer had no Lift button
Added primary-CTA Lift capsule to `RestTimerView` next to Skip / +30s. Wired to the existing `onSkip` closure → ends timer + tees up next set, same as focus-mode Lift.

### Bug 3 — minimized rest banner overlapped DONE + inconsistent with header chip
Moved the minimized rest banner out of the focus VStack's bottom slot and into a sibling `.safeAreaInset(edge: .bottom)`. `exerciseNavigation` always renders in the bottom slot now. Banner sits above the home indicator with `Theme.Spacing.sm` clearance — DONE no longer overlapped. Header rest chip simplified to a single informational pill (no tap-to-expand variant from PR #409) so list + focus look identical.

### Bug 4 — current-set indicator
- **Focus chips**: outer accent ring + 22%-alpha fill + 1.1× scale on focused-incomplete set
- **List rows**: new `isCurrentSet` prop on `SetRowView`; `ExerciseCard` computes first-incomplete (fallback: last) and tints with 12%-alpha fill + 1.5pt accent border

### Bug 5 — remove sets from focus view
Long-press was already wired but undiscoverable. Added `.contextMenu` with destructive "Remove set" on each focus set chip. Both routes drive the same `viewModel.removeSet(exerciseIndex:setIndex:)` flow.

### Bug 6 — keyboard overlapping inputs
New `keyboardCompactMode` driven by `weightFieldFocused || repsFieldFocused`. When true, hides exercise header / config row / set chips / drop-set / exercise nav — leaving just exercise name + weight/reps/DONE visible. Animated `.xomChill`. New DEBUG env var `XOMFIT_AUTO_FOCUS_WEIGHT=1` for screenshot reproducibility.

## Verified (5 screenshots on iPhone 17 simulator)
1. List, no rest — toolbar tight to DI (~10pt gap)
2. List, rest active — Lift button visible inline
3. Focus, rest minimized — banner below DONE, no overlap
4. Focus, weight field active — top collapsed
5. List — current set highlighted

## Test plan
- [ ] List view — no big void at the top
- [ ] List rest timer — Lift button works
- [ ] Focus rest minimized — DONE still tappable
- [ ] Set chips highlight the active set in both views
- [ ] Long-press a focus chip → context menu with Remove
- [ ] Tap weight → top collapses, keyboard doesn't cover