### PR TITLE
feat: feed filter modal + feed detail rating/avatar fixes

### DIFF
--- a/Xomfit/Services/AuthService.swift
+++ b/Xomfit/Services/AuthService.swift
@@ -290,7 +290,10 @@ extension AppUser {
         id: "00000000-0000-0000-0000-00000000DEB6",
         username: "debug_user",
         displayName: "Debug User",
-        avatarURL: nil,
+        // Seeded avatar so the bypass verification flow exercises the
+        // profile-picture path (XomAvatar image branch) instead of always
+        // falling back to initials.
+        avatarURL: "https://i.pravatar.cc/300?img=68",
         bio: "Debug bypass — used by agent UI verification (#353)",
         stats: UserStats(
             totalWorkouts: 4,
@@ -314,7 +317,7 @@ extension AppUser {
         id: "00000000-0000-0000-0000-00000000FA17",
         username: "lift_buddy",
         displayName: "Lift Buddy",
-        avatarURL: nil,
+        avatarURL: "https://i.pravatar.cc/300?img=12",
         bio: "Debug bypass friend (#403)",
         stats: UserStats(
             totalWorkouts: 51,

--- a/Xomfit/ViewModels/FeedViewModel.swift
+++ b/Xomfit/ViewModels/FeedViewModel.swift
@@ -33,12 +33,29 @@ final class FeedViewModel {
     // Filters
     var dateRange: FeedDateRange = .all
     var selectedMuscleGroups: Set<MuscleGroup> = []
+    /// Minimum overall workout rating to show (0 = no filter). Only applies to
+    /// workout posts — non-workout activity is filtered out when set.
+    var minRating: Int = 0
+    /// User ids to restrict the feed to (empty = all users).
+    var selectedUserIds: Set<String> = []
+    /// Sort order applied after filtering.
+    var sortOption: FeedSortOption = .recent
 
     var filteredFeedItems: [SocialFeedItem] {
-        feedItems.filter { item in
+        let filtered = feedItems.filter { item in
             // Date filter
             if let start = dateRange.startDate, item.createdAt < start {
                 return false
+            }
+            // User filter
+            if !selectedUserIds.isEmpty, !selectedUserIds.contains(item.userId) {
+                return false
+            }
+            // Minimum rating filter (only applies to workout posts)
+            if minRating > 0 {
+                guard let rating = item.workoutActivity?.rating, rating >= minRating else {
+                    return false
+                }
             }
             // Muscle group filter (only applies to workout posts)
             if !selectedMuscleGroups.isEmpty {
@@ -50,9 +67,43 @@ final class FeedViewModel {
             }
             return true
         }
+        return sortItems(filtered)
     }
 
-    var isFiltered: Bool { dateRange != .all || !selectedMuscleGroups.isEmpty }
+    /// Applies `sortOption`. Posts without a rating sort as 0 so they sink to
+    /// the bottom for "highest rated" and rise to the top for "lowest rated".
+    private func sortItems(_ items: [SocialFeedItem]) -> [SocialFeedItem] {
+        switch sortOption {
+        case .recent:
+            return items.sorted { $0.createdAt > $1.createdAt }
+        case .highestRated:
+            return items.sorted { ($0.workoutActivity?.rating ?? 0) > ($1.workoutActivity?.rating ?? 0) }
+        case .lowestRated:
+            return items.sorted { ($0.workoutActivity?.rating ?? 0) < ($1.workoutActivity?.rating ?? 0) }
+        }
+    }
+
+    /// Distinct users present in the loaded feed, for the user filter chips.
+    /// Keyed on `item.userId` so the chip identity matches the filter key.
+    var availableUsers: [FeedUserOption] {
+        var seen = Set<String>()
+        var result: [FeedUserOption] = []
+        for item in feedItems where !seen.contains(item.userId) {
+            seen.insert(item.userId)
+            let name = item.user.displayName.isEmpty ? item.user.username : item.user.displayName
+            result.append(FeedUserOption(id: item.userId, name: name, avatarURL: item.user.avatarURL))
+        }
+        return result.sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+    }
+
+    /// `sortOption` is intentionally excluded — sorting reorders but never
+    /// reduces the result set, so it shouldn't trigger the "no matches" state.
+    var isFiltered: Bool {
+        dateRange != .all
+            || !selectedMuscleGroups.isEmpty
+            || !selectedUserIds.isEmpty
+            || minRating > 0
+    }
 
     // Pagination state
     private let pageSize = 20

--- a/Xomfit/Views/Feed/FeedDetailView.swift
+++ b/Xomfit/Views/Feed/FeedDetailView.swift
@@ -147,6 +147,12 @@ struct FeedDetailView: View {
                     }
                 }
 
+                // Detailed ratings — fatigue/difficulty/gym crowd/music/energy/
+                // mood captured at finish time. Lives on the full `Workout`
+                // (not the feed snapshot), so it renders once `fetchedWorkout`
+                // loads. The feed card only shows the single overall star.
+                detailedRatingsSection
+
                 // Personal Records (#415) — dedicated gold section listing each
                 // exercise that set a PR with the PR set details (weight × reps).
                 personalRecordsSection
@@ -218,6 +224,56 @@ struct FeedDetailView: View {
                 .clipShape(.rect(cornerRadius: Theme.Radius.sm))
             }
         }
+    }
+
+    // MARK: - Detailed Ratings Section
+
+    /// Read-only grid of every detailed rating category the poster filled in
+    /// when finishing the workout. Sourced from `fetchedWorkout.detailedRatings`
+    /// so it only renders once the full workout loads and at least one category
+    /// has a value. Mirrors `WorkoutDetailView.detailedRatingsCard`.
+    @ViewBuilder
+    private var detailedRatingsSection: some View {
+        if let ratings = fetchedWorkout?.detailedRatings, ratings.hasAnyRating {
+            VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+                Text("Detailed Ratings")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(Theme.textSecondary)
+
+                LazyVGrid(columns: [
+                    GridItem(.flexible(), spacing: Theme.Spacing.sm),
+                    GridItem(.flexible(), spacing: Theme.Spacing.sm)
+                ], spacing: Theme.Spacing.sm) {
+                    ForEach(WorkoutRatings.Category.allCases) { category in
+                        if let value = ratings.value(for: category) {
+                            detailedRatingRow(category: category, value: value)
+                        }
+                    }
+                }
+            }
+            .padding(Theme.Spacing.sm)
+            .background(Theme.background)
+            .clipShape(.rect(cornerRadius: Theme.cornerRadiusSmall))
+        }
+    }
+
+    private func detailedRatingRow(category: WorkoutRatings.Category, value: Int) -> some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.tighter) {
+            Text(category.label)
+                .font(Theme.fontCaption)
+                .foregroundStyle(Theme.textSecondary)
+
+            HStack(spacing: 2) {
+                ForEach(1...5, id: \.self) { star in
+                    Image(systemName: star <= value ? "star.fill" : "star")
+                        .font(Theme.fontCaption2)
+                        .foregroundStyle(star <= value ? Theme.accent : Theme.textSecondary.opacity(0.3))
+                }
+                Spacer()
+            }
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(category.label): \(value) out of 5")
     }
 
     // MARK: - Exercise Section

--- a/Xomfit/Views/Feed/FeedDetailView.swift
+++ b/Xomfit/Views/Feed/FeedDetailView.swift
@@ -104,9 +104,26 @@ struct FeedDetailView: View {
                 XomDivider()
 
                 VStack(alignment: .leading, spacing: 6) {
-                    Text(activity.workoutName)
-                        .font(.title3.weight(.bold))
-                        .foregroundStyle(Theme.textPrimary)
+                    HStack(spacing: Theme.Spacing.sm) {
+                        Text(activity.workoutName)
+                            .font(.title3.weight(.bold))
+                            .foregroundStyle(Theme.textPrimary)
+
+                        // Star rating — mirrors the feed card (#FeedItemCard) so
+                        // the overall workout rating is visible in the expanded
+                        // detail view, not just on the card.
+                        if let rating = activity.rating, rating > 0 {
+                            HStack(spacing: Theme.Spacing.tighter) {
+                                ForEach(1...5, id: \.self) { star in
+                                    Image(systemName: star <= rating ? "star.fill" : "star")
+                                        .font(.system(size: 12))
+                                        .foregroundStyle(star <= rating ? Theme.accent : Theme.textSecondary.opacity(0.3))
+                                }
+                            }
+                            .accessibilityElement(children: .ignore)
+                            .accessibilityLabel("Rated \(rating) of 5 stars")
+                        }
+                    }
 
                     HStack(spacing: Theme.Spacing.sm) {
                         Image(systemName: "calendar")

--- a/Xomfit/Views/Feed/FeedFilterBar.swift
+++ b/Xomfit/Views/Feed/FeedFilterBar.swift
@@ -1,26 +1,10 @@
 import SwiftUI
 
-enum FeedDateRange: String, CaseIterable, Identifiable {
-    case all = "All Time"
-    case today = "Today"
-    case thisWeek = "This Week"
-    case thisMonth = "This Month"
-
-    var id: String { rawValue }
-
-    /// Returns the start date for this range, or nil for "all time".
-    var startDate: Date? {
-        let cal = Calendar.current
-        let now = Date()
-        switch self {
-        case .all: return nil
-        case .today: return cal.startOfDay(for: now)
-        case .thisWeek: return cal.dateInterval(of: .weekOfYear, for: now)?.start
-        case .thisMonth: return cal.dateInterval(of: .month, for: now)?.start
-        }
-    }
-}
-
+/// Horizontal scrolling filter pills used by the profile feed / workout-history
+/// views. The main social feed migrated to a filter modal (`FeedFilterSheet`,
+/// #feed-filter-modal); these profile lists still use the inline pill bar.
+///
+/// The shared filter types (`FeedDateRange`, etc.) live in `FeedFilterSheet.swift`.
 struct FeedFilterBar: View {
     @Binding var selectedDateRange: FeedDateRange
     @Binding var selectedMuscleGroups: Set<MuscleGroup>

--- a/Xomfit/Views/Feed/FeedFilterSheet.swift
+++ b/Xomfit/Views/Feed/FeedFilterSheet.swift
@@ -1,0 +1,371 @@
+import SwiftUI
+
+// MARK: - Filter Types
+
+enum FeedDateRange: String, CaseIterable, Identifiable {
+    case all = "All Time"
+    case today = "Today"
+    case thisWeek = "This Week"
+    case thisMonth = "This Month"
+
+    var id: String { rawValue }
+
+    /// Returns the start date for this range, or nil for "all time".
+    var startDate: Date? {
+        let cal = Calendar.current
+        let now = Date()
+        switch self {
+        case .all: return nil
+        case .today: return cal.startOfDay(for: now)
+        case .thisWeek: return cal.dateInterval(of: .weekOfYear, for: now)?.start
+        case .thisMonth: return cal.dateInterval(of: .month, for: now)?.start
+        }
+    }
+}
+
+/// Sort order for the feed. `recent` is the default and matches the backend
+/// ordering; the rating variants reorder by overall workout rating.
+enum FeedSortOption: String, CaseIterable, Identifiable {
+    case recent = "Recent"
+    case highestRated = "Highest Rated"
+    case lowestRated = "Lowest Rated"
+
+    var id: String { rawValue }
+
+    var icon: String {
+        switch self {
+        case .recent: return "clock"
+        case .highestRated: return "arrow.down"
+        case .lowestRated: return "arrow.up"
+        }
+    }
+}
+
+/// Lightweight user option for the feed's per-user filter. `id` is the
+/// poster's `userId` so it matches `FeedViewModel.selectedUserIds`.
+struct FeedUserOption: Identifiable, Hashable {
+    let id: String
+    let name: String
+    let avatarURL: String?
+}
+
+// MARK: - Feed Filter Sheet
+
+/// Modal that owns every feed filter control (#feed-filter-modal). Replaces the
+/// old horizontal pill bar. Edits a local draft so the feed only re-filters
+/// when the user taps **Apply**; **Clear** resets the draft to defaults, and
+/// dismissing without applying discards changes.
+struct FeedFilterSheet: View {
+    let availableUsers: [FeedUserOption]
+    let onApply: (_ sort: FeedSortOption,
+                  _ dateRange: FeedDateRange,
+                  _ minRating: Int,
+                  _ muscleGroups: Set<MuscleGroup>,
+                  _ userIds: Set<String>) -> Void
+
+    @State private var draftSort: FeedSortOption
+    @State private var draftDateRange: FeedDateRange
+    @State private var draftMinRating: Int
+    @State private var draftMuscleGroups: Set<MuscleGroup>
+    @State private var draftUserIds: Set<String>
+
+    @Environment(\.dismiss) private var dismiss
+
+    init(
+        sortOption: FeedSortOption,
+        dateRange: FeedDateRange,
+        minRating: Int,
+        selectedMuscleGroups: Set<MuscleGroup>,
+        selectedUserIds: Set<String>,
+        availableUsers: [FeedUserOption],
+        onApply: @escaping (FeedSortOption, FeedDateRange, Int, Set<MuscleGroup>, Set<String>) -> Void
+    ) {
+        self.availableUsers = availableUsers
+        self.onApply = onApply
+        _draftSort = State(initialValue: sortOption)
+        _draftDateRange = State(initialValue: dateRange)
+        _draftMinRating = State(initialValue: minRating)
+        _draftMuscleGroups = State(initialValue: selectedMuscleGroups)
+        _draftUserIds = State(initialValue: selectedUserIds)
+    }
+
+    /// True when the draft differs from the no-filter defaults — drives the
+    /// Clear button's enabled state.
+    private var hasActiveDraft: Bool {
+        draftSort != .recent
+            || draftDateRange != .all
+            || draftMinRating > 0
+            || !draftMuscleGroups.isEmpty
+            || !draftUserIds.isEmpty
+    }
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Theme.background.ignoresSafeArea()
+
+                ScrollView {
+                    VStack(alignment: .leading, spacing: Theme.Spacing.lg) {
+                        sortSection
+                        dateSection
+                        ratingSection
+                        if availableUsers.count > 1 { usersSection }
+                        muscleSection
+                    }
+                    .padding(Theme.Spacing.md)
+                    // Leave room for the pinned action bar.
+                    .padding(.bottom, 96)
+                }
+
+                VStack(spacing: 0) {
+                    Spacer()
+                    actionBar
+                }
+            }
+            .navigationTitle("Filters")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbarColorScheme(.dark, for: .navigationBar)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button {
+                        dismiss()
+                    } label: {
+                        Image(systemName: "xmark")
+                            .font(.subheadline.weight(.semibold))
+                            .foregroundStyle(Theme.textSecondary)
+                    }
+                    .accessibilityLabel("Close filters")
+                }
+            }
+        }
+        .presentationDetents([.large])
+        .presentationCornerRadius(Theme.Radius.lg)
+    }
+
+    // MARK: - Sort
+
+    private var sortSection: some View {
+        sectionContainer(title: "Sort By", icon: "arrow.up.arrow.down") {
+            Picker("Sort By", selection: $draftSort) {
+                ForEach(FeedSortOption.allCases) { option in
+                    Text(option.rawValue).tag(option)
+                }
+            }
+            .pickerStyle(.segmented)
+        }
+    }
+
+    // MARK: - Date Range
+
+    private var dateSection: some View {
+        sectionContainer(title: "Date Range", icon: "calendar") {
+            chipFlow(FeedDateRange.allCases) { range in
+                filterChip(
+                    label: range.rawValue,
+                    isActive: draftDateRange == range
+                ) {
+                    withAnimation(.xomSnappy) { draftDateRange = range }
+                }
+            }
+        }
+    }
+
+    // MARK: - Minimum Rating
+
+    /// Tappable star row that picks a minimum overall-rating threshold. Tapping
+    /// the current value clears it back to "Any".
+    private var ratingSection: some View {
+        sectionContainer(title: "Minimum Rating", icon: "star.fill") {
+            VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+                HStack(spacing: Theme.Spacing.sm) {
+                    ForEach(1...5, id: \.self) { star in
+                        Button {
+                            withAnimation(.xomSnappy) {
+                                draftMinRating = (draftMinRating == star) ? 0 : star
+                            }
+                        } label: {
+                            Image(systemName: star <= draftMinRating ? "star.fill" : "star")
+                                .font(.title3)
+                                .foregroundStyle(star <= draftMinRating ? Theme.accent : Theme.textSecondary.opacity(0.4))
+                                .frame(minWidth: 36, minHeight: 36)
+                                .contentShape(Rectangle())
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityLabel("Minimum \(star) star\(star == 1 ? "" : "s")")
+                        .accessibilityAddTraits(star <= draftMinRating ? .isSelected : [])
+                    }
+                    Spacer()
+                }
+
+                Text(draftMinRating == 0 ? "Any rating" : "\(draftMinRating)+ stars")
+                    .font(Theme.fontCaption)
+                    .foregroundStyle(Theme.textSecondary)
+            }
+        }
+    }
+
+    // MARK: - Users
+
+    private var usersSection: some View {
+        sectionContainer(title: "Users", icon: "person.2.fill") {
+            VStack(spacing: 0) {
+                ForEach(Array(availableUsers.enumerated()), id: \.element.id) { index, user in
+                    Button {
+                        withAnimation(.xomSnappy) { toggleUser(user.id) }
+                    } label: {
+                        userRow(user: user, isSelected: draftUserIds.contains(user.id))
+                    }
+                    .buttonStyle(.plain)
+
+                    if index < availableUsers.count - 1 {
+                        XomDivider()
+                    }
+                }
+            }
+        }
+    }
+
+    private func userRow(user: FeedUserOption, isSelected: Bool) -> some View {
+        HStack(spacing: Theme.Spacing.sm) {
+            XomAvatar(
+                name: user.name,
+                size: 36,
+                imageURL: user.avatarURL.flatMap { URL(string: $0) }
+            )
+            Text(user.name)
+                .font(.subheadline.weight(.medium))
+                .foregroundStyle(Theme.textPrimary)
+                .lineLimit(1)
+            Spacer()
+            Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                .font(.title3)
+                .foregroundStyle(isSelected ? Theme.accent : Theme.textSecondary.opacity(0.4))
+        }
+        .padding(.vertical, Theme.Spacing.sm)
+        .frame(minHeight: 44)
+        .contentShape(Rectangle())
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(user.name)\(isSelected ? ", selected" : "")")
+    }
+
+    // MARK: - Muscle Groups
+
+    private var muscleSection: some View {
+        sectionContainer(title: "Body Parts", icon: "figure.strengthtraining.traditional") {
+            chipFlow(MuscleGroup.allCases) { group in
+                filterChip(
+                    label: group.displayName,
+                    icon: group.icon,
+                    isActive: draftMuscleGroups.contains(group)
+                ) {
+                    withAnimation(.xomSnappy) { toggleMuscle(group) }
+                }
+            }
+        }
+    }
+
+    // MARK: - Action Bar
+
+    private var actionBar: some View {
+        HStack(spacing: Theme.Spacing.md) {
+            XomButton("Clear", variant: .ghost) {
+                Haptics.light()
+                withAnimation(.xomSnappy) { clearDraft() }
+            }
+            .disabled(!hasActiveDraft)
+            .opacity(hasActiveDraft ? 1 : 0.5)
+
+            XomButton("Apply", variant: .primary) {
+                Haptics.success()
+                onApply(draftSort, draftDateRange, draftMinRating, draftMuscleGroups, draftUserIds)
+                dismiss()
+            }
+        }
+        .padding(Theme.Spacing.md)
+        .background(.ultraThinMaterial)
+        .overlay(alignment: .top) {
+            XomDivider()
+        }
+    }
+
+    // MARK: - Mutations
+
+    private func toggleMuscle(_ group: MuscleGroup) {
+        if draftMuscleGroups.contains(group) {
+            draftMuscleGroups.remove(group)
+        } else {
+            draftMuscleGroups.insert(group)
+        }
+    }
+
+    private func toggleUser(_ id: String) {
+        if draftUserIds.contains(id) {
+            draftUserIds.remove(id)
+        } else {
+            draftUserIds.insert(id)
+        }
+    }
+
+    private func clearDraft() {
+        draftSort = .recent
+        draftDateRange = .all
+        draftMinRating = 0
+        draftMuscleGroups = []
+        draftUserIds = []
+    }
+
+    // MARK: - Reusable Pieces
+
+    private func sectionContainer<Content: View>(
+        title: String,
+        icon: String,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+            HStack(spacing: Theme.Spacing.tight) {
+                Image(systemName: icon)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(Theme.accent)
+                Text(title)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(Theme.textPrimary)
+            }
+            content()
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(Theme.Spacing.md)
+        .background(Theme.surface)
+        .clipShape(.rect(cornerRadius: Theme.cornerRadius))
+    }
+
+    /// Wrapping chip layout. Uses `LazyVGrid` with adaptive columns so chips
+    /// flow onto multiple rows without manual width math.
+    private func chipFlow<T: Identifiable, ChipView: View>(
+        _ items: [T],
+        @ViewBuilder chip: @escaping (T) -> ChipView
+    ) -> some View {
+        LazyVGrid(
+            columns: [GridItem(.adaptive(minimum: 90), spacing: Theme.Spacing.sm, alignment: .leading)],
+            alignment: .leading,
+            spacing: Theme.Spacing.sm
+        ) {
+            ForEach(items) { item in
+                chip(item)
+            }
+        }
+    }
+
+    private func filterChip(
+        label: String,
+        icon: String? = nil,
+        isActive: Bool,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            XomBadge(label, icon: icon, variant: .interactive, isActive: isActive)
+                .frame(maxWidth: .infinity, alignment: .center)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("\(label)\(isActive ? ", selected" : "")")
+    }
+}

--- a/Xomfit/Views/Feed/FeedView.swift
+++ b/Xomfit/Views/Feed/FeedView.swift
@@ -5,6 +5,7 @@ struct FeedView: View {
     @State private var viewModel = FeedViewModel()
     @State private var showUserSearch = false
     @State private var showNotifications = false
+    @State private var showFilters = false
     @State private var selectedFeedItem: SocialFeedItem? = nil
 
     /// #319: locally-hidden feed item ids. Backed by AppStorage so hides persist
@@ -58,10 +59,7 @@ struct FeedView: View {
                 emptyState
             } else {
                 VStack(spacing: 0) {
-                    FeedFilterBar(
-                        selectedDateRange: $viewModel.dateRange,
-                        selectedMuscleGroups: $viewModel.selectedMuscleGroups
-                    )
+                    filterBar
 
                     if viewModel.isFiltered && visibleFeedItems.isEmpty {
                         Spacer()
@@ -95,6 +93,15 @@ struct FeedView: View {
                     Task { await viewModel.applyFilterChange() }
                 }
                 .onChange(of: viewModel.selectedMuscleGroups) { _, _ in
+                    Task { await viewModel.applyFilterChange() }
+                }
+                .onChange(of: viewModel.sortOption) { _, _ in
+                    Task { await viewModel.applyFilterChange() }
+                }
+                .onChange(of: viewModel.minRating) { _, _ in
+                    Task { await viewModel.applyFilterChange() }
+                }
+                .onChange(of: viewModel.selectedUserIds) { _, _ in
                     Task { await viewModel.applyFilterChange() }
                 }
             }
@@ -151,6 +158,22 @@ struct FeedView: View {
         .sheet(isPresented: $showNotifications) {
             NotificationInboxView()
         }
+        .sheet(isPresented: $showFilters) {
+            FeedFilterSheet(
+                sortOption: viewModel.sortOption,
+                dateRange: viewModel.dateRange,
+                minRating: viewModel.minRating,
+                selectedMuscleGroups: viewModel.selectedMuscleGroups,
+                selectedUserIds: viewModel.selectedUserIds,
+                availableUsers: viewModel.availableUsers
+            ) { sort, dateRange, minRating, muscleGroups, userIds in
+                viewModel.sortOption = sort
+                viewModel.dateRange = dateRange
+                viewModel.minRating = minRating
+                viewModel.selectedMuscleGroups = muscleGroups
+                viewModel.selectedUserIds = userIds
+            }
+        }
         .onAppear {
             guard !userId.isEmpty else { return }
             Task { await viewModel.loadFeed(userId: userId) }
@@ -158,6 +181,76 @@ struct FeedView: View {
         // #385: patch cached feed item avatars when the local user updates their photo.
         .task {
             await viewModel.subscribeToProfileUpdates()
+        }
+    }
+
+    // MARK: - Filter Bar
+
+    /// Number of active filters, surfaced as a badge on the filter button so
+    /// the user can tell at a glance the feed is narrowed. Sort is excluded —
+    /// it reorders but doesn't reduce the set.
+    private var activeFilterCount: Int {
+        var count = 0
+        if viewModel.dateRange != .all { count += 1 }
+        if viewModel.minRating > 0 { count += 1 }
+        count += viewModel.selectedMuscleGroups.count
+        count += viewModel.selectedUserIds.count
+        return count
+    }
+
+    /// Slim top bar with a single Filter button (#feed-filter-modal). Replaces
+    /// the old horizontal pill list — tapping opens `FeedFilterSheet`.
+    private var filterBar: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Button {
+                    Haptics.light()
+                    showFilters = true
+                } label: {
+                    HStack(spacing: Theme.Spacing.sm) {
+                        Image(systemName: "line.3.horizontal.decrease")
+                            .font(.subheadline.weight(.semibold))
+                        Text("Filter")
+                            .font(.subheadline.weight(.semibold))
+                        if activeFilterCount > 0 {
+                            Text("\(activeFilterCount)")
+                                .font(.caption2.weight(.bold))
+                                .foregroundStyle(.black)
+                                .frame(minWidth: 18, minHeight: 18)
+                                .background(Circle().fill(Theme.accent))
+                        }
+                    }
+                    .foregroundStyle(activeFilterCount > 0 ? Theme.accent : Theme.textPrimary)
+                    .padding(.horizontal, Theme.Spacing.md)
+                    .padding(.vertical, Theme.Spacing.sm)
+                    .frame(minHeight: 44)
+                    .background(
+                        Capsule()
+                            .fill(activeFilterCount > 0 ? Theme.accent.opacity(0.15) : Theme.surface)
+                            .overlay(
+                                Capsule().strokeBorder(
+                                    activeFilterCount > 0 ? Color.clear : Theme.hairline,
+                                    lineWidth: 0.5
+                                )
+                            )
+                    )
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(activeFilterCount > 0
+                    ? "Filters, \(activeFilterCount) active"
+                    : "Filters")
+                .accessibilityHint("Opens filter options")
+
+                Spacer()
+
+                if viewModel.sortOption != .recent {
+                    XomBadge(viewModel.sortOption.rawValue, icon: viewModel.sortOption.icon, variant: .secondary)
+                }
+            }
+            .padding(.horizontal, Theme.Spacing.md)
+            .padding(.vertical, Theme.Spacing.sm)
+
+            XomDivider()
         }
     }
 


### PR DESCRIPTION
This branch now carries three related feed improvements.

## 1. Feed filter modal (new)
Replaces the horizontal scrolling filter pills at the top of `FeedView` with a single **Filter** button that opens a modal.

- Removes the inline pill bar from the feed; adds a funnel **Filter** button with an **active-filter count badge** when narrowed
- `FeedFilterSheet` groups every control in its own card:
  - **Sort** — segmented picker (Recent / Highest / Lowest rated)
  - **Date range** — chip flow
  - **Minimum rating** — tappable 1–5 star row (tap current value to clear)
  - **Users** — multi-select list with avatars (shown when >1 poster)
  - **Body parts** — multi-select muscle-group chips
- **Apply** / **Clear** action bar; edits a local draft so the feed only re-filters on Apply and dismissing discards changes
- `FeedFilterBar` (the pill bar) is retained — still used by the profile feed / workout-history views

## 2. Detailed ratings in feed detail (new)
`FeedDetailView` now shows a read-only grid of every per-category rating (fatigue, difficulty, etc.) captured at finish time, mirroring `WorkoutDetailView`.

## 3. Feed detail rating + verifiable avatars (original)
- `FeedDetailView`: show the 5-star overall workout rating next to the workout name, mirroring `FeedItemCard`
- `AuthService` debug fixtures: seed `avatarURL` on mock users so the avatar image path is exercised during bypass verification

## Testing
- `xcodebuild` Debug build for iPhone 17 simulator: **BUILD SUCCEEDED**
- Launched via `XOMFIT_AUTH_BYPASS=1`; confirmed the Filter button renders in place of the old pills