### PR TITLE
ci(testflight): fetch tags so git describe sees v2.1.3+

### DIFF
--- a/.github/workflows/testflight-deploy.yml
+++ b/.github/workflows/testflight-deploy.yml
@@ -20,6 +20,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          # `git describe --tags` in the version-compute step needs the tag
+          # objects, which `fetch-depth: 0` alone doesn't pull on v4.
+          fetch-tags: true
 
       - name: Select Xcode
         run: sudo xcode-select -s /Applications/Xcode.app


### PR DESCRIPTION
actions/checkout@v4 with fetch-depth: 0 alone doesn't fetch tag objects. Added fetch-tags: true. The v2.1.3 deploy went out as 2.1.2 because the tag wasn't visible to git describe.