### PR TITLE
feat(feed,soundtrack): pull-to-refresh fix + featured track + share toggle + deep links

### DIFF
--- a/Xomfit/Models/SocialFeedItem.swift
+++ b/Xomfit/Models/SocialFeedItem.swift
@@ -64,6 +64,14 @@ struct WorkoutActivity: Codable {
     /// `trackCount` is 0 and `firstTrackTitle` is nil when the workout had no captured tracks.
     var trackCount: Int?
     var firstTrackTitle: String?
+    /// Featured track surfaced prominently on the feed card (#410). Filled in
+    /// by `FeedService.buildWorkoutActivity` when the workout has a
+    /// `featuredTrackId` — otherwise nil so the card falls back to the
+    /// `firstTrackTitle` teaser or no soundtrack chrome at all.
+    var featuredTrackTitle: String?
+    var featuredTrackArtist: String?
+    var featuredTrackSource: String?
+    var featuredTrackURL: String?
 
     struct ExerciseSummary: Codable, Identifiable {
         let id: String

--- a/Xomfit/Models/Workout.swift
+++ b/Xomfit/Models/Workout.swift
@@ -38,6 +38,14 @@ struct Workout: Codable, Identifiable {
     /// Target round count. Used by `.amrap` (best-effort cap) and `.emom`
     /// (work intervals). Nil for `.setsReps` and `.timedCircuit`.
     var roundsGoal: Int? = nil
+    /// Featured soundtrack id — references one of `tracks` to display
+    /// prominently on the feed card. `nil` when the user didn't pick one (#410).
+    /// Stored as `String?` to match the `WorkoutTrack.id` UUID's `uuidString`.
+    var featuredTrackId: String? = nil
+    /// When `false` only the featured track is shown to other users in the feed
+    /// expanded view; the rest stay private. Defaults to `true` (share all) so
+    /// existing posts keep their behavior. (#410)
+    var shareFullSoundtrack: Bool = true
 
     var startDate: Date { startTime }
 
@@ -48,6 +56,7 @@ struct Workout: Codable, Identifiable {
     enum CodingKeys: String, CodingKey {
         case id, userId, name, exercises, startTime, endTime, notes, location, rating, tracks
         case kind, durationGoalMinutes, roundsGoal
+        case featuredTrackId, shareFullSoundtrack
     }
 
     init(
@@ -63,7 +72,9 @@ struct Workout: Codable, Identifiable {
         tracks: [WorkoutTrack] = [],
         kind: WorkoutKind = .setsReps,
         durationGoalMinutes: Int? = nil,
-        roundsGoal: Int? = nil
+        roundsGoal: Int? = nil,
+        featuredTrackId: String? = nil,
+        shareFullSoundtrack: Bool = true
     ) {
         self.id = id
         self.userId = userId
@@ -78,6 +89,8 @@ struct Workout: Codable, Identifiable {
         self.kind = kind
         self.durationGoalMinutes = durationGoalMinutes
         self.roundsGoal = roundsGoal
+        self.featuredTrackId = featuredTrackId
+        self.shareFullSoundtrack = shareFullSoundtrack
     }
 
     init(from decoder: Decoder) throws {
@@ -95,6 +108,15 @@ struct Workout: Codable, Identifiable {
         kind = try container.decodeIfPresent(WorkoutKind.self, forKey: .kind) ?? .setsReps
         durationGoalMinutes = try container.decodeIfPresent(Int.self, forKey: .durationGoalMinutes)
         roundsGoal = try container.decodeIfPresent(Int.self, forKey: .roundsGoal)
+        featuredTrackId = try container.decodeIfPresent(String.self, forKey: .featuredTrackId)
+        shareFullSoundtrack = try container.decodeIfPresent(Bool.self, forKey: .shareFullSoundtrack) ?? true
+    }
+
+    /// Convenience lookup for the featured `WorkoutTrack`. Returns `nil` if no
+    /// featured id is set or the id no longer points to a captured track.
+    var featuredTrack: WorkoutTrack? {
+        guard let featuredTrackId else { return nil }
+        return tracks.first { $0.id.uuidString == featuredTrackId }
     }
 
     var duration: TimeInterval {

--- a/Xomfit/Models/WorkoutTrack.swift
+++ b/Xomfit/Models/WorkoutTrack.swift
@@ -16,4 +16,46 @@ struct WorkoutTrack: Codable, Hashable, Identifiable {
     /// Source application that surfaced the track (e.g. "Apple Music"). Hard-coded for v1
     /// because Apple Music is the only legal capture target.
     var sourceApp: String
+    /// Canonical URL or URI of the track on its source service. Used to power
+    /// per-track deep links in the feed expanded view (#410). Optional and
+    /// backward-compatible — older cached / decoded payloads decode as `nil`.
+    ///
+    /// Examples:
+    /// - Spotify: `spotify:track:<id>` or `https://open.spotify.com/track/<id>`
+    /// - Apple Music: `https://music.apple.com/...`
+    /// - SoundCloud: track permalink URL
+    var url: String? = nil
+
+    enum CodingKeys: String, CodingKey {
+        case id, title, artist, album, capturedAt, sourceApp, url
+    }
+
+    init(
+        id: UUID = UUID(),
+        title: String,
+        artist: String? = nil,
+        album: String? = nil,
+        capturedAt: Date,
+        sourceApp: String,
+        url: String? = nil
+    ) {
+        self.id = id
+        self.title = title
+        self.artist = artist
+        self.album = album
+        self.capturedAt = capturedAt
+        self.sourceApp = sourceApp
+        self.url = url
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decodeIfPresent(UUID.self, forKey: .id) ?? UUID()
+        title = try container.decode(String.self, forKey: .title)
+        artist = try container.decodeIfPresent(String.self, forKey: .artist)
+        album = try container.decodeIfPresent(String.self, forKey: .album)
+        capturedAt = try container.decode(Date.self, forKey: .capturedAt)
+        sourceApp = try container.decode(String.self, forKey: .sourceApp)
+        url = try container.decodeIfPresent(String.self, forKey: .url)
+    }
 }

--- a/Xomfit/Services/DebugFixtures.swift
+++ b/Xomfit/Services/DebugFixtures.swift
@@ -56,8 +56,15 @@ enum DebugFixtures {
                     location: "Home Gym",
                     rating: 4,
                     photoURLs: nil,
-                    trackCount: nil,
-                    firstTrackTitle: nil
+                    trackCount: 3,
+                    firstTrackTitle: "Power",
+                    // #410 — seed a featured track + URL so the feed card +
+                    // expanded detail render the anthem-style row and the
+                    // deep-link buttons under bypass.
+                    featuredTrackTitle: "Power",
+                    featuredTrackArtist: "Kanye West",
+                    featuredTrackSource: "Spotify",
+                    featuredTrackURL: "https://open.spotify.com/track/2gZUPNdnz5Y45eiGxpHGSc"
                 ),
                 caption: "Felt strong on bench today.",
                 visibility: .friends
@@ -99,6 +106,72 @@ enum DebugFixtures {
                 visibility: .friends
             )
         ]
+    }
+
+    /// Mock workout used by `WorkoutService.fetchWorkout` under bypass (#410).
+    /// Includes a captured soundtrack with one featured track + per-track URLs
+    /// so the expanded feed view can render deep-link buttons end-to-end.
+    static func bypassWorkout(id: String) -> Workout? {
+        guard id == "bypass-w-1" else { return nil }
+        let now = Date()
+        let track1ID = UUID()
+        let track2ID = UUID()
+        let track3ID = UUID()
+        let tracks: [WorkoutTrack] = [
+            WorkoutTrack(
+                id: track1ID,
+                title: "Power",
+                artist: "Kanye West",
+                album: "My Beautiful Dark Twisted Fantasy",
+                capturedAt: now.addingTimeInterval(-3300),
+                sourceApp: "Spotify",
+                url: "https://open.spotify.com/track/2gZUPNdnz5Y45eiGxpHGSc"
+            ),
+            WorkoutTrack(
+                id: track2ID,
+                title: "Till I Collapse",
+                artist: "Eminem",
+                album: "The Eminem Show",
+                capturedAt: now.addingTimeInterval(-2700),
+                sourceApp: "Apple Music",
+                url: nil
+            ),
+            WorkoutTrack(
+                id: track3ID,
+                title: "Stronger",
+                artist: "Kanye West",
+                album: "Graduation",
+                capturedAt: now.addingTimeInterval(-1800),
+                sourceApp: "SoundCloud",
+                url: "https://soundcloud.com/kanyewest/stronger"
+            )
+        ]
+
+        return Workout(
+            id: id,
+            userId: AppUser.mockDebugFriend.id,
+            name: "Push Day",
+            exercises: [
+                WorkoutExercise(
+                    id: "bypass-we-1",
+                    exercise: .benchPress,
+                    sets: [
+                        WorkoutSet(id: "bypass-s-1", exerciseId: "ex-1", weight: 185, reps: 8, rpe: 7, isPersonalRecord: false, completedAt: now),
+                        WorkoutSet(id: "bypass-s-2", exerciseId: "ex-1", weight: 205, reps: 6, rpe: 8, isPersonalRecord: false, completedAt: now),
+                        WorkoutSet(id: "bypass-s-3", exerciseId: "ex-1", weight: 225, reps: 5, rpe: 9, isPersonalRecord: true, completedAt: now)
+                    ],
+                    notes: nil
+                )
+            ],
+            startTime: now.addingTimeInterval(-3300),
+            endTime: now.addingTimeInterval(-300),
+            notes: "Felt strong on bench today.",
+            location: "Home Gym",
+            rating: 4,
+            tracks: tracks,
+            featuredTrackId: track1ID.uuidString,
+            shareFullSoundtrack: true
+        )
     }
 
     // MARK: - Private

--- a/Xomfit/Services/FeedService.swift
+++ b/Xomfit/Services/FeedService.swift
@@ -311,6 +311,16 @@ final class FeedService {
         let trackCount: Int? = workout.tracks.isEmpty ? nil : workout.tracks.count
         let firstTrackTitle: String? = workout.tracks.first?.title
 
+        // Featured track payload (#410). When the poster picked a featured
+        // track we surface its title/artist/source/url so feed cards render
+        // the prominent anthem-style row without needing to fetch the full
+        // workout. Falls back to nil when no featured pick was made.
+        let featured = workout.featuredTrack
+        let featuredTrackTitle = featured?.title
+        let featuredTrackArtist = featured?.artist
+        let featuredTrackSource = featured?.sourceApp
+        let featuredTrackURL = featured?.url
+
         return WorkoutActivity(
             workoutId: workout.id,
             workoutName: workout.name,
@@ -324,7 +334,11 @@ final class FeedService {
             rating: workout.rating,
             photoURLs: photoURLs,
             trackCount: trackCount,
-            firstTrackTitle: firstTrackTitle
+            firstTrackTitle: firstTrackTitle,
+            featuredTrackTitle: featuredTrackTitle,
+            featuredTrackArtist: featuredTrackArtist,
+            featuredTrackSource: featuredTrackSource,
+            featuredTrackURL: featuredTrackURL
         )
     }
 

--- a/Xomfit/Services/SoundCloudNowPlayingService.swift
+++ b/Xomfit/Services/SoundCloudNowPlayingService.swift
@@ -148,12 +148,16 @@ final class SoundCloudNowPlayingService {
         // SoundCloud puts the uploader's display name on `user.username` — closest analogue
         // to a primary artist. Real "artist" metadata is rarely populated on SC uploads.
         let artist = latest.track?.user?.username
+        // Carry the permalink so the feed expanded view can deep-link straight
+        // back into SoundCloud (#410). Nil-safe fallback handled by the
+        // deep-link resolver — empty permalink degrades to a SoundCloud search.
         let track = WorkoutTrack(
             title: title,
             artist: (artist?.isEmpty == false) ? artist : nil,
             album: nil,
             capturedAt: Date(),
-            sourceApp: "SoundCloud"
+            sourceApp: "SoundCloud",
+            url: latest.track?.permalink_url
         )
         captured.append(track)
         lastCapturedTrack = track

--- a/Xomfit/Services/SpotifyNowPlayingService.swift
+++ b/Xomfit/Services/SpotifyNowPlayingService.swift
@@ -153,12 +153,26 @@ final class SpotifyNowPlayingService {
             seenKeys.insert(key)
 
             let artist = item.artists?.compactMap { $0.name }.joined(separator: ", ")
+            // Prefer the https web URL (#410) — opens cleanly in browser and
+            // on phones with the Spotify app installed it routes natively.
+            // Fall back to the `spotify:track:<id>` URI if neither is present
+            // we leave `url` nil and the feed deep link falls back to search.
+            let trackURL: String? = {
+                if let id = item.id, !id.isEmpty {
+                    return "https://open.spotify.com/track/\(id)"
+                }
+                if let uri = item.uri, !uri.isEmpty {
+                    return uri
+                }
+                return nil
+            }()
             let track = WorkoutTrack(
                 title: title,
                 artist: (artist?.isEmpty == false) ? artist : nil,
                 album: item.album?.name,
                 capturedAt: Date(),
-                sourceApp: "Spotify"
+                sourceApp: "Spotify",
+                url: trackURL
             )
             captured.append(track)
             lastCapturedTrack = track

--- a/Xomfit/Services/WorkoutService.swift
+++ b/Xomfit/Services/WorkoutService.swift
@@ -263,6 +263,16 @@ final class WorkoutService {
     // MARK: - Fetch
 
     func fetchWorkout(id: String) async -> Workout? {
+        #if DEBUG
+        // #410 + #353 bypass — surface a mock workout with tracks + featured
+        // pick so FeedDetailView's expanded soundtrack list + deep-link buttons
+        // can be screenshot-verified from a cold launch.
+        if ProcessInfo.processInfo.environment["XOMFIT_AUTH_BYPASS"] == "1",
+           let mock = DebugFixtures.bypassWorkout(id: id) {
+            return mock
+        }
+        #endif
+
         do {
             let rows: [WorkoutWithRelations] = try await supabase
                 .from("workouts")

--- a/Xomfit/Utils/WorkoutTrackDeepLink.swift
+++ b/Xomfit/Utils/WorkoutTrackDeepLink.swift
@@ -1,0 +1,86 @@
+import Foundation
+
+/// Resolves a deep link URL for a captured `WorkoutTrack` so the feed expanded
+/// view can punt the user out to Spotify / Apple Music / SoundCloud. (#410)
+///
+/// Each service has a preferred form:
+/// - Spotify: `spotify:track:<id>` if we captured a URI, else a https web URL,
+///   else a search URL by title+artist.
+/// - Apple Music: the captured track URL when present, else a search URL.
+/// - SoundCloud: the captured permalink URL when present, else a search URL.
+///
+/// `WorkoutTrack.url` is filled in by the per-source capture services starting
+/// in #410 — older captured tracks (no `url`) fall through to the search-URL
+/// branch so the deep link still gets the user to roughly the right place.
+enum WorkoutTrackDeepLink {
+    /// Returns the best deep link `URL` for the given track, or `nil` if we
+    /// can't build one (title empty + unknown source).
+    static func url(for track: WorkoutTrack) -> URL? {
+        let source = track.sourceApp.lowercased()
+        switch source {
+        case "spotify":
+            return spotifyURL(for: track)
+        case "apple music":
+            return appleMusicURL(for: track)
+        case "soundcloud":
+            return soundCloudURL(for: track)
+        default:
+            // Manual / unknown — fall back to a generic Apple Music search so
+            // the button still does *something* useful for the user.
+            return appleMusicSearchURL(for: track)
+        }
+    }
+
+    /// Human-readable label for the deep-link button. Mirrors the source so the
+    /// VoiceOver string + visible chevron stay aligned.
+    static func label(for sourceApp: String) -> String {
+        switch sourceApp.lowercased() {
+        case "spotify":     return "Open in Spotify"
+        case "apple music": return "Open in Apple Music"
+        case "soundcloud":  return "Open in SoundCloud"
+        case "manual":      return "Search this track"
+        default:            return "Open track"
+        }
+    }
+
+    // MARK: - Private builders
+
+    private static func spotifyURL(for track: WorkoutTrack) -> URL? {
+        if let raw = track.url, !raw.isEmpty, let url = URL(string: raw) {
+            return url
+        }
+        // No captured uri — punt to web search.
+        let q = encodedQuery(title: track.title, artist: track.artist)
+        return URL(string: "https://open.spotify.com/search/\(q)")
+    }
+
+    private static func appleMusicURL(for track: WorkoutTrack) -> URL? {
+        if let raw = track.url, !raw.isEmpty, let url = URL(string: raw) {
+            return url
+        }
+        return appleMusicSearchURL(for: track)
+    }
+
+    private static func appleMusicSearchURL(for track: WorkoutTrack) -> URL? {
+        let q = encodedQuery(title: track.title, artist: track.artist)
+        return URL(string: "https://music.apple.com/us/search?term=\(q)")
+    }
+
+    private static func soundCloudURL(for track: WorkoutTrack) -> URL? {
+        if let raw = track.url, !raw.isEmpty, let url = URL(string: raw) {
+            return url
+        }
+        let q = encodedQuery(title: track.title, artist: track.artist)
+        return URL(string: "https://soundcloud.com/search?q=\(q)")
+    }
+
+    /// URL-encodes "title artist" with `+` separators. Empty artist is fine.
+    private static func encodedQuery(title: String, artist: String?) -> String {
+        var raw = title
+        if let artist, !artist.isEmpty {
+            raw += " " + artist
+        }
+        let allowed = CharacterSet.urlQueryAllowed
+        return raw.addingPercentEncoding(withAllowedCharacters: allowed) ?? raw
+    }
+}

--- a/Xomfit/ViewModels/FeedViewModel.swift
+++ b/Xomfit/ViewModels/FeedViewModel.swift
@@ -61,8 +61,18 @@ final class FeedViewModel {
 
     // MARK: - Load Feed
 
+    /// Initial fetch (or full reload on error retry). Shows the full skeleton
+    /// while the network is in flight by flipping `isLoading`. Replaces the
+    /// existing feed wholesale on success. Use `refreshFeed` for pull-to-refresh
+    /// — that variant keeps the prior items visible so the system spinner
+    /// owns the loading affordance.
     func loadFeed(userId: String) async {
-        isLoading = true
+        // Only flip the loading skeleton when the feed is empty. Re-entering
+        // this function after a prior successful load (e.g. tab switch) keeps
+        // the existing rows on-screen while we refetch in the background so
+        // the user never sees a flash of the skeleton (#410).
+        let showSkeleton = feedItems.isEmpty
+        if showSkeleton { isLoading = true }
         errorMessage = nil
         loadMoreError = nil
         offset = 0
@@ -93,10 +103,38 @@ final class FeedViewModel {
         isLoading = false
     }
 
+    /// Pull-to-refresh entry point. Re-fetches the first page without touching
+    /// `isLoading` so the existing list stays mounted and the system pull
+    /// spinner owns the loading UI. The await chain runs all the way through
+    /// the network call so SwiftUI's `.refreshable` correctly dismisses its
+    /// spinner only after the new data is applied. (#410)
     func refreshFeed(userId: String) async {
+        // Don't trip `isLoading` — that swaps the list for the skeleton and
+        // races with the system pull-to-refresh spinner.
         isRefreshing = true
-        await loadFeed(userId: userId)
-        isRefreshing = false
+        defer { isRefreshing = false }
+
+        loadMoreError = nil
+
+        do {
+            let items = try await FeedService.shared.fetchFeed(
+                userId: userId,
+                limit: pageSize,
+                offset: 0
+            )
+            feedItems = items
+            offset = items.count
+            hasMore = items.count == pageSize
+            errorMessage = nil
+        } catch is CancellationError {
+            // A subsequent refresh replaced this one — leave the existing
+            // list intact.
+            return
+        } catch let urlError as URLError where urlError.code == .cancelled {
+            return
+        } catch {
+            errorMessage = error.localizedDescription
+        }
     }
 
     /// #311: re-applies the current filters without re-fetching, but flips

--- a/Xomfit/ViewModels/WorkoutLoggerViewModel.swift
+++ b/Xomfit/ViewModels/WorkoutLoggerViewModel.swift
@@ -33,6 +33,26 @@ final class WorkoutLoggerViewModel {
     /// the merged snapshot of (Apple Music + Spotify + manual).
     var removedTrackIDs: Set<UUID> = []
 
+    /// Featured track id (the soundtrack pick surfaced on the feed card). Set
+    /// by tapping the star icon on a soundtrack row in the finish sheet (#410).
+    /// At most one track is featured at a time; tapping the same row clears it.
+    var featuredTrackId: UUID? = nil
+
+    /// When `false` only the featured track is shared on the feed; the rest of
+    /// the captured soundtrack stays private (#410). Default ON to preserve
+    /// existing behavior for users who don't touch the toggle.
+    var shareFullSoundtrack: Bool = true
+
+    /// Toggle the featured track id. Tapping the same row clears the pick so
+    /// the user can fully unstick a featured choice without leaving the sheet.
+    func toggleFeaturedTrack(_ id: UUID) {
+        if featuredTrackId == id {
+            featuredTrackId = nil
+        } else {
+            featuredTrackId = id
+        }
+    }
+
     // Rest timer
     var restTimeRemaining: Double = 0
     var restDuration: Double = 0
@@ -1551,6 +1571,15 @@ final class WorkoutLoggerViewModel {
             .filter { !removedTrackIDs.contains($0.id) }
             .sorted { $0.capturedAt < $1.capturedAt }
 
+        // Featured soundtrack pick (#410). Only carry through when the chosen
+        // track survived the curated soundtrack (i.e. wasn't removed before
+        // finish), otherwise drop it so we don't ship a dangling id.
+        let validFeaturedId: String? = {
+            guard let picked = featuredTrackId,
+                  capturedTracks.contains(where: { $0.id == picked }) else { return nil }
+            return picked.uuidString
+        }()
+
         let workout = Workout(
             id: UUID().uuidString,
             userId: userId,
@@ -1564,7 +1593,9 @@ final class WorkoutLoggerViewModel {
             tracks: capturedTracks,
             kind: kind,
             durationGoalMinutes: durationGoalMinutes,
-            roundsGoal: roundsGoal
+            roundsGoal: roundsGoal,
+            featuredTrackId: validFeaturedId,
+            shareFullSoundtrack: shareFullSoundtrack
         )
 
         do {

--- a/Xomfit/Views/Feed/FeedDetailView.swift
+++ b/Xomfit/Views/Feed/FeedDetailView.swift
@@ -134,6 +134,15 @@ struct FeedDetailView: View {
 
                 // Real exercise data from DB
                 exerciseSection
+
+                // Soundtrack (#410). Respects `shareFullSoundtrack`:
+                // - own post: always show everything
+                // - other user's post: show all when share-full is on; show
+                //   only the featured track when off
+                if let workout = fetchedWorkout, !workout.tracks.isEmpty {
+                    XomDivider()
+                    soundtrackSection(workout: workout)
+                }
             }
 
             XomDivider()
@@ -388,6 +397,130 @@ struct FeedDetailView: View {
 
             Spacer()
         }
+    }
+
+    // MARK: - Soundtrack (#410)
+
+    /// Captured-soundtrack list shown under the workout summary. Respects the
+    /// poster's `shareFullSoundtrack` toggle for non-owner views — when off,
+    /// only the featured track surfaces. The owner always sees the full list
+    /// so they can review what's stored on the workout.
+    @ViewBuilder
+    private func soundtrackSection(workout: Workout) -> some View {
+        let visibleTracks = visibleTracks(in: workout)
+        if !visibleTracks.isEmpty {
+            VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+                HStack(spacing: 6) {
+                    Image(systemName: "music.note")
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(Theme.accent)
+                    Text("Soundtrack")
+                        .font(.subheadline.weight(.bold))
+                        .foregroundStyle(Theme.textPrimary)
+                    Spacer()
+                    Text("\(visibleTracks.count)")
+                        .font(.caption.weight(.semibold).monospaced())
+                        .foregroundStyle(Theme.textSecondary)
+                }
+
+                VStack(spacing: 0) {
+                    ForEach(Array(visibleTracks.enumerated()), id: \.element.id) { index, track in
+                        feedTrackRow(track: track, isFeatured: workout.featuredTrackId == track.id.uuidString)
+                        if index < visibleTracks.count - 1 {
+                            Divider()
+                                .background(Theme.textSecondary.opacity(0.15))
+                                .padding(.leading, Theme.Spacing.md)
+                        }
+                    }
+                }
+                .background(Theme.background)
+                .clipShape(.rect(cornerRadius: Theme.cornerRadiusSmall))
+
+                if !workout.shareFullSoundtrack && !isOwnPost {
+                    Text("Only the featured track was shared.")
+                        .font(Theme.fontSmall)
+                        .foregroundStyle(Theme.textTertiary)
+                }
+            }
+        }
+    }
+
+    /// Returns the slice of `workout.tracks` that should be displayed for the
+    /// current viewer. Owner sees everything; friends see everything when
+    /// `shareFullSoundtrack` is true, otherwise just the featured track.
+    private func visibleTracks(in workout: Workout) -> [WorkoutTrack] {
+        if isOwnPost || workout.shareFullSoundtrack {
+            return workout.tracks
+        }
+        if let featured = workout.featuredTrack {
+            return [featured]
+        }
+        return []
+    }
+
+    /// Single track row used inside the feed expanded soundtrack section. Wraps
+    /// title/artist/source plus a trailing deep-link button.
+    @ViewBuilder
+    private func feedTrackRow(track: WorkoutTrack, isFeatured: Bool) -> some View {
+        let deepLinkURL = WorkoutTrackDeepLink.url(for: track)
+        HStack(spacing: Theme.Spacing.sm) {
+            if isFeatured {
+                Image(systemName: "star.fill")
+                    .font(Theme.fontCaption.weight(.bold))
+                    .foregroundStyle(Theme.accent)
+                    .frame(width: 20)
+                    .accessibilityHidden(true)
+            } else {
+                Image(systemName: "music.note")
+                    .font(Theme.fontCaption)
+                    .foregroundStyle(Theme.textSecondary)
+                    .frame(width: 20)
+                    .accessibilityHidden(true)
+            }
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(track.title)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(Theme.textPrimary)
+                    .lineLimit(1)
+                HStack(spacing: 6) {
+                    if let artist = track.artist, !artist.isEmpty {
+                        Text(artist)
+                            .font(Theme.fontCaption)
+                            .foregroundStyle(Theme.textSecondary)
+                            .lineLimit(1)
+                        Text("\u{2022}")
+                            .font(.caption2.weight(.bold))
+                            .foregroundStyle(Theme.textTertiary)
+                            .accessibilityHidden(true)
+                    }
+                    Text(track.sourceApp)
+                        .font(Theme.fontSmall)
+                        .foregroundStyle(Theme.textTertiary)
+                }
+            }
+
+            Spacer()
+
+            if let url = deepLinkURL {
+                Button {
+                    Haptics.light()
+                    UIApplication.shared.open(url)
+                } label: {
+                    Image(systemName: "arrow.up.right.square")
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(Theme.accent)
+                        .frame(width: 44, height: 44)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(WorkoutTrackDeepLink.label(for: track.sourceApp))
+                .accessibilityHint("Opens this track in \(track.sourceApp).")
+            }
+        }
+        .padding(.horizontal, Theme.Spacing.md)
+        .padding(.vertical, 8)
+        .accessibilityElement(children: .contain)
     }
 
     // MARK: - Helpers

--- a/Xomfit/Views/Feed/FeedItemCard.swift
+++ b/Xomfit/Views/Feed/FeedItemCard.swift
@@ -37,6 +37,20 @@ struct FeedItemCard: View {
                     AnthemRow(anthem: anthem, style: .feed)
                 }
 
+                // Featured soundtrack row (#410) — surfaces the poster's
+                // featured-track pick from this workout in the same compact
+                // anthem-row style. Nil when no featured pick was made.
+                if let activity = item.workoutActivity,
+                   let featuredTitle = activity.featuredTrackTitle,
+                   !featuredTitle.isEmpty {
+                    FeaturedSoundtrackRow(
+                        title: featuredTitle,
+                        artist: activity.featuredTrackArtist ?? "",
+                        sourceApp: activity.featuredTrackSource ?? "",
+                        deepLinkURL: featuredDeepLinkURL(activity: activity)
+                    )
+                }
+
                 activityContent
 
                 if let caption = item.caption, !caption.isEmpty {
@@ -289,6 +303,23 @@ struct FeedItemCard: View {
         }
     }
 
+    // MARK: - Featured soundtrack helper (#410)
+
+    /// Builds a deep-link `URL` from the captured payload fields. Falls through
+    /// to a synthesized `WorkoutTrack` so we can reuse the shared resolver
+    /// without having to fetch the full workout just to render the feed card.
+    private func featuredDeepLinkURL(activity: WorkoutActivity) -> URL? {
+        guard let title = activity.featuredTrackTitle, !title.isEmpty else { return nil }
+        let synthesized = WorkoutTrack(
+            title: title,
+            artist: activity.featuredTrackArtist,
+            capturedAt: Date(),
+            sourceApp: activity.featuredTrackSource ?? "",
+            url: activity.featuredTrackURL
+        )
+        return WorkoutTrackDeepLink.url(for: synthesized)
+    }
+
     // MARK: - Share
 
     private func shareFeedItem() {
@@ -513,5 +544,87 @@ private struct StreakActivityContent: View {
         .accessibilityLabel(activity.isNewRecord
             ? "\(activity.currentStreak) day streak, new personal record"
             : "\(activity.currentStreak) day streak, previous best \(activity.previousBest) days")
+    }
+}
+
+// MARK: - Featured Soundtrack Row (#410)
+
+/// Compact "featured soundtrack" row used on each workout feed card. Visual
+/// matches `AnthemRow` (#403) so the two stacks read as siblings — the anthem
+/// is the poster's profile pick, the featured soundtrack is from this specific
+/// workout. Tapping the trailing button deep-links into the source service.
+private struct FeaturedSoundtrackRow: View {
+    let title: String
+    let artist: String
+    let sourceApp: String
+    let deepLinkURL: URL?
+
+    var body: some View {
+        HStack(spacing: Theme.Spacing.sm) {
+            ZStack {
+                Circle()
+                    .fill(Theme.accent)
+                    .frame(width: 28, height: 28)
+                Image(systemName: "star.fill")
+                    .font(.system(size: 12, weight: .black))
+                    .foregroundStyle(Theme.background)
+            }
+
+            VStack(alignment: .leading, spacing: 1) {
+                Text(title)
+                    .font(Theme.fontCaption.weight(.semibold))
+                    .foregroundStyle(Theme.textPrimary)
+                    .lineLimit(1)
+                HStack(spacing: 6) {
+                    if !artist.isEmpty {
+                        Text(artist)
+                            .font(Theme.fontCaption2)
+                            .foregroundStyle(Theme.textSecondary)
+                            .lineLimit(1)
+                        Text("\u{2022}")
+                            .font(.caption2.weight(.bold))
+                            .foregroundStyle(Theme.textTertiary)
+                            .accessibilityHidden(true)
+                    }
+                    if !sourceApp.isEmpty {
+                        Text(sourceApp)
+                            .font(Theme.fontCaption2)
+                            .foregroundStyle(Theme.textTertiary)
+                    }
+                }
+            }
+
+            Spacer(minLength: 0)
+
+            if let url = deepLinkURL {
+                Button {
+                    Haptics.light()
+                    UIApplication.shared.open(url)
+                } label: {
+                    Image(systemName: "arrow.up.right.square")
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundStyle(Theme.accent)
+                        .frame(minWidth: 44, minHeight: 44)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                // Don't bubble taps to the parent card (which opens detail).
+                .simultaneousGesture(TapGesture().onEnded {})
+                .accessibilityLabel(WorkoutTrackDeepLink.label(for: sourceApp))
+                .accessibilityHint("Opens this featured track in \(sourceApp).")
+            }
+        }
+        .padding(.vertical, Theme.Spacing.xs)
+        .padding(.horizontal, Theme.Spacing.sm)
+        .background(
+            RoundedRectangle(cornerRadius: Theme.Radius.sm)
+                .fill(Theme.accent.opacity(0.10))
+                .overlay(
+                    RoundedRectangle(cornerRadius: Theme.Radius.sm)
+                        .strokeBorder(Theme.accent.opacity(0.35), lineWidth: 0.5)
+                )
+        )
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Featured track: \(title)\(artist.isEmpty ? "" : ", by \(artist)")")
     }
 }

--- a/Xomfit/Views/Feed/FeedView.swift
+++ b/Xomfit/Views/Feed/FeedView.swift
@@ -74,16 +74,18 @@ struct FeedView: View {
                     } else {
                         ZStack {
                             feedList
-                            // #311: brief skeleton overlay while a refresh
-                            // or filter change is in flight so the list
-                            // doesn't pop without feedback.
-                            if viewModel.isRefreshing || viewModel.isFiltering {
+                            // #311: brief skeleton overlay while a filter
+                            // change is in flight so the list doesn't pop
+                            // without feedback. Pull-to-refresh is handled
+                            // by the system `.refreshable` spinner on the
+                            // list itself — overlaying a skeleton on top of
+                            // that caused a double-spinner glitch (#410).
+                            if viewModel.isFiltering {
                                 feedSkeleton
                                     .background(Theme.background)
                                     .transition(.opacity)
                             }
                         }
-                        .animation(.easeInOut(duration: 0.2), value: viewModel.isRefreshing)
                         .animation(.easeInOut(duration: 0.2), value: viewModel.isFiltering)
                     }
                 }

--- a/Xomfit/Views/Workout/ActiveWorkoutView.swift
+++ b/Xomfit/Views/Workout/ActiveWorkoutView.swift
@@ -1872,11 +1872,20 @@ private struct FinishWorkoutSheet: View {
             } else {
                 VStack(spacing: 0) {
                     ForEach(tracks) { track in
-                        SoundtrackRow(track: track) {
-                            withAnimation(.xomChill) {
-                                viewModel.removeCapturedTrack(id: track.id)
+                        SoundtrackRow(
+                            track: track,
+                            isFeatured: viewModel.featuredTrackId == track.id,
+                            onToggleFeatured: {
+                                withAnimation(.xomChill) {
+                                    viewModel.toggleFeaturedTrack(track.id)
+                                }
+                            },
+                            onRemove: {
+                                withAnimation(.xomChill) {
+                                    viewModel.removeCapturedTrack(id: track.id)
+                                }
                             }
-                        }
+                        )
                         if track.id != tracks.last?.id {
                             Divider()
                                 .background(Theme.textSecondary.opacity(0.15))
@@ -1890,6 +1899,25 @@ private struct FinishWorkoutSheet: View {
                     RoundedRectangle(cornerRadius: Theme.cornerRadiusSmall)
                         .stroke(Theme.textSecondary.opacity(0.2), lineWidth: 1)
                 )
+
+                // Share-full-soundtrack toggle (#410). When OFF, only the
+                // featured track shows on the feed. Lives in the captured
+                // branch because there's nothing to share when no tracks
+                // exist.
+                Toggle(isOn: Bindable(viewModel).shareFullSoundtrack) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Share full soundtrack")
+                            .font(.subheadline.weight(.medium))
+                            .foregroundStyle(Theme.textPrimary)
+                        Text(viewModel.shareFullSoundtrack
+                             ? "Friends will see every track on this workout."
+                             : "Only the featured track will show on your feed.")
+                            .font(Theme.fontCaption)
+                            .foregroundStyle(Theme.textSecondary)
+                    }
+                }
+                .tint(Theme.accent)
+                .accessibilityHint("Toggle whether the full soundtrack is shared with friends or only the featured track.")
             }
 
             Button {
@@ -1918,10 +1946,12 @@ private struct FinishWorkoutSheet: View {
 // MARK: - Soundtrack Row (#387.2)
 
 /// Single captured-track row used by the finish sheet. Renders an icon + title
-/// + artist + source pill with a trailing trash button. Hit target on the trash
-/// is sized to 44pt per HIG.
+/// + artist + source pill with a leading featured-star button and a trailing
+/// trash button. Hit target on each button is sized to 44pt per HIG.
 private struct SoundtrackRow: View {
     let track: WorkoutTrack
+    let isFeatured: Bool
+    let onToggleFeatured: () -> Void
     let onRemove: () -> Void
 
     var body: some View {
@@ -1958,6 +1988,25 @@ private struct SoundtrackRow: View {
             }
             Spacer()
 
+            // Featured-star toggle (#410). Filled star = picked as featured;
+            // tapping again clears the pick. Color shifts to accent when on so
+            // the highlight reads at a glance.
+            Button {
+                Haptics.selection()
+                onToggleFeatured()
+            } label: {
+                Image(systemName: isFeatured ? "star.fill" : "star")
+                    .font(Theme.fontSubheadline.weight(.semibold))
+                    .foregroundStyle(isFeatured ? Theme.accent : Theme.textSecondary)
+                    .frame(width: 44, height: 44)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(isFeatured
+                ? "Unset \(track.title) as featured track"
+                : "Set \(track.title) as featured track")
+            .accessibilityHint("Featured tracks show prominently on your feed card.")
+
             Button {
                 Haptics.light()
                 onRemove()
@@ -1974,8 +2023,7 @@ private struct SoundtrackRow: View {
         .padding(.horizontal, Theme.Spacing.md)
         .padding(.vertical, 8)
         .contentShape(Rectangle())
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel("\(track.title)\(track.artist.map { ", \($0)" } ?? "") from \(track.sourceApp)")
+        .accessibilityElement(children: .contain)
     }
 
     private var sourceIcon: String {


### PR DESCRIPTION
## Summary

### Pull-to-refresh fix
\`refreshFeed\` no longer flips \`isLoading\` (the system \`.refreshable\` spinner owns the indicator), and \`loadFeed\` only shows the skeleton when the feed is empty — was previously blowing away the rendered feed on every refresh. Combined with #408's cancellation-error swallowing, the swipe-down flow should feel native now.

### Featured soundtrack picker
- New \`featuredTrackId: String?\` on \`Workout\`
- Finish sheet — each track row in the Soundtrack section gets a featured-star button (one at a time)
- \`FeedItemCard\` renders a new \`FeaturedSoundtrackRow\` under the anthem row when the workout has one

### Share / hide full soundtrack
- New \`shareFullSoundtrack: Bool = true\` on \`Workout\`
- Toggle below the soundtrack list in the finish sheet
- \`FeedDetailView\` (expanded view) respects the flag for non-owners — when off, only the featured track shows; the rest are hidden

### Deep links
- New \`Utils/WorkoutTrackDeepLink.swift\` resolves per-source deep links with search-URL fallbacks (Apple Music / Spotify / SoundCloud)
- Spotify capture now stores \`https://open.spotify.com/track/<id>\`
- SoundCloud capture stores \`permalink_url\`
- New optional \`url: String?\` on \`WorkoutTrack\` (backward-compatible decoder)
- Every track row in \`FeedDetailView\` gets an "Open in [provider]" green button

### Backend
New \`Workout\` + \`WorkoutTrack\` fields ship as optional / default-valued so the Supabase \`workouts\` + \`workout_tracks\` migrations can land separately. Decoder tolerates missing columns.

## Test plan
- [ ] Pull down on feed → spinner, fetch, smooth dismissal
- [ ] Finish a workout → tap star on a track → feed card shows that track prominently
- [ ] Toggle share-full off → friends see only the featured track in expanded view
- [ ] Tap "Open in Spotify" on a tracked song → Spotify app/web opens