### PR TITLE
feat: populate notifications inbox with live backend data

### DIFF
--- a/Xomfit/Services/NotificationService.swift
+++ b/Xomfit/Services/NotificationService.swift
@@ -241,6 +241,103 @@ final class NotificationService {
         saveNotifications()
     }
 
+    // MARK: - Backend Refresh (#inbox)
+
+    /// Whether a refresh is currently in flight — drives the inbox loading state.
+    var isRefreshing = false
+
+    /// Pull live notifications from the backend and merge them into the inbox.
+    /// Three sources, each independently best-effort (a failure in one never
+    /// blocks the others):
+    ///   * pending friend requests        -> `.friendRequest`
+    ///   * friends' recent workouts        -> `.friendWorkout`
+    ///   * an under-trained-muscle nudge   -> `.suggestedWorkout`
+    ///
+    /// Stable, source-derived ids let us merge without duplicating across
+    /// refreshes while preserving the user's read state (see `merge(server:)`).
+    func refresh(currentUserId: String) async {
+        guard !currentUserId.isEmpty else { return }
+        isRefreshing = true
+        defer { isRefreshing = false }
+
+        var built: [AppNotification] = []
+
+        // Friend requests sent TO this user.
+        if let requests = try? await FriendsService.shared.fetchPendingRequests(userId: currentUserId) {
+            for row in requests {
+                let name = try? await ProfileService.shared.fetchProfile(userId: row.requesterId).displayName
+                built.append(AppNotification(
+                    id: "friendreq-\(row.id)",
+                    type: .friendRequest,
+                    title: name.map { "\($0) sent you a friend request" } ?? "New friend request",
+                    body: "Tap to review and respond.",
+                    senderId: row.requesterId,
+                    targetId: nil,
+                    createdAt: ISO8601DateFormatter().date(from: row.createdAt) ?? Date()
+                ))
+            }
+        }
+
+        // Friends' recent workout activity from the social feed.
+        if let feed = try? await FeedService.shared.fetchFeed(userId: currentUserId, limit: 15) {
+            for item in feed where item.userId != currentUserId && item.activityType == .workout {
+                let workoutName = item.workoutActivity?.workoutName ?? "a workout"
+                built.append(AppNotification(
+                    id: "feed-\(item.id)",
+                    type: .friendWorkout,
+                    title: "\(item.user.displayName) finished \(workoutName)",
+                    body: Self.workoutSummaryLine(item),
+                    senderId: item.userId,
+                    targetId: item.id,
+                    createdAt: item.createdAt
+                ))
+            }
+        }
+
+        // Workout suggestion — surfaced when a muscle group is under-trained.
+        let workouts = WorkoutService.shared.fetchWorkoutsFromCache(userId: currentUserId)
+        if let suggestion = TrainingNudgeService.suggestionForInbox(workouts: workouts) {
+            built.append(AppNotification(
+                id: "suggest-\(suggestion.muscle.rawValue)",
+                type: .suggestedWorkout,
+                title: "Suggested: \(suggestion.muscle.displayName) session",
+                body: suggestion.reason,
+                senderId: nil,
+                targetId: suggestion.muscle.rawValue,
+                createdAt: Date()
+            ))
+        }
+
+        merge(server: built)
+    }
+
+    /// One-line teaser for a friend's workout feed item.
+    private static func workoutSummaryLine(_ item: SocialFeedItem) -> String {
+        guard let w = item.workoutActivity else { return item.caption ?? "" }
+        return "\(w.exerciseCount) exercises · \(w.totalSets) sets"
+    }
+
+    /// Merge backend-derived notifications into the local list. Existing ids keep
+    /// their read state (and updated content); new ones are inserted. Locally
+    /// stored push notifications (different id space) are preserved.
+    private func merge(server incoming: [AppNotification]) {
+        var byId: [String: AppNotification] = Dictionary(
+            notifications.map { ($0.id, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        for var note in incoming {
+            if let existing = byId[note.id] {
+                note.isRead = existing.isRead
+            }
+            byId[note.id] = note
+        }
+        notifications = byId.values.sorted { $0.createdAt > $1.createdAt }
+        if notifications.count > 100 {
+            notifications = Array(notifications.prefix(100))
+        }
+        saveNotifications()
+    }
+
     // MARK: - Handle Incoming Push
 
     func handlePushPayload(_ userInfo: [AnyHashable: Any]) {
@@ -313,6 +410,20 @@ struct AppNotification: Codable, Identifiable {
         self.createdAt = Date()
     }
 
+    /// Stable-id initializer for backend-derived notifications. The caller supplies
+    /// a deterministic id (e.g. `"feed-\(itemId)"`) so repeated refreshes merge
+    /// onto the same row instead of duplicating.
+    init(id: String, type: NotificationType, title: String, body: String, isRead: Bool = false, senderId: String? = nil, targetId: String? = nil, createdAt: Date) {
+        self.id = id
+        self.type = type
+        self.title = title
+        self.body = body
+        self.isRead = isRead
+        self.senderId = senderId
+        self.targetId = targetId
+        self.createdAt = createdAt
+    }
+
     enum NotificationType: String, Codable, CaseIterable {
         case friendRequest = "friend_request"
         case friendAccepted = "friend_accepted"
@@ -321,6 +432,7 @@ struct AppNotification: Codable, Identifiable {
         case newPR = "new_pr"
         case streakMilestone = "streak_milestone"
         case friendWorkout = "friend_workout"
+        case suggestedWorkout = "suggested_workout"
 
         var defaultTitle: String {
             switch self {
@@ -331,6 +443,7 @@ struct AppNotification: Codable, Identifiable {
             case .newPR: return "New Personal Record!"
             case .streakMilestone: return "Streak Milestone"
             case .friendWorkout: return "Friend Completed a Workout"
+            case .suggestedWorkout: return "Suggested Workout"
             }
         }
 
@@ -342,7 +455,33 @@ struct AppNotification: Codable, Identifiable {
             case .newPR: return "trophy.fill"
             case .streakMilestone: return "flame.fill"
             case .friendWorkout: return "figure.strengthtraining.traditional"
+            case .suggestedWorkout: return "sparkles"
             }
+        }
+
+        /// Inbox filter bucket this type belongs to.
+        var filter: NotificationFilter {
+            switch self {
+            case .friendRequest, .friendAccepted, .like, .comment: return .friends
+            case .friendWorkout, .newPR, .streakMilestone: return .workouts
+            case .suggestedWorkout: return .suggestions
+            }
+        }
+    }
+}
+
+/// Top-level filter buckets surfaced as chips in the notification inbox.
+/// Distinct from `NotificationCategory` (which models user preference toggles).
+enum NotificationFilter: String, CaseIterable, Identifiable {
+    case all, friends, workouts, suggestions
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .all: return "All"
+        case .friends: return "Friends"
+        case .workouts: return "Workouts"
+        case .suggestions: return "Suggestions"
         }
     }
 }

--- a/Xomfit/Services/TrainingNudgeService.swift
+++ b/Xomfit/Services/TrainingNudgeService.swift
@@ -72,6 +72,22 @@ enum TrainingNudgeService {
         return nudge
     }
 
+    /// Non-committing variant for the notification inbox. Applies the same
+    /// suppression gates (cold-start + already-trained-today) but does NOT touch
+    /// the once-per-day `lastNudgeDay` marker, so surfacing a suggestion in the
+    /// inbox never consumes the launch nudge. Returns nil when no muscle is
+    /// under-trained or the user has too little history.
+    static func suggestionForInbox(
+        workouts: [Workout],
+        now: Date = Date()
+    ) -> UnderTrainedMuscle? {
+        guard workouts.count >= minWorkoutsForNudge else { return nil }
+        let cal = WorkoutInsights.userCalendar()
+        let today = cal.startOfDay(for: now)
+        if workouts.contains(where: { cal.startOfDay(for: $0.startTime) == today }) { return nil }
+        return resolvedBaseline().underTrainedMuscle(workouts: workouts, now: now)
+    }
+
     /// Test seam — clear persisted state.
     static func resetForTesting() {
         UserDefaults.standard.removeObject(forKey: lastNudgeDayKey)

--- a/Xomfit/Utils/SwipeToDelete.swift
+++ b/Xomfit/Utils/SwipeToDelete.swift
@@ -71,8 +71,15 @@ struct SwipeToDeleteRow<Content: View>: View {
             content()
                 .background(Theme.background) // keep underlying delete hidden when closed
                 .offset(x: currentOffset)
-                .gesture(
-                    DragGesture(minimumDistance: 8)
+                // `.simultaneousGesture` (not `.gesture`) so the parent
+                // ScrollView's pan recognizer runs in parallel. A plain
+                // `.gesture` claims the touch exclusively and starves the
+                // ScrollView, making the whole list unscrollable. The
+                // axis-lock logic below still gates the swipe reveal: a
+                // vertical drag never flips `gestureAxis` to `.horizontal`,
+                // so `dragOffset` stays 0 and only the ScrollView reacts.
+                .simultaneousGesture(
+                    DragGesture(minimumDistance: 12)
                         .onChanged { value in
                             let dx = abs(value.translation.width)
                             let dy = abs(value.translation.height)

--- a/Xomfit/Views/Feed/FeedView.swift
+++ b/Xomfit/Views/Feed/FeedView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct FeedView: View {
     @Environment(AuthService.self) private var authService
+    @Environment(GeneratorPreseed.self) private var generatorPreseed
     @State private var viewModel = FeedViewModel()
     @State private var showUserSearch = false
     @State private var showNotifications = false
@@ -156,7 +157,15 @@ struct FeedView: View {
             UserSearchView()
         }
         .sheet(isPresented: $showNotifications) {
-            NotificationInboxView()
+            NotificationInboxView(
+                currentUserId: authService.currentUser?.id.uuidString.lowercased(),
+                onStartSuggestion: { muscle in
+                    // FeedView can't switch tabs itself; seed the generator so the
+                    // Workout tab opens pre-filled when the user navigates there.
+                    Haptics.light()
+                    generatorPreseed.pending = muscle
+                }
+            )
         }
         .sheet(isPresented: $showFilters) {
             FeedFilterSheet(

--- a/Xomfit/Views/MainTabView.swift
+++ b/Xomfit/Views/MainTabView.swift
@@ -179,7 +179,14 @@ struct MainTabView: View {
                 .interactiveDismissDisabled(workoutSession.isActive)
         }
         .sheet(isPresented: $showNotifications) {
-            NotificationInboxView()
+            NotificationInboxView(
+                currentUserId: authService.currentUser?.id.uuidString.lowercased(),
+                onStartSuggestion: { muscle in
+                    Haptics.light()
+                    generatorPreseed.pending = muscle
+                    select(destination: .workout)
+                }
+            )
         }
         .toast($launchBadgeToast) {
             // Toast tap: only the training nudge has an action. Badge toasts

--- a/Xomfit/Views/Notifications/NotificationInboxView.swift
+++ b/Xomfit/Views/Notifications/NotificationInboxView.swift
@@ -4,31 +4,71 @@ struct NotificationInboxView: View {
     @Environment(\.dismiss) private var dismiss
     private let service = NotificationService.shared
 
+    /// Current user id — used to fetch friend requests / feed / suggestions.
+    let currentUserId: String?
+    /// Invoked when the user taps a suggested-workout notification. The parent
+    /// (MainTabView) dismisses the sheet, pre-seeds the generator, and switches
+    /// to the Workout tab.
+    let onStartSuggestion: (MuscleGroup) -> Void
+
+    @State private var filter: NotificationFilter = .all
+    @State private var route: NotifRoute?
+
+    init(currentUserId: String?, onStartSuggestion: @escaping (MuscleGroup) -> Void) {
+        self.currentUserId = currentUserId
+        self.onStartSuggestion = onStartSuggestion
+    }
+
+    /// Notifications matching the active filter, newest first.
+    private var visibleNotifications: [AppNotification] {
+        guard filter != .all else { return service.notifications }
+        return service.notifications.filter { $0.type.filter == filter }
+    }
+
     var body: some View {
         NavigationStack {
             ZStack {
                 Theme.background.ignoresSafeArea()
 
-                if service.notifications.isEmpty {
-                    emptyState
-                } else {
-                    List {
-                        ForEach(service.notifications) { notification in
-                            NotificationRow(notification: notification)
-                                .onTapGesture {
-                                    service.markAsRead(notification.id)
+                VStack(spacing: 0) {
+                    filterChips
+
+                    if service.notifications.isEmpty {
+                        emptyState
+                            .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    } else if visibleNotifications.isEmpty {
+                        filteredEmptyState
+                            .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    } else {
+                        List {
+                            ForEach(visibleNotifications) { notification in
+                                Button {
+                                    handleTap(notification)
+                                } label: {
+                                    NotificationRow(notification: notification)
                                 }
+                                .buttonStyle(.plain)
                                 .listRowBackground(
                                     notification.isRead ? Theme.surface : Theme.accent.opacity(0.06)
                                 )
+                            }
                         }
+                        .listStyle(.plain)
+                        .refreshable { await load() }
                     }
-                    .listStyle(.plain)
                 }
             }
             .navigationTitle("Notifications")
             .navigationBarTitleDisplayMode(.inline)
             .toolbarColorScheme(.dark, for: .navigationBar)
+            .navigationDestination(item: $route) { dest in
+                switch dest {
+                case .profile(let userId):
+                    ProfileView(userId: userId)
+                case .friends:
+                    FriendsView()
+                }
+            }
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Close") { dismiss() }
@@ -54,16 +94,108 @@ struct NotificationInboxView: View {
                     }
                 }
             }
+            .overlay(alignment: .top) {
+                if service.isRefreshing {
+                    ProgressView()
+                        .padding(.top, Theme.Spacing.sm)
+                }
+            }
+        }
+        .task { await load() }
+    }
+
+    // MARK: - Filter Chips
+
+    private var filterChips: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: Theme.Spacing.sm) {
+                ForEach(NotificationFilter.allCases) { category in
+                    let isSelected = filter == category
+                    Button {
+                        Haptics.selection()
+                        withAnimation(.easeInOut(duration: 0.15)) { filter = category }
+                    } label: {
+                        HStack(spacing: 4) {
+                            Text(category.title)
+                            if category != .all {
+                                let count = service.notifications.filter { $0.type.filter == category && !$0.isRead }.count
+                                if count > 0 {
+                                    Text("\(count)")
+                                        .font(.caption2.weight(.black))
+                                        .padding(.horizontal, 5)
+                                        .padding(.vertical, 1)
+                                        .background(isSelected ? Color.black.opacity(0.2) : Theme.accent.opacity(0.2))
+                                        .clipShape(.capsule)
+                                }
+                            }
+                        }
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(isSelected ? .black : Theme.textSecondary)
+                        .padding(.horizontal, Theme.Spacing.md)
+                        .padding(.vertical, Theme.Spacing.sm)
+                        .background(isSelected ? Theme.accent : Theme.surface)
+                        .clipShape(.capsule)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("\(category.title) filter")
+                    .accessibilityAddTraits(isSelected ? .isSelected : [])
+                }
+            }
+            .padding(.horizontal, Theme.Spacing.md)
+            .padding(.vertical, Theme.Spacing.sm)
         }
     }
+
+    // MARK: - Empty States
 
     private var emptyState: some View {
         XomEmptyState(
             icon: "bell.slash",
             title: "No notifications yet",
-            subtitle: "You'll see likes, comments, friend requests, and more here."
+            subtitle: "You'll see friend requests, friends' workouts, and workout suggestions here."
         )
     }
+
+    private var filteredEmptyState: some View {
+        XomEmptyState(
+            icon: "line.3.horizontal.decrease.circle",
+            title: "Nothing in \(filter.title)",
+            subtitle: "Switch filters or pull to refresh."
+        )
+    }
+
+    // MARK: - Actions
+
+    private func load() async {
+        guard let userId = currentUserId else { return }
+        await service.refresh(currentUserId: userId)
+    }
+
+    private func handleTap(_ notification: AppNotification) {
+        Haptics.light()
+        service.markAsRead(notification.id)
+
+        switch notification.type {
+        case .suggestedWorkout:
+            // targetId carries the muscle raw value — hand off to the generator.
+            if let raw = notification.targetId, let muscle = MuscleGroup(rawValue: raw) {
+                dismiss()
+                onStartSuggestion(muscle)
+            }
+        case .friendRequest:
+            route = .friends
+        case .friendAccepted, .friendWorkout, .like, .comment, .newPR, .streakMilestone:
+            if let senderId = notification.senderId {
+                route = .profile(senderId)
+            }
+        }
+    }
+}
+
+/// In-sheet navigation targets pushed from a notification tap.
+private enum NotifRoute: Hashable {
+    case profile(String)
+    case friends
 }
 
 // MARK: - Notification Row
@@ -84,12 +216,14 @@ private struct NotificationRow: View {
                 Text(notification.title)
                     .font(.subheadline.weight(notification.isRead ? .regular : .semibold))
                     .foregroundStyle(Theme.textPrimary)
+                    .multilineTextAlignment(.leading)
 
                 if !notification.body.isEmpty {
                     Text(notification.body)
                         .font(Theme.fontCaption)
                         .foregroundStyle(Theme.textSecondary)
                         .lineLimit(2)
+                        .multilineTextAlignment(.leading)
                 }
 
                 Text(notification.createdAt.timeAgo)
@@ -97,7 +231,11 @@ private struct NotificationRow: View {
                     .foregroundStyle(Theme.textTertiary)
             }
 
-            Spacer()
+            Spacer(minLength: Theme.Spacing.sm)
+
+            Image(systemName: "chevron.right")
+                .font(.caption.weight(.bold))
+                .foregroundStyle(Theme.textTertiary)
 
             if !notification.isRead {
                 Circle()
@@ -106,6 +244,7 @@ private struct NotificationRow: View {
             }
         }
         .padding(.vertical, Theme.Spacing.tight)
+        .contentShape(Rectangle())
     }
 
     private var iconColor: Color {
@@ -116,6 +255,7 @@ private struct NotificationRow: View {
         case .newPR: return Theme.prGold
         case .streakMilestone: return Theme.badgeStreak
         case .friendWorkout: return Theme.badgeMilestone
+        case .suggestedWorkout: return Theme.accent
         }
     }
 }

--- a/Xomfit/Views/Workout/ActiveWorkoutView.swift
+++ b/Xomfit/Views/Workout/ActiveWorkoutView.swift
@@ -108,17 +108,17 @@ struct ActiveWorkoutView: View {
                                 ScrollView {
                                     LazyVStack(spacing: Theme.Spacing.md) {
                                         ForEach(viewModel.exercises.indices, id: \.self) { exIdx in
-                                            let exerciseName = viewModel.exercises[exIdx].exercise.name
+                                            // No card-level `.swipeToDelete` here. A swipe
+                                            // recognizer on every full-height card fought the
+                                            // ScrollView's vertical pan and made the list feel
+                                            // stuck. Removal is fully covered by the always-
+                                            // visible trash button inside each card; set rows
+                                            // keep their (smaller) swipe affordance.
                                             ExerciseCard(
                                                 exerciseIndex: exIdx,
                                                 viewModel: viewModel
                                             )
                                             .id(exIdx)
-                                            .swipeToDelete(
-                                                accessibilityActionName: "Remove \(exerciseName) from workout"
-                                            ) {
-                                                viewModel.removeExercise(at: exIdx)
-                                            }
                                         }
                                     }
                                     .padding(Theme.Spacing.md)
@@ -1032,6 +1032,13 @@ private struct ExerciseCard: View {
             && viewModel.exercises[exerciseIndex].supersetGroupId != nil
     }
 
+    /// True when this card is the exercise the lifter is currently on. Drives the
+    /// highlight treatment (elevated surface, accent border, glow, "CURRENT"
+    /// badge) so the active card stands out from the rest of the list.
+    private var isCurrent: Bool {
+        viewModel.focusExerciseIndex == exerciseIndex
+    }
+
     private var supersetLetter: String? {
         viewModel.supersetLetter(forExercise: exerciseIndex)
     }
@@ -1049,8 +1056,20 @@ private struct ExerciseCard: View {
             let exercise = viewModel.exercises[exerciseIndex]
             VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
             // Exercise header
-            HStack {
+            HStack(alignment: .top, spacing: Theme.Spacing.sm) {
                 VStack(alignment: .leading, spacing: 3) {
+                    // "CURRENT" badge — only on the in-focus card so the lifter
+                    // can spot where they are at a glance in list mode.
+                    if isCurrent {
+                        HStack(spacing: 3) {
+                            Image(systemName: "scope")
+                                .font(.system(size: 9, weight: .black))
+                            Text("CURRENT")
+                                .font(.caption2.weight(.black))
+                        }
+                        .foregroundStyle(Theme.accent)
+                        .accessibilityLabel("Current exercise")
+                    }
                     // Superset pill — moved to its OWN row so the title gets
                     // the full card width. Previously sat to the left of the
                     // title and shrunk it to ~2 chars per line on supersetted
@@ -1066,8 +1085,10 @@ private struct ExerciseCard: View {
                             .accessibilityLabel("Superset \(letter)")
                     }
                     HStack(spacing: 6) {
+                        // Current exercise gets a larger, heavier title so the
+                        // in-focus card reads as bigger / more prominent than the rest.
                         Text(exercise.exercise.name)
-                            .font(.body.weight(.bold))
+                            .font(isCurrent ? .title3.weight(.heavy) : .body.weight(.bold))
                             .foregroundStyle(Theme.textPrimary)
                             .lineLimit(2)
                             .minimumScaleFactor(0.7)
@@ -1103,74 +1124,80 @@ private struct ExerciseCard: View {
                     }
                 }
 
-                Button {
-                    Haptics.selection()
-                    showDetails = true
-                } label: {
-                    Image(systemName: "info.circle")
-                        .font(.subheadline.weight(.semibold))
-                        .foregroundStyle(Theme.textSecondary)
-                        .frame(width: Theme.Spacing.xl, height: Theme.Spacing.xl)
-                        .contentShape(Rectangle())
-                }
-                .buttonStyle(.plain)
-                .accessibilityLabel("Show details for \(exercise.exercise.name)")
+                Spacer(minLength: Theme.Spacing.xs)
 
-                Button {
-                    Haptics.light()
-                    withAnimation(.xomConfident) {
-                        isCollapsed.toggle()
+                // Action cluster — all card controls grouped on the trailing
+                // edge so the title + tags get the full leading width and never
+                // collide with the buttons (previously info/collapse sat between
+                // the title and the spacer, crowding long names + tag rows).
+                HStack(spacing: 0) {
+                    Button {
+                        Haptics.selection()
+                        showDetails = true
+                    } label: {
+                        Image(systemName: "info.circle")
+                            .font(.subheadline.weight(.semibold))
+                            .foregroundStyle(Theme.textSecondary)
+                            .frame(width: 36, height: 44)
+                            .contentShape(Rectangle())
                     }
-                } label: {
-                    Image(systemName: "chevron.down")
-                        .font(.subheadline.weight(.semibold))
-                        .foregroundStyle(Theme.textSecondary)
-                        .rotationEffect(.degrees(isCollapsed ? -90 : 0))
-                        .frame(width: Theme.Spacing.xl, height: Theme.Spacing.xl)
-                        .contentShape(Rectangle())
-                }
-                .buttonStyle(.plain)
-                .accessibilityLabel(isCollapsed ? "Expand \(exercise.exercise.name)" : "Collapse \(exercise.exercise.name)")
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Show details for \(exercise.exercise.name)")
 
-                Spacer()
+                    Button {
+                        Haptics.light()
+                        withAnimation(.xomConfident) {
+                            isCollapsed.toggle()
+                        }
+                    } label: {
+                        Image(systemName: "chevron.down")
+                            .font(.subheadline.weight(.semibold))
+                            .foregroundStyle(Theme.textSecondary)
+                            .rotationEffect(.degrees(isCollapsed ? -90 : 0))
+                            .frame(width: 36, height: 44)
+                            .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel(isCollapsed ? "Expand \(exercise.exercise.name)" : "Collapse \(exercise.exercise.name)")
 
-                // Superset toggle (#294) — visible affordance for grouping with the
-                // next exercise. Disabled (but still rendered) when neither action
-                // is meaningful, so the button row layout stays stable.
-                Button {
-                    Haptics.selection()
-                    showSupersetToggleConfirm = true
-                } label: {
-                    Image(systemName: isInSuperset ? "link.circle.fill" : "link")
-                        .font(.subheadline.weight(.semibold))
-                        .foregroundStyle(isInSuperset ? Theme.accent : Theme.textSecondary)
-                        .frame(width: 44, height: 44)
-                        .contentShape(Rectangle())
-                }
-                .buttonStyle(.plain)
-                .disabled(!isInSuperset && !canGroupWithNext)
-                .accessibilityLabel(isInSuperset
-                    ? "Ungroup superset"
-                    : "Group with next exercise as superset")
-                .accessibilityHint(isInSuperset
-                    ? "Removes this exercise from its superset"
-                    : "Pairs this exercise with the next one for back-to-back sets")
+                    // Superset toggle (#294) — visible affordance for grouping with the
+                    // next exercise. Disabled (but still rendered) when neither action
+                    // is meaningful, so the button row layout stays stable.
+                    Button {
+                        Haptics.selection()
+                        showSupersetToggleConfirm = true
+                    } label: {
+                        Image(systemName: isInSuperset ? "link.circle.fill" : "link")
+                            .font(.subheadline.weight(.semibold))
+                            .foregroundStyle(isInSuperset ? Theme.accent : Theme.textSecondary)
+                            .frame(width: 40, height: 44)
+                            .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(!isInSuperset && !canGroupWithNext)
+                    .accessibilityLabel(isInSuperset
+                        ? "Ungroup superset"
+                        : "Group with next exercise as superset")
+                    .accessibilityHint(isInSuperset
+                        ? "Removes this exercise from its superset"
+                        : "Pairs this exercise with the next one for back-to-back sets")
 
-                // Visible delete button — swipe-to-delete can compete with scroll
-                // gestures, so this provides an always-accessible alternative.
-                Button {
-                    Haptics.warning()
-                    showRemoveExerciseConfirm = true
-                } label: {
-                    Image(systemName: "trash")
-                        .font(.subheadline.weight(.semibold))
-                        .foregroundStyle(Theme.destructive.opacity(0.8))
-                        .frame(width: 44, height: 44)
-                        .contentShape(Rectangle())
+                    // Visible delete button — the card-level swipe was removed to
+                    // keep the list scrollable, so this is the primary removal path.
+                    Button {
+                        Haptics.warning()
+                        showRemoveExerciseConfirm = true
+                    } label: {
+                        Image(systemName: "trash")
+                            .font(.subheadline.weight(.semibold))
+                            .foregroundStyle(Theme.destructive.opacity(0.8))
+                            .frame(width: 40, height: 44)
+                            .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Remove \(exercise.exercise.name) from workout")
+                    .accessibilityHint("Deletes this exercise and all its sets from the current workout")
                 }
-                .buttonStyle(.plain)
-                .accessibilityLabel("Remove \(exercise.exercise.name) from workout")
-                .accessibilityHint("Deletes this exercise and all its sets from the current workout")
             }
 
             if isCollapsed {
@@ -1313,7 +1340,7 @@ private struct ExerciseCard: View {
             }
         }
         .padding(Theme.Spacing.md)
-        .background(Theme.surface)
+        .background(isCurrent ? Theme.surfaceElevated : Theme.surface)
         .overlay(alignment: .leading) {
             // Vertical accent bar marking superset members
             if isInSuperset {
@@ -1324,6 +1351,20 @@ private struct ExerciseCard: View {
             }
         }
         .clipShape(.rect(cornerRadius: Theme.cornerRadius))
+        // Highlight the in-focus card: accent border + glow so it visually
+        // "lifts" above the dimmed, non-current cards around it.
+        .overlay {
+            RoundedRectangle(cornerRadius: Theme.cornerRadius)
+                .strokeBorder(Theme.accent, lineWidth: isCurrent ? 2 : 0)
+        }
+        .shadow(color: isCurrent ? Theme.accent.opacity(0.25) : .clear,
+                radius: isCurrent ? 10 : 0)
+        .opacity(isCurrent ? 1 : 0.9)
+        // Slightly shrink the off-focus cards so the current card stands taller
+        // and bigger relative to its neighbors. scaleEffect doesn't reflow the
+        // LazyVStack, so the md spacing keeps the cards from overlapping.
+        .scaleEffect(isCurrent ? 1 : 0.96, anchor: .center)
+        .animation(.easeInOut(duration: 0.2), value: isCurrent)
         // NOTE: no card-wide `.onLongPressGesture` here. A 0.5s long-press
         // recognizer on every row inside the `ScrollView` + `LazyVStack` defers
         // touch-down and fought the vertical scroll pan, making the list feel


### PR DESCRIPTION
## What

The notification inbox (`NotificationInboxView`) rendered empty because `NotificationService.notifications` was only ever populated by incoming push payloads. This wires it to real backend data and adds filtering + tap-through navigation.

## Changes

**Data fetching** — `NotificationService.refresh(currentUserId:)` composes the inbox from three independent, best-effort backend sources (a failure in one never blocks the others):
- **Friend requests** — pending requests sent to the user (`FriendsService.fetchPendingRequests`)
- **Friend workouts** — friends' recent workout activity from the social feed (`FeedService.fetchFeed`)
- **Workout suggestions** — an under-trained-muscle nudge (`TrainingNudgeService.suggestionForInbox`)

Stable, source-derived ids (`friendreq-…`, `feed-…`, `suggest-…`) let repeated refreshes merge onto the same rows without duplicating, while preserving the user's local read state.

**Notification type** — added `suggestedWorkout` (icon, default title, filter bucket).

**Category filter** — new `NotificationFilter` enum (All / Friends / Workouts / Suggestions) surfaced as filter chips with per-bucket unread counts.

**Tap-through navigation**
- Friend request → Friends screen
- Friend activity (workout / accepted / like / comment / PR) → sender's profile
- Suggestion → hands off to the workout generator pre-seeded with the muscle group

**Fetch triggers** — `.task` on appear + pull-to-refresh.

**TrainingNudgeService.suggestionForInbox** — non-committing variant of the launch nudge; applies the same suppression gates but does not consume the once-per-day marker, so surfacing a suggestion in the inbox never steals the launch nudge.

Both inbox call sites (`MainTabView`, `FeedView`) updated for the new initializer.

## Notes
- Builds clean: `xcodebuild -scheme Xomfit -destination 'platform=iOS Simulator,name=iPhone 17'` → **BUILD SUCCEEDED**.
- Read state is tracked locally (UserDefaults); the `notification_events` table is RLS read-only and not yet populated by the dispatch trigger, so the live-source approach is more reliable today.
- An unrelated working-tree change (`SetRowView.swift` drop-set clipping) was intentionally left out of this PR.

## Test plan
- [ ] Open the inbox (bell icon) — friend requests, friends' workouts, and a suggestion appear
- [ ] Filter chips switch buckets; unread counts are correct
- [ ] Tapping a friend request opens Friends; a friend workout opens their profile; a suggestion opens the generator
- [ ] Pull to refresh re-fetches without duplicating rows