### PR TITLE
refactor(drawer): reorganize and group navigation items (#431)

### DIFF
--- a/Xomfit/Views/Common/AppDrawer.swift
+++ b/Xomfit/Views/Common/AppDrawer.swift
@@ -6,15 +6,13 @@ import SwiftUI
 // Replaces the previous 4-tab `FloatingTabBar`. Each case carries its title
 // (shown in the shell top bar + drawer row) and SF Symbol icon.
 
-enum AppDestination: String, CaseIterable, Identifiable, Hashable {
+enum AppDestination: String, Identifiable, Hashable {
     case feed
     case workout
+    case stretches
     case progress
     case stats
     case profile
-    case reports
-    case stretches
-    case tools
     case settings
 
     var id: String { rawValue }
@@ -23,12 +21,10 @@ enum AppDestination: String, CaseIterable, Identifiable, Hashable {
         switch self {
         case .feed:      "Feed"
         case .workout:   "Workout"
+        case .stretches: "Stretches"
         case .progress:  "Progress"
         case .stats:     "Stats"
         case .profile:   "Profile"
-        case .reports:   "Reports"
-        case .stretches: "Stretches"
-        case .tools:     "Tools"
         case .settings:  "Settings"
         }
     }
@@ -37,13 +33,26 @@ enum AppDestination: String, CaseIterable, Identifiable, Hashable {
         switch self {
         case .feed:      "house.fill"
         case .workout:   "dumbbell.fill"
+        case .stretches: "figure.flexibility"
         case .progress:  "chart.line.uptrend.xyaxis"
         case .stats:     "chart.bar.fill"
         case .profile:   "person.fill"
-        case .reports:   "doc.text.fill"
-        case .stretches: "figure.flexibility"
-        case .tools:     "wrench.and.screwdriver.fill"
         case .settings:  "gearshape.fill"
+        }
+    }
+
+    /// Grouped drawer sections for visual hierarchy.
+    enum Section: CaseIterable {
+        case main
+        case insights
+        case account
+
+        var destinations: [AppDestination] {
+            switch self {
+            case .main:     [.feed, .workout, .stretches]
+            case .insights: [.progress, .stats]
+            case .account:  [.profile, .settings]
+            }
         }
     }
 }
@@ -79,9 +88,19 @@ struct AppDrawer: View {
                 .overlay(Theme.hairline)
 
             ScrollView {
-                VStack(alignment: .leading, spacing: Theme.Spacing.xs) {
-                    ForEach(AppDestination.allCases) { destination in
-                        drawerRow(for: destination)
+                VStack(alignment: .leading, spacing: 0) {
+                    ForEach(Array(AppDestination.Section.allCases.enumerated()), id: \.element) { index, section in
+                        if index > 0 {
+                            Divider()
+                                .overlay(Theme.hairline)
+                                .padding(.vertical, Theme.Spacing.sm)
+                                .padding(.horizontal, Theme.Spacing.md)
+                        }
+                        VStack(alignment: .leading, spacing: Theme.Spacing.xs) {
+                            ForEach(section.destinations) { destination in
+                                drawerRow(for: destination)
+                            }
+                        }
                     }
                 }
                 .padding(.horizontal, Theme.Spacing.sm)

--- a/Xomfit/Views/MainTabView.swift
+++ b/Xomfit/Views/MainTabView.swift
@@ -270,12 +270,10 @@ struct MainTabView: View {
             switch destination {
             case .feed:      FeedView()
             case .workout:   WorkoutView()
+            case .stretches: StretchesView()
             case .progress:  XomProgressView()
             case .stats:     StatsView()
             case .profile:   ProfileView()
-            case .reports:   ReportsListView()
-            case .stretches: StretchesView()
-            case .tools:     ToolsView()
             case .settings:  SettingsView()
             }
         }


### PR DESCRIPTION
## Summary
- Reduced drawer from 9 items to 7 by removing Tools and Reports (both already accessible from Settings)
- Grouped items into sections with visual dividers:
  - **Main**: Feed, Workout, Stretches
  - **Insights**: Progress, Stats  
  - **Account**: Profile, Settings
- Reordered items to put related destinations together

## Test plan
- [ ] Open drawer and verify 7 items appear in 3 grouped sections
- [ ] Verify dividers appear between sections
- [ ] Verify all destinations still work
- [ ] Verify Reports is accessible from Settings → Training
- [ ] Verify Tools (Plate Calc, 1RM) is accessible from Settings → Tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)