### PR TITLE
chore: bump GitHub Actions to Node-24-compatible versions

### DIFF
--- a/.github/workflows/claude-issues.yml
+++ b/.github/workflows/claude-issues.yml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # CONFIGURE: set to your base branch (main or develop)
           ref: main

--- a/.github/workflows/testflight-deploy.yml
+++ b/.github/workflows/testflight-deploy.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 60
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           # `git describe --tags` in the version-compute step needs the tag


### PR DESCRIPTION
## Summary

Bumps pinned GitHub Actions to Node-24-compatible major versions ahead of the Node 20 deprecation deadline (~2026-06-02 per GitHub Actions runner deprecation notice).

## Version bumps applied (where present)

- `actions/checkout` → v6
- `actions/setup-python` → v6
- `actions/setup-node` → v6
- `hashicorp/setup-terraform` → v4
- `aws-actions/configure-aws-credentials` → v6
- `actions/cache` → v5
- `actions/upload-artifact` → v7
- `actions/download-artifact` → v6

## Test plan

- CI passes on this PR
- No Node 20 deprecation annotation in the workflow run