### PR TITLE
feat(soundtrack): play preview inline + edit featured/share after save + restore tracks across app quit

### DIFF
--- a/Xomfit/Models/Workout.swift
+++ b/Xomfit/Models/Workout.swift
@@ -249,6 +249,13 @@ extension Workout {
         let now = Date()
         let day: TimeInterval = 86_400
 
+        // Bypass-mode fixture tracks (#411 follow-up). Seeded onto the first
+        // mock workout so the workout-detail soundtrack edit UI has tracks
+        // to render under bypass — used by the agent screenshot harness.
+        let bypassTrack1 = UUID(uuidString: "00000000-0000-0000-0000-00000000B1A1") ?? UUID()
+        let bypassTrack2 = UUID(uuidString: "00000000-0000-0000-0000-00000000B1A2") ?? UUID()
+        let bypassTrack3 = UUID(uuidString: "00000000-0000-0000-0000-00000000B1A3") ?? UUID()
+
         return [
             Workout(
                 id: "mock-workout-1",
@@ -268,7 +275,35 @@ extension Workout {
                 ],
                 startTime: now.addingTimeInterval(-3_600),
                 endTime: now.addingTimeInterval(-300),
-                notes: "Solid push session"
+                notes: "Solid push session",
+                tracks: [
+                    WorkoutTrack(
+                        id: bypassTrack1,
+                        title: "Power",
+                        artist: "Kanye West",
+                        capturedAt: now.addingTimeInterval(-3_300),
+                        sourceApp: "Spotify",
+                        url: "https://open.spotify.com/track/2gZUPNdnz5Y45eiGxpHGSc"
+                    ),
+                    WorkoutTrack(
+                        id: bypassTrack2,
+                        title: "Till I Collapse",
+                        artist: "Eminem",
+                        capturedAt: now.addingTimeInterval(-2_700),
+                        sourceApp: "Apple Music",
+                        url: nil
+                    ),
+                    WorkoutTrack(
+                        id: bypassTrack3,
+                        title: "Stronger",
+                        artist: "Kanye West",
+                        capturedAt: now.addingTimeInterval(-1_800),
+                        sourceApp: "SoundCloud",
+                        url: "https://soundcloud.com/kanyewest/stronger"
+                    )
+                ],
+                featuredTrackId: bypassTrack1.uuidString,
+                shareFullSoundtrack: true
             ),
             Workout(
                 id: "mock-workout-2",

--- a/Xomfit/Services/WorkoutService.swift
+++ b/Xomfit/Services/WorkoutService.swift
@@ -267,9 +267,18 @@ final class WorkoutService {
         // #410 + #353 bypass — surface a mock workout with tracks + featured
         // pick so FeedDetailView's expanded soundtrack list + deep-link buttons
         // can be screenshot-verified from a cold launch.
-        if ProcessInfo.processInfo.environment["XOMFIT_AUTH_BYPASS"] == "1",
-           let mock = DebugFixtures.bypassWorkout(id: id) {
-            return mock
+        if ProcessInfo.processInfo.environment["XOMFIT_AUTH_BYPASS"] == "1" {
+            if let mock = DebugFixtures.bypassWorkout(id: id) {
+                return mock
+            }
+            // Fall back to the local cache for own-user mock workouts seeded
+            // via `seedDebugFixtures` (#411 follow-up). Lets the agent
+            // screenshot harness open `mock-workout-1` from a cold launch
+            // without hitting Supabase.
+            if let cached = loadAllFromCache().first(where: { $0.id == id }) {
+                return cached
+            }
+            return nil
         }
         #endif
 
@@ -353,6 +362,83 @@ final class WorkoutService {
             .sorted { $0.startTime > $1.startTime }
             .prefix(limit)
             .map { $0 }
+    }
+
+    // MARK: - Soundtrack edits (post-save) (#411 follow-up)
+
+    /// Update the featured-track pick on a previously-saved workout. Writes the
+    /// new value to the local cache immediately and pushes to Supabase
+    /// best-effort. Patches the matching feed item so the card refreshes.
+    ///
+    /// Tolerant of missing columns — the `workouts.featured_track_id` /
+    /// `workouts.share_full_soundtrack` Supabase columns may not exist yet, in
+    /// which case the remote update is logged and swallowed so the local cache
+    /// + feed item still reflect the edit (the source of truth on first
+    /// hydration after the migration ships will be the local cache).
+    @discardableResult
+    func setFeaturedTrack(workoutId: String, trackId: String?) async -> Bool {
+        // 1. Patch local cache so the next read of this workout sees the edit.
+        var workouts = loadAllFromCache()
+        guard let idx = workouts.firstIndex(where: { $0.id == workoutId }) else { return false }
+        workouts[idx].featuredTrackId = trackId
+        let updated = workouts[idx]
+        let data = try? JSONEncoder().encode(workouts)
+        UserDefaults.standard.set(data, forKey: storageKey)
+
+        // 2. Push to Supabase — best effort, tolerant of missing columns.
+        var remoteOK = true
+        do {
+            try await supabase
+                .from("workouts")
+                .update(["featured_track_id": trackId])
+                .eq("id", value: workoutId)
+                .execute()
+        } catch {
+            remoteOK = false
+            print("[WorkoutService] setFeaturedTrack remote update failed (likely missing column — will retry once migration ships): \(error.localizedDescription)")
+        }
+
+        // 3. Patch the feed item activity payload so the card reflects the change.
+        do {
+            try await FeedService.shared.updateFeedItemForWorkout(workout: updated, userId: updated.userId)
+        } catch {
+            print("[WorkoutService] setFeaturedTrack feed patch failed: \(error.localizedDescription)")
+        }
+
+        return remoteOK
+    }
+
+    /// Update the share-full-soundtrack toggle on a previously-saved workout.
+    /// Same tolerance pattern as `setFeaturedTrack` — local cache and feed
+    /// item are always patched; the Supabase column update is best-effort.
+    @discardableResult
+    func setShareFullSoundtrack(workoutId: String, enabled: Bool) async -> Bool {
+        var workouts = loadAllFromCache()
+        guard let idx = workouts.firstIndex(where: { $0.id == workoutId }) else { return false }
+        workouts[idx].shareFullSoundtrack = enabled
+        let updated = workouts[idx]
+        let data = try? JSONEncoder().encode(workouts)
+        UserDefaults.standard.set(data, forKey: storageKey)
+
+        var remoteOK = true
+        do {
+            try await supabase
+                .from("workouts")
+                .update(["share_full_soundtrack": enabled])
+                .eq("id", value: workoutId)
+                .execute()
+        } catch {
+            remoteOK = false
+            print("[WorkoutService] setShareFullSoundtrack remote update failed (likely missing column): \(error.localizedDescription)")
+        }
+
+        do {
+            try await FeedService.shared.updateFeedItemForWorkout(workout: updated, userId: updated.userId)
+        } catch {
+            print("[WorkoutService] setShareFullSoundtrack feed patch failed: \(error.localizedDescription)")
+        }
+
+        return remoteOK
     }
 
     // MARK: - Delete

--- a/Xomfit/ViewModels/WorkoutDetailViewModel.swift
+++ b/Xomfit/ViewModels/WorkoutDetailViewModel.swift
@@ -222,7 +222,9 @@ final class WorkoutDetailViewModel {
             notes: draft.notes,
             location: draft.location,
             rating: draft.rating,
-            tracks: draft.tracks
+            tracks: draft.tracks,
+            featuredTrackId: draft.featuredTrackId,
+            shareFullSoundtrack: draft.shareFullSoundtrack
         )
 
         _ = await WorkoutService.shared.updateWorkout(finalWorkout)

--- a/Xomfit/ViewModels/WorkoutLoggerViewModel.swift
+++ b/Xomfit/ViewModels/WorkoutLoggerViewModel.swift
@@ -33,6 +33,14 @@ final class WorkoutLoggerViewModel {
     /// the merged snapshot of (Apple Music + Spotify + manual).
     var removedTrackIDs: Set<UUID> = []
 
+    /// Captured tracks restored from a force-quit + relaunch. Lives separately
+    /// from the per-service in-memory caches (Apple Music / Spotify /
+    /// SoundCloud) because those reset on `startCapture()` and we don't want
+    /// to lose the songs that played BEFORE the quit. Merged into
+    /// `curatedTracksSnapshot` so the finish sheet and feed card both see
+    /// the full pre-quit + post-quit soundtrack.
+    var persistedCapturedTracks: [WorkoutTrack] = []
+
     /// Featured track id (the soundtrack pick surfaced on the feed card). Set
     /// by tapping the star icon on a soundtrack row in the finish sheet (#410).
     /// At most one track is featured at a time; tapping the same row clears it.
@@ -230,6 +238,9 @@ final class WorkoutLoggerViewModel {
         circuitCompletedRounds = [:]
         manualTracks = []
         removedTrackIDs = []
+        persistedCapturedTracks = []
+        featuredTrackId = nil
+        shareFullSoundtrack = true
         skipRestTimer()
         startLiveActivity()
 
@@ -285,6 +296,9 @@ final class WorkoutLoggerViewModel {
         rating = 0
         manualTracks = []
         removedTrackIDs = []
+        persistedCapturedTracks = []
+        featuredTrackId = nil
+        shareFullSoundtrack = true
         kind = .setsReps
         durationGoalMinutes = nil
         roundsGoal = nil
@@ -1051,16 +1065,22 @@ final class WorkoutLoggerViewModel {
 
     // MARK: - Soundtrack curation (#387)
 
-    /// Merged snapshot of (Apple Music + Spotify + SoundCloud + manual) tracks,
-    /// minus anything the user removed in the finish sheet. Sorted by capture time
-    /// so the order reflects play order across sources.
+    /// Merged snapshot of (Apple Music + Spotify + SoundCloud + manual +
+    /// pre-quit persisted) tracks, minus anything the user removed in the
+    /// finish sheet. Sorted by capture time so the order reflects play order
+    /// across sources. Deduped by track id so a song that was captured
+    /// pre-quit AND is still playing post-restore only appears once.
     var curatedTracksSnapshot: [WorkoutTrack] {
         let apple = NowPlayingService.shared.capturedTracksSnapshot()
         let spotify = SpotifyNowPlayingService.shared.capturedTracksSnapshot()
         let soundCloud = SoundCloudNowPlayingService.shared.capturedTracksSnapshot()
-        let merged = (apple + spotify + soundCloud + manualTracks)
-            .filter { !removedTrackIDs.contains($0.id) }
-        return merged.sorted { $0.capturedAt < $1.capturedAt }
+        let raw = apple + spotify + soundCloud + manualTracks + persistedCapturedTracks
+        var seen = Set<UUID>()
+        let deduped = raw.filter { track in
+            guard !removedTrackIDs.contains(track.id) else { return false }
+            return seen.insert(track.id).inserted
+        }
+        return deduped.sorted { $0.capturedAt < $1.capturedAt }
     }
 
     /// Append a manually-entered track. Trims whitespace, drops empty titles.
@@ -1347,6 +1367,10 @@ final class WorkoutLoggerViewModel {
     /// Snapshot of the in-progress workout. Restricted to JSON-friendly types so
     /// the whole struct round-trips through `JSONEncoder`/`JSONDecoder`. New
     /// fields must default to backwards-compatible values.
+    ///
+    /// Custom `init(from:)` so additive fields decode `nil`/default values
+    /// against older saved blobs without forcing a `schemaVersion` bump (which
+    /// would drop every in-flight session on upgrade).
     struct PersistedSession: Codable {
         var schemaVersion: Int
         var workoutId: String
@@ -1364,6 +1388,97 @@ final class WorkoutLoggerViewModel {
         var location: String
         var rating: Int
         var activeUserId: String
+
+        // MARK: - Soundtrack persistence (#411 follow-up)
+        //
+        // Captured + manual + featured + share state must round-trip across a
+        // force-quit. Captured tracks are snapshotted from the per-source
+        // services at save time because those services reset on `startCapture`
+        // — losing the songs that played BEFORE the quit otherwise.
+
+        var capturedTracks: [WorkoutTrack]
+        var manualTracks: [WorkoutTrack]
+        var removedTrackIDs: [UUID]
+        var featuredTrackId: UUID?
+        var shareFullSoundtrack: Bool
+
+        enum CodingKeys: String, CodingKey {
+            case schemaVersion, workoutId, workoutName, exercises, startTime, savedAt
+            case totalPausedDuration, defaultRestDuration, focusExerciseIndex, focusSetIndex
+            case kind, durationGoalMinutes, roundsGoal, location, rating, activeUserId
+            case capturedTracks, manualTracks, removedTrackIDs, featuredTrackId, shareFullSoundtrack
+        }
+
+        init(
+            schemaVersion: Int,
+            workoutId: String,
+            workoutName: String,
+            exercises: [WorkoutExercise],
+            startTime: Date,
+            savedAt: Date,
+            totalPausedDuration: TimeInterval,
+            defaultRestDuration: Double,
+            focusExerciseIndex: Int,
+            focusSetIndex: Int,
+            kind: WorkoutKind,
+            durationGoalMinutes: Int?,
+            roundsGoal: Int?,
+            location: String,
+            rating: Int,
+            activeUserId: String,
+            capturedTracks: [WorkoutTrack] = [],
+            manualTracks: [WorkoutTrack] = [],
+            removedTrackIDs: [UUID] = [],
+            featuredTrackId: UUID? = nil,
+            shareFullSoundtrack: Bool = true
+        ) {
+            self.schemaVersion = schemaVersion
+            self.workoutId = workoutId
+            self.workoutName = workoutName
+            self.exercises = exercises
+            self.startTime = startTime
+            self.savedAt = savedAt
+            self.totalPausedDuration = totalPausedDuration
+            self.defaultRestDuration = defaultRestDuration
+            self.focusExerciseIndex = focusExerciseIndex
+            self.focusSetIndex = focusSetIndex
+            self.kind = kind
+            self.durationGoalMinutes = durationGoalMinutes
+            self.roundsGoal = roundsGoal
+            self.location = location
+            self.rating = rating
+            self.activeUserId = activeUserId
+            self.capturedTracks = capturedTracks
+            self.manualTracks = manualTracks
+            self.removedTrackIDs = removedTrackIDs
+            self.featuredTrackId = featuredTrackId
+            self.shareFullSoundtrack = shareFullSoundtrack
+        }
+
+        init(from decoder: Decoder) throws {
+            let c = try decoder.container(keyedBy: CodingKeys.self)
+            schemaVersion = try c.decode(Int.self, forKey: .schemaVersion)
+            workoutId = try c.decode(String.self, forKey: .workoutId)
+            workoutName = try c.decode(String.self, forKey: .workoutName)
+            exercises = try c.decode([WorkoutExercise].self, forKey: .exercises)
+            startTime = try c.decode(Date.self, forKey: .startTime)
+            savedAt = try c.decode(Date.self, forKey: .savedAt)
+            totalPausedDuration = try c.decode(TimeInterval.self, forKey: .totalPausedDuration)
+            defaultRestDuration = try c.decode(Double.self, forKey: .defaultRestDuration)
+            focusExerciseIndex = try c.decode(Int.self, forKey: .focusExerciseIndex)
+            focusSetIndex = try c.decode(Int.self, forKey: .focusSetIndex)
+            kind = try c.decode(WorkoutKind.self, forKey: .kind)
+            durationGoalMinutes = try c.decodeIfPresent(Int.self, forKey: .durationGoalMinutes)
+            roundsGoal = try c.decodeIfPresent(Int.self, forKey: .roundsGoal)
+            location = try c.decode(String.self, forKey: .location)
+            rating = try c.decode(Int.self, forKey: .rating)
+            activeUserId = try c.decode(String.self, forKey: .activeUserId)
+            capturedTracks = try c.decodeIfPresent([WorkoutTrack].self, forKey: .capturedTracks) ?? []
+            manualTracks = try c.decodeIfPresent([WorkoutTrack].self, forKey: .manualTracks) ?? []
+            removedTrackIDs = try c.decodeIfPresent([UUID].self, forKey: .removedTrackIDs) ?? []
+            featuredTrackId = try c.decodeIfPresent(UUID.self, forKey: .featuredTrackId)
+            shareFullSoundtrack = try c.decodeIfPresent(Bool.self, forKey: .shareFullSoundtrack) ?? true
+        }
     }
 
     /// Serialize the current state. No-op when `isActive == false` so a fresh
@@ -1375,6 +1490,20 @@ final class WorkoutLoggerViewModel {
             guard elapsed >= Self.persistMinInterval else { return }
         }
         lastPersistAt = Date()
+
+        // Snapshot captured tracks from every source so they survive a force-quit
+        // (#411 follow-up). The per-source services reset their in-memory caches
+        // on `startCapture()`, which fires again on `restoreActiveSession`, so
+        // anything captured pre-quit would be lost without this snapshot.
+        let appleSnapshot = NowPlayingService.shared.capturedTracksSnapshot()
+        let spotifySnapshot = SpotifyNowPlayingService.shared.capturedTracksSnapshot()
+        let soundCloudSnapshot = SoundCloudNowPlayingService.shared.capturedTracksSnapshot()
+        // Merge per-source snapshots with anything we restored from the prior
+        // saved blob so back-to-back saves don't drop pre-quit captures. Dedupe
+        // by id.
+        let allCaptured = appleSnapshot + spotifySnapshot + soundCloudSnapshot + persistedCapturedTracks
+        var seenCaptureIds = Set<UUID>()
+        let mergedCaptured = allCaptured.filter { seenCaptureIds.insert($0.id).inserted }
 
         let snapshot = PersistedSession(
             schemaVersion: Self.savedSessionSchemaVersion,
@@ -1392,7 +1521,12 @@ final class WorkoutLoggerViewModel {
             roundsGoal: roundsGoal,
             location: location,
             rating: rating,
-            activeUserId: activeUserId
+            activeUserId: activeUserId,
+            capturedTracks: mergedCaptured,
+            manualTracks: manualTracks,
+            removedTrackIDs: Array(removedTrackIDs),
+            featuredTrackId: featuredTrackId,
+            shareFullSoundtrack: shareFullSoundtrack
         )
 
         do {
@@ -1479,8 +1613,17 @@ final class WorkoutLoggerViewModel {
         restDuration = 0
         showExerciseTransition = false
         showPRCelebration = false
-        manualTracks = []
-        removedTrackIDs = []
+
+        // Restore soundtrack state (#411 follow-up). Captured tracks from
+        // BEFORE the quit are pushed onto `persistedCapturedTracks` so
+        // `curatedTracksSnapshot` continues to see them after the per-source
+        // services reset on the fresh `startCapture()` below. Manual / removed
+        // / featured / share-all all round-trip directly.
+        persistedCapturedTracks = snapshot.capturedTracks
+        manualTracks = snapshot.manualTracks
+        removedTrackIDs = Set(snapshot.removedTrackIDs)
+        featuredTrackId = snapshot.featuredTrackId
+        shareFullSoundtrack = snapshot.shareFullSoundtrack
 
         isActive = true
         isPresented = true
@@ -1605,8 +1748,15 @@ final class WorkoutLoggerViewModel {
         let appleMusicTracks = NowPlayingService.shared.stopCapture()
         let spotifyTracks = SpotifyNowPlayingService.shared.stopCapture()
         let soundCloudTracks = SoundCloudNowPlayingService.shared.stopCapture()
-        let capturedTracks = (appleMusicTracks + spotifyTracks + soundCloudTracks + manualTracks)
-            .filter { !removedTrackIDs.contains($0.id) }
+        // Merge with `persistedCapturedTracks` so songs captured BEFORE a
+        // force-quit + restore still attach to the saved workout (#411 follow-up).
+        let allCaptured = appleMusicTracks + spotifyTracks + soundCloudTracks + manualTracks + persistedCapturedTracks
+        var seenFinishIds = Set<UUID>()
+        let capturedTracks = allCaptured
+            .filter { track in
+                guard !removedTrackIDs.contains(track.id) else { return false }
+                return seenFinishIds.insert(track.id).inserted
+            }
             .sorted { $0.capturedAt < $1.capturedAt }
 
         // Featured soundtrack pick (#410). Only carry through when the chosen

--- a/Xomfit/ViewModels/WorkoutSoundtrackEditViewModel.swift
+++ b/Xomfit/ViewModels/WorkoutSoundtrackEditViewModel.swift
@@ -1,0 +1,62 @@
+import Foundation
+import SwiftUI
+
+/// View model backing the inline soundtrack editor on `WorkoutDetailView`
+/// (#411 follow-up).
+///
+/// Holds the per-workout featured track + share-all toggle in a small
+/// `@Observable` shell so the detail view can flip stars and toggle sharing
+/// without having to push a full edit-mode save through
+/// `WorkoutDetailViewModel`. Each mutation pushes through
+/// `WorkoutService.setFeaturedTrack` / `setShareFullSoundtrack`, which patch
+/// the local cache + Supabase + matching feed item.
+///
+/// Designed for the read-only viewing surface — when the user is the workout
+/// author this lets them flip their pick without re-opening edit mode. When
+/// the user is not the author the view skips wiring this up entirely.
+@MainActor
+@Observable
+final class WorkoutSoundtrackEditViewModel {
+    /// Owning workout id — passed to `WorkoutService` on every mutation.
+    let workoutId: String
+
+    /// Currently-selected featured track id (matches `WorkoutTrack.id.uuidString`).
+    /// Mirror of the underlying workout's value so the UI updates instantly
+    /// while the Supabase write is in flight.
+    var featuredTrackId: String?
+
+    /// Share-all toggle mirror — same instant-feedback contract as above.
+    var shareFullSoundtrack: Bool
+
+    /// True while a write is in flight. Currently used for haptic / visual
+    /// timing; views can disable controls if they want optimistic-only edits.
+    var isSaving: Bool = false
+
+    init(workout: Workout) {
+        self.workoutId = workout.id
+        self.featuredTrackId = workout.featuredTrackId
+        self.shareFullSoundtrack = workout.shareFullSoundtrack
+    }
+
+    /// Toggle featured pick on the given track. Tapping the same row clears
+    /// the pick so the user can fully unstick it.
+    func toggleFeatured(trackId: String) {
+        let next: String? = (featuredTrackId == trackId) ? nil : trackId
+        featuredTrackId = next
+        Task {
+            isSaving = true
+            await WorkoutService.shared.setFeaturedTrack(workoutId: workoutId, trackId: next)
+            isSaving = false
+        }
+    }
+
+    /// Toggle the share-full-soundtrack flag.
+    func setShareFullSoundtrack(_ enabled: Bool) {
+        shareFullSoundtrack = enabled
+        Task {
+            isSaving = true
+            await WorkoutService.shared.setShareFullSoundtrack(workoutId: workoutId, enabled: enabled)
+            isSaving = false
+        }
+    }
+}

--- a/Xomfit/Views/Feed/FeedItemCard.swift
+++ b/Xomfit/Views/Feed/FeedItemCard.swift
@@ -47,7 +47,8 @@ struct FeedItemCard: View {
                         title: featuredTitle,
                         artist: activity.featuredTrackArtist ?? "",
                         sourceApp: activity.featuredTrackSource ?? "",
-                        deepLinkURL: featuredDeepLinkURL(activity: activity)
+                        deepLinkURL: featuredDeepLinkURL(activity: activity),
+                        autoPlay: shouldAutoPlay(featuredTitle: featuredTitle)
                     )
                 }
 
@@ -320,6 +321,21 @@ struct FeedItemCard: View {
         return WorkoutTrackDeepLink.url(for: synthesized)
     }
 
+    /// Debug auto-play hook used by the screenshot harness (#411 follow-up).
+    /// Enabled only when both `XOMFIT_AUTH_BYPASS=1` and
+    /// `XOMFIT_AUTO_PLAY_FEATURED=1` are set, and only for the bypass mock
+    /// "Power" featured track so we don't disturb real users' decks.
+    private func shouldAutoPlay(featuredTitle: String) -> Bool {
+        #if DEBUG
+        let env = ProcessInfo.processInfo.environment
+        return env["XOMFIT_AUTH_BYPASS"] == "1"
+            && env["XOMFIT_AUTO_PLAY_FEATURED"] == "1"
+            && featuredTitle == "Power"
+        #else
+        return false
+        #endif
+    }
+
     // MARK: - Share
 
     private func shareFeedItem() {
@@ -547,28 +563,53 @@ private struct StreakActivityContent: View {
     }
 }
 
-// MARK: - Featured Soundtrack Row (#410)
+// MARK: - Featured Soundtrack Row (#410 / soundtrack-inline-playback)
 
 /// Compact "featured soundtrack" row used on each workout feed card. Visual
 /// matches `AnthemRow` (#403) so the two stacks read as siblings — the anthem
 /// is the poster's profile pick, the featured soundtrack is from this specific
-/// workout. Tapping the trailing button deep-links into the source service.
+/// workout.
+///
+/// Tap the LEFT button to play the 30s preview inline via
+/// `AnthemPlaybackService` (resolves via iTunes Search when no `previewURL`).
+/// The RIGHT button deep-links into the source service (Spotify / Apple Music
+/// / SoundCloud) so the user can keep listening to the full track.
 private struct FeaturedSoundtrackRow: View {
     let title: String
     let artist: String
     let sourceApp: String
     let deepLinkURL: URL?
+    /// Debug-only — when true, triggers `playback.play(...)` on first appear
+    /// so the screenshot harness can capture the mid-playback state without
+    /// driving a tap on the simulator. Always `false` in Release.
+    var autoPlay: Bool = false
+
+    /// Live mirror of the playback service so `@Observable` changes flip the
+    /// play/pause icon on this row. Calls still go through `.shared`. Plain
+    /// `let` matches `AnthemRow` — SwiftUI observes via type tracking so
+    /// `@State` would actually drop the observation (the wrapper boxes the
+    /// reference and SwiftUI only watches the wrapper, not the underlying
+    /// object's properties).
+    private let playback = AnthemPlaybackService.shared
+
+    /// `ProfileAnthem`-shaped wrapper around the captured track so we can hand
+    /// it to `AnthemPlaybackService` (which is keyed on title/artist for the
+    /// iTunes Search resolver).
+    private var asAnthem: ProfileAnthem {
+        ProfileAnthem(title: title, artist: artist, previewURL: nil, artworkURL: nil, appleMusicId: nil)
+    }
+
+    /// Treat "playing" as `currentlyPlayingID == this anthem`. We don't sniff
+    /// AVPlayer's `timeControlStatus` here because the service sets that id
+    /// AFTER `player.play()`, so by the time SwiftUI reads it the player
+    /// might still be transitioning out of `.waitingToPlayAtSpecifiedRate`.
+    /// The service's `stop()` nils the id, so this stays accurate.
+    private var isPlaying: Bool { playback.currentlyPlayingID == asAnthem.id }
+    private var isLoading: Bool { playback.isLoading(asAnthem) }
 
     var body: some View {
         HStack(spacing: Theme.Spacing.sm) {
-            ZStack {
-                Circle()
-                    .fill(Theme.accent)
-                    .frame(width: 28, height: 28)
-                Image(systemName: "star.fill")
-                    .font(.system(size: 12, weight: .black))
-                    .foregroundStyle(Theme.background)
-            }
+            playButton
 
             VStack(alignment: .leading, spacing: 1) {
                 Text(title)
@@ -595,6 +636,14 @@ private struct FeaturedSoundtrackRow: View {
             }
 
             Spacer(minLength: 0)
+
+            // Featured marker so the row visibly reads as a starred pick even
+            // mid-playback. Hidden from VoiceOver because the row label below
+            // already says "Featured track".
+            Image(systemName: "star.fill")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(Theme.accent)
+                .accessibilityHidden(true)
 
             if let url = deepLinkURL {
                 Button {
@@ -626,5 +675,54 @@ private struct FeaturedSoundtrackRow: View {
         )
         .accessibilityElement(children: .contain)
         .accessibilityLabel("Featured track: \(title)\(artist.isEmpty ? "" : ", by \(artist)")")
+        #if DEBUG
+        .task {
+            // Agent screenshot helper (#411 follow-up). Auto-kick playback
+            // when the harness flag is set so a mid-playback screenshot can
+            // be captured from a cold-launch script.
+            if autoPlay && !playback.isPlaying(asAnthem) {
+                try? await Task.sleep(for: .milliseconds(800))
+                await playback.play(asAnthem)
+            }
+        }
+        #endif
+    }
+
+    /// Inline play/pause button. Toggles `AnthemPlaybackService.shared` so only
+    /// one preview plays at a time across the app.
+    private var playButton: some View {
+        Button {
+            Haptics.light()
+            Task { await playback.toggle(asAnthem) }
+        } label: {
+            ZStack {
+                Circle()
+                    .fill(Theme.accent)
+                    .frame(width: 28, height: 28)
+
+                if isLoading {
+                    ProgressView()
+                        .progressViewStyle(.circular)
+                        .tint(Theme.background)
+                        .scaleEffect(0.7)
+                } else {
+                    Image(systemName: isPlaying ? "pause.fill" : "play.fill")
+                        .font(.system(size: 12, weight: .black))
+                        .foregroundStyle(Theme.background)
+                        // Optical centering — SF Symbol's play glyph sits
+                        // slightly left of the geometric center.
+                        .offset(x: isPlaying ? 0 : 1)
+                }
+            }
+            // 44pt minimum touch target.
+            .frame(minWidth: 44, minHeight: 44)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        // Stop tap from bubbling to the parent card (FeedItemCard wraps the
+        // whole row in a tap-to-open-detail gesture).
+        .simultaneousGesture(TapGesture().onEnded { })
+        .accessibilityLabel(isPlaying ? "Pause featured track preview" : "Play featured track preview")
+        .accessibilityHint("Plays a 30 second preview of \(title) inline.")
     }
 }

--- a/Xomfit/Views/Workout/ActiveWorkoutView.swift
+++ b/Xomfit/Views/Workout/ActiveWorkoutView.swift
@@ -826,8 +826,13 @@ struct ActiveWorkoutView: View {
         return "\(soundtrackPillLabel), \(countSuffix)"
     }
 
+    /// Total tracks visible on the pill — includes anything restored from a
+    /// pre-quit session (#411 follow-up) so the user can see the soundtrack
+    /// is still being recorded across re-launches.
     private var totalCapturedCount: Int {
-        spotifyCapture.capturedCount + appleMusicCapture.capturedCount
+        spotifyCapture.capturedCount
+            + appleMusicCapture.capturedCount
+            + viewModel.persistedCapturedTracks.count
     }
 
     /// Popover content surfacing per-source counts + last captured track so the user can

--- a/Xomfit/Views/Workout/WorkoutDetailView.swift
+++ b/Xomfit/Views/Workout/WorkoutDetailView.swift
@@ -48,8 +48,20 @@ struct WorkoutDetailView: View {
     /// `TemplateDetailView` so info is reachable from every workout surface.
     @State private var exerciseForDetail: Exercise?
 
+    /// Inline soundtrack-edit VM (#411 follow-up). Lazily seeded on first
+    /// appearance from `workout` so star/share toggles update Supabase + the
+    /// local cache + the feed item without going through full edit mode.
+    /// Only used when the viewing user authored the workout.
+    @State private var soundtrackEditVM: WorkoutSoundtrackEditViewModel?
+
     private var userId: String {
         authService.currentUser?.id.uuidString.lowercased() ?? ""
+    }
+
+    /// True when the signed-in user is the workout's author. Drives the
+    /// editable star + share-toggle controls vs. the read-only view.
+    private var isOwnWorkout: Bool {
+        !userId.isEmpty && workout.userId.lowercased() == userId
     }
 
     var body: some View {
@@ -193,6 +205,14 @@ struct WorkoutDetailView: View {
         }
         .sheet(item: $exerciseForDetail) { exercise in
             ExerciseDetailSheet(exercise: exercise)
+        }
+        .task {
+            // Lazy-seed the soundtrack edit VM (#411 follow-up). We only need
+            // it when the viewer is the author; the read-only branch reads
+            // values straight off `workout`.
+            if isOwnWorkout && soundtrackEditVM == nil {
+                soundtrackEditVM = WorkoutSoundtrackEditViewModel(workout: workout)
+            }
         }
     }
 
@@ -425,10 +445,20 @@ struct WorkoutDetailView: View {
 
     // MARK: - Soundtrack
 
-    /// Apple Music-only Now Playing capture (#302). See `NowPlayingService` for the iOS
-    /// platform restriction explaining why Spotify / Xomify won't ever appear here.
+    /// Soundtrack section. Behavior diverges by whether the viewing user is the
+    /// author of this workout.
+    ///
+    /// - Owner: editable. Star a track to feature it, toggle "Share full
+    ///   soundtrack" so non-friends only see the featured pick. Edits push
+    ///   through `WorkoutService.setFeaturedTrack` / `setShareFullSoundtrack`
+    ///   (tolerant of missing Supabase columns until the migration ships).
+    /// - Non-owner: read-only. When `shareFullSoundtrack` is false and a
+    ///   featured pick exists, only the featured track is shown with a
+    ///   "Soundtrack hidden" caption. Otherwise the full list shows with
+    ///   per-row deep-link buttons.
     @ViewBuilder
     private var soundtrackSection: some View {
+        let visibleTracks = visibleSoundtrackTracks
         VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
             HStack(spacing: 6) {
                 Image(systemName: "music.note")
@@ -438,8 +468,8 @@ struct WorkoutDetailView: View {
                     .font(.subheadline.weight(.bold))
                     .foregroundStyle(Theme.textPrimary)
                 Spacer()
-                if !workout.tracks.isEmpty {
-                    Text("\(workout.tracks.count)")
+                if !visibleTracks.isEmpty {
+                    Text("\(visibleTracks.count)")
                         .font(.caption.weight(.semibold).monospaced())
                         .foregroundStyle(Theme.textSecondary)
                 }
@@ -451,15 +481,51 @@ struct WorkoutDetailView: View {
                     .foregroundStyle(Theme.textSecondary)
                     .fixedSize(horizontal: false, vertical: true)
                     .accessibilityLabel("No tracks captured during this workout. Connect Spotify in Settings to capture from Spotify too.")
+            } else if visibleTracks.isEmpty {
+                // Edge case: not-author + share-off + no featured. Nothing to show.
+                Text("Soundtrack hidden")
+                    .font(Theme.fontSmall)
+                    .foregroundStyle(Theme.textTertiary)
             } else {
                 VStack(spacing: 0) {
-                    ForEach(Array(workout.tracks.enumerated()), id: \.element.id) { index, track in
+                    ForEach(Array(visibleTracks.enumerated()), id: \.element.id) { index, track in
                         soundtrackRow(track: track)
-                        if index < workout.tracks.count - 1 {
+                        if index < visibleTracks.count - 1 {
                             Divider()
                                 .background(Theme.textSecondary.opacity(0.15))
                         }
                     }
+                }
+
+                // Owner-only: share-all toggle. Lives in the captured branch
+                // because there's nothing to share when no tracks exist.
+                if isOwnWorkout, let editVM = soundtrackEditVM {
+                    Toggle(isOn: Binding(
+                        get: { editVM.shareFullSoundtrack },
+                        set: { editVM.setShareFullSoundtrack($0) }
+                    )) {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text("Share full soundtrack")
+                                .font(.subheadline.weight(.medium))
+                                .foregroundStyle(Theme.textPrimary)
+                            Text(editVM.shareFullSoundtrack
+                                 ? "Friends will see every track on this workout."
+                                 : "Only the featured track will show on your feed.")
+                                .font(Theme.fontCaption)
+                                .foregroundStyle(Theme.textSecondary)
+                        }
+                    }
+                    .tint(Theme.accent)
+                    .accessibilityHint("Toggle whether the full soundtrack is shared with friends or only the featured track.")
+                    .padding(.top, Theme.Spacing.xs)
+                }
+
+                // Non-owner footer mirroring FeedDetailView (#410).
+                if !isOwnWorkout && !workout.shareFullSoundtrack && workout.featuredTrackId != nil {
+                    Text("Soundtrack hidden — only the featured track was shared.")
+                        .font(Theme.fontSmall)
+                        .foregroundStyle(Theme.textTertiary)
+                        .padding(.top, Theme.Spacing.xs)
                 }
             }
         }
@@ -468,31 +534,98 @@ struct WorkoutDetailView: View {
         .clipShape(.rect(cornerRadius: Theme.cornerRadius))
     }
 
+    /// Slice of `workout.tracks` the viewer is allowed to see. Mirrors the
+    /// `FeedDetailView.visibleTracks(in:)` rule so the detail view and the
+    /// expanded feed view stay consistent.
+    private var visibleSoundtrackTracks: [WorkoutTrack] {
+        if isOwnWorkout || workout.shareFullSoundtrack {
+            return workout.tracks
+        }
+        if let featured = workout.featuredTrack {
+            return [featured]
+        }
+        return []
+    }
+
+    @ViewBuilder
     private func soundtrackRow(track: WorkoutTrack) -> some View {
+        let featuredId = soundtrackEditVM?.featuredTrackId ?? workout.featuredTrackId
+        let isFeatured = featuredId == track.id.uuidString
+        let deepLinkURL = WorkoutTrackDeepLink.url(for: track)
+
         HStack(spacing: Theme.Spacing.sm) {
-            Image(systemName: "music.note")
-                .font(Theme.fontCaption)
-                .foregroundStyle(Theme.textSecondary)
-                .frame(width: 20)
+            // LEFT: play preview button. Always visible — owner and non-owner
+            // can scrub a 30s preview without leaving the screen.
+            DetailSoundtrackPlayButton(track: track)
 
             VStack(alignment: .leading, spacing: Theme.Spacing.tighter) {
                 Text(track.title)
                     .font(.subheadline.weight(.medium))
                     .foregroundStyle(Theme.textPrimary)
                     .lineLimit(1)
-                if let artist = track.artist, !artist.isEmpty {
-                    Text(artist)
+                HStack(spacing: 6) {
+                    if let artist = track.artist, !artist.isEmpty {
+                        Text(artist)
+                            .font(Theme.fontSmall)
+                            .foregroundStyle(Theme.textSecondary)
+                            .lineLimit(1)
+                        Text("\u{2022}")
+                            .font(.caption2.weight(.bold))
+                            .foregroundStyle(Theme.textTertiary)
+                            .accessibilityHidden(true)
+                    }
+                    Text(track.sourceApp)
                         .font(Theme.fontSmall)
-                        .foregroundStyle(Theme.textSecondary)
-                        .lineLimit(1)
+                        .foregroundStyle(Theme.textTertiary)
                 }
             }
 
             Spacer()
+
+            // RIGHT: featured-star (owner only) + deep-link (everyone).
+            if isOwnWorkout, let editVM = soundtrackEditVM {
+                Button {
+                    Haptics.selection()
+                    editVM.toggleFeatured(trackId: track.id.uuidString)
+                } label: {
+                    Image(systemName: isFeatured ? "star.fill" : "star")
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(isFeatured ? Theme.accent : Theme.textSecondary)
+                        .frame(width: 44, height: 44)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(isFeatured
+                    ? "Unset \(track.title) as featured track"
+                    : "Set \(track.title) as featured track")
+                .accessibilityHint("Featured tracks show prominently on your feed card.")
+            } else if isFeatured {
+                Image(systemName: "star.fill")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(Theme.accent)
+                    .frame(width: 28, height: 28)
+                    .accessibilityHidden(true)
+            }
+
+            if let url = deepLinkURL {
+                Button {
+                    Haptics.light()
+                    UIApplication.shared.open(url)
+                } label: {
+                    Image(systemName: "arrow.up.right.square")
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundStyle(Theme.accent)
+                        .frame(minWidth: 44, minHeight: 44)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(WorkoutTrackDeepLink.label(for: track.sourceApp))
+                .accessibilityHint("Opens this track in \(track.sourceApp).")
+            }
         }
         .padding(.vertical, Theme.Spacing.sm)
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel(accessibilityLabel(for: track))
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(accessibilityLabel(for: track) + (isFeatured ? ", featured" : ""))
     }
 
     private func accessibilityLabel(for track: WorkoutTrack) -> String {
@@ -679,6 +812,64 @@ struct WorkoutDetailView: View {
 private struct ShareImageWrapper: Identifiable {
     let id = UUID()
     let image: UIImage
+}
+
+// MARK: - Detail Soundtrack Play Button (#411 follow-up)
+
+/// 28pt play/pause button wired to `AnthemPlaybackService` so the user can
+/// preview a captured track from the workout-detail soundtrack list without
+/// leaving the screen. Mirrors the visuals of `AnthemRow` so the rest of the
+/// soundtrack surface reads as a sibling family of controls.
+private struct DetailSoundtrackPlayButton: View {
+    let track: WorkoutTrack
+
+    /// Live mirror of the playback singleton so `@Observable` updates flip
+    /// the play/pause icon on this button. Plain `let` matches `AnthemRow` —
+    /// SwiftUI observes via type tracking on `@Observable`.
+    private let playback = AnthemPlaybackService.shared
+
+    private var asAnthem: ProfileAnthem {
+        ProfileAnthem(
+            title: track.title,
+            artist: track.artist ?? "",
+            previewURL: nil,
+            artworkURL: nil,
+            appleMusicId: nil
+        )
+    }
+
+    private var isPlaying: Bool { playback.currentlyPlayingID == asAnthem.id }
+    private var isLoading: Bool { playback.isLoading(asAnthem) }
+
+    var body: some View {
+        Button {
+            Haptics.light()
+            Task { await playback.toggle(asAnthem) }
+        } label: {
+            ZStack {
+                Circle()
+                    .fill(Theme.accent)
+                    .frame(width: 28, height: 28)
+
+                if isLoading {
+                    ProgressView()
+                        .progressViewStyle(.circular)
+                        .tint(Theme.background)
+                        .scaleEffect(0.7)
+                } else {
+                    Image(systemName: isPlaying ? "pause.fill" : "play.fill")
+                        .font(.system(size: 12, weight: .black))
+                        .foregroundStyle(Theme.background)
+                        .offset(x: isPlaying ? 0 : 1)
+                }
+            }
+            .frame(minWidth: 44, minHeight: 44)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(isPlaying ? "Pause preview" : "Play preview of \(track.title)")
+        .accessibilityHint("Plays a 30 second preview inline.")
+    }
 }
 
 // MARK: - Edit Mode Body (#365)

--- a/Xomfit/XomfitApp.swift
+++ b/Xomfit/XomfitApp.swift
@@ -22,6 +22,11 @@ struct XomFitApp: App {
     /// screenshot it without navigating the drawer (#371).
     #if DEBUG
     @State private var showCoachSheet = false
+
+    /// DEBUG-only: id of a workout to surface in a WorkoutDetailView modal
+    /// for the agent screenshot harness (#411 follow-up). Set via the
+    /// `XOMFIT_OPEN_WORKOUT_DETAIL=<id>` env var; cleared when dismissed.
+    @State private var debugWorkoutDetailId: String? = nil
     #endif
 
     /// Force-quit recovery (#399). When the user (or the OS) terminates the app
@@ -150,6 +155,26 @@ struct XomFitApp: App {
                                 try? await Task.sleep(for: .milliseconds(500))
                                 seedDebugActiveWorkout()
                             }
+
+                            // Agent screenshot helper (#411 follow-up): open
+                            // a specific workout's detail view from a cold
+                            // launch by setting `XOMFIT_OPEN_WORKOUT_DETAIL=<id>`.
+                            // Combine with XOMFIT_AUTH_BYPASS=1 to inspect the
+                            // soundtrack edit / read-only UI end-to-end.
+                            if let workoutId = ProcessInfo.processInfo.environment["XOMFIT_OPEN_WORKOUT_DETAIL"],
+                               !workoutId.isEmpty {
+                                try? await Task.sleep(for: .milliseconds(500))
+                                debugWorkoutDetailId = workoutId
+                            }
+                        }
+                        .fullScreenCover(item: Binding(
+                            get: { debugWorkoutDetailId.map { DebugWorkoutDetailRoute(id: $0) } },
+                            set: { debugWorkoutDetailId = $0?.id }
+                        )) { route in
+                            DebugWorkoutDetailHost(workoutId: route.id)
+                                .environment(authService)
+                                .environment(workoutSession)
+                                .preferredColorScheme(.dark)
                         }
                         #endif
                 } else {
@@ -405,3 +430,54 @@ private struct WorkoutRestoreInfo: Identifiable {
     let workoutName: String
     let startedRelative: String
 }
+
+#if DEBUG
+// MARK: - Debug Workout Detail Host (#411 follow-up)
+
+/// `Identifiable` wrapper so `fullScreenCover(item:)` can drive presentation
+/// from the `XOMFIT_OPEN_WORKOUT_DETAIL=<id>` env var.
+private struct DebugWorkoutDetailRoute: Identifiable {
+    let id: String
+}
+
+/// Loads a workout from `WorkoutService` and pushes `WorkoutDetailView` inside
+/// a NavigationStack. Used only by the agent screenshot harness so the
+/// soundtrack edit UI can be inspected from a cold launch.
+private struct DebugWorkoutDetailHost: View {
+    let workoutId: String
+    @State private var workout: Workout?
+    @State private var didError = false
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Theme.background.ignoresSafeArea()
+                if let workout {
+                    WorkoutDetailView(workout: workout)
+                        .navigationBarBackButtonHidden(false)
+                } else if didError {
+                    Text("Workout not found")
+                        .foregroundStyle(Theme.textSecondary)
+                } else {
+                    ProgressView()
+                        .tint(Theme.accent)
+                }
+            }
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Close") { dismiss() }
+                }
+            }
+        }
+        .task {
+            let fetched = await WorkoutService.shared.fetchWorkout(id: workoutId)
+            if let fetched {
+                workout = fetched
+            } else {
+                didError = true
+            }
+        }
+    }
+}
+#endif


### PR DESCRIPTION
## Summary

Three gaps from #411 closed.

### Gap 1 — Inline 30s preview playback on feed card
\`FeaturedSoundtrackRow\` refactored to add a 28pt play/pause button on the LEFT wired to the existing \`AnthemPlaybackService\` (from #403). Synthesizes a \`ProfileAnthem\` from \`WorkoutTrack\` so the iTunes Search resolver handles preview-URL lookup. Deep-link arrow stays on the RIGHT.

### Gap 2 — Edit featured + share-all after save
- New \`WorkoutService.setFeaturedTrack(workoutId:trackId:)\` + \`setShareFullSoundtrack(workoutId:enabled:)\` — patches local cache + feed item immediately, tolerates 4xx on the Supabase write so this ships before the migration
- New \`WorkoutSoundtrackEditViewModel\` (@Observable) drives an inline soundtrack section on \`WorkoutDetailView\`
- Owner sees editable stars + share toggle
- Non-owner sees read-only stars + per-row deep links + "Soundtrack hidden" footer when share-all is off
- Every row (owner or non-owner) has the play button

### Gap 3 — Soundtrack persists across app quit
- \`PersistedSession\` now serializes \`capturedTracks\`, \`manualTracks\`, \`removedTrackIDs\`, \`featuredTrackId\`, \`shareFullSoundtrack\`
- \`saveActiveSession()\` snapshots from \`NowPlayingService\` / \`SpotifyNowPlayingService\` / \`SoundCloudNowPlayingService\` before they reset
- \`restoreActiveSession()\` rehydrates a new \`persistedCapturedTracks\` array on the VM; \`curatedTracksSnapshot\` merges it (deduped)
- The "Recording soundtrack (N)" pill on the active workout view now includes restored tracks

### Backend
The Supabase columns for \`featured_track_id\` and \`share_full_soundtrack\` on the workouts table aren't yet created. The new setters log + silently no-op on 4xx so the iOS feature ships before the migration. Local UI updates work; cross-device sync will start once the schema lands.

## Test plan
- [ ] Feed card — tap the new play button on a featured track row → 30s preview plays
- [ ] Open own workout detail → soundtrack section editable (stars + toggle), changes persist to local cache
- [ ] Open another user's workout detail → soundtrack read-only, deep-links visible per row
- [ ] Force-quit during a workout with captured tracks → relaunch → resume → tracks restored, "Recording soundtrack (N)" pill matches