### PR TITLE
feat(workout): add exercise delete button, PR badge, and progressive overload

### DIFF
--- a/Xomfit.xcodeproj/project.pbxproj
+++ b/Xomfit.xcodeproj/project.pbxproj
@@ -721,7 +721,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.2.2;
+				MARKETING_VERSION = 2.2.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.Xomware.Xomfit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -758,7 +758,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.2.2;
+				MARKETING_VERSION = 2.2.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.Xomware.Xomfit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -792,7 +792,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.2.2;
+				MARKETING_VERSION = 2.2.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.Xomware.Xomfit.XomfitWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -824,7 +824,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.2.2;
+				MARKETING_VERSION = 2.2.3;
 				PRODUCT_BUNDLE_IDENTIFIER = com.Xomware.Xomfit.XomfitWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/Xomfit/ViewModels/WorkoutLoggerViewModel.swift
+++ b/Xomfit/ViewModels/WorkoutLoggerViewModel.swift
@@ -715,6 +715,15 @@ final class WorkoutLoggerViewModel {
                 )
             }
 
+            // Auto-fill next set with progressive overload suggestion.
+            // Only prefill when the next set is incomplete and not a drop set.
+            prefillNextSetWithProgression(
+                exerciseIndex: exerciseIndex,
+                completedSetIndex: setIndex,
+                completedWeight: set.weight,
+                completedReps: set.reps
+            )
+
             // Check if all sets in this exercise are now complete
             let allDone = exercises[exerciseIndex].sets.allSatisfy { $0.completedAt != Date.distantPast }
             if allDone {
@@ -767,6 +776,75 @@ final class WorkoutLoggerViewModel {
               exercises[exerciseIndex].sets.indices.contains(setIndex) else { return }
         exercises[exerciseIndex].sets[setIndex].weightMode =
             exercises[exerciseIndex].sets[setIndex].weightMode == .total ? .perSide : .total
+    }
+
+    // MARK: - Progressive Overload Auto-fill
+
+    /// Auto-fill the next incomplete set with a progressive overload suggestion based on
+    /// what the user just completed. Uses a simple double-progression model:
+    /// - If user hit 12+ reps: suggest +5 lbs at 8 reps (move to next weight)
+    /// - If user hit 8-11 reps: suggest same weight, +1 rep (work toward 12)
+    /// - If user hit < 8 reps: suggest same weight, same reps (consolidate)
+    ///
+    /// Only prefills sets that are:
+    /// - Incomplete (completedAt == distantPast)
+    /// - Not drop sets (drop sets inherit from parent, not progression)
+    /// - Have weight/reps at 0 or matching the "last" prefill (avoid overwriting user edits)
+    private func prefillNextSetWithProgression(
+        exerciseIndex: Int,
+        completedSetIndex: Int,
+        completedWeight: Double,
+        completedReps: Int
+    ) {
+        guard exercises.indices.contains(exerciseIndex) else { return }
+        guard completedWeight > 0, completedReps > 0 else { return }
+
+        // Find the next incomplete, non-drop set in this exercise
+        let sets = exercises[exerciseIndex].sets
+        let nextSetIndex = sets.indices.first { idx in
+            idx > completedSetIndex
+            && sets[idx].completedAt == Date.distantPast
+            && !sets[idx].isDropSet
+        }
+
+        guard let nextIdx = nextSetIndex else { return }
+
+        let nextSet = sets[nextIdx]
+
+        // Only prefill if the set appears untouched (zeros or already matching suggestion).
+        // This avoids overwriting intentional user edits mid-workout.
+        let isUntouched = (nextSet.weight == 0 && nextSet.reps == 0)
+            || (nextSet.weight == completedWeight && nextSet.reps == completedReps)
+            || (nextSet.weight == completedWeight && nextSet.reps == completedReps + 1)
+            || (nextSet.weight == completedWeight + 5 && nextSet.reps == 8)
+
+        guard isUntouched || nextSet.weight == 0 else { return }
+
+        // Double-progression logic:
+        // - Rep target range is typically 8-12 for hypertrophy
+        // - Hit top of range (12+): add weight, reset to bottom of range
+        // - In range (8-11): same weight, add a rep
+        // - Below range (<8): same weight, same reps (need to build up)
+
+        let suggestedWeight: Double
+        let suggestedReps: Int
+
+        if completedReps >= 12 {
+            // User hit or exceeded top of range — progress to heavier weight
+            suggestedWeight = completedWeight + 5
+            suggestedReps = 8
+        } else if completedReps >= 8 {
+            // User is in the working range — suggest one more rep
+            suggestedWeight = completedWeight
+            suggestedReps = completedReps + 1
+        } else {
+            // User is below target range — consolidate at current weight/reps
+            suggestedWeight = completedWeight
+            suggestedReps = completedReps
+        }
+
+        exercises[exerciseIndex].sets[nextIdx].weight = suggestedWeight
+        exercises[exerciseIndex].sets[nextIdx].reps = suggestedReps
     }
 
     // MARK: - Supersets

--- a/Xomfit/Views/Workout/ActiveWorkoutView.swift
+++ b/Xomfit/Views/Workout/ActiveWorkoutView.swift
@@ -1024,6 +1024,7 @@ private struct ExerciseCard: View {
 
     @State private var showDetails = false
     @State private var showSupersetToggleConfirm = false
+    @State private var showRemoveExerciseConfirm = false
     @State private var isCollapsed = false
 
     private var isInSuperset: Bool {
@@ -1083,6 +1084,22 @@ private struct ExerciseCard: View {
                                 .background(Theme.accent.opacity(0.15))
                                 .clipShape(.rect(cornerRadius: 4))
                         }
+                        // PR badge — show the user's personal record for this exercise
+                        if let pr = viewModel.personalRecordForExercise(exercise.exercise.id),
+                           pr.weight > 0, pr.reps > 0 {
+                            HStack(spacing: 3) {
+                                Image(systemName: "trophy.fill")
+                                    .font(.system(size: 9, weight: .bold))
+                                Text("PR: \(pr.weight.formattedWeight) x \(pr.reps)")
+                                    .font(.system(size: 10, weight: .bold))
+                            }
+                            .foregroundStyle(Theme.prGold)
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, Theme.Spacing.tighter)
+                            .background(Theme.prGold.opacity(0.15))
+                            .clipShape(.rect(cornerRadius: 4))
+                            .accessibilityLabel("Personal record: \(pr.weight.formattedWeight) pounds for \(pr.reps) reps")
+                        }
                     }
                 }
 
@@ -1139,10 +1156,21 @@ private struct ExerciseCard: View {
                     ? "Removes this exercise from its superset"
                     : "Pairs this exercise with the next one for back-to-back sets")
 
-                // Exercise removal moved to swipe-to-delete on the card (#xom).
-                // The inline xmark button used to live here; it's now redundant
-                // because the parent `LazyVStack` wraps the card with a swipe-
-                // gesture row that reveals a destructive Delete pill.
+                // Visible delete button — swipe-to-delete can compete with scroll
+                // gestures, so this provides an always-accessible alternative.
+                Button {
+                    Haptics.warning()
+                    showRemoveExerciseConfirm = true
+                } label: {
+                    Image(systemName: "trash")
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(Theme.destructive.opacity(0.8))
+                        .frame(width: 44, height: 44)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Remove \(exercise.exercise.name) from workout")
+                .accessibilityHint("Deletes this exercise and all its sets from the current workout")
             }
 
             if isCollapsed {
@@ -1312,6 +1340,19 @@ private struct ExerciseCard: View {
             Text(isInSuperset
                  ? "Removes \(exercise.exercise.name) from its superset."
                  : "Pairs \(exercise.exercise.name) with the next exercise for back-to-back sets.")
+        }
+        .confirmationDialog(
+            "Remove Exercise?",
+            isPresented: $showRemoveExerciseConfirm,
+            titleVisibility: .visible
+        ) {
+            Button("Remove \(exercise.exercise.name)", role: .destructive) {
+                Haptics.warning()
+                viewModel.removeExercise(at: exerciseIndex)
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("This will delete \(exercise.exercise.name) and all its sets from this workout.")
         }
         .sheet(isPresented: $showDetails) {
             ExerciseDetailSheet(exercise: exercise.exercise)


### PR DESCRIPTION
## Summary
- Add visible delete button (trash icon) in ExerciseCard header as alternative to swipe-to-delete which can compete with scroll gestures
- Display PR badge on each ExerciseCard showing user's personal record for that exercise (e.g., "PR: 225 x 8")
- Implement auto-fill progressive overload suggestions when completing sets using double-progression model
- Bump MARKETING_VERSION to 2.2.3

## Changes

### Issue 1: Can't Remove Exercises During Workout
Added a visible trash icon button in the ExerciseCard header that triggers a confirmation dialog before removing the exercise. This provides an always-accessible alternative to swipe-to-delete, which can compete with scroll gestures in ScrollView+LazyVStack.

### Issue 2: Show PR on Exercise Card
Added a PR badge next to muscle group chips in the ExerciseCard header. The badge displays the user's personal record for that exercise (e.g., "PR: 225 x 8") with a trophy icon and gold styling.

### Issue 3: Auto-fill Next Set with Progressive Overload
Implemented `prefillNextSetWithProgression()` in WorkoutLoggerViewModel that auto-fills the next incomplete set with a progressive overload suggestion when a set is completed:
- **12+ reps**: Suggest +5 lbs at 8 reps (move to heavier weight)
- **8-11 reps**: Suggest same weight, +1 rep (work toward top of range)
- **<8 reps**: Suggest same weight/reps (consolidate before progressing)

The prefill only applies to sets that appear untouched (zeros or already matching suggestion) to avoid overwriting intentional user edits.

## Test plan
- [ ] Verify trash button appears in ExerciseCard header and triggers confirmation dialog
- [ ] Verify exercise is removed after confirming deletion
- [ ] Verify PR badge displays correctly for exercises with history
- [ ] Verify PR badge shows "PR: [weight] x [reps]" format
- [ ] Complete a set with 12+ reps and verify next set suggests +5 lbs at 8 reps
- [ ] Complete a set with 8-11 reps and verify next set suggests same weight +1 rep
- [ ] Complete a set with <8 reps and verify next set suggests same weight/reps
- [ ] Verify user-edited sets are not overwritten by progressive overload

Generated with [Claude Code](https://claude.com/claude-code)