### PR TITLE
Fix: auto-save template reordering

### DIFF
--- a/Xomfit/Views/Workout/TemplateDetailView.swift
+++ b/Xomfit/Views/Workout/TemplateDetailView.swift
@@ -509,6 +509,18 @@ struct TemplateDetailView: View {
     private func markDirty() {
         if !hasUnsavedChanges { hasUnsavedChanges = true }
         saveError = nil
+
+        // Auto-save custom templates so reordering persists immediately
+        if draft.isCustom {
+            autoSave()
+        }
+    }
+
+    /// Quietly saves changes to custom templates without UI feedback.
+    private func autoSave() {
+        var updated = draft
+        updated.estimatedDuration = estimatedDuration
+        TemplateService.shared.saveCustomTemplate(updated)
     }
 
     // MARK: - Actions: Save Paths


### PR DESCRIPTION
## Summary
Custom template changes (reordering, sets, reps) now auto-save immediately.

## Problem
When you reorder exercises on a custom template and close the sheet, changes were lost because you had to manually hit Save.

## Fix
Added `autoSave()` that quietly persists changes to `TemplateService` whenever `markDirty()` is called on a custom template.

## Test plan
- [ ] Go to Workout tab > My Workouts
- [ ] Tap a custom template
- [ ] Reorder exercises using up/down chevrons
- [ ] Close the sheet
- [ ] Reopen the template
- [ ] Verify the new order persisted

🤖 Generated with [Claude Code](https://claude.com/claude-code)