### PR TITLE
fix(music): prevent paused Apple Music counting and add track play count

### DIFF
--- a/Xomfit.xcodeproj/project.pbxproj
+++ b/Xomfit.xcodeproj/project.pbxproj
@@ -721,7 +721,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.1.7;
+				MARKETING_VERSION = 2.1.8;
 				PRODUCT_BUNDLE_IDENTIFIER = com.Xomware.Xomfit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -758,7 +758,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.1.7;
+				MARKETING_VERSION = 2.1.8;
 				PRODUCT_BUNDLE_IDENTIFIER = com.Xomware.Xomfit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -792,7 +792,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.1.7;
+				MARKETING_VERSION = 2.1.8;
 				PRODUCT_BUNDLE_IDENTIFIER = com.Xomware.Xomfit.XomfitWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -824,7 +824,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.1.7;
+				MARKETING_VERSION = 2.1.8;
 				PRODUCT_BUNDLE_IDENTIFIER = com.Xomware.Xomfit.XomfitWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/Xomfit/Models/WorkoutTrack.swift
+++ b/Xomfit/Models/WorkoutTrack.swift
@@ -25,9 +25,13 @@ struct WorkoutTrack: Codable, Hashable, Identifiable {
     /// - Apple Music: `https://music.apple.com/...`
     /// - SoundCloud: track permalink URL
     var url: String? = nil
+    /// Number of times this track was played during the workout session. Incremented when
+    /// a previously captured track reappears after playing a different song (i.e., the user
+    /// repeated the song). Defaults to 1 for backward compatibility with older payloads.
+    var playCount: Int = 1
 
     enum CodingKeys: String, CodingKey {
-        case id, title, artist, album, capturedAt, sourceApp, url
+        case id, title, artist, album, capturedAt, sourceApp, url, playCount
     }
 
     init(
@@ -37,7 +41,8 @@ struct WorkoutTrack: Codable, Hashable, Identifiable {
         album: String? = nil,
         capturedAt: Date,
         sourceApp: String,
-        url: String? = nil
+        url: String? = nil,
+        playCount: Int = 1
     ) {
         self.id = id
         self.title = title
@@ -46,6 +51,7 @@ struct WorkoutTrack: Codable, Hashable, Identifiable {
         self.capturedAt = capturedAt
         self.sourceApp = sourceApp
         self.url = url
+        self.playCount = playCount
     }
 
     init(from decoder: Decoder) throws {
@@ -57,5 +63,7 @@ struct WorkoutTrack: Codable, Hashable, Identifiable {
         capturedAt = try container.decode(Date.self, forKey: .capturedAt)
         sourceApp = try container.decode(String.self, forKey: .sourceApp)
         url = try container.decodeIfPresent(String.self, forKey: .url)
+        // Backward compat: older payloads won't have playCount, default to 1
+        playCount = try container.decodeIfPresent(Int.self, forKey: .playCount) ?? 1
     }
 }

--- a/Xomfit/Services/NowPlayingService.swift
+++ b/Xomfit/Services/NowPlayingService.swift
@@ -26,6 +26,10 @@ final class NowPlayingService {
     /// Accumulated tracks for the current capture session, deduped by `dedupeKey`.
     private var captured: [WorkoutTrack] = []
     @ObservationIgnored private var seenKeys: Set<String> = []
+    /// Maps dedupe keys to indices in `captured` for O(1) lookup when incrementing playCount.
+    @ObservationIgnored private var keyToIndex: [String: Int] = [:]
+    /// Tracks the last confirmed (committed) track key to detect repeats vs continuous play.
+    @ObservationIgnored private var lastCapturedKey: String?
     @ObservationIgnored private var pollTask: Task<Void, Never>?
     @ObservationIgnored private var isAuthorized: Bool = false
     @ObservationIgnored private var pendingKey: String?
@@ -114,6 +118,8 @@ final class NowPlayingService {
         // Reset session state up-front so a back-to-back start clears prior captures
         captured.removeAll()
         seenKeys.removeAll()
+        keyToIndex.removeAll()
+        lastCapturedKey = nil
         pendingKey = nil
         pendingFirstSeen = nil
         lastCapturedTrack = nil
@@ -165,6 +171,8 @@ final class NowPlayingService {
         let result = captured
         captured.removeAll()
         seenKeys.removeAll()
+        keyToIndex.removeAll()
+        lastCapturedKey = nil
         return result
     }
 
@@ -172,14 +180,23 @@ final class NowPlayingService {
 
     /// Reads `systemMusicPlayer.nowPlayingItem` once. No-op when:
     ///   - Apple Music auth is denied
-    ///   - Nothing is playing via Apple Music (Spotify/podcasts/etc. won't surface here)
-    ///   - The current track was already captured (deduped by title+artist+persistentID)
+    ///   - Nothing is actively playing via Apple Music (paused/stopped won't count)
+    ///   - The current track was already captured and is still the same as last poll
+    ///
+    /// If a previously captured track reappears after a different track was captured,
+    /// its `playCount` is incremented rather than adding a duplicate entry.
     private func captureCurrentTrack() {
         guard isAuthorized else {
             print("[NowPlayingService] captureCurrentTrack: skipped — not authorized")
             return
         }
-        guard let item = MPMusicPlayerController.systemMusicPlayer.nowPlayingItem else {
+        let player = MPMusicPlayerController.systemMusicPlayer
+        guard player.playbackState == .playing else {
+            // Not actively playing — skip capture. This prevents counting songs when
+            // Apple Music is paused or not open.
+            return
+        }
+        guard let item = player.nowPlayingItem else {
             print("[NowPlayingService] captureCurrentTrack: nowPlayingItem is nil (nothing playing via Apple Music)")
             return
         }
@@ -189,8 +206,23 @@ final class NowPlayingService {
         }
 
         let key = dedupeKey(title: title, artist: item.artist, persistentID: item.persistentID)
-        guard !seenKeys.contains(key) else { return }
 
+        // If we've seen this track before and it's returning after a different track,
+        // increment its playCount instead of deduping silently.
+        if seenKeys.contains(key) {
+            if let lastKey = lastCapturedKey, lastKey != key, let index = keyToIndex[key] {
+                // Track is repeating after we played something else — increment playCount
+                captured[index].playCount += 1
+                lastCapturedKey = key
+                lastCapturedTrack = captured[index]
+                print("[NowPlayingService] repeat detected for '\(title)' — playCount now \(captured[index].playCount)")
+            }
+            // Either way, update lastCapturedKey so we don't keep incrementing on consecutive polls
+            lastCapturedKey = key
+            return
+        }
+
+        // New track — apply minimum listen duration before committing
         if pendingKey == key, let firstSeen = pendingFirstSeen,
            Date().timeIntervalSince(firstSeen) >= minimumListenDuration {
             seenKeys.insert(key)
@@ -204,7 +236,9 @@ final class NowPlayingService {
                 capturedAt: Date(),
                 sourceApp: "Apple Music"
             )
+            keyToIndex[key] = captured.count
             captured.append(track)
+            lastCapturedKey = key
             lastCapturedTrack = track
             print("[NowPlayingService] captured '\(title)' by \(item.artist ?? "unknown") — total: \(captured.count)")
         } else if pendingKey != key {

--- a/Xomfit/Services/SpotifyNowPlayingService.swift
+++ b/Xomfit/Services/SpotifyNowPlayingService.swift
@@ -22,6 +22,10 @@ final class SpotifyNowPlayingService {
 
     private var captured: [WorkoutTrack] = []
     @ObservationIgnored private var seenKeys: Set<String> = []
+    /// Maps dedupe keys to indices in `captured` for O(1) lookup when incrementing playCount.
+    @ObservationIgnored private var keyToIndex: [String: Int] = [:]
+    /// Tracks the last confirmed (committed) track key to detect repeats vs continuous play.
+    @ObservationIgnored private var lastCapturedKey: String?
     @ObservationIgnored private var pollTask: Task<Void, Never>?
 
     // MARK: - Observable surface (Spotify capture polish)
@@ -57,6 +61,8 @@ final class SpotifyNowPlayingService {
         print("[SpotifyNowPlayingService] startCapture called — resetting session state")
         captured.removeAll()
         seenKeys.removeAll()
+        keyToIndex.removeAll()
+        lastCapturedKey = nil
         lastCapturedTrack = nil
         pollTask?.cancel()
 
@@ -97,11 +103,20 @@ final class SpotifyNowPlayingService {
         let result = captured
         captured.removeAll()
         seenKeys.removeAll()
+        keyToIndex.removeAll()
+        lastCapturedKey = nil
         return result
     }
 
     // MARK: - Polling
 
+    /// Polls Spotify's currently-playing endpoint once. No-op when:
+    ///   - User is not authenticated with Spotify
+    ///   - Nothing is playing (204 response)
+    ///   - The current track was already captured and is still the same as last poll
+    ///
+    /// If a previously captured track reappears after a different track was captured,
+    /// its `playCount` is incremented rather than adding a duplicate entry.
     private func captureCurrentTrack() async {
         guard let token = await SpotifyAuthService.shared.currentTokenRefreshingIfNeeded() else {
             // Not signed in (or refresh failed). Silent no-op — see class doc.
@@ -146,12 +161,26 @@ final class SpotifyNowPlayingService {
             guard !title.isEmpty else { return }
 
             let key = dedupeKey(uri: item.uri, id: item.id, title: title)
-            guard !seenKeys.contains(key) else { return }
+            let artist = item.artists?.compactMap { $0.name }.joined(separator: ", ")
 
-            // Capture immediately — if it's playing, log it. No delay needed.
+            // If we've seen this track before and it's returning after a different track,
+            // increment its playCount instead of deduping silently.
+            if seenKeys.contains(key) {
+                if let lastKey = lastCapturedKey, lastKey != key, let index = keyToIndex[key] {
+                    // Track is repeating after we played something else — increment playCount
+                    captured[index].playCount += 1
+                    lastCapturedKey = key
+                    lastCapturedTrack = captured[index]
+                    print("[SpotifyNowPlayingService] repeat detected for '\(title)' — playCount now \(captured[index].playCount)")
+                }
+                // Either way, update lastCapturedKey so we don't keep incrementing on consecutive polls
+                lastCapturedKey = key
+                return
+            }
+
+            // New track — capture immediately
             seenKeys.insert(key)
 
-            let artist = item.artists?.compactMap { $0.name }.joined(separator: ", ")
             let trackURL: String? = {
                 if let id = item.id, !id.isEmpty {
                     return "https://open.spotify.com/track/\(id)"
@@ -167,7 +196,9 @@ final class SpotifyNowPlayingService {
                 sourceApp: "Spotify",
                 url: trackURL
             )
+            keyToIndex[key] = captured.count
             captured.append(track)
+            lastCapturedKey = key
             lastCapturedTrack = track
             print("[SpotifyNowPlayingService] captured '\(title)' by \(artist ?? "unknown") — total: \(captured.count)")
         } catch {


### PR DESCRIPTION
## Summary
- Fix Apple Music counting songs when paused/stopped by adding playbackState check
- Add playCount field to WorkoutTrack to track repeat plays during workouts
- Implement play count increment logic in both NowPlayingService and SpotifyNowPlayingService
- Bump version to 2.1.8

## Changes
**Problem 1: Apple Music counts songs when not playing**
- Added `player.playbackState == .playing` guard in `NowPlayingService.captureCurrentTrack()`
- Songs are now only counted when Apple Music is actively playing, not when paused or the app is closed

**Problem 2: Track repeat plays per rest timer**
- Added `playCount: Int` field to `WorkoutTrack` model with default value of 1
- Backward compatible Codable implementation (decodes as 1 if missing)
- Both services now track `lastCapturedKey` to detect when a previously seen track reappears
- When a track returns after playing a different song, its `playCount` is incremented rather than being silently deduped
- Added `keyToIndex` dictionary for O(1) lookup when incrementing play counts

## Test plan
- [ ] Start workout, pause Apple Music, verify no tracks are captured while paused
- [ ] Start workout with Apple Music, play song A, then B, then A again - verify A has playCount of 2
- [ ] Start workout with Spotify, play song A, then B, then A again - verify A has playCount of 2
- [ ] Load older workout with cached tracks - verify playCount defaults to 1 (backward compat)
- [ ] Build succeeds without errors

Generated with [Claude Code](https://claude.com/claude-code)