### PR TITLE
fix: WorkoutFocusView layout crush when rest timer minimized

### DIFF
--- a/Xomfit/Views/Workout/WorkoutFocusView.swift
+++ b/Xomfit/Views/Workout/WorkoutFocusView.swift
@@ -125,15 +125,27 @@ struct WorkoutFocusView: View {
                             .transition(.opacity)
                     }
 
-                    // MIDDLE — weight / reps / done. Absorbs slack so the top
-                    // header stays pinned under the Dynamic Island regardless of
-                    // whether the minimized rest banner is showing (#344-A).
+                    // Flexible top spacer — expands to vertically center the
+                    // weight/reps/done block when content fits, collapses to its
+                    // minLength so the VStack can grow past `proxy.size.height`
+                    // (and the ScrollView takes over) when the minimized rest
+                    // banner or keyboard pushes content past the screen. This
+                    // replaces the old `.frame(maxHeight: .infinity)` on the
+                    // middle block, which fought the scroll layout and crushed
+                    // the cards together when the banner appeared.
+                    Spacer(minLength: Theme.Spacing.md)
+
+                    // MIDDLE — weight / reps / done at natural content height.
                     VStack(spacing: Theme.Spacing.md) {
                         weightDisplay(currentSet: currentSet)
                         repsDisplay(currentSet: currentSet)
                         doneButton(currentSet: currentSet)
                     }
-                    .frame(maxHeight: .infinity)
+
+                    // Flexible bottom spacer — mirrors the top spacer so the
+                    // middle block stays centered between the pinned header and
+                    // the bottom navigation when there's slack.
+                    Spacer(minLength: Theme.Spacing.md)
 
                     // BOTTOM — exercise navigation (prev/next/add + rest config).
                     // Hidden in compact keyboard mode.


### PR DESCRIPTION
## Problem
`WorkoutFocusView` layout broke when the rest timer was minimized — weight/reps inputs crushed together, the DONE button got compressed, and bottom content clipped.

## Root cause
The middle weight/reps/done block had `.frame(maxHeight: .infinity)` inside a VStack pinned to `minHeight: proxy.size.height`. That flexible frame absorbed slack fine when content fit, but when the minimized rest banner pushed total content past screen height, the frame got **squeezed** — compressing the cards instead of letting the VStack grow past `proxy.size.height` and triggering the ScrollView.

## Fix
Replace the flexible `.frame` with `Spacer()` elements above and below the middle block. Spacers expand to vertically center the content when it fits, and collapse to their `minLength` when content overflows — so the VStack grows naturally and the ScrollView scrolls.

Result:
1. Header stays pinned at top
2. Weight/Reps/Done centered vertically when content fits
3. Navigation stays at bottom
4. Minimized timer banner sits below navigation (in-flow)
5. Content scrolls when it overflows

## Verification
- `xcodebuild` Debug build: **BUILD SUCCEEDED**
- Launched in simulator with focus mode + minimized rest timer flags (`XOMFIT_AUTO_ENTER_FOCUS` + `XOMFIT_AUTO_MINIMIZE_REST`) — the exact previously-broken state now renders cleanly with properly-spaced cards, full-width DONE, and bottom nav intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
