### PR TITLE
feat: UI polish + soundtrack fixes + music profile + location autocomplete

### DIFF
--- a/Xomfit/Services/NowPlayingService.swift
+++ b/Xomfit/Services/NowPlayingService.swift
@@ -28,6 +28,9 @@ final class NowPlayingService {
     @ObservationIgnored private var seenKeys: Set<String> = []
     @ObservationIgnored private var pollTask: Task<Void, Never>?
     @ObservationIgnored private var isAuthorized: Bool = false
+    @ObservationIgnored private var pendingKey: String?
+    @ObservationIgnored private var pendingFirstSeen: Date?
+    @ObservationIgnored private let minimumListenDuration: TimeInterval = 25
 
     /// Becomes true after the user explicitly denies Apple Music access. Used to suppress
     /// repeated `MPMediaLibrary.requestAuthorization` traffic and noisy logs across multiple
@@ -111,6 +114,8 @@ final class NowPlayingService {
         // Reset session state up-front so a back-to-back start clears prior captures
         captured.removeAll()
         seenKeys.removeAll()
+        pendingKey = nil
+        pendingFirstSeen = nil
         lastCapturedTrack = nil
         pollTask?.cancel()
 
@@ -184,22 +189,28 @@ final class NowPlayingService {
         }
 
         let key = dedupeKey(title: title, artist: item.artist, persistentID: item.persistentID)
-        guard !seenKeys.contains(key) else {
-            print("[NowPlayingService] captureCurrentTrack: '\(title)' already captured, deduped")
-            return
-        }
-        seenKeys.insert(key)
+        guard !seenKeys.contains(key) else { return }
 
-        let track = WorkoutTrack(
-            title: title,
-            artist: item.artist,
-            album: item.albumTitle,
-            capturedAt: Date(),
-            sourceApp: "Apple Music"
-        )
-        captured.append(track)
-        lastCapturedTrack = track
-        print("[NowPlayingService] captured '\(title)' by \(item.artist ?? "unknown") — total: \(captured.count)")
+        if pendingKey == key, let firstSeen = pendingFirstSeen,
+           Date().timeIntervalSince(firstSeen) >= minimumListenDuration {
+            seenKeys.insert(key)
+            pendingKey = nil
+            pendingFirstSeen = nil
+
+            let track = WorkoutTrack(
+                title: title,
+                artist: item.artist,
+                album: item.albumTitle,
+                capturedAt: Date(),
+                sourceApp: "Apple Music"
+            )
+            captured.append(track)
+            lastCapturedTrack = track
+            print("[NowPlayingService] captured '\(title)' by \(item.artist ?? "unknown") — total: \(captured.count)")
+        } else if pendingKey != key {
+            pendingKey = key
+            pendingFirstSeen = Date()
+        }
     }
 
     private func dedupeKey(title: String, artist: String?, persistentID: MPMediaEntityPersistentID) -> String {

--- a/Xomfit/Services/SpotifyNowPlayingService.swift
+++ b/Xomfit/Services/SpotifyNowPlayingService.swift
@@ -23,6 +23,9 @@ final class SpotifyNowPlayingService {
     private var captured: [WorkoutTrack] = []
     @ObservationIgnored private var seenKeys: Set<String> = []
     @ObservationIgnored private var pollTask: Task<Void, Never>?
+    @ObservationIgnored private var pendingKey: String?
+    @ObservationIgnored private var pendingFirstSeen: Date?
+    @ObservationIgnored private let minimumListenDuration: TimeInterval = 25
 
     // MARK: - Observable surface (Spotify capture polish)
 
@@ -57,6 +60,8 @@ final class SpotifyNowPlayingService {
         print("[SpotifyNowPlayingService] startCapture called — resetting session state")
         captured.removeAll()
         seenKeys.removeAll()
+        pendingKey = nil
+        pendingFirstSeen = nil
         lastCapturedTrack = nil
         pollTask?.cancel()
 
@@ -146,37 +151,38 @@ final class SpotifyNowPlayingService {
             guard !title.isEmpty else { return }
 
             let key = dedupeKey(uri: item.uri, id: item.id, title: title)
-            guard !seenKeys.contains(key) else {
-                print("[SpotifyNowPlayingService] '\(title)' already captured, deduped")
-                return
-            }
-            seenKeys.insert(key)
+            guard !seenKeys.contains(key) else { return }
 
-            let artist = item.artists?.compactMap { $0.name }.joined(separator: ", ")
-            // Prefer the https web URL (#410) — opens cleanly in browser and
-            // on phones with the Spotify app installed it routes natively.
-            // Fall back to the `spotify:track:<id>` URI if neither is present
-            // we leave `url` nil and the feed deep link falls back to search.
-            let trackURL: String? = {
-                if let id = item.id, !id.isEmpty {
-                    return "https://open.spotify.com/track/\(id)"
-                }
-                if let uri = item.uri, !uri.isEmpty {
-                    return uri
-                }
-                return nil
-            }()
-            let track = WorkoutTrack(
-                title: title,
-                artist: (artist?.isEmpty == false) ? artist : nil,
-                album: item.album?.name,
-                capturedAt: Date(),
-                sourceApp: "Spotify",
-                url: trackURL
-            )
-            captured.append(track)
-            lastCapturedTrack = track
-            print("[SpotifyNowPlayingService] captured '\(title)' by \(artist ?? "unknown") — total: \(captured.count)")
+            if pendingKey == key, let firstSeen = pendingFirstSeen,
+               Date().timeIntervalSince(firstSeen) >= minimumListenDuration {
+                seenKeys.insert(key)
+                pendingKey = nil
+                pendingFirstSeen = nil
+
+                let artist = item.artists?.compactMap { $0.name }.joined(separator: ", ")
+                let trackURL: String? = {
+                    if let id = item.id, !id.isEmpty {
+                        return "https://open.spotify.com/track/\(id)"
+                    }
+                    if let uri = item.uri, !uri.isEmpty { return uri }
+                    return nil
+                }()
+                let track = WorkoutTrack(
+                    title: title,
+                    artist: (artist?.isEmpty == false) ? artist : nil,
+                    album: item.album?.name,
+                    capturedAt: Date(),
+                    sourceApp: "Spotify",
+                    url: trackURL
+                )
+                captured.append(track)
+                lastCapturedTrack = track
+                print("[SpotifyNowPlayingService] captured '\(title)' by \(artist ?? "unknown") — total: \(captured.count)")
+            } else if pendingKey != key {
+                pendingKey = key
+                pendingFirstSeen = Date()
+                print("[SpotifyNowPlayingService] pending '\(title)' — will capture after \(Int(minimumListenDuration))s")
+            }
         } catch {
             // Network blips happen — log and continue. Polling will retry on the next tick.
             print("[SpotifyNowPlayingService] poll error: \(error)")

--- a/Xomfit/ViewModels/ProfileViewModel.swift
+++ b/Xomfit/ViewModels/ProfileViewModel.swift
@@ -9,6 +9,7 @@ enum ProfileTab: String, CaseIterable, Identifiable {
     case feed
     case calendar
     case stats
+    case music
 
     var id: String { rawValue }
 
@@ -17,6 +18,7 @@ enum ProfileTab: String, CaseIterable, Identifiable {
         case .feed: return "list.bullet"
         case .calendar: return "calendar"
         case .stats: return "chart.bar"
+        case .music: return "music.note"
         }
     }
 
@@ -25,8 +27,20 @@ enum ProfileTab: String, CaseIterable, Identifiable {
         case .feed: return "Feed"
         case .calendar: return "Calendar"
         case .stats: return "Stats"
+        case .music: return "Music"
         }
     }
+}
+
+struct AggregatedTrack: Identifiable, Hashable {
+    let title: String
+    let artist: String?
+    let sourceApp: String
+    let url: String?
+    var playCount: Int
+    var lastPlayed: Date
+
+    var id: String { "\(title.lowercased())|\(artist?.lowercased() ?? "")|\(sourceApp)" }
 }
 
 // MARK: - ProfileViewModel
@@ -103,6 +117,35 @@ final class ProfileViewModel {
     // MARK: - Muscle Group Heatmap
     var muscleGroupSetsThisWeek: [String: Int] = [:]
     var muscleGroupSetsThisMonth: [String: Int] = [:]
+
+    // MARK: - Music (aggregated listening history)
+    var aggregatedTracks: [AggregatedTrack] = []
+
+    func computeAggregatedTracks() {
+        var trackMap: [String: AggregatedTrack] = [:]
+        for workout in workouts {
+            for track in workout.tracks {
+                let key = "\(track.title.lowercased())|\(track.artist?.lowercased() ?? "")|\(track.sourceApp)"
+                if var existing = trackMap[key] {
+                    existing.playCount += 1
+                    if track.capturedAt > existing.lastPlayed {
+                        existing.lastPlayed = track.capturedAt
+                    }
+                    trackMap[key] = existing
+                } else {
+                    trackMap[key] = AggregatedTrack(
+                        title: track.title,
+                        artist: track.artist,
+                        sourceApp: track.sourceApp,
+                        url: track.url,
+                        playCount: 1,
+                        lastPlayed: track.capturedAt
+                    )
+                }
+            }
+        }
+        aggregatedTracks = trackMap.values.sorted { $0.playCount > $1.playCount }
+    }
 
     // MARK: - Tab state
     var selectedTab: ProfileTab = .feed
@@ -260,6 +303,7 @@ final class ProfileViewModel {
         totalVolume = fetchedWorkouts.reduce(0) { $0 + $1.totalVolume }
         loadCalendarData(workouts: fetchedWorkouts)
         computeMuscleGroupSets(workouts: fetchedWorkouts)
+        computeAggregatedTracks()
 
         await prsTask
         await feedTask

--- a/Xomfit/ViewModels/WorkoutLoggerViewModel.swift
+++ b/Xomfit/ViewModels/WorkoutLoggerViewModel.swift
@@ -579,6 +579,10 @@ final class WorkoutLoggerViewModel {
         exercises.swapAt(source, destination)
     }
 
+    func moveExercises(from source: IndexSet, to destination: Int) {
+        exercises.move(fromOffsets: source, toOffset: destination)
+    }
+
     // MARK: - Exercise Config (Grip / Attachment / Position)
 
     func setGrip(exerciseIndex: Int, grip: GripType) {

--- a/Xomfit/Views/Components/LocationSearchField.swift
+++ b/Xomfit/Views/Components/LocationSearchField.swift
@@ -1,0 +1,128 @@
+import SwiftUI
+import MapKit
+
+struct LocationSearchField: View {
+    @Binding var text: String
+    var placeholder: String = "Search for a place..."
+
+    @State private var completer = LocationCompleter()
+    @State private var showSuggestions = false
+    @FocusState private var isFocused: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack(spacing: Theme.Spacing.sm) {
+                Image(systemName: "location.fill")
+                    .font(Theme.fontCaption)
+                    .foregroundStyle(Theme.textSecondary)
+                TextField(placeholder, text: $text)
+                    .font(Theme.fontBody)
+                    .foregroundStyle(Theme.textPrimary)
+                    .textInputAutocapitalization(.words)
+                    .focused($isFocused)
+                    .accessibilityLabel("Workout location")
+                if !text.isEmpty {
+                    Button {
+                        text = ""
+                        completer.results = []
+                    } label: {
+                        Image(systemName: "xmark.circle.fill")
+                            .font(.caption)
+                            .foregroundStyle(Theme.textTertiary)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .padding(Theme.Spacing.sm)
+            .background(Theme.surface)
+            .clipShape(.rect(cornerRadius: Theme.cornerRadiusSmall))
+            .overlay(
+                RoundedRectangle(cornerRadius: Theme.cornerRadiusSmall)
+                    .stroke(Theme.textSecondary.opacity(0.2), lineWidth: 1)
+            )
+
+            if showSuggestions && !completer.results.isEmpty {
+                VStack(alignment: .leading, spacing: 0) {
+                    ForEach(completer.results.prefix(5), id: \.self) { result in
+                        Button {
+                            text = result.title
+                            showSuggestions = false
+                            isFocused = false
+                        } label: {
+                            VStack(alignment: .leading, spacing: Theme.Spacing.tighter) {
+                                Text(result.title)
+                                    .font(.subheadline.weight(.medium))
+                                    .foregroundStyle(Theme.textPrimary)
+                                    .lineLimit(1)
+                                if !result.subtitle.isEmpty {
+                                    Text(result.subtitle)
+                                        .font(Theme.fontCaption)
+                                        .foregroundStyle(Theme.textSecondary)
+                                        .lineLimit(1)
+                                }
+                            }
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(.horizontal, Theme.Spacing.sm)
+                            .padding(.vertical, Theme.Spacing.sm)
+                        }
+                        .buttonStyle(.plain)
+
+                        if result != completer.results.prefix(5).last {
+                            Divider().padding(.leading, Theme.Spacing.sm)
+                        }
+                    }
+                }
+                .background(Theme.surfaceElevated)
+                .clipShape(.rect(cornerRadius: Theme.cornerRadiusSmall))
+                .shadow(color: .black.opacity(0.15), radius: 8, y: 4)
+                .padding(.top, Theme.Spacing.xs)
+                .transition(.opacity.combined(with: .move(edge: .top)))
+            }
+        }
+        .onChange(of: text) { _, newValue in
+            completer.search(query: newValue)
+            showSuggestions = isFocused && !newValue.isEmpty
+        }
+        .onChange(of: isFocused) { _, focused in
+            showSuggestions = focused && !text.isEmpty && !completer.results.isEmpty
+        }
+        .animation(.xomChill, value: showSuggestions)
+    }
+}
+
+@MainActor
+@Observable
+private final class LocationCompleter: NSObject, MKLocalSearchCompleterDelegate {
+    var results: [MKLocalSearchCompletion] = []
+
+    private let completer: MKLocalSearchCompleter = {
+        let c = MKLocalSearchCompleter()
+        c.resultTypes = .pointOfInterest
+        return c
+    }()
+
+    override init() {
+        super.init()
+        completer.delegate = self
+    }
+
+    func search(query: String) {
+        guard !query.trimmingCharacters(in: .whitespaces).isEmpty else {
+            results = []
+            return
+        }
+        completer.queryFragment = query
+    }
+
+    nonisolated func completerDidUpdateResults(_ completer: MKLocalSearchCompleter) {
+        Task { @MainActor in
+            self.results = completer.results
+        }
+    }
+
+    nonisolated func completer(_ completer: MKLocalSearchCompleter, didFailWithError error: Error) {
+        Task { @MainActor in
+            self.results = []
+        }
+    }
+}

--- a/Xomfit/Views/Feed/FeedItemCard.swift
+++ b/Xomfit/Views/Feed/FeedItemCard.swift
@@ -37,9 +37,15 @@ struct FeedItemCard: View {
                     AnthemRow(anthem: anthem, style: .feed)
                 }
 
-                // Featured soundtrack row (#410) — surfaces the poster's
-                // featured-track pick from this workout in the same compact
-                // anthem-row style. Nil when no featured pick was made.
+                activityContent
+
+                if let caption = item.caption, !caption.isEmpty {
+                    Text(caption)
+                        .font(Theme.fontBody)
+                        .foregroundStyle(Theme.textPrimary)
+                        .padding(.top, Theme.Spacing.tighter)
+                }
+
                 if let activity = item.workoutActivity,
                    let featuredTitle = activity.featuredTrackTitle,
                    !featuredTitle.isEmpty {
@@ -50,15 +56,6 @@ struct FeedItemCard: View {
                         deepLinkURL: featuredDeepLinkURL(activity: activity),
                         autoPlay: shouldAutoPlay(featuredTitle: featuredTitle)
                     )
-                }
-
-                activityContent
-
-                if let caption = item.caption, !caption.isEmpty {
-                    Text(caption)
-                        .font(Theme.fontBody)
-                        .foregroundStyle(Theme.textPrimary)
-                        .padding(.top, Theme.Spacing.tighter)
                 }
 
                 XomDivider()

--- a/Xomfit/Views/MainTabView.swift
+++ b/Xomfit/Views/MainTabView.swift
@@ -70,6 +70,7 @@ struct MainTabView: View {
     /// here subscribes the shell to capture-state changes via the `@Observable` macro.
     @State private var spotifyCapture = SpotifyNowPlayingService.shared
     @State private var appleMusicCapture = NowPlayingService.shared
+    @State private var soundCloudCapture = SoundCloudNowPlayingService.shared
 
     /// Default drawer width: ~78% of the screen, clamped so it doesn't grow
     /// absurd on iPad widths. iOS resolves this via GeometryReader below.
@@ -145,7 +146,7 @@ struct MainTabView: View {
                     // Live-updating via `@Observable` on the singletons (Spotify capture
                     // polish). When the workout is active and tracks have been captured,
                     // the resume bar surfaces a subtle "💿 N tracks" label.
-                    capturedTrackCount: spotifyCapture.capturedCount + appleMusicCapture.capturedCount,
+                    capturedTrackCount: spotifyCapture.capturedCount + appleMusicCapture.capturedCount + soundCloudCapture.capturedCount,
                     onTap: {
                         withAnimation(.spring(response: 0.35, dampingFraction: 0.82)) {
                             workoutSession.isPresented = true

--- a/Xomfit/Views/Profile/ProfileMusicView.swift
+++ b/Xomfit/Views/Profile/ProfileMusicView.swift
@@ -1,0 +1,144 @@
+import SwiftUI
+
+struct ProfileMusicView: View {
+    let tracks: [AggregatedTrack]
+
+    @State private var sourceFilter: String?
+
+    private var sources: [String] {
+        Array(Set(tracks.map(\.sourceApp))).sorted()
+    }
+
+    private var filteredTracks: [AggregatedTrack] {
+        guard let filter = sourceFilter else { return tracks }
+        return tracks.filter { $0.sourceApp == filter }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.md) {
+            if tracks.isEmpty {
+                emptyState
+            } else {
+                filterBar
+                trackList
+            }
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: Theme.Spacing.md) {
+            Image(systemName: "music.note.list")
+                .font(.system(size: 40))
+                .foregroundStyle(Theme.textTertiary)
+            Text("No listening history yet")
+                .font(.subheadline.weight(.medium))
+                .foregroundStyle(Theme.textSecondary)
+            Text("Tracks will appear here after workouts with music capture enabled.")
+                .font(Theme.fontCaption)
+                .foregroundStyle(Theme.textTertiary)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, Theme.Spacing.xxl)
+    }
+
+    private var filterBar: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: Theme.Spacing.sm) {
+                FilterChip(label: "All", isActive: sourceFilter == nil) {
+                    sourceFilter = nil
+                }
+                ForEach(sources, id: \.self) { source in
+                    FilterChip(label: source, isActive: sourceFilter == source) {
+                        sourceFilter = source
+                    }
+                }
+            }
+            .padding(.horizontal, Theme.Spacing.md)
+        }
+    }
+
+    private var trackList: some View {
+        LazyVStack(spacing: Theme.Spacing.xs) {
+            ForEach(filteredTracks) { track in
+                TrackRow(track: track)
+            }
+        }
+        .padding(.horizontal, Theme.Spacing.md)
+    }
+}
+
+private struct FilterChip: View {
+    let label: String
+    let isActive: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Text(label)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(isActive ? .black : Theme.textPrimary)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 6)
+                .background(isActive ? Theme.accent : Theme.surface)
+                .clipShape(.capsule)
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+private struct TrackRow: View {
+    let track: AggregatedTrack
+
+    private var sourceIcon: String {
+        switch track.sourceApp {
+        case "Spotify": return "music.note"
+        case "Apple Music": return "music.quarternote.3"
+        case "SoundCloud": return "waveform"
+        default: return "music.note"
+        }
+    }
+
+    var body: some View {
+        HStack(spacing: Theme.Spacing.sm) {
+            Image(systemName: sourceIcon)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(Theme.accent)
+                .frame(width: 32, height: 32)
+                .background(Theme.accent.opacity(0.12))
+                .clipShape(Circle())
+
+            VStack(alignment: .leading, spacing: Theme.Spacing.tighter) {
+                Text(track.title)
+                    .font(.subheadline.weight(.medium))
+                    .foregroundStyle(Theme.textPrimary)
+                    .lineLimit(1)
+                HStack(spacing: Theme.Spacing.xs) {
+                    if let artist = track.artist, !artist.isEmpty {
+                        Text(artist)
+                            .font(Theme.fontCaption)
+                            .foregroundStyle(Theme.textSecondary)
+                            .lineLimit(1)
+                    }
+                    Text("· \(track.sourceApp)")
+                        .font(Theme.fontCaption)
+                        .foregroundStyle(Theme.textTertiary)
+                }
+            }
+
+            Spacer()
+
+            VStack(alignment: .trailing, spacing: Theme.Spacing.tighter) {
+                Text("\(track.playCount)")
+                    .font(.subheadline.weight(.bold).monospacedDigit())
+                    .foregroundStyle(Theme.accent)
+                Text(track.playCount == 1 ? "play" : "plays")
+                    .font(.system(size: 9, weight: .semibold))
+                    .foregroundStyle(Theme.textTertiary)
+            }
+        }
+        .padding(Theme.Spacing.sm)
+        .background(Theme.surface)
+        .clipShape(.rect(cornerRadius: Theme.cornerRadiusSmall))
+    }
+}

--- a/Xomfit/Views/Profile/ProfileView.swift
+++ b/Xomfit/Views/Profile/ProfileView.swift
@@ -229,6 +229,8 @@ struct ProfileView: View {
                 firstPRDate: viewModel.allPRs.map(\.date).min(),
                 onStartWorkout: statsEmptyStateAction
             )
+        case .music:
+            ProfileMusicView(tracks: viewModel.aggregatedTracks)
         }
     }
 

--- a/Xomfit/Views/Workout/ActiveWorkoutView.swift
+++ b/Xomfit/Views/Workout/ActiveWorkoutView.swift
@@ -17,8 +17,8 @@ struct ActiveWorkoutView: View {
     @State private var timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
     @State private var restTimerHapticFired = false
     @State private var showStartingExercisePicker = false
-    /// Mid-workout exercise jumper (#253). Reachable any time via the persistent pill.
     @State private var showExerciseJumper = false
+    @State private var showReorderSheet = false
     /// Set after `jumpToExercise` runs; consumed by the list-mode `ScrollViewReader`
     /// to scroll to the picked card, then cleared.
     @State private var pendingScrollIndex: Int?
@@ -31,6 +31,7 @@ struct ActiveWorkoutView: View {
     /// `@Observable` changes — calls still go through `.shared`.
     @State private var spotifyCapture = SpotifyNowPlayingService.shared
     @State private var appleMusicCapture = NowPlayingService.shared
+    @State private var soundCloudCapture = SoundCloudNowPlayingService.shared
 
     // First-run polish (#310)
     /// Persisted flag — once dismissed, the active-workout tutorial overlay never re-shows.
@@ -127,6 +128,7 @@ struct ActiveWorkoutView: View {
                                 // FAB is gone (#402); add-exercise lives in the
                                 // top header now. Keeping a generous 24pt so the
                                 // last set rows don't kiss the home indicator.
+                                .contentMargins(.top, Theme.Spacing.xs, for: .scrollContent)
                                 .contentMargins(.bottom, Theme.Spacing.lg, for: .scrollContent)
                                 .onTapGesture {
                                     UIApplication.shared.sendAction(
@@ -150,12 +152,8 @@ struct ActiveWorkoutView: View {
                 .animation(.xomChill, value: viewModel.showExerciseTransition)
                 .animation(.xomChill, value: viewModel.focusMode)
 
-                // Soundtrack capture pill (Spotify capture polish). Visible only
-                // while at least one capture loop is alive. The Add Exercise FAB
-                // moved to the top header (#402) — remove it from the bottom
-                // entirely. The soundtrack pill rides above the home indicator
-                // via `.safeAreaInset(.bottom)` further down so it never overlaps
-                // set rows OR a fullscreen rest timer's LIFT button.
+                // Soundtrack capture icon — small circle in bottom-right corner,
+                // visible while at least one capture service is polling.
 
                 // PR Celebration Banner
                 if viewModel.showPRCelebration, let pr = viewModel.newPR {
@@ -204,18 +202,11 @@ struct ActiveWorkoutView: View {
                     .animation(.xomConfident, value: viewModel.showExerciseTransition)
                 }
             }
-            // Bottom safe-area inset (#402). When music capture is running,
-            // surface the soundtrack pill anchored above the home indicator —
-            // never floating over set rows or a fullscreen rest timer's LIFT
-            // button. Otherwise just a hair of padding so the last row clears
-            // the OS gesture area.
-            .safeAreaInset(edge: .bottom, spacing: 0) {
-                if !viewModel.focusMode &&
-                    (spotifyCapture.isCapturing || appleMusicCapture.isCapturing) {
-                    soundtrackCapturePill
-                        .padding(.bottom, Theme.Spacing.xs)
-                } else {
-                    Color.clear.frame(height: Theme.Spacing.xs)
+            .overlay(alignment: .bottomTrailing) {
+                if !viewModel.focusMode && isAnyCaptureActive {
+                    soundtrackCaptureIcon
+                        .padding(.trailing, Theme.Spacing.md)
+                        .padding(.bottom, Theme.Spacing.sm)
                 }
             }
             .toolbar(.hidden, for: .navigationBar)
@@ -253,8 +244,7 @@ struct ActiveWorkoutView: View {
         .onChange(of: viewModel.isRestTimerActive) { _, isActive in
             if isActive {
                 restTimerHapticFired = false
-                // First-time rest timer toast (#310). Surface a small explainer
-                // the very first time the rest timer fires, then never again.
+                pendingScrollIndex = viewModel.focusExerciseIndex
                 if !firstRestTimerSeen {
                     firstRestTimerSeen = true
                     restTimerToast = Toast(
@@ -357,6 +347,9 @@ struct ActiveWorkoutView: View {
                 }
             }
             .presentationDetents([.medium])
+        }
+        .sheet(isPresented: $showReorderSheet) {
+            ExerciseReorderSheet(viewModel: viewModel)
         }
         // First-run rest timer toast (#310). Uses the existing toast pattern
         // shared with launch streak/PR badges in MainTabView.
@@ -674,6 +667,13 @@ struct ActiveWorkoutView: View {
             .contentShape(Capsule())
         }
         .buttonStyle(.plain)
+        .contextMenu {
+            Button {
+                showReorderSheet = true
+            } label: {
+                Label("Reorder Exercises", systemImage: "arrow.up.arrow.down")
+            }
+        }
         .padding(.horizontal, Theme.Spacing.md)
         .padding(.top, Theme.Spacing.xs)
         .accessibilityLabel(pillAccessibilityLabel)
@@ -766,41 +766,41 @@ struct ActiveWorkoutView: View {
         .padding(.vertical, Theme.Spacing.sm)
     }
 
-    // MARK: - Soundtrack Capture Pill (Spotify capture polish)
+    // MARK: - Soundtrack Capture Icon
 
-    /// Compact, accent-tinted pill telling the user that workout music capture is running.
-    /// One pill total — sources are summarized in the label and the popover. Hidden when
-    /// neither service is actively polling.
-    private var soundtrackCapturePill: some View {
+    private var isAnyCaptureActive: Bool {
+        spotifyCapture.isCapturing || appleMusicCapture.isCapturing || soundCloudCapture.isCapturing
+    }
+
+    /// Small corner icon showing soundtrack capture is active. Tappable to
+    /// reveal per-source counts in a popover.
+    private var soundtrackCaptureIcon: some View {
         Button {
             Haptics.light()
             showSoundtrackPopover = true
         } label: {
-            HStack(spacing: Theme.Spacing.xs) {
+            ZStack(alignment: .topTrailing) {
                 Image(systemName: "music.note")
-                    .font(.caption.weight(.bold))
-                Text(soundtrackPillLabel)
-                    .font(.caption.weight(.semibold))
-                    .lineLimit(1)
+                    .font(.footnote.weight(.bold))
+                    .foregroundStyle(Theme.accent)
+                    .frame(width: 36, height: 36)
+                    .background(Theme.accent.opacity(0.15), in: Circle())
+                    .overlay(Circle().stroke(Theme.accent.opacity(0.35), lineWidth: 0.5))
+
                 if totalCapturedCount > 0 {
                     Text("\(totalCapturedCount)")
-                        .font(.caption2.weight(.heavy).monospacedDigit())
-                        .foregroundStyle(Theme.accent)
-                        .padding(.horizontal, 6)
-                        .padding(.vertical, 1)
-                        .background(Theme.accent.opacity(0.22), in: Capsule())
+                        .font(.system(size: 10, weight: .heavy).monospacedDigit())
+                        .foregroundStyle(.white)
+                        .padding(.horizontal, 4)
+                        .frame(minWidth: 16, minHeight: 16)
+                        .background(Theme.accent, in: Capsule())
+                        .offset(x: 4, y: -4)
                 }
             }
-            .foregroundStyle(Theme.accent)
-            .padding(.horizontal, Theme.Spacing.sm)
-            .padding(.vertical, 6)
-            .frame(minHeight: 32)
-            .background(Theme.accent.opacity(0.12), in: Capsule())
-            .overlay(Capsule().stroke(Theme.accent.opacity(0.35), lineWidth: 0.5))
-            .contentShape(Capsule())
+            .contentShape(Circle())
         }
         .buttonStyle(.plain)
-        .accessibilityLabel(soundtrackPillAccessibilityLabel)
+        .accessibilityLabel(soundtrackIconAccessibilityLabel)
         .accessibilityHint("Shows the songs captured so far for this workout's soundtrack")
         .popover(isPresented: $showSoundtrackPopover, attachmentAnchor: .point(.top)) {
             soundtrackPopoverContent
@@ -808,22 +808,12 @@ struct ActiveWorkoutView: View {
         }
     }
 
-    /// Pill label — composes from whichever services are currently capturing.
-    private var soundtrackPillLabel: String {
-        switch (spotifyCapture.isCapturing, appleMusicCapture.isCapturing) {
-        case (true, true):  return "Recording soundtrack"
-        case (true, false): return "Recording soundtrack via Spotify"
-        case (false, true): return "Recording soundtrack via Apple Music"
-        case (false, false): return "Recording soundtrack" // unreachable — pill is hidden
-        }
-    }
-
-    private var soundtrackPillAccessibilityLabel: String {
+    private var soundtrackIconAccessibilityLabel: String {
         let count = totalCapturedCount
         let countSuffix = count == 0
             ? "no tracks yet"
             : "\(count) track\(count == 1 ? "" : "s") captured"
-        return "\(soundtrackPillLabel), \(countSuffix)"
+        return "Recording soundtrack, \(countSuffix)"
     }
 
     /// Total tracks visible on the pill — includes anything restored from a
@@ -832,6 +822,7 @@ struct ActiveWorkoutView: View {
     private var totalCapturedCount: Int {
         spotifyCapture.capturedCount
             + appleMusicCapture.capturedCount
+            + soundCloudCapture.capturedCount
             + viewModel.persistedCapturedTracks.count
     }
 
@@ -860,6 +851,13 @@ struct ActiveWorkoutView: View {
                     name: "Apple Music",
                     count: appleMusicCapture.capturedCount,
                     last: appleMusicCapture.lastCapturedTrack
+                )
+            }
+            if soundCloudCapture.isCapturing {
+                soundtrackPopoverSource(
+                    name: "SoundCloud",
+                    count: soundCloudCapture.capturedCount,
+                    last: soundCloudCapture.lastCapturedTrack
                 )
             }
 
@@ -1017,10 +1015,8 @@ private struct ExerciseCard: View {
 
     @State private var showDetails = false
     @State private var showSupersetActionSheet = false
-    /// Driven by the visible link-icon button in the header. Distinct from
-    /// `showSupersetActionSheet` so the long-press and tap paths don't fight
-    /// over a single binding (#294).
     @State private var showSupersetToggleConfirm = false
+    @State private var isCollapsed = false
 
     private var isInSuperset: Bool {
         viewModel.exercises.indices.contains(exerciseIndex)
@@ -1095,42 +1091,23 @@ private struct ExerciseCard: View {
                 .buttonStyle(.plain)
                 .accessibilityLabel("Show details for \(exercise.exercise.name)")
 
+                Button {
+                    Haptics.light()
+                    withAnimation(.xomConfident) {
+                        isCollapsed.toggle()
+                    }
+                } label: {
+                    Image(systemName: "chevron.down")
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(Theme.textSecondary)
+                        .rotationEffect(.degrees(isCollapsed ? -90 : 0))
+                        .frame(width: Theme.Spacing.xl, height: Theme.Spacing.xl)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(isCollapsed ? "Expand \(exercise.exercise.name)" : "Collapse \(exercise.exercise.name)")
+
                 Spacer()
-
-                // Reorder buttons
-                if exerciseIndex > 0 {
-                    Button {
-                        withAnimation(.xomConfident) {
-                            viewModel.moveExercise(from: exerciseIndex, direction: -1)
-                        }
-                    } label: {
-                        Image(systemName: "chevron.up")
-                            .font(.subheadline.weight(.bold))
-                            .foregroundStyle(Theme.textPrimary)
-                            .frame(width: 44, height: 44)
-                            .background(Theme.surface.opacity(0.5))
-                            .clipShape(Circle())
-                            .contentShape(Rectangle())
-                    }
-                    .accessibilityLabel("Move \(exercise.exercise.name) up")
-                }
-
-                if exerciseIndex < viewModel.exercises.count - 1 {
-                    Button {
-                        withAnimation(.xomConfident) {
-                            viewModel.moveExercise(from: exerciseIndex, direction: 1)
-                        }
-                    } label: {
-                        Image(systemName: "chevron.down")
-                            .font(.subheadline.weight(.bold))
-                            .foregroundStyle(Theme.textPrimary)
-                            .frame(width: 44, height: 44)
-                            .background(Theme.surface.opacity(0.5))
-                            .clipShape(Circle())
-                            .contentShape(Rectangle())
-                    }
-                    .accessibilityLabel("Move \(exercise.exercise.name) down")
-                }
 
                 // Superset toggle (#294) — visible affordance for grouping with the
                 // next exercise. Disabled (but still rendered) when neither action
@@ -1160,132 +1137,131 @@ private struct ExerciseCard: View {
                 // gesture row that reveals a destructive Delete pill.
             }
 
-            // Variant config (grip, attachment, position, laterality) + per-session extras
-            // (notes pill, rest override). The extras pills always render so the user can
-            // edit notes / rest even on exercises without grip/attachment/position variants.
-            ExerciseConfigRow(
-                exercise: exercise,
-                onGripChanged: { grip in viewModel.setGrip(exerciseIndex: exerciseIndex, grip: grip) },
-                onAttachmentChanged: { att in viewModel.setAttachment(exerciseIndex: exerciseIndex, attachment: att) },
-                onPositionChanged: { pos in viewModel.setPosition(exerciseIndex: exerciseIndex, position: pos) },
-                onLateralityChanged: { lat in viewModel.setLaterality(exerciseIndex: exerciseIndex, laterality: lat) },
-                onNotesChanged: { notes in viewModel.setNotes(exerciseIndex: exerciseIndex, notes: notes) },
-                onRestSecondsChanged: { secs in viewModel.setRestSeconds(exerciseIndex: exerciseIndex, seconds: secs) },
-                defaultRestSeconds: Int(viewModel.defaultRestDuration)
-            )
-
-            // Laterality badge
-            if exercise.exercise.supportsUnilateral && exercise.selectedLaterality != .bilateral {
-                HStack(spacing: Theme.Spacing.tight) {
-                    Image(systemName: "arrow.left.and.right")
-                        .font(Theme.fontCaption2)
-                    Text(exercise.selectedLaterality.displayName)
-                        .font(.caption2.weight(.semibold))
-                }
-                .foregroundStyle(Theme.accent)
-                .padding(.horizontal, 6)
-                .padding(.vertical, Theme.Spacing.tighter)
-                .background(Theme.accent.opacity(0.15))
-                .clipShape(.capsule)
-            }
-
-            // Column headers
-            if !exercise.sets.isEmpty {
+            if isCollapsed {
+                let completedCount = exercise.sets.filter { $0.completedAt != Date.distantPast }.count
                 HStack(spacing: Theme.Spacing.sm) {
-                    Spacer().frame(width: 30) // delete button spacer
-                    Text("SET")
-                        .frame(width: Theme.Spacing.lg)
-                    Spacer()
-                    Text("WEIGHT")
-                        .frame(maxWidth: .infinity)
-                    Text("")
-                        .frame(width: 40)
-                    Text("REPS")
-                        .frame(maxWidth: .infinity)
-                    Text("")
-                        .frame(width: 36)
+                    Text("\(completedCount)/\(exercise.sets.count) sets")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(Theme.textSecondary)
+                    if let topWeight = exercise.sets.map(\.weight).max(), topWeight > 0 {
+                        Text("· \(topWeight.formattedWeight) lbs")
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(Theme.textSecondary)
+                    }
                 }
-                .font(Theme.fontSmall)
-                .foregroundStyle(Theme.textSecondary)
-                .padding(.horizontal, Theme.Spacing.md)
-            }
-
-            // Per-exercise current set index — first incomplete row, or the
-            // last row if all sets are complete. Drives the accent border +
-            // tint on the SetRowView so the lifter always knows where they
-            // are in list mode (#411 bug 4).
-            let currentSetIdx: Int? = {
-                if let firstIncomplete = exercise.sets.firstIndex(where: { $0.completedAt == Date.distantPast }) {
-                    return firstIncomplete
-                }
-                return exercise.sets.indices.last
-            }()
-
-            // Sets — use stable element IDs to prevent state loss on expand/collapse
-            ForEach(Array(exercise.sets.enumerated()), id: \.element.id) { setIdx, workoutSet in
-                SetRowView(
-                    setNumber: setIdx + 1,
-                    workoutSet: workoutSet,
-                    onWeightChange: { w in
-                        viewModel.updateSet(
-                            exerciseIndex: exerciseIndex,
-                            setIndex: setIdx,
-                            weight: w,
-                            reps: viewModel.exercises[exerciseIndex].sets[setIdx].reps
-                        )
-                    },
-                    onRepsChange: { r in
-                        viewModel.updateSet(
-                            exerciseIndex: exerciseIndex,
-                            setIndex: setIdx,
-                            weight: viewModel.exercises[exerciseIndex].sets[setIdx].weight,
-                            reps: r
-                        )
-                    },
-                    onComplete: {
-                        viewModel.completeSet(exerciseIndex: exerciseIndex, setIndex: setIdx)
-                    },
-                    onDelete: {
-                        viewModel.removeSet(exerciseIndex: exerciseIndex, setIndex: setIdx)
-                    },
-                    onToggleWeightMode: {
-                        viewModel.toggleWeightMode(exerciseIndex: exerciseIndex, setIndex: setIdx)
-                    },
-                    onAddDropSet: {
-                        viewModel.addDropSet(exerciseIndex: exerciseIndex, parentSetIndex: setIdx)
-                    },
-                    lateralityLabel: exercise.selectedLaterality != .bilateral ? (exercise.exercise.muscleGroups.contains(where: { [.quads, .hamstrings, .glutes, .calves].contains($0) }) ? "/leg" : "/arm") : nil,
-                    // "Last" prefers the previous completed set in THIS session
-                    // so progressive overload guidance reflects what the user
-                    // just lifted. Falls back to history when no prior in-session
-                    // set has been completed yet (e.g. set 1).
-                    lastSet: viewModel.lastSetHint(exerciseIndex: exerciseIndex, setIndex: setIdx),
-                    personalRecord: viewModel.personalRecordForExercise(exercise.exercise.id),
-                    isCurrentSet: setIdx == currentSetIdx
+            } else {
+                ExerciseConfigRow(
+                    exercise: exercise,
+                    onGripChanged: { grip in viewModel.setGrip(exerciseIndex: exerciseIndex, grip: grip) },
+                    onAttachmentChanged: { att in viewModel.setAttachment(exerciseIndex: exerciseIndex, attachment: att) },
+                    onPositionChanged: { pos in viewModel.setPosition(exerciseIndex: exerciseIndex, position: pos) },
+                    onLateralityChanged: { lat in viewModel.setLaterality(exerciseIndex: exerciseIndex, laterality: lat) },
+                    onNotesChanged: { notes in viewModel.setNotes(exerciseIndex: exerciseIndex, notes: notes) },
+                    onRestSecondsChanged: { secs in viewModel.setRestSeconds(exerciseIndex: exerciseIndex, seconds: secs) },
+                    defaultRestSeconds: Int(viewModel.defaultRestDuration)
                 )
-                .swipeToDelete(
-                    accessibilityActionName: "Delete set \(setIdx + 1)"
-                ) {
-                    viewModel.removeSet(exerciseIndex: exerciseIndex, setIndex: setIdx)
-                }
-            }
 
-            // Add Set button
-            Button {
-                viewModel.addSet(to: exerciseIndex)
-            } label: {
-                HStack(spacing: 6) {
-                    Image(systemName: "plus")
-                    Text("Add Set")
+                if exercise.exercise.supportsUnilateral && exercise.selectedLaterality != .bilateral {
+                    HStack(spacing: Theme.Spacing.tight) {
+                        Image(systemName: "arrow.left.and.right")
+                            .font(Theme.fontCaption2)
+                        Text(exercise.selectedLaterality.displayName)
+                            .font(.caption2.weight(.semibold))
+                    }
+                    .foregroundStyle(Theme.accent)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, Theme.Spacing.tighter)
+                    .background(Theme.accent.opacity(0.15))
+                    .clipShape(.capsule)
                 }
-                .font(.caption.weight(.semibold))
-                .foregroundStyle(Theme.accent)
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 10)
-                .background(Theme.accent.opacity(0.08))
-                .clipShape(.rect(cornerRadius: Theme.cornerRadiusSmall))
+
+                if !exercise.sets.isEmpty {
+                    HStack(spacing: Theme.Spacing.sm) {
+                        Spacer().frame(width: 30)
+                        Text("SET")
+                            .frame(width: Theme.Spacing.lg)
+                        Spacer()
+                        Text("WEIGHT")
+                            .frame(maxWidth: .infinity)
+                        Text("")
+                            .frame(width: 40)
+                        Text("REPS")
+                            .frame(maxWidth: .infinity)
+                        Text("")
+                            .frame(width: 36)
+                    }
+                    .font(Theme.fontSmall)
+                    .foregroundStyle(Theme.textSecondary)
+                    .padding(.horizontal, Theme.Spacing.md)
+                }
+
+                let currentSetIdx: Int? = {
+                    if let firstIncomplete = exercise.sets.firstIndex(where: { $0.completedAt == Date.distantPast }) {
+                        return firstIncomplete
+                    }
+                    return exercise.sets.indices.last
+                }()
+
+                ForEach(Array(exercise.sets.enumerated()), id: \.element.id) { setIdx, workoutSet in
+                    SetRowView(
+                        setNumber: setIdx + 1,
+                        workoutSet: workoutSet,
+                        onWeightChange: { w in
+                            viewModel.updateSet(
+                                exerciseIndex: exerciseIndex,
+                                setIndex: setIdx,
+                                weight: w,
+                                reps: viewModel.exercises[exerciseIndex].sets[setIdx].reps
+                            )
+                        },
+                        onRepsChange: { r in
+                            viewModel.updateSet(
+                                exerciseIndex: exerciseIndex,
+                                setIndex: setIdx,
+                                weight: viewModel.exercises[exerciseIndex].sets[setIdx].weight,
+                                reps: r
+                            )
+                        },
+                        onComplete: {
+                            viewModel.completeSet(exerciseIndex: exerciseIndex, setIndex: setIdx)
+                        },
+                        onDelete: {
+                            viewModel.removeSet(exerciseIndex: exerciseIndex, setIndex: setIdx)
+                        },
+                        onToggleWeightMode: {
+                            viewModel.toggleWeightMode(exerciseIndex: exerciseIndex, setIndex: setIdx)
+                        },
+                        onAddDropSet: {
+                            viewModel.addDropSet(exerciseIndex: exerciseIndex, parentSetIndex: setIdx)
+                        },
+                        lateralityLabel: exercise.selectedLaterality != .bilateral ? (exercise.exercise.muscleGroups.contains(where: { [.quads, .hamstrings, .glutes, .calves].contains($0) }) ? "/leg" : "/arm") : nil,
+                        lastSet: viewModel.lastSetHint(exerciseIndex: exerciseIndex, setIndex: setIdx),
+                        personalRecord: viewModel.personalRecordForExercise(exercise.exercise.id),
+                        isCurrentSet: setIdx == currentSetIdx
+                    )
+                    .swipeToDelete(
+                        accessibilityActionName: "Delete set \(setIdx + 1)"
+                    ) {
+                        viewModel.removeSet(exerciseIndex: exerciseIndex, setIndex: setIdx)
+                    }
+                }
+
+                Button {
+                    viewModel.addSet(to: exerciseIndex)
+                } label: {
+                    HStack(spacing: 6) {
+                        Image(systemName: "plus")
+                        Text("Add Set")
+                    }
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(Theme.accent)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 10)
+                    .background(Theme.accent.opacity(0.08))
+                    .clipShape(.rect(cornerRadius: Theme.cornerRadiusSmall))
+                }
+                .padding(.top, Theme.Spacing.tight)
             }
-            .padding(.top, Theme.Spacing.tight)
         }
         .padding(Theme.Spacing.md)
         .background(Theme.surface)
@@ -1637,30 +1613,13 @@ private struct FinishWorkoutSheet: View {
                             }
                         }
 
-                        // Location (#387.3) — single-line free-text input above
-                        // the soundtrack section. Placeholder steers the user to
-                        // any short label (gym, home, park...). Trimming happens
-                        // in the save path on the view model.
                         VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
                             Text("Location")
                                 .font(.subheadline.weight(.semibold))
                                 .foregroundStyle(Theme.textPrimary)
-                            HStack(spacing: Theme.Spacing.sm) {
-                                Image(systemName: "location.fill")
-                                    .font(Theme.fontCaption)
-                                    .foregroundStyle(Theme.textSecondary)
-                                TextField("Where? (gym, home, park...)", text: $location)
-                                    .font(Theme.fontBody)
-                                    .foregroundStyle(Theme.textPrimary)
-                                    .accessibilityLabel("Workout location")
-                                    .accessibilityHint("Optional. Where you did this workout — gym, home, park, etc.")
-                            }
-                            .padding(Theme.Spacing.sm)
-                            .background(Theme.surface)
-                            .clipShape(.rect(cornerRadius: Theme.cornerRadiusSmall))
-                            .overlay(
-                                RoundedRectangle(cornerRadius: Theme.cornerRadiusSmall)
-                                    .stroke(Theme.textSecondary.opacity(0.2), lineWidth: 1)
+                            LocationSearchField(
+                                text: $location,
+                                placeholder: "Search gym, home, park..."
                             )
                         }
 

--- a/Xomfit/Views/Workout/ExerciseReorderSheet.swift
+++ b/Xomfit/Views/Workout/ExerciseReorderSheet.swift
@@ -1,0 +1,61 @@
+import SwiftUI
+
+struct ExerciseReorderSheet: View {
+    let viewModel: WorkoutLoggerViewModel
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            List {
+                ForEach(Array(viewModel.exercises.enumerated()), id: \.element.id) { idx, exercise in
+                    HStack(spacing: Theme.Spacing.sm) {
+                        Image(systemName: "line.3.horizontal")
+                            .font(.subheadline.weight(.medium))
+                            .foregroundStyle(Theme.textTertiary)
+
+                        VStack(alignment: .leading, spacing: Theme.Spacing.tighter) {
+                            Text(exercise.exercise.name)
+                                .font(.body.weight(.medium))
+                                .foregroundStyle(Theme.textPrimary)
+
+                            let completed = exercise.sets.filter { $0.completedAt != Date.distantPast }.count
+                            Text("\(completed)/\(exercise.sets.count) sets")
+                                .font(Theme.fontCaption)
+                                .foregroundStyle(Theme.textSecondary)
+                        }
+
+                        Spacer()
+
+                        if let groups = exercise.exercise.muscleGroups.first {
+                            Text(groups.displayName)
+                                .font(.caption2.weight(.semibold))
+                                .foregroundStyle(Theme.accent)
+                                .padding(.horizontal, 6)
+                                .padding(.vertical, Theme.Spacing.tighter)
+                                .background(Theme.accent.opacity(0.15))
+                                .clipShape(.rect(cornerRadius: 4))
+                        }
+                    }
+                    .listRowBackground(Theme.surface)
+                }
+                .onMove { source, destination in
+                    viewModel.moveExercises(from: source, to: destination)
+                }
+            }
+            .listStyle(.plain)
+            .scrollContentBackground(.hidden)
+            .background(Theme.background)
+            .environment(\.editMode, .constant(.active))
+            .navigationTitle("Reorder Exercises")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { dismiss() }
+                        .foregroundStyle(Theme.accent)
+                }
+            }
+        }
+        .presentationDetents([.medium, .large])
+        .presentationDragIndicator(.visible)
+    }
+}

--- a/Xomfit/Views/Workout/LogPastWorkoutView.swift
+++ b/Xomfit/Views/Workout/LogPastWorkoutView.swift
@@ -294,21 +294,9 @@ struct LogPastWorkoutView: View {
             Text("Location")
                 .font(.subheadline.weight(.semibold))
                 .foregroundStyle(Theme.textPrimary)
-            HStack(spacing: Theme.Spacing.sm) {
-                Image(systemName: "location.fill")
-                    .font(Theme.fontCaption)
-                    .foregroundStyle(Theme.textSecondary)
-                TextField("Gym name", text: $viewModel.location)
-                    .font(Theme.fontBody)
-                    .foregroundStyle(Theme.textPrimary)
-                    .textInputAutocapitalization(.words)
-            }
-            .padding(Theme.Spacing.sm)
-            .background(Theme.surfaceElevated)
-            .clipShape(.rect(cornerRadius: Theme.cornerRadiusSmall))
-            .overlay(
-                RoundedRectangle(cornerRadius: Theme.cornerRadiusSmall)
-                    .stroke(Theme.textSecondary.opacity(0.2), lineWidth: 1)
+            LocationSearchField(
+                text: $viewModel.location,
+                placeholder: "Search gym, home, park..."
             )
         }
     }

--- a/Xomfit/Views/Workout/WorkoutDetailView.swift
+++ b/Xomfit/Views/Workout/WorkoutDetailView.swift
@@ -1007,20 +1007,13 @@ private struct WorkoutEditMetadataCard: View {
     private var locationField: some View {
         VStack(alignment: .leading, spacing: Theme.Spacing.xs) {
             fieldLabel("Location")
-            TextField("e.g. Home gym", text: Binding(
-                get: { viewModel.locationBinding },
-                set: { viewModel.locationBinding = $0 }
-            ))
-            .font(Theme.fontBody)
-            .foregroundStyle(Theme.textPrimary)
-            .padding(Theme.Spacing.sm)
-            .background(Theme.surfaceElevated)
-            .clipShape(.rect(cornerRadius: Theme.Radius.sm))
-            .overlay(
-                RoundedRectangle(cornerRadius: Theme.Radius.sm)
-                    .strokeBorder(Theme.hairline, lineWidth: 0.5)
+            LocationSearchField(
+                text: Binding(
+                    get: { viewModel.locationBinding },
+                    set: { viewModel.locationBinding = $0 }
+                ),
+                placeholder: "Search gym, home, park..."
             )
-            .accessibilityLabel("Workout location")
         }
     }
 


### PR DESCRIPTION
## Summary
- **Workout list view**: auto-scroll to current exercise on rest timer, top content margin, collapsible exercise sections with set summary
- **Soundtrack indicator**: shrunk from intrusive bottom banner to small 36pt circle icon in bottom-right corner with badge count
- **SoundCloud capture**: wired into active workout UI (was missing from indicator, popover, and MainTabView track count)
- **Feed**: moved featured song below caption text
- **Exercise reorder**: replaced per-card up/down arrows with drag-to-reorder modal (long-press exercise pill → "Reorder Exercises")
- **Location autocomplete**: new `LocationSearchField` using `MKLocalSearchCompleter` for real gym/place search; still allows freeform entry
- **Minimum listen threshold**: Spotify + Apple Music require ~25s before counting a track (pending-track pattern across polls)
- **Profile Music tab**: aggregated listening history with play counts, sorted by most played, filterable by source app (Spotify/SoundCloud/Apple Music)

## Test plan
- [ ] Start a workout → verify small music icon appears in bottom-right (not a banner)
- [ ] Tap the icon → popover shows per-source counts including SoundCloud
- [ ] Complete a set → rest timer appears, scroll auto-adjusts to keep current exercise visible
- [ ] Tap collapse chevron on exercise card → sets collapse to summary line
- [ ] Long-press exercise pill → "Reorder Exercises" context menu → drag to reorder in modal
- [ ] Finish workout → location field shows MapKit autocomplete suggestions; can still type custom name
- [ ] Check feed → featured song appears below caption
- [ ] Open profile → Music tab shows aggregated tracks with play counts and source filter chips

Closes #415, Closes #416, Closes #417, Closes #418, Closes #419, Closes #420, Closes #421, Closes #422, Closes #423, Closes #424, Closes #425