### PR TITLE
fix(workout): preserve scroll position when exiting focus mode (#430)

### DIFF
--- a/Xomfit/Views/Workout/ActiveWorkoutView.swift
+++ b/Xomfit/Views/Workout/ActiveWorkoutView.swift
@@ -574,6 +574,10 @@ struct ActiveWorkoutView: View {
                         if viewModel.completedSets == 0 && viewModel.exercises.count > 1 {
                             showStartingExercisePicker = true
                         }
+                    } else {
+                        // Exiting focus mode — scroll the list to the current exercise
+                        // so the user doesn't lose their place (#430).
+                        pendingScrollIndex = viewModel.focusExerciseIndex
                     }
                 }
             } label: {


### PR DESCRIPTION
## Summary
- When toggling from focus (zoomed) view back to list view, the scroll position now stays on the current exercise instead of resetting to the top
- Sets `pendingScrollIndex` to `focusExerciseIndex` when exiting focus mode

## Test plan
- [ ] Start a workout with multiple exercises
- [ ] Switch to focus mode (eye icon)
- [ ] Navigate to an exercise in the middle of the list
- [ ] Switch back to list view (list icon)
- [ ] Verify the list is scrolled to the same exercise you were viewing

🤖 Generated with [Claude Code](https://claude.com/claude-code)