### PR TITLE
feat(workout): add quick action buttons for sets

### DIFF
--- a/Xomfit.xcodeproj/project.pbxproj
+++ b/Xomfit.xcodeproj/project.pbxproj
@@ -721,7 +721,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.2.3;
+				MARKETING_VERSION = 2.2.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.Xomware.Xomfit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -758,7 +758,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.2.3;
+				MARKETING_VERSION = 2.2.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.Xomware.Xomfit;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -792,7 +792,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.2.3;
+				MARKETING_VERSION = 2.2.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.Xomware.Xomfit.XomfitWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -824,7 +824,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.2.3;
+				MARKETING_VERSION = 2.2.4;
 				PRODUCT_BUNDLE_IDENTIFIER = com.Xomware.Xomfit.XomfitWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/Xomfit/ViewModels/WorkoutLoggerViewModel.swift
+++ b/Xomfit/ViewModels/WorkoutLoggerViewModel.swift
@@ -937,6 +937,18 @@ final class WorkoutLoggerViewModel {
 
     // MARK: - Drop Sets
 
+    /// Mark an existing set as a drop set. Optionally reduces weight by 20% if
+    /// the set already has a weight value.
+    func markSetAsDropSet(exerciseIndex: Int, setIndex: Int) {
+        guard exercises.indices.contains(exerciseIndex),
+              exercises[exerciseIndex].sets.indices.contains(setIndex) else { return }
+        exercises[exerciseIndex].sets[setIndex].isDropSet = true
+        let currentWeight = exercises[exerciseIndex].sets[setIndex].weight
+        if currentWeight > 0 {
+            exercises[exerciseIndex].sets[setIndex].weight = (currentWeight * 0.8).rounded(.toNearestOrEven)
+        }
+    }
+
     /// Insert a drop set immediately after `parentSetIndex`. The drop set inherits
     /// reps from the parent and uses 80% of the parent's weight as a reasonable starting point.
     func addDropSet(exerciseIndex: Int, parentSetIndex: Int) {

--- a/Xomfit/Views/Workout/ActiveWorkoutView.swift
+++ b/Xomfit/Views/Workout/ActiveWorkoutView.swift
@@ -1270,6 +1270,19 @@ private struct ExerciseCard: View {
                         onAddDropSet: {
                             viewModel.addDropSet(exerciseIndex: exerciseIndex, parentSetIndex: setIdx)
                         },
+                        onMarkDropSet: {
+                            viewModel.markSetAsDropSet(exerciseIndex: exerciseIndex, setIndex: setIdx)
+                        },
+                        onFillMax: {
+                            if let pr = viewModel.personalRecordForExercise(exercise.exercise.id) {
+                                viewModel.updateSet(exerciseIndex: exerciseIndex, setIndex: setIdx, weight: pr.weight, reps: viewModel.exercises[exerciseIndex].sets[setIdx].reps)
+                            }
+                        },
+                        onFillMaxPlus5: {
+                            if let pr = viewModel.personalRecordForExercise(exercise.exercise.id) {
+                                viewModel.updateSet(exerciseIndex: exerciseIndex, setIndex: setIdx, weight: pr.weight + 5, reps: viewModel.exercises[exerciseIndex].sets[setIdx].reps)
+                            }
+                        },
                         lateralityLabel: exercise.selectedLaterality != .bilateral ? (exercise.exercise.muscleGroups.contains(where: { [.quads, .hamstrings, .glutes, .calves].contains($0) }) ? "/leg" : "/arm") : nil,
                         lastSet: viewModel.lastSetHint(exerciseIndex: exerciseIndex, setIndex: setIdx),
                         personalRecord: viewModel.personalRecordForExercise(exercise.exercise.id),

--- a/Xomfit/Views/Workout/SetRowView.swift
+++ b/Xomfit/Views/Workout/SetRowView.swift
@@ -9,6 +9,9 @@ struct SetRowView: View {
     let onDelete: () -> Void
     let onToggleWeightMode: () -> Void
     let onAddDropSet: (() -> Void)?
+    var onMarkDropSet: (() -> Void)? = nil
+    var onFillMax: (() -> Void)? = nil
+    var onFillMaxPlus5: (() -> Void)? = nil
     var lateralityLabel: String? = nil
     /// Most recent set the user has logged for this exercise from history.
     /// Drives the "Last: 135×8" hint below the row. nil = first time doing this exercise.
@@ -81,6 +84,9 @@ struct SetRowView: View {
         onDelete: @escaping () -> Void,
         onToggleWeightMode: @escaping () -> Void = {},
         onAddDropSet: (() -> Void)? = nil,
+        onMarkDropSet: (() -> Void)? = nil,
+        onFillMax: (() -> Void)? = nil,
+        onFillMaxPlus5: (() -> Void)? = nil,
         lateralityLabel: String? = nil,
         lastSet: WorkoutSet? = nil,
         personalRecord: WorkoutSet? = nil,
@@ -94,6 +100,9 @@ struct SetRowView: View {
         self.onDelete = onDelete
         self.onToggleWeightMode = onToggleWeightMode
         self.onAddDropSet = onAddDropSet
+        self.onMarkDropSet = onMarkDropSet
+        self.onFillMax = onFillMax
+        self.onFillMaxPlus5 = onFillMaxPlus5
         self.lateralityLabel = lateralityLabel
         self.lastSet = lastSet
         self.personalRecord = personalRecord
@@ -110,6 +119,9 @@ struct SetRowView: View {
             mainRow
             if hasHints || beatsPriorPR {
                 hintRow
+            }
+            if isCurrentSet && !isCompleted {
+                quickActionButtons
             }
             if isCompleted, !isDropSet, let onAddDropSet {
                 addDropSetButton(onAddDropSet)
@@ -347,6 +359,78 @@ struct SetRowView: View {
         }
         .accessibilityElement(children: .combine)
         .accessibilityLabel("\(label) \(value)")
+    }
+
+    // MARK: - Quick action buttons
+
+    @ViewBuilder
+    private var quickActionButtons: some View {
+        HStack(spacing: Theme.Spacing.sm) {
+            Spacer().frame(width: Theme.Spacing.xs + Theme.Spacing.sm + Theme.Spacing.lg)
+
+            if let onMarkDropSet, !isDropSet {
+                Button {
+                    Haptics.light()
+                    onMarkDropSet()
+                } label: {
+                    HStack(spacing: 3) {
+                        Image(systemName: "arrow.down")
+                            .font(.caption2.weight(.bold))
+                        Text("Drop")
+                            .font(.caption2.weight(.semibold))
+                    }
+                    .foregroundStyle(Theme.accent)
+                    .padding(.horizontal, Theme.Spacing.sm)
+                    .padding(.vertical, 4)
+                    .background(Theme.accent.opacity(0.10))
+                    .clipShape(.capsule)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Mark as drop set")
+            }
+
+            if let onFillMax {
+                Button {
+                    Haptics.light()
+                    onFillMax()
+                } label: {
+                    HStack(spacing: 3) {
+                        Image(systemName: "trophy")
+                            .font(.caption2.weight(.bold))
+                        Text("Max")
+                            .font(.caption2.weight(.semibold))
+                    }
+                    .foregroundStyle(Theme.accent)
+                    .padding(.horizontal, Theme.Spacing.sm)
+                    .padding(.vertical, 4)
+                    .background(Theme.accent.opacity(0.10))
+                    .clipShape(.capsule)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Fill with PR weight")
+            }
+
+            if let onFillMaxPlus5 {
+                Button {
+                    Haptics.light()
+                    onFillMaxPlus5()
+                } label: {
+                    Text("+5")
+                        .font(.caption2.weight(.semibold))
+                        .foregroundStyle(Theme.accent)
+                        .padding(.horizontal, Theme.Spacing.sm)
+                        .padding(.vertical, 4)
+                        .background(Theme.accent.opacity(0.10))
+                        .clipShape(.capsule)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Fill with PR weight plus 5 pounds")
+            }
+
+            Spacer()
+        }
+        .padding(.horizontal, Theme.Spacing.md)
+        .padding(.bottom, Theme.Spacing.tight)
     }
 
     // MARK: - Drop set button


### PR DESCRIPTION
## Summary
- Add quick action buttons on the current (active) set row:
  - **Drop**: Mark the current set as a drop set (reduces weight by 20%)
  - **Max**: Fill weight with PR weight for this exercise
  - **+5**: Fill weight with PR weight + 5 lbs
- Buttons only appear on the active/incomplete set to keep the UI clean
- Bumps version to 2.2.4

## Test plan
- [ ] Start a workout with an exercise that has historical PR data
- [ ] Verify quick action buttons appear only on the current (incomplete) set
- [ ] Tap "Drop" button and verify set is marked as drop set with 20% weight reduction
- [ ] Tap "Max" button and verify weight field fills with PR weight
- [ ] Tap "+5" button and verify weight field fills with PR weight + 5 lbs
- [ ] Verify buttons disappear after completing a set
- [ ] Verify buttons move to the next active set

Generated with [Claude Code](https://claude.com/claude-code)