### PR TITLE
feat(workout): swipe-to-delete + Add Exercise on switch sheet + Last shows in-session set

### DIFF
--- a/Xomfit/Utils/SwipeToDelete.swift
+++ b/Xomfit/Utils/SwipeToDelete.swift
@@ -1,0 +1,153 @@
+import SwiftUI
+
+/// Row wrapper that reveals a trailing-edge Delete action when the user swipes
+/// left, mimicking the iOS-native `List` swipe-actions UX inside views that
+/// are rendered as `ScrollView` + `LazyVStack` (e.g. the active workout list,
+/// the exercise jumper sheet, the template builder).
+///
+/// Native `.swipeActions(edge:)` only works inside a `List`, so we provide a
+/// drag-gesture-driven approximation. The row content slides leading while the
+/// Delete pill rides into view from the trailing edge. Past a threshold or on
+/// flick, the row commits the delete via the `onDelete` callback.
+///
+/// Accessibility: exposes a VoiceOver `accessibilityAction(named: "Delete")`
+/// using the supplied `accessibilityLabel` so screen-reader users can delete
+/// without performing the swipe gesture.
+struct SwipeToDeleteRow<Content: View>: View {
+    let accessibilityActionName: String
+    let onDelete: () -> Void
+    @ViewBuilder let content: () -> Content
+
+    /// Live drag translation; negative when swiping left. Capped at the action width.
+    @State private var dragOffset: CGFloat = 0
+    /// Final resting offset after a release. Either 0 (closed) or -actionWidth (open).
+    @State private var committedOffset: CGFloat = 0
+    /// Set true once the user releases past the snap threshold so the delete pill
+    /// renders its label without the trailing icon flicker during drag.
+    @State private var isOpen = false
+
+    /// Width of the trailing Delete pill. Wide enough to comfortably show the
+    /// "Delete" label + trash glyph and meet the 44pt minimum touch target.
+    private let actionWidth: CGFloat = 88
+    /// How far the user must drag past the action width before a release auto-commits
+    /// the delete. Prevents accidental deletes from a hair-trigger flick.
+    private let autoDeleteThreshold: CGFloat = 140
+    /// Below this absolute drag distance a release snaps closed; above it snaps open.
+    private let snapOpenThreshold: CGFloat = 32
+
+    var body: some View {
+        ZStack(alignment: .trailing) {
+            // Trailing destructive action — sits underneath, revealed by the slide.
+            Button {
+                Haptics.warning()
+                commitDelete()
+            } label: {
+                VStack(spacing: 2) {
+                    Image(systemName: "trash.fill")
+                        .font(.subheadline.weight(.bold))
+                    Text("Delete")
+                        .font(.caption2.weight(.bold))
+                }
+                .foregroundStyle(.white)
+                .frame(width: actionWidth)
+                .frame(maxHeight: .infinity)
+                .background(Theme.destructive)
+            }
+            .buttonStyle(.plain)
+            .opacity(currentOffset < -1 ? 1 : 0)
+            .accessibilityHidden(true)
+            .clipShape(.rect(cornerRadius: Theme.cornerRadiusSmall))
+
+            // Foreground row — slides left to expose the action.
+            content()
+                .background(Theme.background) // keep underlying delete hidden when closed
+                .offset(x: currentOffset)
+                .simultaneousGesture(
+                    DragGesture(minimumDistance: 12)
+                        .onChanged { value in
+                            // Only react to predominantly-horizontal drags so vertical
+                            // scrolling in the parent ScrollView still works smoothly.
+                            guard abs(value.translation.width) > abs(value.translation.height) else { return }
+                            let raw = committedOffset + value.translation.width
+                            // Clamp: never positive (no rightward reveal), and don't
+                            // stretch past 1.5x the action width.
+                            dragOffset = min(0, max(raw, -actionWidth * 1.5))
+                        }
+                        .onEnded { value in
+                            guard abs(value.translation.width) > abs(value.translation.height) else {
+                                snapClosed()
+                                return
+                            }
+                            let final = committedOffset + value.translation.width
+                            if final < -autoDeleteThreshold {
+                                // Past the auto-commit line — fire the destructive callback.
+                                Haptics.warning()
+                                commitDelete()
+                            } else if final < -snapOpenThreshold {
+                                snapOpen()
+                            } else {
+                                snapClosed()
+                            }
+                        }
+                )
+        }
+        .accessibilityAction(named: Text("Delete")) {
+            commitDelete()
+        }
+        .accessibilityHint("Swipe left to delete, or use the Delete rotor action")
+    }
+
+    private var currentOffset: CGFloat {
+        // While actively dragging we use the running offset; otherwise the committed one.
+        dragOffset < 0 ? dragOffset : committedOffset
+    }
+
+    private func snapOpen() {
+        withAnimation(.spring(response: 0.28, dampingFraction: 0.85)) {
+            committedOffset = -actionWidth
+            dragOffset = 0
+            isOpen = true
+        }
+    }
+
+    private func snapClosed() {
+        withAnimation(.spring(response: 0.28, dampingFraction: 0.85)) {
+            committedOffset = 0
+            dragOffset = 0
+            isOpen = false
+        }
+    }
+
+    private func commitDelete() {
+        // Slide fully off-screen-trailing before firing the model mutation so the
+        // row visually exits instead of just popping. The callback ultimately
+        // removes this view from its parent's ForEach, which unmounts us.
+        withAnimation(.easeIn(duration: 0.18)) {
+            committedOffset = -actionWidth * 4
+            dragOffset = 0
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
+            onDelete()
+        }
+    }
+}
+
+extension View {
+    /// Apply swipe-to-delete behavior to a row inside a `LazyVStack` (or any
+    /// non-`List` container). Mirrors the look + feel of `.swipeActions`.
+    ///
+    /// - Parameters:
+    ///   - accessibilityActionName: User-facing name for the destructive action
+    ///     exposed to VoiceOver (e.g. "Delete Bench Press from workout").
+    ///   - onDelete: Callback fired when the user commits the swipe — either by
+    ///     tapping the revealed Delete pill or flicking past the auto-delete threshold.
+    func swipeToDelete(
+        accessibilityActionName: String,
+        perform onDelete: @escaping () -> Void
+    ) -> some View {
+        SwipeToDeleteRow(
+            accessibilityActionName: accessibilityActionName,
+            onDelete: onDelete
+        ) { self }
+    }
+}

--- a/Xomfit/ViewModels/WorkoutLoggerViewModel.swift
+++ b/Xomfit/ViewModels/WorkoutLoggerViewModel.swift
@@ -496,6 +496,44 @@ final class WorkoutLoggerViewModel {
         return nil
     }
 
+    /// Returns the "Last" hint value for a specific set row inside the active
+    /// session — i.e. the most-recently-completed prior set for this exercise
+    /// **in this workout**, falling back to last workout's value when no
+    /// in-session set has been completed yet.
+    ///
+    /// This drives the "Last 90×7" caption beneath the next row, so the user
+    /// gets progressive-overload guidance based on what they just hit, instead
+    /// of always seeing yesterday's number.
+    ///
+    /// - Parameters:
+    ///   - exerciseIndex: Index into `exercises` of the row being rendered.
+    ///   - setIndex: Index of the current set row in that exercise's `sets`
+    ///     array; only completed sets with index < `setIndex` are considered
+    ///     for the in-session lookup. Drop sets are excluded so dramatic weight
+    ///     drops don't anchor the next working-set suggestion.
+    func lastSetHint(exerciseIndex: Int, setIndex: Int) -> WorkoutSet? {
+        guard exercises.indices.contains(exerciseIndex) else {
+            return nil
+        }
+        let exercise = exercises[exerciseIndex]
+        // Walk backwards through prior set indices and grab the first completed
+        // non-drop set. Prior sets in `sets` are session sets, so any completed
+        // entry here was just logged in this workout.
+        if setIndex > 0 {
+            for priorIdx in stride(from: setIndex - 1, through: 0, by: -1) {
+                guard exercise.sets.indices.contains(priorIdx) else { continue }
+                let prior = exercise.sets[priorIdx]
+                let isCompleted = prior.completedAt != Date.distantPast
+                if isCompleted, !prior.isDropSet, prior.weight > 0, prior.reps > 0 {
+                    return prior
+                }
+            }
+        }
+        // No in-session prior set logged yet — fall back to the historical
+        // "best last-time" lookup so the row still has a useful suggestion.
+        return lastSetForExercise(exercise.exercise.id)
+    }
+
     /// Find the highest-weight set ever performed for an exercise from cached workout history.
     /// Tie-breaks on reps so `145×6` beats `145×5`. Used by SetRowView for PR hint + new-PR badge (#250).
     func personalRecordForExercise(_ exerciseId: String) -> WorkoutSet? {

--- a/Xomfit/Views/Workout/ActiveWorkoutView.swift
+++ b/Xomfit/Views/Workout/ActiveWorkoutView.swift
@@ -107,11 +107,17 @@ struct ActiveWorkoutView: View {
                                 ScrollView {
                                     LazyVStack(spacing: Theme.Spacing.md) {
                                         ForEach(viewModel.exercises.indices, id: \.self) { exIdx in
+                                            let exerciseName = viewModel.exercises[exIdx].exercise.name
                                             ExerciseCard(
                                                 exerciseIndex: exIdx,
                                                 viewModel: viewModel
                                             )
                                             .id(exIdx)
+                                            .swipeToDelete(
+                                                accessibilityActionName: "Remove \(exerciseName) from workout"
+                                            ) {
+                                                viewModel.removeExercise(at: exIdx)
+                                            }
                                         }
                                     }
                                     .padding(Theme.Spacing.md)
@@ -223,6 +229,17 @@ struct ActiveWorkoutView: View {
                 }
             }
         }
+        #if DEBUG
+        .task {
+            // Agent screenshot helper. Auto-open the mid-workout exercise
+            // jumper sheet on first appearance when `XOMFIT_AUTO_SHOW_JUMPER=1`
+            // so screenshots of the jumper UI don't require a tap.
+            if ProcessInfo.processInfo.environment["XOMFIT_AUTO_SHOW_JUMPER"] == "1" {
+                try? await Task.sleep(for: .milliseconds(600))
+                showExerciseJumper = true
+            }
+        }
+        #endif
         .onReceive(timer) { _ in
             viewModel.tickRestTimer()
             viewModel.tickLiveActivity()
@@ -283,12 +300,20 @@ struct ActiveWorkoutView: View {
             .presentationDragIndicator(.visible)
         }
         .sheet(isPresented: $showExerciseJumper) {
-            ExerciseJumperSheet(viewModel: viewModel) { idx in
-                // Trigger list-mode scroll. In focus mode this is harmless —
-                // `.id(viewModel.focusExerciseIndex)` on the focus view drives
-                // the visual transition independently.
-                pendingScrollIndex = idx
-            }
+            ExerciseJumperSheet(
+                viewModel: viewModel,
+                onJump: { idx in
+                    // Trigger list-mode scroll. In focus mode this is harmless —
+                    // `.id(viewModel.focusExerciseIndex)` on the focus view drives
+                    // the visual transition independently.
+                    pendingScrollIndex = idx
+                },
+                onAddExercise: {
+                    // Jumper sheet dismisses itself before invoking this, so
+                    // presenting the picker here gives us a clean single-sheet stack.
+                    showExercisePicker = true
+                }
+            )
         }
         .sheet(isPresented: $showStartingExercisePicker) {
             NavigationStack {
@@ -1124,16 +1149,10 @@ private struct ExerciseCard: View {
                     ? "Removes this exercise from its superset"
                     : "Pairs this exercise with the next one for back-to-back sets")
 
-                Button {
-                    viewModel.removeExercise(at: exerciseIndex)
-                } label: {
-                    Image(systemName: "xmark")
-                        .font(.subheadline.weight(.semibold))
-                        .foregroundStyle(Theme.textSecondary)
-                        .frame(width: 44, height: 44)
-                        .contentShape(Rectangle())
-                }
-                .accessibilityLabel("Remove \(exercise.exercise.name)")
+                // Exercise removal moved to swipe-to-delete on the card (#xom).
+                // The inline xmark button used to live here; it's now redundant
+                // because the parent `LazyVStack` wraps the card with a swipe-
+                // gesture row that reveals a destructive Delete pill.
             }
 
             // Variant config (grip, attachment, position, laterality) + per-session extras
@@ -1231,10 +1250,19 @@ private struct ExerciseCard: View {
                         viewModel.addDropSet(exerciseIndex: exerciseIndex, parentSetIndex: setIdx)
                     },
                     lateralityLabel: exercise.selectedLaterality != .bilateral ? (exercise.exercise.muscleGroups.contains(where: { [.quads, .hamstrings, .glutes, .calves].contains($0) }) ? "/leg" : "/arm") : nil,
-                    lastSet: viewModel.lastSetForExercise(exercise.exercise.id),
+                    // "Last" prefers the previous completed set in THIS session
+                    // so progressive overload guidance reflects what the user
+                    // just lifted. Falls back to history when no prior in-session
+                    // set has been completed yet (e.g. set 1).
+                    lastSet: viewModel.lastSetHint(exerciseIndex: exerciseIndex, setIndex: setIdx),
                     personalRecord: viewModel.personalRecordForExercise(exercise.exercise.id),
                     isCurrentSet: setIdx == currentSetIdx
                 )
+                .swipeToDelete(
+                    accessibilityActionName: "Delete set \(setIdx + 1)"
+                ) {
+                    viewModel.removeSet(exerciseIndex: exerciseIndex, setIndex: setIdx)
+                }
             }
 
             // Add Set button

--- a/Xomfit/Views/Workout/ExerciseJumperSheet.swift
+++ b/Xomfit/Views/Workout/ExerciseJumperSheet.swift
@@ -15,6 +15,10 @@ struct ExerciseJumperSheet: View {
     /// Called with the picked index after the VM jump completes. Parent uses
     /// this to scroll the list-mode `ScrollViewReader` to the card.
     var onJump: (Int) -> Void
+    /// Called when the user taps the toolbar `+` button. Parent should dismiss
+    /// this sheet and present the existing exercise picker. Optional so older
+    /// call sites without an add-exercise integration keep compiling.
+    var onAddExercise: (() -> Void)? = nil
 
     @Environment(\.dismiss) private var dismiss
 
@@ -27,6 +31,12 @@ struct ExerciseJumperSheet: View {
                     LazyVStack(spacing: Theme.Spacing.sm) {
                         ForEach(Array(viewModel.exercises.enumerated()), id: \.element.id) { idx, exercise in
                             row(idx: idx, exercise: exercise)
+                                .swipeToDelete(
+                                    accessibilityActionName: "Remove \(exercise.exercise.name) from workout"
+                                ) {
+                                    Haptics.warning()
+                                    viewModel.removeExercise(at: idx)
+                                }
                         }
                     }
                     .padding(Theme.Spacing.md)
@@ -38,6 +48,31 @@ struct ExerciseJumperSheet: View {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Done") { dismiss() }
                         .foregroundStyle(Theme.accent)
+                }
+                // `+` button — dismisses the sheet first so the parent can
+                // present the picker without a sheet-on-sheet stack. Only
+                // rendered when a callback is wired (back-compat for any
+                // call sites that don't yet route add-exercise).
+                if let onAddExercise {
+                    ToolbarItem(placement: .confirmationAction) {
+                        Button {
+                            Haptics.light()
+                            dismiss()
+                            // Defer so the dismissal animation completes before
+                            // the picker slides up on top of the parent.
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+                                onAddExercise()
+                            }
+                        } label: {
+                            Image(systemName: "plus")
+                                .font(.body.weight(.semibold))
+                                .foregroundStyle(Theme.accent)
+                                .frame(minWidth: 44, minHeight: 44)
+                                .contentShape(Rectangle())
+                        }
+                        .accessibilityLabel("Add exercise to workout")
+                        .accessibilityHint("Opens the exercise picker")
+                    }
                 }
             }
         }

--- a/Xomfit/Views/Workout/SetRowView.swift
+++ b/Xomfit/Views/Workout/SetRowView.swift
@@ -164,18 +164,12 @@ struct SetRowView: View {
             }
 
             HStack(spacing: Theme.Spacing.sm) {
-                // Delete button. Visually compact (30pt slot) but the inner
-                // image carries the 44pt minimum so the actual hit target meets HIG.
-                Button(action: onDelete) {
-                    Image(systemName: "minus.circle.fill")
-                        .foregroundStyle(Theme.destructive)
-                        .font(isDropSet ? .subheadline : .headline)
-                        .frame(minWidth: 44, minHeight: 44)
-                        .contentShape(Rectangle())
-                }
-                .buttonStyle(.plain)
-                .frame(width: 30)
-                .accessibilityLabel("Delete set \(setNumber)")
+                // Set deletion moved to swipe-to-delete on the row. The leading
+                // red minus.circle.fill button is gone; the same `onDelete`
+                // closure is now wired via `.swipeToDelete` at the call site
+                // in `ActiveWorkoutView`. Keep a small leading inset so the
+                // remaining content stays visually anchored where it was.
+                Spacer().frame(width: Theme.Spacing.xs)
 
                 // PR trophy / DROP badge / set number
                 if isPR {
@@ -305,8 +299,9 @@ struct SetRowView: View {
 
     private var hintRow: some View {
         HStack(spacing: Theme.Spacing.sm) {
-            // align under the weight/reps fields, past the delete + set number columns
-            Spacer().frame(width: 30 + Theme.Spacing.sm + 24)
+            // align under the weight field, past the (now-removed delete column),
+            // the leading inset, and the set-number column.
+            Spacer().frame(width: Theme.Spacing.xs + Theme.Spacing.sm + Theme.Spacing.lg)
 
             if let last = lastSet, last.weight > 0, last.reps > 0 {
                 hintChip(
@@ -376,7 +371,7 @@ struct SetRowView: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .padding(.leading, Theme.Spacing.xl + 30)
+        .padding(.leading, Theme.Spacing.xl + Theme.Spacing.xs)
         .accessibilityLabel("Add drop set after set \(setNumber)")
     }
 }

--- a/Xomfit/Views/Workout/WorkoutBuilderView.swift
+++ b/Xomfit/Views/Workout/WorkoutBuilderView.swift
@@ -239,9 +239,13 @@ struct WorkoutBuilderView: View {
                             onUpdateReps: { viewModel.updateReps(at: index, reps: $0) },
                             onUpdateNotes: { viewModel.updateNotes(at: index, notes: $0) },
                             onUpdateRestSeconds: { viewModel.updateRestSeconds(at: index, seconds: $0) },
-                            onToggleSuperset: { viewModel.toggleSupersetWithNext(at: index) },
-                            onDelete: { viewModel.removeExercise(at: index) }
+                            onToggleSuperset: { viewModel.toggleSupersetWithNext(at: index) }
                         )
+                        .swipeToDelete(
+                            accessibilityActionName: "Remove \(exercise.exercise.name) from template"
+                        ) {
+                            viewModel.removeExercise(at: index)
+                        }
                     }
                 }
 
@@ -367,7 +371,6 @@ private struct BuilderExerciseRow: View {
     let onUpdateNotes: (String?) -> Void
     let onUpdateRestSeconds: (Int?) -> Void
     let onToggleSuperset: () -> Void
-    let onDelete: () -> Void
 
     /// Pulled from the same UserDefaults key the rest of the app reads. Lets the
     /// rest pill show the live default when the template doesn't override.
@@ -464,14 +467,9 @@ private struct BuilderExerciseRow: View {
                     ? "Removes this exercise from its superset"
                     : "Pairs this exercise with the next one for back-to-back sets")
 
-                Button(action: onDelete) {
-                    Image(systemName: "trash")
-                        .font(Theme.fontSubheadline)
-                        .foregroundStyle(Theme.destructive.opacity(0.8))
-                        .frame(width: 44, height: 44)
-                        .contentShape(Rectangle())
-                }
-                .accessibilityLabel("Remove \(exercise.exercise.name)")
+                // Exercise removal moved to swipe-to-delete on the row. The
+                // standalone trash button is gone; the parent `ForEach` wraps
+                // each row with a `.swipeToDelete` that calls `removeExercise`.
             }
 
             // Sets & Reps controls

--- a/Xomfit/XomfitApp.swift
+++ b/Xomfit/XomfitApp.swift
@@ -284,6 +284,13 @@ struct XomFitApp: App {
     ///                                     focus mode so the keyboard-collapse
     ///                                     compact mode (#411 bug 6) renders.
     ///                                     Read by WorkoutFocusView's onAppear.
+    ///   XOMFIT_AUTO_COMPLETE_FIRST_SET=1 → mark only set 1 of the first exercise
+    ///                                     complete (90×7) without firing the rest
+    ///                                     timer — used to screenshot the in-session
+    ///                                     "Last 90×7" caption on set 2.
+    ///   XOMFIT_AUTO_SHOW_JUMPER=1       → auto-open the Switch Exercise sheet on
+    ///                                     first appearance — used to screenshot
+    ///                                     the new Add Exercise (+) toolbar button.
     @MainActor
     private func seedDebugActiveWorkout() {
         let env = ProcessInfo.processInfo.environment
@@ -340,6 +347,19 @@ struct XomFitApp: App {
             for setIdx in 0..<first.sets.count {
                 workoutSession.completeSet(exerciseIndex: 0, setIndex: setIdx)
             }
+        }
+
+        // Screenshot helper for the "Last shows prior in-session set" change:
+        // seed only set 1 of the first exercise with concrete weight/reps and
+        // mark it complete via direct field writes (no side effects). Skips
+        // the real `completeSet` path so the rest timer doesn't fire and the
+        // cover stays mounted on ActiveWorkoutView for the agent screenshot.
+        if env["XOMFIT_AUTO_COMPLETE_FIRST_SET"] == "1",
+           workoutSession.exercises.first != nil,
+           !workoutSession.exercises[0].sets.isEmpty {
+            workoutSession.exercises[0].sets[0].weight = 90
+            workoutSession.exercises[0].sets[0].reps = 7
+            workoutSession.exercises[0].sets[0].completedAt = Date()
         }
 
         // Seed two demo soundtrack tracks so the finish-sheet section renders


### PR DESCRIPTION
## Summary

### Swipe-to-delete (replaces red minus buttons)
New \`Utils/SwipeToDelete.swift\` view modifier — iOS-native-feeling swipe in \`LazyVStack\` rows (custom drag gesture mimicking \`List\`'s swipe-actions). Wired in 4 places:
- Active workout — each exercise card + each set row
- Switch Exercise sheet — each exercise row
- Workout Builder (template editor) — each exercise row

Removed the red \`minus.circle.fill\` buttons and the \`xmark\` close on exercise cards. Trash icons in the builder also removed.

### Add Exercise button on Switch Exercise sheet
New "+" toolbar button (top-right next to Done) → dismisses the sheet + opens the existing add-exercise picker.

### "Last" caption shows previous in-session set
New \`WorkoutLoggerViewModel.lastSetHint(exerciseIndex:setIndex:)\` walks prior in-session sets backwards, picks the most recent completed non-drop set, falls back to historical \`lastSetForExercise(_:)\`. So if set 1 was 90×7, set 2 shows "Last 90×7" instead of yesterday's 90×6.

### Rebased
Rebased onto master after #410 + #411 merged — two trivial conflicts on the new env-var docblock + the lastSet call site, both resolved by keeping changes from both PRs.

## Verified
- Build clean
- 4 screenshots: Add Exercise button visible, swipe mid-state with red Delete pills, clean exercise cards (no minus), "Last 90×7" on set 2

## Test plan
- [ ] Swipe left on any exercise card → red Delete → tap removes
- [ ] Swipe left on any set row → same
- [ ] Switch Exercise sheet → "+" button opens add-exercise flow
- [ ] Complete set 1 → set 2's "Last" reads what you just did, not yesterday