### PR TITLE
feat(ratings): add detailed workout ratings system

### DIFF
--- a/Xomfit.xcodeproj/project.pbxproj
+++ b/Xomfit.xcodeproj/project.pbxproj
@@ -721,7 +721,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.1.9;
+				MARKETING_VERSION = 2.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.Xomware.Xomfit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -758,7 +758,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.1.9;
+				MARKETING_VERSION = 2.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.Xomware.Xomfit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -792,7 +792,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.1.9;
+				MARKETING_VERSION = 2.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.Xomware.Xomfit.XomfitWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -824,7 +824,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.1.9;
+				MARKETING_VERSION = 2.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.Xomware.Xomfit.XomfitWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/Xomfit/Models/Workout.swift
+++ b/Xomfit/Models/Workout.swift
@@ -46,6 +46,10 @@ struct Workout: Codable, Identifiable {
     /// expanded view; the rest stay private. Defaults to `true` (share all) so
     /// existing posts keep their behavior. (#410)
     var shareFullSoundtrack: Bool = true
+    /// Detailed ratings captured at finish time. Optional categories for fatigue,
+    /// difficulty, gym crowdedness, music/vibe, energy before, and mood after.
+    /// Nil when no detailed ratings were provided (backward compatible).
+    var detailedRatings: WorkoutRatings? = nil
 
     var startDate: Date { startTime }
 
@@ -56,7 +60,7 @@ struct Workout: Codable, Identifiable {
     enum CodingKeys: String, CodingKey {
         case id, userId, name, exercises, startTime, endTime, notes, location, rating, tracks
         case kind, durationGoalMinutes, roundsGoal
-        case featuredTrackId, shareFullSoundtrack
+        case featuredTrackId, shareFullSoundtrack, detailedRatings
     }
 
     init(
@@ -74,7 +78,8 @@ struct Workout: Codable, Identifiable {
         durationGoalMinutes: Int? = nil,
         roundsGoal: Int? = nil,
         featuredTrackId: String? = nil,
-        shareFullSoundtrack: Bool = true
+        shareFullSoundtrack: Bool = true,
+        detailedRatings: WorkoutRatings? = nil
     ) {
         self.id = id
         self.userId = userId
@@ -91,6 +96,7 @@ struct Workout: Codable, Identifiable {
         self.roundsGoal = roundsGoal
         self.featuredTrackId = featuredTrackId
         self.shareFullSoundtrack = shareFullSoundtrack
+        self.detailedRatings = detailedRatings
     }
 
     init(from decoder: Decoder) throws {
@@ -110,6 +116,7 @@ struct Workout: Codable, Identifiable {
         roundsGoal = try container.decodeIfPresent(Int.self, forKey: .roundsGoal)
         featuredTrackId = try container.decodeIfPresent(String.self, forKey: .featuredTrackId)
         shareFullSoundtrack = try container.decodeIfPresent(Bool.self, forKey: .shareFullSoundtrack) ?? true
+        detailedRatings = try container.decodeIfPresent(WorkoutRatings.self, forKey: .detailedRatings)
     }
 
     /// Convenience lookup for the featured `WorkoutTrack`. Returns `nil` if no

--- a/Xomfit/Models/WorkoutRatings.swift
+++ b/Xomfit/Models/WorkoutRatings.swift
@@ -1,0 +1,100 @@
+import Foundation
+
+/// Detailed ratings captured when finishing a workout.
+/// All fields are optional so users can fill out as much or as little as they want.
+struct WorkoutRatings: Codable, Equatable {
+    /// How tired are you after this workout? (1 = fresh, 5 = exhausted)
+    var fatigue: Int?
+    /// How hard was the workout itself? (1 = easy, 5 = brutal)
+    var difficulty: Int?
+    /// How busy was the gym? (1 = empty, 5 = packed)
+    var crowdedness: Int?
+    /// How was your music/atmosphere? (1 = poor, 5 = great)
+    var musicVibe: Int?
+    /// Energy level going in (1 = low, 5 = high)
+    var energyBefore: Int?
+    /// How do you feel after? (1 = drained, 5 = energized)
+    var moodAfter: Int?
+
+    /// Empty instance for initialization
+    static let empty = WorkoutRatings()
+
+    /// True when at least one rating has been set
+    var hasAnyRating: Bool {
+        fatigue != nil ||
+        difficulty != nil ||
+        crowdedness != nil ||
+        musicVibe != nil ||
+        energyBefore != nil ||
+        moodAfter != nil
+    }
+
+    /// Category metadata for UI rendering
+    enum Category: CaseIterable, Identifiable {
+        case fatigue
+        case difficulty
+        case crowdedness
+        case musicVibe
+        case energyBefore
+        case moodAfter
+
+        var id: String { label }
+
+        var label: String {
+            switch self {
+            case .fatigue: return "Fatigue"
+            case .difficulty: return "Difficulty"
+            case .crowdedness: return "Gym Crowd"
+            case .musicVibe: return "Music Vibe"
+            case .energyBefore: return "Energy In"
+            case .moodAfter: return "Mood Out"
+            }
+        }
+
+        var lowLabel: String {
+            switch self {
+            case .fatigue: return "Fresh"
+            case .difficulty: return "Easy"
+            case .crowdedness: return "Empty"
+            case .musicVibe: return "Poor"
+            case .energyBefore: return "Low"
+            case .moodAfter: return "Drained"
+            }
+        }
+
+        var highLabel: String {
+            switch self {
+            case .fatigue: return "Exhausted"
+            case .difficulty: return "Brutal"
+            case .crowdedness: return "Packed"
+            case .musicVibe: return "Great"
+            case .energyBefore: return "High"
+            case .moodAfter: return "Energized"
+            }
+        }
+    }
+
+    /// Get the value for a category
+    func value(for category: Category) -> Int? {
+        switch category {
+        case .fatigue: return fatigue
+        case .difficulty: return difficulty
+        case .crowdedness: return crowdedness
+        case .musicVibe: return musicVibe
+        case .energyBefore: return energyBefore
+        case .moodAfter: return moodAfter
+        }
+    }
+
+    /// Set the value for a category
+    mutating func setValue(_ value: Int?, for category: Category) {
+        switch category {
+        case .fatigue: fatigue = value
+        case .difficulty: difficulty = value
+        case .crowdedness: crowdedness = value
+        case .musicVibe: musicVibe = value
+        case .energyBefore: energyBefore = value
+        case .moodAfter: moodAfter = value
+        }
+    }
+}

--- a/Xomfit/ViewModels/WorkoutLoggerViewModel.swift
+++ b/Xomfit/ViewModels/WorkoutLoggerViewModel.swift
@@ -19,6 +19,8 @@ final class WorkoutLoggerViewModel {
     var errorMessage: String?
     var location: String = ""
     var rating: Int = 0
+    /// Detailed ratings captured at finish time. All categories optional.
+    var detailedRatings: WorkoutRatings = .empty
 
     // MARK: - Soundtrack curation (#387)
     //
@@ -241,6 +243,7 @@ final class WorkoutLoggerViewModel {
         persistedCapturedTracks = []
         featuredTrackId = nil
         shareFullSoundtrack = true
+        detailedRatings = .empty
         skipRestTimer()
         startLiveActivity()
 
@@ -294,6 +297,7 @@ final class WorkoutLoggerViewModel {
         totalPausedDuration = 0
         location = ""
         rating = 0
+        detailedRatings = .empty
         manualTracks = []
         removedTrackIDs = []
         persistedCapturedTracks = []
@@ -1423,12 +1427,14 @@ final class WorkoutLoggerViewModel {
         var removedTrackIDs: [UUID]
         var featuredTrackId: UUID?
         var shareFullSoundtrack: Bool
+        var detailedRatings: WorkoutRatings
 
         enum CodingKeys: String, CodingKey {
             case schemaVersion, workoutId, workoutName, exercises, startTime, savedAt
             case totalPausedDuration, defaultRestDuration, focusExerciseIndex, focusSetIndex
             case kind, durationGoalMinutes, roundsGoal, location, rating, activeUserId
             case capturedTracks, manualTracks, removedTrackIDs, featuredTrackId, shareFullSoundtrack
+            case detailedRatings
         }
 
         init(
@@ -1452,7 +1458,8 @@ final class WorkoutLoggerViewModel {
             manualTracks: [WorkoutTrack] = [],
             removedTrackIDs: [UUID] = [],
             featuredTrackId: UUID? = nil,
-            shareFullSoundtrack: Bool = true
+            shareFullSoundtrack: Bool = true,
+            detailedRatings: WorkoutRatings = .empty
         ) {
             self.schemaVersion = schemaVersion
             self.workoutId = workoutId
@@ -1475,6 +1482,7 @@ final class WorkoutLoggerViewModel {
             self.removedTrackIDs = removedTrackIDs
             self.featuredTrackId = featuredTrackId
             self.shareFullSoundtrack = shareFullSoundtrack
+            self.detailedRatings = detailedRatings
         }
 
         init(from decoder: Decoder) throws {
@@ -1500,6 +1508,7 @@ final class WorkoutLoggerViewModel {
             removedTrackIDs = try c.decodeIfPresent([UUID].self, forKey: .removedTrackIDs) ?? []
             featuredTrackId = try c.decodeIfPresent(UUID.self, forKey: .featuredTrackId)
             shareFullSoundtrack = try c.decodeIfPresent(Bool.self, forKey: .shareFullSoundtrack) ?? true
+            detailedRatings = try c.decodeIfPresent(WorkoutRatings.self, forKey: .detailedRatings) ?? .empty
         }
     }
 
@@ -1548,7 +1557,8 @@ final class WorkoutLoggerViewModel {
             manualTracks: manualTracks,
             removedTrackIDs: Array(removedTrackIDs),
             featuredTrackId: featuredTrackId,
-            shareFullSoundtrack: shareFullSoundtrack
+            shareFullSoundtrack: shareFullSoundtrack,
+            detailedRatings: detailedRatings
         )
 
         do {
@@ -1646,6 +1656,7 @@ final class WorkoutLoggerViewModel {
         removedTrackIDs = Set(snapshot.removedTrackIDs)
         featuredTrackId = snapshot.featuredTrackId
         shareFullSoundtrack = snapshot.shareFullSoundtrack
+        detailedRatings = snapshot.detailedRatings
 
         isActive = true
         isPresented = true
@@ -1805,7 +1816,8 @@ final class WorkoutLoggerViewModel {
             durationGoalMinutes: durationGoalMinutes,
             roundsGoal: roundsGoal,
             featuredTrackId: validFeaturedId,
-            shareFullSoundtrack: shareFullSoundtrack
+            shareFullSoundtrack: shareFullSoundtrack,
+            detailedRatings: detailedRatings.hasAnyRating ? detailedRatings : nil
         )
 
         do {

--- a/Xomfit/Views/Workout/ActiveWorkoutView.swift
+++ b/Xomfit/Views/Workout/ActiveWorkoutView.swift
@@ -278,6 +278,7 @@ struct ActiveWorkoutView: View {
                 description: $workoutDescription,
                 location: $viewModel.location,
                 rating: $viewModel.rating,
+                detailedRatings: $viewModel.detailedRatings,
                 saveAsTemplate: $saveAsTemplate,
                 selectedPhotos: $selectedPhotos,
                 photoImages: $photoImages,
@@ -1570,6 +1571,7 @@ private struct FinishWorkoutSheet: View {
     @Binding var description: String
     @Binding var location: String
     @Binding var rating: Int
+    @Binding var detailedRatings: WorkoutRatings
     @Binding var saveAsTemplate: Bool
     @Binding var selectedPhotos: [PhotosPickerItem]
     @Binding var photoImages: [UIImage]
@@ -1578,6 +1580,8 @@ private struct FinishWorkoutSheet: View {
 
     /// Drives the manual-track entry sub-sheet (#387).
     @State private var showManualTrackSheet = false
+    /// Controls the expanded state of the detailed ratings section.
+    @State private var showDetailedRatings = false
 
     var body: some View {
         NavigationStack {
@@ -1625,6 +1629,9 @@ private struct FinishWorkoutSheet: View {
                                 Spacer()
                             }
                         }
+
+                        // Detailed Ratings (collapsible)
+                        detailedRatingsSection
 
                         VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
                             Text("Location")
@@ -1820,6 +1827,76 @@ private struct FinishWorkoutSheet: View {
             }
             .presentationDetents([.medium])
         }
+    }
+
+    // MARK: - Detailed Ratings Section
+
+    @ViewBuilder
+    private var detailedRatingsSection: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+            Button {
+                withAnimation(.xomChill) {
+                    showDetailedRatings.toggle()
+                }
+            } label: {
+                HStack(spacing: Theme.Spacing.sm) {
+                    Image(systemName: showDetailedRatings ? "chevron.down" : "chevron.right")
+                        .font(Theme.fontCaption.weight(.semibold))
+                        .foregroundStyle(Theme.textSecondary)
+                        .frame(width: 12)
+                    Text("More Ratings")
+                        .font(.subheadline.weight(.medium))
+                        .foregroundStyle(Theme.textSecondary)
+                    if detailedRatings.hasAnyRating {
+                        let count = countFilledRatings()
+                        Text("\(count)/6")
+                            .font(.caption.weight(.bold).monospacedDigit())
+                            .foregroundStyle(Theme.accent)
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 1)
+                            .background(Theme.accent.opacity(0.15), in: Capsule())
+                    }
+                    Spacer()
+                }
+                .frame(minHeight: 44)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("More ratings")
+            .accessibilityHint(showDetailedRatings ? "Tap to collapse" : "Tap to expand additional rating categories")
+
+            if showDetailedRatings {
+                VStack(spacing: Theme.Spacing.xs) {
+                    ForEach(WorkoutRatings.Category.allCases) { category in
+                        DetailedRatingRow(
+                            category: category,
+                            value: detailedRatings.value(for: category),
+                            onValueChanged: { newValue in
+                                detailedRatings.setValue(newValue, for: category)
+                            }
+                        )
+                    }
+                }
+                .padding(Theme.Spacing.sm)
+                .background(Theme.surface)
+                .clipShape(.rect(cornerRadius: Theme.cornerRadiusSmall))
+                .overlay(
+                    RoundedRectangle(cornerRadius: Theme.cornerRadiusSmall)
+                        .stroke(Theme.textSecondary.opacity(0.2), lineWidth: 1)
+                )
+                .transition(.opacity.combined(with: .move(edge: .top)))
+            }
+        }
+    }
+
+    private func countFilledRatings() -> Int {
+        var count = 0
+        for category in WorkoutRatings.Category.allCases {
+            if detailedRatings.value(for: category) != nil {
+                count += 1
+            }
+        }
+        return count
     }
 
     // MARK: - Soundtrack section (#387.2)
@@ -2117,5 +2194,62 @@ private struct ManualTrackSheet: View {
         let trimmedArtist = artist.trimmingCharacters(in: .whitespacesAndNewlines)
         onAdd(trimmedTitle, trimmedArtist.isEmpty ? nil : trimmedArtist)
         dismiss()
+    }
+}
+
+// MARK: - Detailed Rating Row
+
+/// A single row for a detailed rating category showing the label and 5 small tappable stars.
+private struct DetailedRatingRow: View {
+    let category: WorkoutRatings.Category
+    let value: Int?
+    let onValueChanged: (Int?) -> Void
+
+    var body: some View {
+        HStack(spacing: Theme.Spacing.sm) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(category.label)
+                    .font(.subheadline.weight(.medium))
+                    .foregroundStyle(Theme.textPrimary)
+                HStack(spacing: 4) {
+                    Text(category.lowLabel)
+                        .font(Theme.fontCaption2)
+                        .foregroundStyle(Theme.textTertiary)
+                    Text("-")
+                        .font(Theme.fontCaption2)
+                        .foregroundStyle(Theme.textTertiary)
+                    Text(category.highLabel)
+                        .font(Theme.fontCaption2)
+                        .foregroundStyle(Theme.textTertiary)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            HStack(spacing: 4) {
+                ForEach(1...5, id: \.self) { star in
+                    Button {
+                        withAnimation(.xomChill) {
+                            // Tap same star to clear
+                            if value == star {
+                                onValueChanged(nil)
+                            } else {
+                                onValueChanged(star)
+                            }
+                        }
+                        Haptics.selection()
+                    } label: {
+                        Image(systemName: star <= (value ?? 0) ? "star.fill" : "star")
+                            .font(Theme.fontCaption)
+                            .foregroundStyle(star <= (value ?? 0) ? Theme.accent : Theme.textSecondary.opacity(0.4))
+                            .frame(width: 28, height: 28)
+                            .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("\(star) star\(star > 1 ? "s" : "") for \(category.label)")
+                    .accessibilityAddTraits(star <= (value ?? 0) ? .isSelected : [])
+                }
+            }
+        }
+        .padding(.vertical, Theme.Spacing.xs)
     }
 }

--- a/Xomfit/Views/Workout/WorkoutDetailView.swift
+++ b/Xomfit/Views/Workout/WorkoutDetailView.swift
@@ -80,6 +80,7 @@ struct WorkoutDetailView: View {
                 } else {
                     VStack(spacing: Theme.Spacing.md) {
                         summaryCard
+                        detailedRatingsCard
                         exerciseList
                         soundtrackSection
                         startThisWorkoutButton
@@ -301,6 +302,33 @@ struct WorkoutDetailView: View {
         .padding(Theme.Spacing.md)
         .background(Theme.surface)
         .clipShape(.rect(cornerRadius: Theme.cornerRadius))
+    }
+
+    // MARK: - Detailed Ratings Card
+
+    @ViewBuilder
+    private var detailedRatingsCard: some View {
+        if let ratings = workout.detailedRatings, ratings.hasAnyRating {
+            VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+                Text("Detailed Ratings")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(Theme.textPrimary)
+
+                LazyVGrid(columns: [
+                    GridItem(.flexible(), spacing: Theme.Spacing.sm),
+                    GridItem(.flexible(), spacing: Theme.Spacing.sm)
+                ], spacing: Theme.Spacing.sm) {
+                    ForEach(WorkoutRatings.Category.allCases) { category in
+                        if let value = ratings.value(for: category) {
+                            DetailedRatingDisplay(category: category, value: value)
+                        }
+                    }
+                }
+            }
+            .padding(Theme.Spacing.md)
+            .background(Theme.surface)
+            .clipShape(.rect(cornerRadius: Theme.cornerRadius))
+        }
     }
 
     // MARK: - Exercise List
@@ -1376,5 +1404,32 @@ private struct WorkoutEditSetRow: View {
             .accessibilityLabel("Delete set \(setNumber)")
         }
         .frame(minHeight: 44)
+    }
+}
+
+// MARK: - Detailed Rating Display
+
+/// Read-only display of a single detailed rating category value.
+private struct DetailedRatingDisplay: View {
+    let category: WorkoutRatings.Category
+    let value: Int
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.tighter) {
+            Text(category.label)
+                .font(Theme.fontCaption)
+                .foregroundStyle(Theme.textSecondary)
+
+            HStack(spacing: 2) {
+                ForEach(1...5, id: \.self) { star in
+                    Image(systemName: star <= value ? "star.fill" : "star")
+                        .font(Theme.fontCaption2)
+                        .foregroundStyle(star <= value ? Theme.accent : Theme.textSecondary.opacity(0.3))
+                }
+                Spacer()
+            }
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(category.label): \(value) out of 5")
     }
 }


### PR DESCRIPTION
## Summary
- Add optional detailed workout ratings with 6 categories: Fatigue, Difficulty, Gym Crowdedness, Music/Vibe, Energy Before, and Mood After
- Users can optionally fill out these ratings in a collapsible "More Ratings" section when finishing a workout
- Detailed ratings display in WorkoutDetailView when present

## Test plan
- [ ] Start and complete a workout
- [ ] On the finish sheet, verify the 5-star overall rating still works
- [ ] Tap "More Ratings" to expand the detailed ratings section
- [ ] Verify all 6 categories show with small stars (1-5)
- [ ] Rate some categories, leave others empty
- [ ] Finish the workout and verify it saves
- [ ] Open the workout from history and verify detailed ratings display correctly
- [ ] Test force-quit recovery to ensure ratings persist

Generated with [Claude Code](https://claude.com/claude-code)