### PR TITLE
fix(template): improve scroll behavior in TemplateDetailView exercise list

### DIFF
--- a/Xomfit.xcodeproj/project.pbxproj
+++ b/Xomfit.xcodeproj/project.pbxproj
@@ -721,7 +721,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.1.6;
+				MARKETING_VERSION = 2.1.7;
 				PRODUCT_BUNDLE_IDENTIFIER = com.Xomware.Xomfit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -758,7 +758,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.1.6;
+				MARKETING_VERSION = 2.1.7;
 				PRODUCT_BUNDLE_IDENTIFIER = com.Xomware.Xomfit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -792,7 +792,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.1.6;
+				MARKETING_VERSION = 2.1.7;
 				PRODUCT_BUNDLE_IDENTIFIER = com.Xomware.Xomfit.XomfitWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -824,7 +824,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.1.6;
+				MARKETING_VERSION = 2.1.7;
 				PRODUCT_BUNDLE_IDENTIFIER = com.Xomware.Xomfit.XomfitWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/Xomfit/Views/Workout/TemplateDetailView.swift
+++ b/Xomfit/Views/Workout/TemplateDetailView.swift
@@ -290,20 +290,22 @@ struct TemplateDetailView: View {
             if draft.exercises.isEmpty {
                 emptyState
             } else {
-                ForEach(Array(draft.exercises.enumerated()), id: \.element.id) { index, exercise in
-                    let exerciseId = exercise.id
-                    EditableExerciseRow(
-                        index: index + 1,
-                        exercise: exercise,
-                        targetWeight: bindingForWeight(exerciseId: exerciseId),
-                        canMoveUp: index > 0,
-                        canMoveDown: index < draft.exercises.count - 1,
-                        onUpdateSets: { newValue in updateSetsById(exerciseId, value: newValue) },
-                        onUpdateReps: { newValue in updateRepsById(exerciseId, value: newValue) },
-                        onMoveUp: { moveExerciseById(exerciseId, direction: -1) },
-                        onMoveDown: { moveExerciseById(exerciseId, direction: 1) },
-                        onDelete: { removeExerciseById(exerciseId) }
-                    )
+                LazyVStack(spacing: Theme.Spacing.sm) {
+                    ForEach(Array(draft.exercises.enumerated()), id: \.element.id) { index, exercise in
+                        let exerciseId = exercise.id
+                        EditableExerciseRow(
+                            index: index + 1,
+                            exercise: exercise,
+                            targetWeight: bindingForWeight(exerciseId: exerciseId),
+                            canMoveUp: index > 0,
+                            canMoveDown: index < draft.exercises.count - 1,
+                            onUpdateSets: { newValue in updateSetsById(exerciseId, value: newValue) },
+                            onUpdateReps: { newValue in updateRepsById(exerciseId, value: newValue) },
+                            onMoveUp: { moveExerciseById(exerciseId, direction: -1) },
+                            onMoveDown: { moveExerciseById(exerciseId, direction: 1) },
+                            onDelete: { removeExerciseById(exerciseId) }
+                        )
+                    }
                 }
             }
         }
@@ -867,6 +869,7 @@ private struct EditableExerciseRow: View {
         .padding(Theme.Spacing.md)
         .background(Theme.surface)
         .clipShape(.rect(cornerRadius: Theme.cornerRadius))
+        .contentShape(Rectangle())
         .sheet(isPresented: $showDetails) {
             ExerciseDetailSheet(exercise: exercise.exercise)
         }


### PR DESCRIPTION
## Summary
- Wrap ForEach in LazyVStack for better scroll performance with long exercise lists
- Add `.contentShape(Rectangle())` to EditableExerciseRow for proper hit testing
- Bump version to 2.1.7

## Problem
Users could not scroll the exercise list in TemplateDetailView. The scroll gestures were being intercepted by interactive elements (buttons, text fields) within the EditableExerciseRow views.

## Solution
1. **LazyVStack**: Replaced the implicit VStack behavior with an explicit LazyVStack, which improves scroll performance by only rendering visible rows and helps SwiftUI better coordinate scroll gestures.

2. **contentShape(Rectangle())**: Added to EditableExerciseRow to define a proper hit testing area. This ensures the row participates correctly in the gesture system, allowing scroll gestures to propagate to the parent ScrollView while maintaining button tap functionality.

## Test plan
- [ ] Verify scrolling works smoothly in TemplateDetailView with multiple exercises
- [ ] Verify all buttons (move up/down, info, delete) still function correctly
- [ ] Verify sets stepper (+/-) buttons work
- [ ] Verify reps and weight text fields can be edited
- [ ] Verify keyboard dismisses on scroll (.scrollDismissesKeyboard already present)

Generated with [Claude Code](https://claude.com/claude-code)