### PR TITLE
feat(workout): improve finish workflow and fix SoundCloud capture (#432)

### DIFF
--- a/Xomfit/Services/SoundCloudConfig.swift
+++ b/Xomfit/Services/SoundCloudConfig.swift
@@ -38,10 +38,14 @@ enum SoundCloudConfig {
     static let tokenURL = URL(string: "https://api.soundcloud.com/oauth2/token")!
 
     /// SoundCloud's recent listening history endpoint. Unlike Spotify, SoundCloud does
-    /// not expose a real-time "currently playing" — only `play-history` (most recent 50
-    /// tracks). We poll and look at the LATEST entry; if it's new since last tick, we
-    /// capture it. This is best-effort and may lag a few seconds behind playback.
-    static let recentlyPlayedURL = URL(string: "https://api.soundcloud.com/me/play-history/tracks?limit=5")!
+    /// not expose a real-time "currently playing". We use `/me/activities/tracks` which
+    /// returns the user's recent track interactions (plays, likes, reposts). We poll and
+    /// look for track activities; if one is new since last tick, we capture it.
+    /// This is best-effort and may lag a few seconds behind playback.
+    ///
+    /// NOTE: The `/me/play-history/tracks` endpoint does not exist in SoundCloud's public
+    /// API. Using `/me/activities/tracks` as the closest available alternative (#432).
+    static let recentlyPlayedURL = URL(string: "https://api.soundcloud.com/me/activities/tracks?limit=10")!
 
     /// URL scheme component of `redirectURI` — what ASWebAuthenticationSession needs separately.
     static let callbackURLScheme = "xomfit"

--- a/Xomfit/Services/SoundCloudNowPlayingService.swift
+++ b/Xomfit/Services/SoundCloudNowPlayingService.swift
@@ -125,17 +125,26 @@ final class SoundCloudNowPlayingService {
         print("[SoundCloudNowPlayingService] snapshot complete — \(seenKeys.count) prior entry/entries skipped")
     }
 
-    /// Poll once and capture only the LATEST history entry if it's new since last tick.
+    /// Poll once and capture only the LATEST track activity if it's new since last tick.
     /// Looking at just the head is intentional — if the user plays 3 tracks in quick
     /// succession we'll catch the most recent on this tick and the others on prior /
     /// subsequent ticks (the 30s cadence vs typical 3-4 minute song length leaves plenty
     /// of margin in practice).
+    ///
+    /// NOTE: We filter for "track" type activities to only capture direct plays, not
+    /// reposts or playlist activities (#432).
     private func captureLatestTrack() async {
-        guard let entries = await fetchHistory(), let latest = entries.first else {
-            return
-        }
+        guard let entries = await fetchHistory() else { return }
 
-        let title = latest.track?.title ?? ""
+        // Filter for track-type activities only (not reposts)
+        let trackActivities = entries.filter { entry in
+            // Accept "track" type or entries with no type (legacy play-history format)
+            entry.type == "track" || entry.type == nil
+        }
+        guard let latest = trackActivities.first else { return }
+
+        let resolvedTrack = latest.resolvedTrack
+        let title = resolvedTrack?.title ?? ""
         guard !title.isEmpty else { return }
 
         let key = dedupeKey(for: latest)
@@ -147,7 +156,7 @@ final class SoundCloudNowPlayingService {
 
         // SoundCloud puts the uploader's display name on `user.username` — closest analogue
         // to a primary artist. Real "artist" metadata is rarely populated on SC uploads.
-        let artist = latest.track?.user?.username
+        let artist = resolvedTrack?.user?.username
         // Carry the permalink so the feed expanded view can deep-link straight
         // back into SoundCloud (#410). Nil-safe fallback handled by the
         // deep-link resolver — empty permalink degrades to a SoundCloud search.
@@ -157,7 +166,7 @@ final class SoundCloudNowPlayingService {
             album: nil,
             capturedAt: Date(),
             sourceApp: "SoundCloud",
-            url: latest.track?.permalink_url
+            url: resolvedTrack?.permalink_url
         )
         captured.append(track)
         lastCapturedTrack = track
@@ -184,7 +193,7 @@ final class SoundCloudNowPlayingService {
             case 200:
                 break
             case 401:
-                print("[SoundCloudNowPlayingService] 401 from /play-history — token rejected")
+                print("[SoundCloudNowPlayingService] 401 from /activities — token rejected")
                 return nil
             case 429:
                 print("[SoundCloudNowPlayingService] rate-limited (429) — skipping this tick")
@@ -206,27 +215,46 @@ final class SoundCloudNowPlayingService {
     }
 
     private func dedupeKey(for entry: SoundCloudHistoryEntry) -> String {
-        // Prefer the track id (stable, numeric), then the permalink, then a (title + played_at)
-        // fallback. Including `played_at` in the fallback prevents the same song played twice
+        // Prefer the track id (stable, numeric), then the permalink, then a (title + created_at)
+        // fallback. Including the timestamp in the fallback prevents the same song played twice
         // from being deduped against itself.
-        if let id = entry.track?.id { return "id|\(id)" }
-        if let permalink = entry.track?.permalink_url, !permalink.isEmpty { return "permalink|\(permalink)" }
-        let title = entry.track?.title ?? ""
-        let played = entry.played_at ?? 0
-        return "title|\(title.lowercased())|\(played)"
+        let track = entry.resolvedTrack
+        if let id = track?.id { return "id|\(id)" }
+        if let permalink = track?.permalink_url, !permalink.isEmpty { return "permalink|\(permalink)" }
+        let title = track?.title ?? ""
+        // Use created_at (activities) or played_at (legacy) as the timestamp component
+        let timestamp = entry.created_at ?? String(entry.played_at ?? 0)
+        return "title|\(title.lowercased())|\(timestamp)"
     }
 }
 
 // MARK: - SoundCloud payload shapes
+//
+// NOTE: SoundCloud's `/me/activities/tracks` returns activity objects, not raw
+// play-history. Each activity has a `type` (e.g. "track", "track-repost") and
+// an `origin` containing the track details. We only capture activities where
+// type == "track" (direct plays), ignoring reposts. (#432)
 
 private struct SoundCloudHistoryResponse: Decodable {
     let collection: [SoundCloudHistoryEntry]
 }
 
 private struct SoundCloudHistoryEntry: Decodable {
-    /// Unix millisecond timestamp of when the play was recorded.
+    /// Activity type: "track", "track-repost", "playlist", "playlist-repost", etc.
+    let type: String?
+    /// ISO 8601 timestamp of when the activity occurred.
+    let created_at: String?
+    /// The track object (for track-type activities).
+    let origin: SoundCloudTrack?
+
+    // Legacy fields for backwards compatibility if play-history ever returns
     let played_at: Int64?
     let track: SoundCloudTrack?
+
+    /// Returns the track, preferring `origin` (activities format) over `track` (legacy).
+    var resolvedTrack: SoundCloudTrack? {
+        origin ?? track
+    }
 }
 
 private struct SoundCloudTrack: Decodable {

--- a/Xomfit/Views/Workout/ActiveWorkoutView.swift
+++ b/Xomfit/Views/Workout/ActiveWorkoutView.swift
@@ -12,6 +12,7 @@ struct ActiveWorkoutView: View {
     @State private var showFinishSheet = false
     @State private var workoutDescription = ""
     @State private var saveAsTemplate = false
+    @State private var templateName = ""
     @State private var selectedPhotos: [PhotosPickerItem] = []
     @State private var photoImages: [UIImage] = []
     @State private var timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
@@ -272,6 +273,8 @@ struct ActiveWorkoutView: View {
         .sheet(isPresented: $showFinishSheet) {
             FinishWorkoutSheet(
                 viewModel: viewModel,
+                workoutName: Bindable(viewModel).workoutName,
+                templateName: $templateName,
                 description: $workoutDescription,
                 location: $viewModel.location,
                 rating: $viewModel.rating,
@@ -921,21 +924,32 @@ struct ActiveWorkoutView: View {
         let userId = user.id.uuidString.lowercased()
         let notes = workoutDescription.trimmingCharacters(in: .whitespacesAndNewlines)
 
-        // Save as template if requested
+        // Save as template if requested (#432) — only include exercises that have
+        // at least one completed set, and use the user-provided template name.
         if saveAsTemplate {
-            let templateExercises = viewModel.exercises.map { ex in
-                WorkoutTemplate.TemplateExercise(
+            let completedExercises = viewModel.exercises.filter { ex in
+                ex.sets.contains { $0.completedAt != Date.distantPast }
+            }
+            guard !completedExercises.isEmpty else {
+                // Nothing to save — skip silently
+                saveAsTemplate = false
+                return
+            }
+            let templateExercises = completedExercises.map { ex in
+                let completedSets = ex.sets.filter { $0.completedAt != Date.distantPast }
+                return WorkoutTemplate.TemplateExercise(
                     id: UUID().uuidString,
                     exercise: ex.exercise,
-                    targetSets: ex.sets.count,
-                    targetReps: ex.bestSet.map { "\($0.reps)" } ?? "8",
+                    targetSets: completedSets.count,
+                    targetReps: completedSets.first.map { "\($0.reps)" } ?? "8",
                     notes: ex.notes,
                     restSeconds: ex.restSeconds
                 )
             }
+            let finalTemplateName = templateName.trimmingCharacters(in: .whitespacesAndNewlines)
             let template = WorkoutTemplate(
                 id: UUID().uuidString,
-                name: viewModel.workoutName,
+                name: finalTemplateName.isEmpty ? viewModel.workoutName : finalTemplateName,
                 description: notes.isEmpty ? "Custom template" : notes,
                 exercises: templateExercises,
                 estimatedDuration: Int(Date().timeIntervalSince(viewModel.startTime) / 60),
@@ -1551,6 +1565,8 @@ private struct FinishWorkoutSheet: View {
     /// call methods + read computed properties; `@Observable` already invalidates
     /// the body on mutations to those properties.
     let viewModel: WorkoutLoggerViewModel
+    @Binding var workoutName: String
+    @Binding var templateName: String
     @Binding var description: String
     @Binding var location: String
     @Binding var rating: Int
@@ -1570,6 +1586,23 @@ private struct FinishWorkoutSheet: View {
 
                 ScrollView {
                     VStack(spacing: Theme.Spacing.lg) {
+                        // Workout Name (#432)
+                        VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+                            Text("Workout Name")
+                                .font(.subheadline.weight(.semibold))
+                                .foregroundStyle(Theme.textPrimary)
+                            TextField("Workout", text: $workoutName)
+                                .font(Theme.fontBody)
+                                .foregroundStyle(Theme.textPrimary)
+                                .padding(Theme.Spacing.sm)
+                                .background(Theme.surface)
+                                .clipShape(.rect(cornerRadius: Theme.cornerRadiusSmall))
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: Theme.cornerRadiusSmall)
+                                        .stroke(Theme.textSecondary.opacity(0.2), lineWidth: 1)
+                                )
+                        }
+
                         // Star Rating
                         VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
                             Text("How was your workout?")
@@ -1644,6 +1677,29 @@ private struct FinishWorkoutSheet: View {
                             }
                         }
                         .tint(Theme.accent)
+
+                        // Template name field (#432) — only shows when saving as template
+                        if saveAsTemplate {
+                            VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+                                Text("Template Name")
+                                    .font(.subheadline.weight(.semibold))
+                                    .foregroundStyle(Theme.textPrimary)
+                                Text("Only exercises you completed sets for will be saved.")
+                                    .font(Theme.fontCaption)
+                                    .foregroundStyle(Theme.textSecondary)
+                                TextField("My Template", text: $templateName)
+                                    .font(Theme.fontBody)
+                                    .foregroundStyle(Theme.textPrimary)
+                                    .padding(Theme.Spacing.sm)
+                                    .background(Theme.surface)
+                                    .clipShape(.rect(cornerRadius: Theme.cornerRadiusSmall))
+                                    .overlay(
+                                        RoundedRectangle(cornerRadius: Theme.cornerRadiusSmall)
+                                            .stroke(Theme.textSecondary.opacity(0.2), lineWidth: 1)
+                                    )
+                            }
+                            .transition(.opacity.combined(with: .move(edge: .top)))
+                        }
 
                         // Photos
                         VStack(alignment: .leading, spacing: Theme.Spacing.sm) {


### PR DESCRIPTION
## Summary

### Finish Workout improvements
- Add workout name editing field at top of finish sheet
- Add template name prompt that appears when "Save as Template" is toggled on
- Only include exercises that have at least one completed set in saved templates
- Show hint text: "Only exercises you completed sets for will be saved."

### SoundCloud capture fix
- The `/me/play-history/tracks` endpoint doesn't exist in SoundCloud's public API
- Switched to `/me/activities/tracks` which returns the user's recent track interactions
- Updated response parsing to handle the activities format (`type`, `origin` fields)
- Filter for "track" type activities only (ignoring reposts, playlist activities)
- Added `resolvedTrack` computed property for backwards compatibility

## Test plan
- [ ] Start a workout, add exercises, complete some sets but not all
- [ ] Tap Finish and verify workout name field appears at top
- [ ] Edit the workout name
- [ ] Toggle "Save as Template" and verify template name field appears
- [ ] Enter a template name and finish workout
- [ ] Verify the saved template only contains exercises you did sets for
- [ ] Connect SoundCloud in Settings, play music during workout
- [ ] Verify SoundCloud tracks are captured (check console logs for capture messages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)